### PR TITLE
Updates to prompt for tool calls

### DIFF
--- a/llama_toolchain/agentic_system/api/datatypes.py
+++ b/llama_toolchain/agentic_system/api/datatypes.py
@@ -111,6 +111,12 @@ class Session(BaseModel):
 
 
 @json_schema_type
+class ToolPromptFormat(Enum):
+    json = "json"
+    function_tag = "function_tag"
+
+
+@json_schema_type
 class AgenticSystemInstanceConfig(BaseModel):
     instructions: str
     sampling_params: Optional[SamplingParams] = SamplingParams()
@@ -127,6 +133,9 @@ class AgenticSystemInstanceConfig(BaseModel):
     # if you completely want to replace the messages prefixed by the system,
     # this is debug only
     debug_prefix_messages: Optional[List[Message]] = Field(default_factory=list)
+    tool_prompt_format: Optional[ToolPromptFormat] = Field(
+        default=ToolPromptFormat.function_tag
+    )
 
 
 class AgenticSystemTurnResponseEventType(Enum):

--- a/llama_toolchain/agentic_system/api/datatypes.py
+++ b/llama_toolchain/agentic_system/api/datatypes.py
@@ -134,7 +134,7 @@ class AgenticSystemInstanceConfig(BaseModel):
     # this is debug only
     debug_prefix_messages: Optional[List[Message]] = Field(default_factory=list)
     tool_prompt_format: Optional[ToolPromptFormat] = Field(
-        default=ToolPromptFormat.function_tag
+        default=ToolPromptFormat.json
     )
 
 

--- a/llama_toolchain/agentic_system/api/datatypes.py
+++ b/llama_toolchain/agentic_system/api/datatypes.py
@@ -112,6 +112,29 @@ class Session(BaseModel):
 
 @json_schema_type
 class ToolPromptFormat(Enum):
+    """This Enum refers to the prompt format for calling zero shot tools
+
+    `json` --
+        Refers to the json format for calling tools.
+        The json format takes the form like
+        {
+            "type": "function",
+            "function" : {
+                "name": "function_name",
+                "description": "function_description",
+                "parameters": {...}
+            }
+        }
+
+    `function_tag` --
+        This is an example of how you could define
+        your own user defined format for making tool calls.
+        The function_tag format looks like this,
+        <function=function_name>(parameters)</function>
+
+    The detailed prompts for each of these formats are defined in `system_prompt.py`
+    """
+
     json = "json"
     function_tag = "function_tag"
 

--- a/llama_toolchain/agentic_system/client.py
+++ b/llama_toolchain/agentic_system/client.py
@@ -105,33 +105,24 @@ async def run_main(host: str, port: int):
             tool_name=BuiltinTool.wolfram_alpha,
         ),
         AgenticSystemToolDefinition(
-            tool_name=BuiltinTool.photogen,
-        ),
-        AgenticSystemToolDefinition(
             tool_name=BuiltinTool.code_interpreter,
         ),
     ]
     tool_definitions += [
         AgenticSystemToolDefinition(
-            tool_name="custom_tool",
-            description="a custom tool",
+            tool_name="get_boiling_point",
+            description="Get the boiling point of a imaginary liquids (eg. polyjuice)",
             parameters={
-                "param1": ToolParamDefinition(
+                "liquid_name": ToolParamDefinition(
                     param_type="str",
-                    description="a string parameter",
+                    description="The name of the liquid",
                     required=True,
-                )
-            },
-        ),
-        AgenticSystemToolDefinition(
-            tool_name="custom_tool_2",
-            description="a second custom tool",
-            parameters={
-                "param2": ToolParamDefinition(
+                ),
+                "celcius": ToolParamDefinition(
                     param_type="str",
-                    description="a string parameter",
-                    required=True,
-                )
+                    description="Whether to return the boiling point in Celcius",
+                    required=False,
+                ),
             },
         ),
     ]
@@ -163,7 +154,10 @@ async def run_main(host: str, port: int):
 
     user_prompts = [
         "Who are you?",
+        "what is the 100th prime number?",
+        "Search web for who was 44th President of USA?",
         "Write code to check if a number is prime. Use that to check if 7 is prime",
+        "What is the boiling point of polyjuicepotion ?",
     ]
     for content in user_prompts:
         cprint(f"User> {content}", color="blue")

--- a/llama_toolchain/agentic_system/client.py
+++ b/llama_toolchain/agentic_system/client.py
@@ -30,6 +30,7 @@ from .api import (
     AgenticSystemToolDefinition,
     AgenticSystemTurnCreateRequest,
     AgenticSystemTurnResponseStreamChunk,
+    ToolPromptFormat,
 )
 
 
@@ -132,6 +133,7 @@ async def run_main(host: str, port: int):
             output_shields=[],
             quantization_config=None,
             debug_prefix_messages=[],
+            tool_prompt_format=ToolPromptFormat.json,
         ),
     )
 

--- a/llama_toolchain/agentic_system/meta_reference/agent_instance.py
+++ b/llama_toolchain/agentic_system/meta_reference/agent_instance.py
@@ -10,6 +10,8 @@ import uuid
 from datetime import datetime
 from typing import AsyncGenerator, List, Optional
 
+from termcolor import cprint
+
 from llama_toolchain.agentic_system.api.datatypes import (
     AgenticSystemInstanceConfig,
     AgenticSystemTurnResponseEvent,
@@ -24,6 +26,7 @@ from llama_toolchain.agentic_system.api.datatypes import (
     ShieldCallStep,
     StepType,
     ToolExecutionStep,
+    ToolPromptFormat,
     Turn,
 )
 
@@ -51,7 +54,6 @@ from llama_toolchain.safety.api.datatypes import (
     ShieldDefinition,
     ShieldResponse,
 )
-from termcolor import cprint
 from llama_toolchain.agentic_system.api.endpoints import *  # noqa
 
 from .safety import SafetyException, ShieldRunnerMixin
@@ -74,6 +76,7 @@ class AgentInstance(ShieldRunnerMixin):
         output_shields: List[ShieldDefinition],
         max_infer_iters: int = 10,
         prefix_messages: Optional[List[Message]] = None,
+        tool_prompt_format: Optional[ToolPromptFormat] = ToolPromptFormat.function_tag,
     ):
         self.system_id = system_id
         self.instance_config = instance_config
@@ -86,7 +89,9 @@ class AgentInstance(ShieldRunnerMixin):
             self.prefix_messages = prefix_messages
         else:
             self.prefix_messages = get_agentic_prefix_messages(
-                builtin_tools, custom_tool_definitions
+                builtin_tools,
+                custom_tool_definitions,
+                tool_prompt_format,
             )
 
         for m in self.prefix_messages:

--- a/llama_toolchain/agentic_system/meta_reference/agent_instance.py
+++ b/llama_toolchain/agentic_system/meta_reference/agent_instance.py
@@ -76,7 +76,7 @@ class AgentInstance(ShieldRunnerMixin):
         output_shields: List[ShieldDefinition],
         max_infer_iters: int = 10,
         prefix_messages: Optional[List[Message]] = None,
-        tool_prompt_format: Optional[ToolPromptFormat] = ToolPromptFormat.function_tag,
+        tool_prompt_format: Optional[ToolPromptFormat] = ToolPromptFormat.json,
     ):
         self.system_id = system_id
         self.instance_config = instance_config

--- a/llama_toolchain/agentic_system/meta_reference/agentic_system.py
+++ b/llama_toolchain/agentic_system/meta_reference/agentic_system.py
@@ -108,6 +108,7 @@ class MetaReferenceAgenticSystemImpl(AgenticSystem):
             input_shields=cfg.input_shields,
             output_shields=cfg.output_shields,
             prefix_messages=cfg.debug_prefix_messages,
+            tool_prompt_format=cfg.tool_prompt_format,
         )
 
         return AgenticSystemCreateResponse(

--- a/llama_toolchain/agentic_system/meta_reference/system_prompt.py
+++ b/llama_toolchain/agentic_system/meta_reference/system_prompt.py
@@ -80,7 +80,7 @@ def prompt_for_json(custom_tools: List[ToolDefinition]) -> str:
         Here is a list of functions in JSON format:
         {tool_defs}
 
-        Return function calls in json format.
+        Return function calls in JSON format.
         """
     )
     content = content.lstrip("\n").format(tool_defs=tool_defs)

--- a/llama_toolchain/agentic_system/meta_reference/system_prompt.py
+++ b/llama_toolchain/agentic_system/meta_reference/system_prompt.py
@@ -8,6 +8,8 @@ import json
 from datetime import datetime
 from typing import List
 
+from llama_toolchain.agentic_system.api.datatypes import ToolPromptFormat
+
 from llama_toolchain.inference.api import (
     BuiltinTool,
     Message,
@@ -19,7 +21,9 @@ from .tools.builtin import SingleMessageBuiltinTool
 
 
 def get_agentic_prefix_messages(
-    builtin_tools: List[SingleMessageBuiltinTool], custom_tools: List[ToolDefinition]
+    builtin_tools: List[SingleMessageBuiltinTool],
+    custom_tools: List[ToolDefinition],
+    tool_prompt_format: ToolPromptFormat,
 ) -> List[Message]:
     messages = []
     content = ""
@@ -44,14 +48,15 @@ Today Date: {formatted_date}\n"""
     content += date_str
 
     if custom_tools:
-        custom_message = get_system_prompt_for_custom_tools(custom_tools)
-        content += custom_message
+        if tool_prompt_format == ToolPromptFormat.function_tag:
+            custom_message = get_system_prompt_for_custom_tools(custom_tools)
+            content += custom_message
+            messages.append(SystemMessage(content=content))
+        else:
+            raise NotImplementedError(
+                f"Tool prompt format {tool_prompt_format} is not supported"
+            )
 
-    # TODO: Replace this hard coded message with instructions coming in the request
-    if False:
-        content += "\nYou are a helpful Assistant."
-
-    messages.append(SystemMessage(content=content))
     return messages
 
 

--- a/llama_toolchain/agentic_system/meta_reference/system_prompt.py
+++ b/llama_toolchain/agentic_system/meta_reference/system_prompt.py
@@ -34,13 +34,13 @@ def get_agentic_prefix_messages(
             ]
         )
         if tool_str:
-            content += f"Tools: {tool_str}\n"
+            content += f"Tools: {tool_str}"
 
     current_date = datetime.now()
     formatted_date = current_date.strftime("%d %B %Y")
     date_str = f"""
 Cutting Knowledge Date: December 2023
-Today Date: {formatted_date}\n\n"""
+Today Date: {formatted_date}\n"""
     content += date_str
 
     if custom_tools:
@@ -49,7 +49,7 @@ Today Date: {formatted_date}\n\n"""
 
     # TODO: Replace this hard coded message with instructions coming in the request
     if False:
-        content += "You are a helpful Assistant."
+        content += "\nYou are a helpful Assistant."
 
     messages.append(SystemMessage(content=content))
     return messages
@@ -76,7 +76,6 @@ Reminder:
 - Required parameters MUST be specified
 - Only call one function at a time
 - Put the entire function call reply on one line
-
 """
     return content
 

--- a/llama_toolchain/agentic_system/meta_reference/system_prompt.py
+++ b/llama_toolchain/agentic_system/meta_reference/system_prompt.py
@@ -48,15 +48,13 @@ def get_agentic_prefix_messages(
 Cutting Knowledge Date: December 2023
 Today Date: {formatted_date}\n"""
     content += date_str
+    messages.append(SystemMessage(content=content))
 
     if custom_tools:
         if tool_prompt_format == ToolPromptFormat.function_tag:
-            custom_message = prompt_for_function_tag(custom_tools)
-            content += custom_message
-            messages.append(SystemMessage(content=content))
+            text = prompt_for_function_tag(custom_tools)
+            messages.append(UserMessage(content=text))
         elif tool_prompt_format == ToolPromptFormat.json:
-            messages.append(SystemMessage(content=content))
-            # json is added as a user prompt
             text = prompt_for_json(custom_tools)
             messages.append(UserMessage(content=text))
         else:

--- a/llama_toolchain/agentic_system/utils.py
+++ b/llama_toolchain/agentic_system/utils.py
@@ -15,6 +15,7 @@ from llama_toolchain.agentic_system.api import (
     AgenticSystemSessionCreateRequest,
     AgenticSystemToolDefinition,
 )
+from llama_toolchain.agentic_system.api.datatypes import ToolPromptFormat
 from llama_toolchain.agentic_system.client import AgenticSystemClient
 
 from llama_toolchain.agentic_system.tools.custom.execute import (
@@ -64,6 +65,7 @@ async def get_agent_system_instance(
     custom_tools: Optional[List[Any]] = None,
     disable_safety: bool = False,
     model: str = "Meta-Llama3.1-8B-Instruct",
+    tool_prompt_format: ToolPromptFormat = ToolPromptFormat.json,
 ) -> AgenticSystemClientWrapper:
     custom_tools = custom_tools or []
 
@@ -113,6 +115,7 @@ async def get_agent_system_instance(
                 ]
             ),
             sampling_params=SamplingParams(),
+            tool_prompt_format=tool_prompt_format,
         ),
     )
     create_response = await api.create_agentic_system(create_request)

--- a/llama_toolchain/safety/api/datatypes.py
+++ b/llama_toolchain/safety/api/datatypes.py
@@ -8,12 +8,11 @@ from enum import Enum
 from typing import Dict, Optional, Union
 
 from llama_models.llama3_1.api.datatypes import ToolParamDefinition
-
 from llama_models.schema_utils import json_schema_type
 
-from llama_toolchain.common.deployment_types import RestAPIExecutionConfig
+from pydantic import BaseModel, validator
 
-from pydantic import BaseModel
+from llama_toolchain.common.deployment_types import RestAPIExecutionConfig
 
 
 @json_schema_type
@@ -43,6 +42,16 @@ class ShieldDefinition(BaseModel):
     on_violation_action: OnViolationAction = OnViolationAction.RAISE
     execution_config: Optional[RestAPIExecutionConfig] = None
 
+    @validator("shield_type", pre=True)
+    @classmethod
+    def validate_field(cls, v):
+        if isinstance(v, str):
+            try:
+                return BuiltinShield(v)
+            except ValueError:
+                return v
+        return v
+
 
 @json_schema_type
 class ShieldResponse(BaseModel):
@@ -51,3 +60,13 @@ class ShieldResponse(BaseModel):
     is_violation: bool
     violation_type: Optional[str] = None
     violation_return_message: Optional[str] = None
+
+    @validator("shield_type", pre=True)
+    @classmethod
+    def validate_field(cls, v):
+        if isinstance(v, str):
+            try:
+                return BuiltinShield(v)
+            except ValueError:
+                return v
+        return v


### PR DESCRIPTION
- Add support for json format in `AgenticSystemInstanceConfig`
- Updated the method `get_agentic_prefix_messages` to support both `json` and `function_tag` formats. 
- Updated the agentic_system client to pass custom tools 
- Other minor fixes to get safety shileds working properly 

Test with 
```
llama distribution start --name hhh
python -m llama_toolchain.agentic_system.client localhost 5000
```
<img width="754" alt="image" src="https://github.com/user-attachments/assets/6d999c0e-7f8e-4a3e-bf9f-4d260bfb4261">

Goes with PR in llama-models 
https://github.com/meta-llama/llama-models/pull/110