### PR TITLE
Add API keys to AgenticSystemConfig instead of relying on dotenv

### DIFF
--- a/llama_toolchain/agentic_system/meta_reference/config.py
+++ b/llama_toolchain/agentic_system/meta_reference/config.py
@@ -4,9 +4,11 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+from typing import Optional
+
 from pydantic import BaseModel
 
 
 class AgenticSystemConfig(BaseModel):
-    # placeholder, no separate configuration is needed for now
-    pass
+    brave_search_api_key: Optional[str] = None
+    wolfram_api_key: Optional[str] = None

--- a/llama_toolchain/distribution/distribution.py
+++ b/llama_toolchain/distribution/distribution.py
@@ -26,7 +26,6 @@ from .datatypes import (
 # `llama-toolchain` is automatically installed by the installation script.
 SERVER_DEPENDENCIES = [
     "fastapi",
-    "python-dotenv",
     "uvicorn",
 ]
 

--- a/llama_toolchain/distribution/server.py
+++ b/llama_toolchain/distribution/server.py
@@ -27,7 +27,6 @@ from typing import (
 import fire
 import httpx
 import yaml
-from dotenv import load_dotenv
 
 from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.exceptions import RequestValidationError
@@ -41,8 +40,6 @@ from .distribution import api_endpoints
 from .dynamic import instantiate_client, instantiate_provider
 
 from .registry import resolve_distribution_spec
-
-load_dotenv()
 
 
 def is_async_iterator_type(typ):


### PR DESCRIPTION
Ever since we introduced distributions, "internal" tools like Brave / Wolfram were broken. This was because we got their keys from `.env`, but the CWD for starting the distribution was inside the installed `llama_toolchain` package. There's no way a user could put a `.env` there. 

Instead, I am moving the API keys specification to the `AgenticSystemConfig` -- a more natural place.