### PR TITLE
fixed bug in download not enough disk space condition

### DIFF
--- a/llama_toolchain/cli/download.py
+++ b/llama_toolchain/cli/download.py
@@ -271,9 +271,10 @@ class ResumableDownloader:
 
             additional_size = self.total_size - self.downloaded_size
             if not self.has_disk_space(additional_size):
+                M = 1024 * 1024  # noqa
                 print(
                     f"Not enough disk space to download `{self.output_file}`. "
-                    f"Required: {(additional_size / M):.2f} MB"
+                    f"Required: {(additional_size // M):.2f} MB"
                 )
                 raise ValueError(
                     f"Not enough disk space to download `{self.output_file}`"


### PR DESCRIPTION
bug:
used undeclared variable (M) in download.py.
when the disk space not enough NameError occured.
![llm error](https://github.com/user-attachments/assets/49010fe8-fcfe-42ec-8768-ebee6565ddf2)

Test:
The error now displays correctly after the fix.
![llm error add print](https://github.com/user-attachments/assets/0a9ee55f-a506-4c9c-aa8b-624b2e833a92)
