### PR TITLE
Simplified Telemetry API and tying it to logger

### DIFF
--- a/llama_toolchain/agentic_system/providers.py
+++ b/llama_toolchain/agentic_system/providers.py
@@ -9,7 +9,7 @@ from typing import List
 from llama_toolchain.core.datatypes import Api, InlineProviderSpec, ProviderSpec
 
 
-def available_agentic_system_providers() -> List[ProviderSpec]:
+def available_providers() -> List[ProviderSpec]:
     return [
         InlineProviderSpec(
             api=Api.agentic_system,

--- a/llama_toolchain/core/datatypes.py
+++ b/llama_toolchain/core/datatypes.py
@@ -19,6 +19,7 @@ class Api(Enum):
     safety = "safety"
     agentic_system = "agentic_system"
     memory = "memory"
+    telemetry = "telemetry"
 
 
 @json_schema_type

--- a/llama_toolchain/core/distribution_registry.py
+++ b/llama_toolchain/core/distribution_registry.py
@@ -21,12 +21,16 @@ def available_distribution_specs() -> List[DistributionSpec]:
                 Api.memory: "meta-reference-faiss",
                 Api.safety: "meta-reference",
                 Api.agentic_system: "meta-reference",
+                Api.telemetry: "console",
             },
         ),
         DistributionSpec(
             distribution_type="remote",
             description="Point to remote services for all llama stack APIs",
-            providers={x: "remote" for x in Api},
+            providers={
+                **{x: "remote" for x in Api},
+                Api.telemetry: "console",
+            },
         ),
         DistributionSpec(
             distribution_type="local-ollama",
@@ -36,6 +40,7 @@ def available_distribution_specs() -> List[DistributionSpec]:
                 Api.safety: "meta-reference",
                 Api.agentic_system: "meta-reference",
                 Api.memory: "meta-reference-faiss",
+                Api.telemetry: "console",
             },
         ),
         DistributionSpec(
@@ -46,6 +51,7 @@ def available_distribution_specs() -> List[DistributionSpec]:
                 Api.safety: "meta-reference",
                 Api.agentic_system: "meta-reference",
                 Api.memory: "meta-reference-faiss",
+                Api.telemetry: "console",
             },
         ),
         DistributionSpec(
@@ -56,6 +62,7 @@ def available_distribution_specs() -> List[DistributionSpec]:
                 Api.safety: "meta-reference",
                 Api.agentic_system: "meta-reference",
                 Api.memory: "meta-reference-faiss",
+                Api.telemetry: "console",
             },
         ),
     ]

--- a/llama_toolchain/inference/providers.py
+++ b/llama_toolchain/inference/providers.py
@@ -9,7 +9,7 @@ from typing import List
 from llama_toolchain.core.datatypes import *  # noqa: F403
 
 
-def available_inference_providers() -> List[ProviderSpec]:
+def available_providers() -> List[ProviderSpec]:
     return [
         InlineProviderSpec(
             api=Api.inference,

--- a/llama_toolchain/memory/meta_reference/faiss/faiss.py
+++ b/llama_toolchain/memory/meta_reference/faiss/faiss.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import logging
 import uuid
 
 from typing import Any, Dict, List, Optional
@@ -20,7 +21,10 @@ from llama_toolchain.memory.common.vector_store import (
     BankWithIndex,
     EmbeddingIndex,
 )
+from llama_toolchain.telemetry import tracing
 from .config import FaissImplConfig
+
+logger = logging.getLogger(__name__)
 
 
 class FaissIndex(EmbeddingIndex):
@@ -32,11 +36,12 @@ class FaissIndex(EmbeddingIndex):
         self.id_by_index = {}
         self.chunk_by_index = {}
 
+    @tracing.span(name="add_chunks")
     async def add_chunks(self, chunks: List[Chunk], embeddings: NDArray):
         indexlen = len(self.id_by_index)
         for i, chunk in enumerate(chunks):
             self.chunk_by_index[indexlen + i] = chunk
-            print(f"Adding chunk #{indexlen + i} tokens={chunk.token_count}")
+            logger.info(f"Adding chunk #{indexlen + i} tokens={chunk.token_count}")
             self.id_by_index[indexlen + i] = chunk.document_id
 
         self.index.add(np.array(embeddings).astype(np.float32))

--- a/llama_toolchain/memory/providers.py
+++ b/llama_toolchain/memory/providers.py
@@ -14,7 +14,7 @@ EMBEDDING_DEPS = [
 ]
 
 
-def available_memory_providers() -> List[ProviderSpec]:
+def available_providers() -> List[ProviderSpec]:
     return [
         InlineProviderSpec(
             api=Api.memory,

--- a/llama_toolchain/safety/providers.py
+++ b/llama_toolchain/safety/providers.py
@@ -9,7 +9,7 @@ from typing import List
 from llama_toolchain.core.datatypes import Api, InlineProviderSpec, ProviderSpec
 
 
-def available_safety_providers() -> List[ProviderSpec]:
+def available_providers() -> List[ProviderSpec]:
     return [
         InlineProviderSpec(
             api=Api.safety,

--- a/llama_toolchain/telemetry/api/api.py
+++ b/llama_toolchain/telemetry/api/api.py
@@ -40,9 +40,15 @@ class Trace(BaseModel):
 
 @json_schema_type
 class EventType(Enum):
-    LOG = "log"
+    UNSTRUCTURED_LOG = "unstructured_log"
+
+    # all structured log events below
     SPAN_START = "span_start"
     SPAN_END = "span_end"
+    METRIC = "metric"
+
+    def is_structured(self) -> bool:
+        return self != EventType.UNSTRUCTURED_LOG
 
 
 @json_schema_type
@@ -64,7 +70,7 @@ class EventCommon(BaseModel):
 
 @json_schema_type
 class LoggingEvent(EventCommon):
-    type: Literal[EventType.LOG.value] = EventType.LOG.value
+    type: Literal[EventType.UNSTRUCTURED_LOG.value] = EventType.UNSTRUCTURED_LOG.value
     message: str
     severity: LogSeverity
 
@@ -80,6 +86,14 @@ class SpanStartEvent(EventCommon):
 class SpanEndEvent(EventCommon):
     type: Literal[EventType.SPAN_END.value] = EventType.SPAN_END.value
     status: SpanStatus
+
+
+@json_schema_type
+class MetricEvent(EventCommon):
+    type: Literal[EventType.METRIC.value] = EventType.METRIC.value
+    metric: str  # this would be an enum
+    value: Union[int, float]
+    unit: str
 
 
 Event = Annotated[

--- a/llama_toolchain/telemetry/console/__init__.py
+++ b/llama_toolchain/telemetry/console/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from .config import ConsoleConfig
+
+
+async def get_provider_impl(config: ConsoleConfig, _deps):
+    from .console import ConsoleTelemetryImpl
+
+    impl = ConsoleTelemetryImpl(config)
+    await impl.initialize()
+    return impl

--- a/llama_toolchain/telemetry/console/config.py
+++ b/llama_toolchain/telemetry/console/config.py
@@ -1,0 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from llama_models.schema_utils import json_schema_type
+
+from pydantic import BaseModel
+
+
+@json_schema_type
+class ConsoleConfig(BaseModel): ...

--- a/llama_toolchain/telemetry/console/console.py
+++ b/llama_toolchain/telemetry/console/console.py
@@ -1,0 +1,100 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from typing import Optional
+
+from llama_toolchain.telemetry.api import *  # noqa: F403
+from .config import ConsoleConfig
+
+
+class ConsoleTelemetryImpl(Telemetry):
+    def __init__(self, config: ConsoleConfig) -> None:
+        self.config = config
+        self.spans = {}
+
+    async def initialize(self) -> None: ...
+
+    async def shutdown(self) -> None: ...
+
+    async def log_event(self, event: Event):
+        if isinstance(event, SpanStartEvent):
+            self.spans[event.span_id] = event
+
+        names = []
+        span_id = event.span_id
+        while True:
+            span_event = self.spans.get(span_id)
+            if not span_event:
+                break
+
+            names = [span_event.name] + names
+            span_id = span_event.parent_span_id
+
+        span_name = ".".join(names) if names else None
+
+        formatted = format_event(event, span_name)
+        if formatted:
+            print(formatted)
+
+    async def get_trace(self, trace_id: str) -> Trace:
+        raise NotImplementedError()
+
+
+COLORS = {
+    "reset": "\033[0m",
+    "bold": "\033[1m",
+    "dim": "\033[2m",
+    "red": "\033[31m",
+    "green": "\033[32m",
+    "yellow": "\033[33m",
+    "blue": "\033[34m",
+    "magenta": "\033[35m",
+    "cyan": "\033[36m",
+    "white": "\033[37m",
+}
+
+SEVERITY_COLORS = {
+    LogSeverity.VERBOSE: COLORS["dim"] + COLORS["white"],
+    LogSeverity.DEBUG: COLORS["cyan"],
+    LogSeverity.INFO: COLORS["green"],
+    LogSeverity.WARN: COLORS["yellow"],
+    LogSeverity.ERROR: COLORS["red"],
+    LogSeverity.CRITICAL: COLORS["bold"] + COLORS["red"],
+}
+
+
+def format_event(event: Event, span_name: str) -> Optional[str]:
+    timestamp = event.timestamp.strftime("%H:%M:%S.%f")[:-3]
+    span = ""
+    if span_name:
+        span = f"{COLORS['magenta']}[{span_name}]{COLORS['reset']} "
+    if isinstance(event, LoggingEvent):
+        severity_color = SEVERITY_COLORS.get(event.severity, COLORS["reset"])
+        return (
+            f"{COLORS['dim']}{timestamp}{COLORS['reset']} "
+            f"{severity_color}[{event.severity.name}]{COLORS['reset']} "
+            f"{span}"
+            f"{event.message}"
+        )
+
+    elif isinstance(event, SpanStartEvent):
+        return None
+
+    #     return (f"{COLORS['dim']}{timestamp}{COLORS['reset']} "
+    #             f"{COLORS['blue']}[SPAN_START]{COLORS['reset']} "
+    #             f"{span}"
+    #             f"{COLORS['bold']}{event.name}{COLORS['reset']}")
+
+    elif isinstance(event, SpanEndEvent):
+        return None
+
+    #     status_color = COLORS['green'] if event.status == SpanStatus.OK else COLORS['red']
+    #     return (f"{COLORS['dim']}{timestamp}{COLORS['reset']} "
+    #             f"{COLORS['blue']}[SPAN_END]{COLORS['reset']} "
+    #             f"{span}"
+    #             f"{status_color}{event.status.value}{COLORS['reset']}")
+
+    return f"Unknown event type: {event}"

--- a/llama_toolchain/telemetry/providers.py
+++ b/llama_toolchain/telemetry/providers.py
@@ -1,0 +1,21 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from typing import List
+
+from llama_toolchain.core.datatypes import *  # noqa: F403
+
+
+def available_providers() -> List[ProviderSpec]:
+    return [
+        InlineProviderSpec(
+            api=Api.telemetry,
+            provider_type="console",
+            pip_packages=[],
+            module="llama_toolchain.telemetry.console",
+            config_class="llama_toolchain.telemetry.console.ConsoleConfig",
+        ),
+    ]

--- a/llama_toolchain/telemetry/tracing.py
+++ b/llama_toolchain/telemetry/tracing.py
@@ -1,0 +1,233 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import asyncio
+import base64
+import logging
+import queue
+import threading
+import uuid
+from datetime import datetime
+from functools import wraps
+from typing import Any, Dict, List
+
+
+from llama_toolchain.telemetry.api import *  # noqa: F403
+
+
+def generate_short_uuid(len: int = 12):
+    full_uuid = uuid.uuid4()
+    uuid_bytes = full_uuid.bytes
+    encoded = base64.urlsafe_b64encode(uuid_bytes)
+    return encoded.rstrip(b"=").decode("ascii")[:len]
+
+
+CURRENT_TRACE_CONTEXT = None
+BACKGROUND_LOGGER = None
+
+
+class BackgroundLogger:
+    def __init__(self, api: Telemetry, capacity: int = 1000):
+        self.api = api
+        self.log_queue = queue.Queue(maxsize=capacity)
+        self.worker_thread = threading.Thread(target=self._process_logs, daemon=True)
+        self.worker_thread.start()
+
+    def log_event(self, event):
+        try:
+            self.log_queue.put_nowait(event)
+        except queue.Full:
+            print("Log queue is full, dropping event")
+
+    def _process_logs(self):
+        logger = logging.getLogger()
+        while True:
+            try:
+                event = self.log_queue.get()
+                # figure out how to use a thread's native loop
+                asyncio.run(self.api.log_event(event))
+            except Exception:
+                import traceback
+
+                traceback.print_exc()
+                print("Error processing log event")
+            finally:
+                self.log_queue.task_done()
+
+    def __del__(self):
+        self.log_queue.join()
+
+
+class TraceContext:
+    spans: List[Span] = []
+
+    def __init__(self, logger: BackgroundLogger, trace_id: str):
+        self.logger = logger
+        self.trace_id = trace_id
+
+    def push_span(self, name: str, attributes: Dict[str, Any] = None):
+        current_span = self.get_current_span()
+        span = Span(
+            span_id=generate_short_uuid(),
+            trace_id=self.trace_id,
+            name=name,
+            start_time=datetime.now(),
+            parent_span_id=current_span.span_id if current_span else None,
+            attributes=attributes,
+        )
+
+        self.logger.log_event(
+            SpanStartEvent(
+                trace_id=span.trace_id,
+                span_id=span.span_id,
+                timestamp=span.start_time,
+                attributes=span.attributes,
+                name=span.name,
+                parent_span_id=span.parent_span_id,
+            )
+        )
+
+        self.spans.append(span)
+
+    def pop_span(self, status: SpanStatus = SpanStatus.OK):
+        span = self.spans.pop()
+        if span is not None:
+            self.logger.log_event(
+                SpanEndEvent(
+                    trace_id=span.trace_id,
+                    span_id=span.span_id,
+                    timestamp=span.start_time,
+                    attributes=span.attributes,
+                    status=status,
+                )
+            )
+
+    def get_current_span(self):
+        return self.spans[-1] if self.spans else None
+
+
+def setup_logger(api: Telemetry, level: int = logging.INFO):
+    global BACKGROUND_LOGGER
+
+    BACKGROUND_LOGGER = BackgroundLogger(api)
+    logger = logging.getLogger()
+    logger.setLevel(level)
+    logger.addHandler(TelemetryHandler())
+
+
+async def start_trace(name: str, attributes: Dict[str, Any] = None):
+    global CURRENT_TRACE_CONTEXT, BACKGROUND_LOGGER
+
+    if BACKGROUND_LOGGER is None:
+        print("No Telemetry implementation set. Skipping trace initialization...")
+        return
+
+    trace_id = generate_short_uuid()
+    context = TraceContext(BACKGROUND_LOGGER, trace_id)
+    context.push_span(name, {"__root__": True, **(attributes or {})})
+
+    CURRENT_TRACE_CONTEXT = context
+
+
+async def end_trace(status: SpanStatus = SpanStatus.OK):
+    global CURRENT_TRACE_CONTEXT
+
+    context = CURRENT_TRACE_CONTEXT
+    if context is None:
+        return
+
+    context.pop_span(status)
+    CURRENT_TRACE_CONTEXT = None
+
+
+def severity(levelname: str) -> LogSeverity:
+    if levelname == "DEBUG":
+        return LogSeverity.DEBUG
+    elif levelname == "INFO":
+        return LogSeverity.INFO
+    elif levelname == "WARNING":
+        return LogSeverity.WARNING
+    elif levelname == "ERROR":
+        return LogSeverity.ERROR
+    elif levelname == "CRITICAL":
+        return LogSeverity.CRITICAL
+    else:
+        raise ValueError(f"Unknown log level: {levelname}")
+
+
+# TODO: ideally, the actual emitting should be done inside a separate daemon
+# (thread or process) that is responsible for flushing the events to the backend.
+class TelemetryHandler(logging.Handler):
+    def emit(self, record: logging.LogRecord):
+        # horrendous hack to avoid logging from asyncio and getting into an infinite loop
+        if record.module in ("asyncio", "selector_events"):
+            return
+
+        global CURRENT_TRACE_CONTEXT, BACKGROUND_LOGGER
+
+        if BACKGROUND_LOGGER is None:
+            raise RuntimeError("Telemetry API not initialized")
+
+        context = CURRENT_TRACE_CONTEXT
+        if context is None:
+            return
+
+        span = context.get_current_span()
+        if span is None:
+            return
+
+        BACKGROUND_LOGGER.log_event(
+            LoggingEvent(
+                trace_id=span.trace_id,
+                span_id=span.span_id,
+                timestamp=datetime.now(),
+                message=self.format(record),
+                severity=severity(record.levelname),
+            )
+        )
+
+    def close(self):
+        pass
+
+
+def span(name: str, attributes: Dict[str, Any] = None):
+    def decorator(func):
+        @wraps(func)
+        def sync_wrapper(*args, **kwargs):
+            try:
+                global CURRENT_TRACE_CONTEXT
+
+                context = CURRENT_TRACE_CONTEXT
+                if context:
+                    context.push_span(name, attributes)
+                result = func(*args, **kwargs)
+            finally:
+                context.pop_span()
+            return result
+
+        @wraps(func)
+        async def async_wrapper(*args, **kwargs):
+            try:
+                global CURRENT_TRACE_CONTEXT
+
+                context = CURRENT_TRACE_CONTEXT
+                if context:
+                    context.push_span(name, attributes)
+                result = await func(*args, **kwargs)
+            finally:
+                context.pop_span()
+            return result
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            if asyncio.iscoroutinefunction(func):
+                return async_wrapper(*args, **kwargs)
+            else:
+                return sync_wrapper(*args, **kwargs)
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
A simple Telemetry API with three basic notions:

- An Event happening at a point in time.
- A Span which represents a time-period and encloses events. Spans are hierarchical -- i.e., they form a tree.
- A Trace which is essentially a "root" Span with some additional metadata.

This should be roughly compatible with OpenTelemetry even though the goal is to keep it extremely minimal as far as possible. The most interesting part will be evolving the Event type to be a discriminated union of very opinionated event types which correspond to things happening in the ML app lifecycle.

I added a simple `console` provider for this API, tied standard Python logger to this API as well (for unstructured logging). We may or may not keep unstructured logging around but it is a start.

Sample output:

<img width="1274" alt="image" src="https://github.com/user-attachments/assets/4438561a-fc87-47cc-8342-173f36c3dff5">
