### PR TITLE
Add config file based CLI

### DIFF
--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -295,13 +295,18 @@ As you can see above, each “distribution” details the “providers” it is 
 Let's imagine you are working with a 8B-Instruct model. The following command will build a package (in the form of a Conda environment) _and_ configure it. As part of the configuration, you will be asked for some inputs (model_id, max_seq_len, etc.) Since we are working with a 8B model, we will name our build `8b-instruct` to help us remember the config.
 
 ```
-llama stack build --distribution local --name 8b-instruct
+llama stack build
 ```
 
-Once it runs successfully , you should see some outputs in the form:
+Once it runs, you will be prompted to enter build name and optional arguments, and should see some outputs in the form:
 
 ```
-$ llama stack build --distribution local --name 8b-instruct
+$ llama stack build
+Enter value for name (required): 8b-instruct
+Enter value for distribution (default: local) (required): local
+Enter value for api_providers (optional):
+Enter value for image_type (default: conda) (required):
+
 ....
 ....
 Successfully installed cfgv-3.4.0 distlib-0.3.8 identify-2.6.0 libcst-1.4.0 llama_toolchain-0.0.2 moreorless-0.4.0 nodeenv-1.9.1 pre-commit-3.8.0 stdlibs-2024.5.15 toml-0.10.2 tomlkit-0.13.0 trailrunner-1.4.0 ufmt-2.7.0 usort-1.0.8 virtualenv-20.26.3
@@ -326,26 +331,21 @@ Successfully setup conda environment. Configuring build...
 ...
 
 YAML configuration has been written to ~/.llama/builds/local/conda/8b-instruct.yaml
-Target `8b-test` built with configuration at /home/xiyan/.llama/builds/local/conda/8b-test.yaml
-Build spec configuration saved at /home/xiyan/.llama/distributions/local/conda/8b-test-build.yaml
+Target `8b-instruct` built with configuration at ~/.llama/builds/local/conda/8b-instruct.yaml
+Build spec configuration saved at ~/.llama/distributions/local/conda/8b-instruct-build.yaml
 ```
 
 ### Step 3.3: Configure a distribution
 
 You can re-configure this distribution by running:
 ```
-llama stack configure --config ~/.llama/distributions/local/conda/8b-instruct-build.yaml
-```
-
-or
-
-```
-llama stack configure --distribution local --name 8b-instruct
+llama stack configure ~/.llama/builds/local/conda/8b-instruct.yaml
 ```
 
 Here is an example run of how the CLI will guide you to fill the configuration
+
 ```
-$ llama stack configure local --name 8b-instruct
+$ llama stack configure ~/.llama/builds/local/conda/8b-instruct.yaml
 
 Configuring API: inference (meta-reference)
 Enter value for model (required): Meta-Llama3.1-8B-Instruct
@@ -386,12 +386,12 @@ Now let’s start Llama Stack Distribution Server.
 You need the YAML configuration file which was written out at the end by the `llama stack build` step.
 
 ```
-llama stack run --config ~/.llama/builds/local/conda/8b-instruct.yaml --port 5000
+llama stack run ~/.llama/builds/local/conda/8b-instruct.yaml --port 5000
 ```
 You should see the Stack server start and print the APIs that it is supporting,
 
 ```
-$ llama stack run --config ~/.llama/builds/local/conda/8b-instruct.yaml --port 5000
+$ llama stack run ~/.llama/builds/local/conda/8b-instruct.yaml --port 5000
 
 > initializing model parallel with size 1
 > initializing ddp with size 1

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -295,13 +295,13 @@ As you can see above, each “distribution” details the “providers” it is 
 Let's imagine you are working with a 8B-Instruct model. The following command will build a package (in the form of a Conda environment) _and_ configure it. As part of the configuration, you will be asked for some inputs (model_id, max_seq_len, etc.) Since we are working with a 8B model, we will name our build `8b-instruct` to help us remember the config.
 
 ```
-llama stack build local --name 8b-instruct
+llama stack build --distribution local --name 8b-instruct
 ```
 
 Once it runs successfully , you should see some outputs in the form:
 
 ```
-$ llama stack build local --name 8b-instruct
+$ llama stack build --distribution local --name 8b-instruct
 ....
 ....
 Successfully installed cfgv-3.4.0 distlib-0.3.8 identify-2.6.0 libcst-1.4.0 llama_toolchain-0.0.2 moreorless-0.4.0 nodeenv-1.9.1 pre-commit-3.8.0 stdlibs-2024.5.15 toml-0.10.2 tomlkit-0.13.0 trailrunner-1.4.0 ufmt-2.7.0 usort-1.0.8 virtualenv-20.26.3
@@ -312,12 +312,35 @@ Successfully setup conda environment. Configuring build...
 ...
 
 YAML configuration has been written to ~/.llama/builds/local/conda/8b-instruct.yaml
+Target `8b-test` built with configuration at /home/xiyan/.llama/builds/local/conda/8b-test.yaml
+Build spec configuration saved at /home/xiyan/.llama/distributions/local/conda/8b-test-build.yaml
 ```
+
+You can re-build package based on build config
+```
+$ llama stack build --config-file ~/.llama/distributions/local/conda/8b-instruct-build.yaml
+
+Successfully setup conda environment. Configuring build...
+
+...
+...
+
+YAML configuration has been written to ~/.llama/builds/local/conda/8b-instruct.yaml
+Target `8b-test` built with configuration at /home/xiyan/.llama/builds/local/conda/8b-test.yaml
+Build spec configuration saved at /home/xiyan/.llama/distributions/local/conda/8b-test-build.yaml
+```
+
 ### Step 3.3: Configure a distribution
 
 You can re-configure this distribution by running:
 ```
-llama stack configure local --name 8b-instruct
+llama stack configure --config-file ~/.llama/distributions/local/conda/8b-instruct-build.yaml
+```
+
+or
+
+```
+llama stack configure --distribution local --name 8b-instruct
 ```
 
 Here is an example run of how the CLI will guide you to fill the configuration
@@ -363,12 +386,12 @@ Now let’s start Llama Stack Distribution Server.
 You need the YAML configuration file which was written out at the end by the `llama stack build` step.
 
 ```
-llama stack run local --name 8b-instruct --port 5000
+llama stack run --run-config ~/.llama/builds/local/conda/8b-instruct.yaml --port 5000
 ```
 You should see the Stack server start and print the APIs that it is supporting,
 
 ```
-$ llama stack run local --name 8b-instruct --port 5000
+$ llama stack run --run-config ~/.llama/builds/local/conda/8b-instruct.yaml --port 5000
 
 > initializing model parallel with size 1
 > initializing ddp with size 1

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -318,7 +318,7 @@ Build spec configuration saved at /home/xiyan/.llama/distributions/local/conda/8
 
 You can re-build package based on build config
 ```
-$ llama stack build --config-file ~/.llama/distributions/local/conda/8b-instruct-build.yaml
+$ llama stack build --config ~/.llama/distributions/local/conda/8b-instruct-build.yaml
 
 Successfully setup conda environment. Configuring build...
 
@@ -334,7 +334,7 @@ Build spec configuration saved at /home/xiyan/.llama/distributions/local/conda/8
 
 You can re-configure this distribution by running:
 ```
-llama stack configure --config-file ~/.llama/distributions/local/conda/8b-instruct-build.yaml
+llama stack configure --config ~/.llama/distributions/local/conda/8b-instruct-build.yaml
 ```
 
 or
@@ -386,12 +386,12 @@ Now let’s start Llama Stack Distribution Server.
 You need the YAML configuration file which was written out at the end by the `llama stack build` step.
 
 ```
-llama stack run --run-config ~/.llama/builds/local/conda/8b-instruct.yaml --port 5000
+llama stack run --config ~/.llama/builds/local/conda/8b-instruct.yaml --port 5000
 ```
 You should see the Stack server start and print the APIs that it is supporting,
 
 ```
-$ llama stack run --run-config ~/.llama/builds/local/conda/8b-instruct.yaml --port 5000
+$ llama stack run --config ~/.llama/builds/local/conda/8b-instruct.yaml --port 5000
 
 > initializing model parallel with size 1
 > initializing ddp with size 1

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -323,6 +323,12 @@ Build spec configuration saved at /home/xiyan/.llama/distributions/local/conda/8
 
 You can re-build package based on build config
 ```
+$ cat ~/.llama/distributions/local/conda/8b-instruct-build.yaml
+name: 8b-instruct
+distribution: local
+api_providers: null
+image_type: conda
+
 $ llama stack build --config ~/.llama/distributions/local/conda/8b-instruct-build.yaml
 
 Successfully setup conda environment. Configuring build...

--- a/llama_toolchain/cli/stack/build.py
+++ b/llama_toolchain/cli/stack/build.py
@@ -184,7 +184,7 @@ class StackBuild(Subcommand):
 
         build_config = BuildConfig(
             name=args.name,
-            distribution_type=args.distribution,
+            distribution=args.distribution,
             package_type=args.package_type,
             api_providers=args.api_providers,
         )

--- a/llama_toolchain/cli/stack/build.py
+++ b/llama_toolchain/cli/stack/build.py
@@ -8,8 +8,13 @@ import argparse
 
 from llama_toolchain.cli.subcommand import Subcommand
 from llama_toolchain.core.datatypes import *  # noqa: F403
+import json
+import os
+
 import yaml
 from llama_toolchain.common.config_dirs import DISTRIBS_BASE_DIR
+from llama_toolchain.common.serialize import EnumEncoder
+from termcolor import cprint
 
 
 def parse_api_provider_tuples(

--- a/llama_toolchain/cli/stack/build.py
+++ b/llama_toolchain/cli/stack/build.py
@@ -85,7 +85,7 @@ class StackBuild(Subcommand):
             choices=[v.value for v in BuildType],
         )
         self.parser.add_argument(
-            "--config-file",
+            "--config",
             type=str,
             help="Path to a config file to use for the build",
         )
@@ -170,14 +170,12 @@ class StackBuild(Subcommand):
         )
 
     def _run_stack_build_command(self, args: argparse.Namespace) -> None:
-        if args.config_file:
-            with open(args.config_file, "r") as f:
+        if args.config:
+            with open(args.config, "r") as f:
                 try:
                     build_config = BuildConfig(**yaml.safe_load(f))
                 except Exception as e:
-                    self.parser.error(
-                        f"Could not parse config file {args.config_file}: {e}"
-                    )
+                    self.parser.error(f"Could not parse config file {args.config}: {e}")
                     return
                 self._run_stack_build_command_from_build_config(build_config)
             return

--- a/llama_toolchain/cli/stack/build.py
+++ b/llama_toolchain/cli/stack/build.py
@@ -8,6 +8,7 @@ import argparse
 
 from llama_toolchain.cli.subcommand import Subcommand
 from llama_toolchain.core.datatypes import *  # noqa: F403
+import yaml
 from llama_toolchain.common.config_dirs import DISTRIBS_BASE_DIR
 
 
@@ -55,14 +56,14 @@ class StackBuild(Subcommand):
 
         allowed_ids = [d.distribution_type for d in available_distribution_specs()]
         self.parser.add_argument(
-            "distribution",
+            "--distribution",
             type=str,
             help='Distribution to build (either "adhoc" OR one of: {})'.format(
                 allowed_ids
             ),
         )
         self.parser.add_argument(
-            "api_providers",
+            "--api-providers",
             nargs="?",
             help="Comma separated list of (api=provider) tuples",
         )
@@ -71,7 +72,6 @@ class StackBuild(Subcommand):
             "--name",
             type=str,
             help="Name of the build target (image, conda env)",
-            required=True,
         )
         self.parser.add_argument(
             "--package-type",

--- a/llama_toolchain/cli/stack/build.py
+++ b/llama_toolchain/cli/stack/build.py
@@ -8,13 +8,8 @@ import argparse
 
 from llama_toolchain.cli.subcommand import Subcommand
 from llama_toolchain.core.datatypes import *  # noqa: F403
-import json
-import os
 
 import yaml
-from llama_toolchain.common.config_dirs import DISTRIBS_BASE_DIR
-from llama_toolchain.common.serialize import EnumEncoder
-from termcolor import cprint
 
 
 def parse_api_provider_tuples(
@@ -93,8 +88,14 @@ class StackBuild(Subcommand):
     def _run_stack_build_command_from_build_config(
         self, build_config: BuildConfig
     ) -> None:
+        import json
+        import os
+
+        from llama_toolchain.common.config_dirs import DISTRIBS_BASE_DIR
+        from llama_toolchain.common.serialize import EnumEncoder
         from llama_toolchain.core.distribution_registry import resolve_distribution_spec
         from llama_toolchain.core.package import ApiInput, build_package, BuildType
+        from termcolor import cprint
 
         api_inputs = []
         if build_config.distribution == "adhoc":

--- a/llama_toolchain/cli/stack/configure.py
+++ b/llama_toolchain/cli/stack/configure.py
@@ -38,42 +38,15 @@ class StackConfigure(Subcommand):
 
         allowed_ids = [d.distribution_type for d in available_distribution_specs()]
         self.parser.add_argument(
-            "--distribution",
+            "config",
             type=str,
-            help='Distribution ("adhoc" or one of: {})'.format(allowed_ids),
-        )
-        self.parser.add_argument(
-            "--name",
-            type=str,
-            help="Name of the build",
-        )
-        self.parser.add_argument(
-            "--image-type",
-            type=str,
-            default="conda",
-            choices=[v.value for v in ImageType],
-        )
-        self.parser.add_argument(
-            "--config",
-            type=str,
-            help="Path to a config file to use for the build",
+            help="Path to the package config file (e.g. ~/.llama/builds/<distribution>/<image_type>/<name>.yaml)",
         )
 
     def _run_stack_configure_cmd(self, args: argparse.Namespace) -> None:
         from llama_toolchain.core.package import ImageType
 
-        if args.config:
-            with open(args.config, "r") as f:
-                build_config = BuildConfig(**yaml.safe_load(f))
-                image_type = ImageType(build_config.image_type)
-                distribution = build_config.distribution
-                name = build_config.name
-        else:
-            image_type = ImageType(args.image_type)
-            name = args.name
-            distribution = args.distribution
-
-        config_file = BUILDS_BASE_DIR / distribution / image_type.value / f"{name}.yaml"
+        config_file = Path(args.config)
         if not config_file.exists():
             self.parser.error(
                 f"Could not find {config_file}. Please run `llama stack build` first"

--- a/llama_toolchain/cli/stack/configure.py
+++ b/llama_toolchain/cli/stack/configure.py
@@ -9,10 +9,10 @@ import json
 from pathlib import Path
 
 import yaml
-from termcolor import cprint
 
 from llama_toolchain.cli.subcommand import Subcommand
 from llama_toolchain.common.config_dirs import BUILDS_BASE_DIR
+from termcolor import cprint
 from llama_toolchain.core.datatypes import *  # noqa: F403
 
 
@@ -38,7 +38,7 @@ class StackConfigure(Subcommand):
 
         allowed_ids = [d.distribution_type for d in available_distribution_specs()]
         self.parser.add_argument(
-            "distribution",
+            "--distribution",
             type=str,
             help='Distribution ("adhoc" or one of: {})'.format(allowed_ids),
         )
@@ -46,20 +46,29 @@ class StackConfigure(Subcommand):
             "--name",
             type=str,
             help="Name of the build",
-            required=True,
         )
         self.parser.add_argument(
-            "--type",
+            "--package-type",
             type=str,
             default="conda_env",
             choices=[v.value for v in BuildType],
+        )
+        self.parser.add_argument(
+            "--config-file",
+            type=str,
+            help="Path to a config file to use for the build",
         )
 
     def _run_stack_configure_cmd(self, args: argparse.Namespace) -> None:
         from llama_toolchain.core.package import BuildType
 
-        build_type = BuildType(args.type)
-        name = args.name
+        if args.config_file:
+            build_config = BuildConfig(**yaml.safe_load(f))
+            build_type = BuildType(build_config.package_type)
+        else:
+            build_type = BuildType(args.package_type)
+            name = args.name
+
         config_file = (
             BUILDS_BASE_DIR
             / args.distribution

--- a/llama_toolchain/cli/stack/configure.py
+++ b/llama_toolchain/cli/stack/configure.py
@@ -63,17 +63,18 @@ class StackConfigure(Subcommand):
         from llama_toolchain.core.package import BuildType
 
         if args.config_file:
-            build_config = BuildConfig(**yaml.safe_load(f))
-            build_type = BuildType(build_config.package_type)
+            with open(args.config_file, "r") as f:
+                build_config = BuildConfig(**yaml.safe_load(f))
+                build_type = BuildType(build_config.package_type)
+                distribution = build_config.distribution
+                name = build_config.name
         else:
             build_type = BuildType(args.package_type)
             name = args.name
+            distribution = args.distribution
 
         config_file = (
-            BUILDS_BASE_DIR
-            / args.distribution
-            / build_type.descriptor()
-            / f"{name}.yaml"
+            BUILDS_BASE_DIR / distribution / build_type.descriptor() / f"{name}.yaml"
         )
         if not config_file.exists():
             self.parser.error(

--- a/llama_toolchain/cli/stack/configure.py
+++ b/llama_toolchain/cli/stack/configure.py
@@ -54,7 +54,7 @@ class StackConfigure(Subcommand):
             choices=[v.value for v in BuildType],
         )
         self.parser.add_argument(
-            "--config-file",
+            "--config",
             type=str,
             help="Path to a config file to use for the build",
         )
@@ -62,8 +62,8 @@ class StackConfigure(Subcommand):
     def _run_stack_configure_cmd(self, args: argparse.Namespace) -> None:
         from llama_toolchain.core.package import BuildType
 
-        if args.config_file:
-            with open(args.config_file, "r") as f:
+        if args.config:
+            with open(args.config, "r") as f:
                 build_config = BuildConfig(**yaml.safe_load(f))
                 build_type = BuildType(build_config.package_type)
                 distribution = build_config.distribution

--- a/llama_toolchain/cli/stack/configure.py
+++ b/llama_toolchain/cli/stack/configure.py
@@ -34,7 +34,7 @@ class StackConfigure(Subcommand):
         from llama_toolchain.core.distribution_registry import (
             available_distribution_specs,
         )
-        from llama_toolchain.core.package import BuildType
+        from llama_toolchain.core.package import ImageType
 
         allowed_ids = [d.distribution_type for d in available_distribution_specs()]
         self.parser.add_argument(
@@ -48,10 +48,10 @@ class StackConfigure(Subcommand):
             help="Name of the build",
         )
         self.parser.add_argument(
-            "--package-type",
+            "--image-type",
             type=str,
-            default="conda_env",
-            choices=[v.value for v in BuildType],
+            default="conda",
+            choices=[v.value for v in ImageType],
         )
         self.parser.add_argument(
             "--config",
@@ -60,22 +60,20 @@ class StackConfigure(Subcommand):
         )
 
     def _run_stack_configure_cmd(self, args: argparse.Namespace) -> None:
-        from llama_toolchain.core.package import BuildType
+        from llama_toolchain.core.package import ImageType
 
         if args.config:
             with open(args.config, "r") as f:
                 build_config = BuildConfig(**yaml.safe_load(f))
-                build_type = BuildType(build_config.package_type)
+                image_type = ImageType(build_config.image_type)
                 distribution = build_config.distribution
                 name = build_config.name
         else:
-            build_type = BuildType(args.package_type)
+            image_type = ImageType(args.image_type)
             name = args.name
             distribution = args.distribution
 
-        config_file = (
-            BUILDS_BASE_DIR / distribution / build_type.descriptor() / f"{name}.yaml"
-        )
+        config_file = BUILDS_BASE_DIR / distribution / image_type.value / f"{name}.yaml"
         if not config_file.exists():
             self.parser.error(
                 f"Could not find {config_file}. Please run `llama stack build` first"

--- a/llama_toolchain/cli/stack/run.py
+++ b/llama_toolchain/cli/stack/run.py
@@ -32,7 +32,7 @@ class StackRun(Subcommand):
         from llama_toolchain.core.package import BuildType
 
         self.parser.add_argument(
-            "distribution",
+            "--distribution",
             type=str,
             help="Distribution whose build you want to start",
         )
@@ -40,7 +40,6 @@ class StackRun(Subcommand):
             "--name",
             type=str,
             help="Name of the build you want to start",
-            required=True,
         )
         self.parser.add_argument(
             "--type",
@@ -60,14 +59,22 @@ class StackRun(Subcommand):
             help="Disable IPv6 support",
             default=False,
         )
+        self.parser.add_argument(
+            "--run-config",
+            type=str,
+            help="Path to config file to use for the run",
+        )
 
     def _run_stack_run_cmd(self, args: argparse.Namespace) -> None:
         from llama_toolchain.common.exec import run_with_pty
         from llama_toolchain.core.package import BuildType
 
-        build_type = BuildType(args.type)
-        build_dir = BUILDS_BASE_DIR / args.distribution / build_type.descriptor()
-        path = build_dir / f"{args.name}.yaml"
+        if args.run_config:
+            path = args.run_config
+        else:
+            build_type = BuildType(args.type)
+            build_dir = BUILDS_BASE_DIR / args.distribution / build_type.descriptor()
+            path = build_dir / f"{args.name}.yaml"
 
         config_file = Path(path)
 

--- a/llama_toolchain/cli/stack/run.py
+++ b/llama_toolchain/cli/stack/run.py
@@ -29,23 +29,12 @@ class StackRun(Subcommand):
         self.parser.set_defaults(func=self._run_stack_run_cmd)
 
     def _add_arguments(self):
-        from llama_toolchain.core.package import BuildType
+        from llama_toolchain.core.package import ImageType
 
         self.parser.add_argument(
-            "--distribution",
+            "config",
             type=str,
-            help="Distribution whose build you want to start",
-        )
-        self.parser.add_argument(
-            "--name",
-            type=str,
-            help="Name of the build you want to start",
-        )
-        self.parser.add_argument(
-            "--type",
-            type=str,
-            default="conda_env",
-            choices=[v.value for v in BuildType],
+            help="Path to config file to use for the run",
         )
         self.parser.add_argument(
             "--port",
@@ -59,23 +48,16 @@ class StackRun(Subcommand):
             help="Disable IPv6 support",
             default=False,
         )
-        self.parser.add_argument(
-            "--config",
-            type=str,
-            help="Path to config file to use for the run",
-        )
 
     def _run_stack_run_cmd(self, args: argparse.Namespace) -> None:
         from llama_toolchain.common.exec import run_with_pty
-        from llama_toolchain.core.package import BuildType
+        from llama_toolchain.core.package import ImageType
 
-        if args.config:
-            path = args.config
-        else:
-            build_type = BuildType(args.type)
-            build_dir = BUILDS_BASE_DIR / args.distribution / build_type.descriptor()
-            path = build_dir / f"{args.name}.yaml"
+        if not args.config:
+            self.parser.error("Must specify a config file to run")
+            return
 
+        path = args.config
         config_file = Path(path)
 
         if not config_file.exists():

--- a/llama_toolchain/cli/stack/run.py
+++ b/llama_toolchain/cli/stack/run.py
@@ -60,7 +60,7 @@ class StackRun(Subcommand):
             default=False,
         )
         self.parser.add_argument(
-            "--run-config",
+            "--config",
             type=str,
             help="Path to config file to use for the run",
         )
@@ -69,8 +69,8 @@ class StackRun(Subcommand):
         from llama_toolchain.common.exec import run_with_pty
         from llama_toolchain.core.package import BuildType
 
-        if args.run_config:
-            path = args.run_config
+        if args.config:
+            path = args.config
         else:
             build_type = BuildType(args.type)
             build_dir = BUILDS_BASE_DIR / args.distribution / build_type.descriptor()

--- a/llama_toolchain/core/build_conda_env.sh
+++ b/llama_toolchain/core/build_conda_env.sh
@@ -117,4 +117,4 @@ ensure_conda_env_python310 "$env_name" "$pip_dependencies"
 
 printf "${GREEN}Successfully setup conda environment. Configuring build...${NC}\n"
 
-$CONDA_PREFIX/bin/python3 -m llama_toolchain.cli.llama stack configure $distribution_type --name "$build_name" --type conda_env
+$CONDA_PREFIX/bin/python3 -m llama_toolchain.cli.llama stack configure --distribution $distribution_type --name "$build_name" --package-type conda_env

--- a/llama_toolchain/core/build_conda_env.sh
+++ b/llama_toolchain/core/build_conda_env.sh
@@ -117,4 +117,4 @@ ensure_conda_env_python310 "$env_name" "$pip_dependencies"
 
 printf "${GREEN}Successfully setup conda environment. Configuring build...${NC}\n"
 
-$CONDA_PREFIX/bin/python3 -m llama_toolchain.cli.llama stack configure --distribution $distribution_type --name "$build_name" --package-type conda_env
+$CONDA_PREFIX/bin/python3 -m llama_toolchain.cli.llama stack configure --distribution $distribution_type --name "$build_name" --image-type conda

--- a/llama_toolchain/core/build_conda_env.sh
+++ b/llama_toolchain/core/build_conda_env.sh
@@ -19,7 +19,7 @@ fi
 
 set -euo pipefail
 
-if [ "$#" -ne 3 ]; then
+if [ "$#" -ne 4 ]; then
   echo "Usage: $0 <distribution_type> <build_name> <pip_dependencies>" >&2
   echo "Example: $0 <distribution_type> mybuild 'numpy pandas scipy'" >&2
   exit 1
@@ -28,7 +28,8 @@ fi
 distribution_type="$1"
 build_name="$2"
 env_name="llamastack-$build_name"
-pip_dependencies="$3"
+config_file="$3"
+pip_dependencies="$4"
 
 # Define color codes
 RED='\033[0;31m'
@@ -117,4 +118,4 @@ ensure_conda_env_python310 "$env_name" "$pip_dependencies"
 
 printf "${GREEN}Successfully setup conda environment. Configuring build...${NC}\n"
 
-$CONDA_PREFIX/bin/python3 -m llama_toolchain.cli.llama stack configure --distribution $distribution_type --name "$build_name" --image-type conda
+$CONDA_PREFIX/bin/python3 -m llama_toolchain.cli.llama stack configure $config_file

--- a/llama_toolchain/core/build_container.sh
+++ b/llama_toolchain/core/build_container.sh
@@ -110,4 +110,4 @@ set +x
 printf "${GREEN}Succesfully setup Podman image. Configuring build...${NC}"
 echo "You can run it with: podman run -p 8000:8000 $image_name"
 
-$CONDA_PREFIX/bin/python3 -m llama_toolchain.cli.llama stack configure $distribution_type --name "$build_name" --type container
+$CONDA_PREFIX/bin/python3 -m llama_toolchain.cli.llama stack configure --distribution $distribution_type --name "$build_name" --package-type container

--- a/llama_toolchain/core/build_container.sh
+++ b/llama_toolchain/core/build_container.sh
@@ -4,7 +4,7 @@ LLAMA_MODELS_DIR=${LLAMA_MODELS_DIR:-}
 LLAMA_TOOLCHAIN_DIR=${LLAMA_TOOLCHAIN_DIR:-}
 TEST_PYPI_VERSION=${TEST_PYPI_VERSION:-}
 
-if [ "$#" -ne 4 ]; then
+if [ "$#" -ne 5 ]; then
   echo "Usage: $0 <distribution_type> <build_name> <docker_base> <pip_dependencies>
   echo "Example: $0 distribution_type my-fastapi-app python:3.9-slim 'fastapi uvicorn'
   exit 1
@@ -14,7 +14,8 @@ distribution_type=$1
 build_name="$2"
 image_name="llamastack-$build_name"
 docker_base=$3
-pip_dependencies=$4
+config_file=$4
+pip_dependencies=$5
 
 # Define color codes
 RED='\033[0;31m'
@@ -110,4 +111,4 @@ set +x
 printf "${GREEN}Succesfully setup Podman image. Configuring build...${NC}"
 echo "You can run it with: podman run -p 8000:8000 $image_name"
 
-$CONDA_PREFIX/bin/python3 -m llama_toolchain.cli.llama stack configure --distribution $distribution_type --name "$build_name" --package-type container
+$CONDA_PREFIX/bin/python3 -m llama_toolchain.cli.llama stack configure $config_file

--- a/llama_toolchain/core/datatypes.py
+++ b/llama_toolchain/core/datatypes.py
@@ -188,3 +188,19 @@ Provider configurations for each of the APIs provided by this package. This incl
 the dependencies of these providers as well.
 """,
     )
+
+
+@json_schema_type
+class BuildConfig(BaseModel):
+    name: str
+    distribution: str = Field(
+        default="local", description="Type of distribution to build (adhoc | {})"
+    )
+    api_providers: Optional[str] = Field(
+        default_factory=list,
+        description="List of API provider names to build",
+    )
+    package_type: str = Field(
+        default="conda_env",
+        description="Type of package to build (conda_env | container)",
+    )

--- a/llama_toolchain/core/datatypes.py
+++ b/llama_toolchain/core/datatypes.py
@@ -200,7 +200,7 @@ class BuildConfig(BaseModel):
         default_factory=list,
         description="List of API provider names to build",
     )
-    package_type: str = Field(
-        default="conda_env",
-        description="Type of package to build (conda_env | container)",
+    image_type: str = Field(
+        default="conda",
+        description="Type of package to build (conda | container)",
     )

--- a/llama_toolchain/core/package.py
+++ b/llama_toolchain/core/package.py
@@ -119,6 +119,7 @@ def build_package(
             distribution_type,
             package_name,
             package_deps.docker_image,
+            str(package_file),
             " ".join(package_deps.pip_packages),
         ]
     else:
@@ -129,6 +130,7 @@ def build_package(
             script,
             distribution_type,
             package_name,
+            str(package_file),
             " ".join(package_deps.pip_packages),
         ]
 


### PR DESCRIPTION
# Example 1 - local + conda
### Build
```
$ llama stack build
Enter value for name (required): a
Enter value for distribution (default: local) (required): 
Enter value for api_providers (optional): 
Enter value for image_type (default: conda) (required): 

...
...
YAML configuration has been written to /home/xiyan/.llama/builds/local/conda/a.yaml
Target `a` built with configuration at /home/xiyan/.llama/builds/local/conda/a.yaml
Build spec configuration saved at /home/xiyan/.llama/distributions/local/conda/a-build.yaml
```

### Build from config file
```
$ cat ~/.llama/distributions/local/conda/8b-test-build.yaml
name: 8b-test
distribution: local
api_providers: null
package_type: conda_env

$ llama stack build --config ~/.llama/distributions/local/conda/a-build.yaml
```

### Configure
```
# reconfigure the run.yaml file
$ llama stack configure ~/.llama/builds/local/conda/a.yaml

Configuration already exists for local. Will overwrite...
Configuring API: inference (meta-reference)
Enter value for model (existing: Meta-Llama3.1-8B-Instruct) (required): 
Enter value for quantization (optional): 
Enter value for torch_seed (optional): 
Enter value for max_seq_len (existing: 4096) (required): 
Enter value for max_batch_size (existing: 1) (required): 

Configuring API: memory (meta-reference-faiss)

Configuring API: safety (meta-reference)
Do you want to configure llama_guard_shield? (y/n): n
Do you want to configure prompt_guard_shield? (y/n): n

Configuring API: agentic_system (meta-reference)
Enter value for brave_search_api_key (optional): 
Enter value for wolfram_api_key (optional): 

YAML configuration has been written to /home/xiyan/.llama/builds/local/conda/a.yaml
```

### Run
```
llama stack run ~/.llama/builds/local/conda/8b-test.yaml --port 5001
```

```
$ cat ~/.llama/builds/local/conda/8b-test.yaml
built_at: '2024-09-10T13:50:32.981692'
package_name: 8b-test
distribution_type: local
docker_image: null
conda_env: 8b-test
providers:
  inference:
    provider_type: meta-reference
    model: Meta-Llama3.1-8B-Instruct
    quantization: null
    torch_seed: null
    max_seq_len: 4096
    max_batch_size: 1
  memory:
    provider_type: meta-reference-faiss
  safety:
    provider_type: meta-reference
    llama_guard_shield: null
    prompt_guard_shield: null
  agentic_system:
    provider_type: meta-reference
    brave_search_api_key: null
    wolfram_api_key: null
```

# EXAMPLE 2 - remote api + docker
### Build
```
$ llama stack build
Enter value for name (required): pgvector
Enter value for distribution (default: local) (required): adhoc
Enter value for api_providers (optional): memory=remote::pgvector
Enter value for image_type (default: conda) (required):
```
### Run
```
llama stack run ~/.llama/builds/local/conda/pgvector.yaml --port 5001
```