### PR TITLE
Support `data:` in URL for memory. Add ootb support for pdfs

### DIFF
--- a/llama_toolchain/agentic_system/client.py
+++ b/llama_toolchain/agentic_system/client.py
@@ -83,13 +83,12 @@ class AgenticSystemClient(AgenticSystem):
                     if line.startswith("data:"):
                         data = line[len("data: ") :]
                         try:
-                            if "error" in data:
+                            jdata = json.loads(data)
+                            if "error" in jdata:
                                 cprint(data, "red")
                                 continue
 
-                            yield AgenticSystemTurnResponseStreamChunk(
-                                **json.loads(data)
-                            )
+                            yield AgenticSystemTurnResponseStreamChunk(**jdata)
                         except Exception as e:
                             print(data)
                             print(f"Error with parsing or validation: {e}")

--- a/llama_toolchain/memory/api/api.py
+++ b/llama_toolchain/memory/api/api.py
@@ -8,7 +8,9 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
-
+import base64
+import mimetypes
+import os
 from typing import List, Optional, Protocol
 
 from llama_models.schema_utils import json_schema_type, webmethod
@@ -23,8 +25,23 @@ from llama_models.llama3.api.datatypes import *  # noqa: F403
 class MemoryBankDocument(BaseModel):
     document_id: str
     content: InterleavedTextMedia | URL
-    mime_type: str
+    mime_type: str | None = None
     metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+def data_url_from_file(file_path: str) -> URL:
+    if not os.path.exists(file_path):
+        raise FileNotFoundError(f"File not found: {file_path}")
+
+    with open(file_path, "rb") as file:
+        file_content = file.read()
+
+    base64_content = base64.b64encode(file_content).decode("utf-8")
+    mime_type, _ = mimetypes.guess_type(file_path)
+
+    data_url = f"data:{mime_type};base64,{base64_content}"
+
+    return URL(uri=data_url)
 
 
 @json_schema_type

--- a/llama_toolchain/memory/api/api.py
+++ b/llama_toolchain/memory/api/api.py
@@ -8,9 +8,6 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
-import base64
-import mimetypes
-import os
 from typing import List, Optional, Protocol
 
 from llama_models.schema_utils import json_schema_type, webmethod
@@ -27,21 +24,6 @@ class MemoryBankDocument(BaseModel):
     content: InterleavedTextMedia | URL
     mime_type: str | None = None
     metadata: Dict[str, Any] = Field(default_factory=dict)
-
-
-def data_url_from_file(file_path: str) -> URL:
-    if not os.path.exists(file_path):
-        raise FileNotFoundError(f"File not found: {file_path}")
-
-    with open(file_path, "rb") as file:
-        file_content = file.read()
-
-    base64_content = base64.b64encode(file_content).decode("utf-8")
-    mime_type, _ = mimetypes.guess_type(file_path)
-
-    data_url = f"data:{mime_type};base64,{base64_content}"
-
-    return URL(uri=data_url)
 
 
 @json_schema_type

--- a/llama_toolchain/memory/client.py
+++ b/llama_toolchain/memory/client.py
@@ -5,11 +5,14 @@
 # the root directory of this source tree.
 
 import asyncio
+import json
+from pathlib import Path
 
 from typing import Any, Dict, List, Optional
 
 import fire
 import httpx
+from termcolor import cprint
 
 from llama_toolchain.core.datatypes import RemoteProviderConfig
 
@@ -120,7 +123,7 @@ async def run_main(host: str, port: int, stream: bool):
             overlap_size_in_tokens=64,
         ),
     )
-    print(bank)
+    cprint(json.dumps(bank.dict(), indent=4), "green")
 
     retrieved_bank = await client.get_memory_bank(bank.bank_id)
     assert retrieved_bank is not None
@@ -143,6 +146,16 @@ async def run_main(host: str, port: int, stream: bool):
             mime_type="text/plain",
         )
         for i, url in enumerate(urls)
+    ]
+
+    this_dir = os.path.dirname(__file__)
+    files = [Path(this_dir).parent.parent / "CONTRIBUTING.md"]
+    documents += [
+        MemoryBankDocument(
+            document_id=f"num-{i}",
+            content=data_url_from_file(path),
+        )
+        for i, path in enumerate(files)
     ]
 
     # insert some documents

--- a/llama_toolchain/memory/client.py
+++ b/llama_toolchain/memory/client.py
@@ -17,6 +17,7 @@ from termcolor import cprint
 from llama_toolchain.core.datatypes import RemoteProviderConfig
 
 from .api import *  # noqa: F403
+from .common.file_utils import data_url_from_file
 
 
 async def get_client_impl(config: RemoteProviderConfig, _deps: Any) -> Memory:

--- a/llama_toolchain/memory/common/file_utils.py
+++ b/llama_toolchain/memory/common/file_utils.py
@@ -1,0 +1,26 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import base64
+import mimetypes
+import os
+
+from llama_models.llama3.api.datatypes import URL
+
+
+def data_url_from_file(file_path: str) -> URL:
+    if not os.path.exists(file_path):
+        raise FileNotFoundError(f"File not found: {file_path}")
+
+    with open(file_path, "rb") as file:
+        file_content = file.read()
+
+    base64_content = base64.b64encode(file_content).decode("utf-8")
+    mime_type, _ = mimetypes.guess_type(file_path)
+
+    data_url = f"data:{mime_type};base64,{base64_content}"
+
+    return URL(uri=data_url)

--- a/llama_toolchain/memory/providers.py
+++ b/llama_toolchain/memory/providers.py
@@ -10,6 +10,8 @@ from llama_toolchain.core.datatypes import *  # noqa: F403
 
 EMBEDDING_DEPS = [
     "blobfile",
+    "chardet",
+    "PdfReader",
     "sentence-transformers",
 ]
 


### PR DESCRIPTION
Adds support for `data:... ` format in URL. 

This way we can now take files as base64 encoded bytes and pass to the server where its decoded. 
Also added support for easy pdf loading. 

Start local distro. 
Run the memory client which also has files that get added to index along with standard URLs. 
```
python -m llama_toolchain.agentic_system.client localhost 5000
```