### PR TITLE
CLI - add back build wizard, configure with name instead of build.yaml

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -8,43 +8,61 @@ This guides allows you to quickly get started with building and running a Llama 
 - Quick 3 line command to build and start a LlamaStack server using our Meta Reference implementation for all API endpoints with `conda` as build type.
 
 **`llama stack build`**
+- You'll be prompted to enter build information interactively.
 ```
-llama stack build ./llama_stack/distribution/example_configs/conda/local-conda-example-build.yaml --name my-local-llama-stack
-...
-...
-Build spec configuration saved at ~/.llama/distributions/conda/my-local-llama-stack-build.yaml
+llama stack build
+
+> Enter an unique name for identifying your Llama Stack build distribution (e.g. my-local-stack): my-local-llama-stack
+> Enter the image type you want your distribution to be built with (docker or conda): conda
+
+ Llama Stack is composed of several APIs working together. Let's configure the providers (implementations) you want to use for these APIs.
+> Enter the API provider for the inference API: (default=meta-reference): meta-reference
+> Enter the API provider for the safety API: (default=meta-reference): meta-reference
+> Enter the API provider for the agents API: (default=meta-reference): meta-reference
+> Enter the API provider for the memory API: (default=meta-reference): meta-reference
+> Enter the API provider for the telemetry API: (default=meta-reference): meta-reference
+
+ > (Optional) Enter a short description for your Llama Stack distribution:
+
+Build spec configuration saved at ~/.conda/envs/llamastack-my-local-llama-stack/my-local-llama-stack-build.yaml
 ```
 
 **`llama stack configure`**
 ```
-llama stack configure ~/.llama/distributions/conda/my-local-llama-stack-build.yaml
+llama stack configure my-local-llama-stack
 
-Configuring API: inference (meta-reference)
+Configuring APIs to serve...
+Enter comma-separated list of APIs to serve:
+
+Configuring API `inference`...
+
+Configuring provider `meta-reference`...
 Enter value for model (default: Meta-Llama3.1-8B-Instruct) (required):
-Enter value for quantization (optional):
+Do you want to configure quantization? (y/n): n
 Enter value for torch_seed (optional):
 Enter value for max_seq_len (required): 4096
 Enter value for max_batch_size (default: 1) (required):
+Configuring API `safety`...
 
-Configuring API: memory (meta-reference-faiss)
-
-Configuring API: safety (meta-reference)
+Configuring provider `meta-reference`...
 Do you want to configure llama_guard_shield? (y/n): n
 Do you want to configure prompt_guard_shield? (y/n): n
+Configuring API `agents`...
 
-Configuring API: agentic_system (meta-reference)
-Enter value for brave_search_api_key (optional):
-Enter value for bing_search_api_key (optional):
-Enter value for wolfram_api_key (optional):
+Configuring provider `meta-reference`...
+Configuring API `memory`...
 
-Configuring API: telemetry (console)
+Configuring provider `meta-reference`...
+Configuring API `telemetry`...
 
-YAML configuration has been written to ~/.llama/builds/conda/my-local-llama-stack-run.yaml
+Configuring provider `meta-reference`...
+> YAML configuration has been written to /home/xiyan/.llama/builds/conda/my-local-llama-stack-run.yaml.
+You can now run `llama stack run my-local-llama-stack --port PORT` or `llama stack run /home/xiyan/.llama/builds/conda/my-local-llama-stack-run.yaml --port PORT
 ```
 
 **`llama stack run`**
 ```
-llama stack run ~/.llama/builds/conda/my-local-llama-stack-run.yaml
+llama stack run my-local-llama-stack
 
 ...
 > initializing model parallel with size 1

--- a/llama_stack/cli/stack/build.py
+++ b/llama_stack/cli/stack/build.py
@@ -11,7 +11,6 @@ from llama_stack.distribution.datatypes import *  # noqa: F403
 from pathlib import Path
 
 import yaml
-from prompt_toolkit import prompt
 from prompt_toolkit.validation import Validator
 from termcolor import cprint
 
@@ -84,7 +83,7 @@ class StackBuild(Subcommand):
     def _run_stack_build_command(self, args: argparse.Namespace) -> None:
         from llama_stack.distribution.distribution import Api, api_providers
         from llama_stack.distribution.utils.dynamic import instantiate_class_type
-        from llama_stack.distribution.utils.prompt_for_config import prompt_for_config
+        from prompt_toolkit import prompt
 
         if not args.config:
             name = prompt(

--- a/llama_stack/cli/stack/build.py
+++ b/llama_stack/cli/stack/build.py
@@ -50,6 +50,7 @@ class StackBuild(Subcommand):
 
         from llama_stack.distribution.utils.config_dirs import DISTRIBS_BASE_DIR
         from llama_stack.distribution.utils.serialize import EnumEncoder
+        from termcolor import cprint
 
         # save build.yaml spec for building same distribution again
         if build_config.image_type == ImageType.docker.value:

--- a/llama_stack/cli/stack/build.py
+++ b/llama_stack/cli/stack/build.py
@@ -58,7 +58,7 @@ class StackBuild(Subcommand):
                 llama_stack_path / "configs/distributions" / build_config.image_type
             )
         else:
-            build_dir = DISTRIBS_BASE_DIR / build_config.image_type
+            build_dir = Path(os.getenv("CONDA_PREFIX")).parent
 
         os.makedirs(build_dir, exist_ok=True)
         build_file_path = build_dir / f"{build_config.name}-build.yaml"
@@ -79,9 +79,6 @@ class StackBuild(Subcommand):
         from llama_stack.distribution.utils.prompt_for_config import prompt_for_config
 
         if not args.config:
-            # self.parser.error(
-            #     "No config file specified. Please use `llama stack build /path/to/*-build.yaml`. Example config files can be found in llama_stack/distribution/example_configs"
-            # )
             build_config = prompt_for_config(BuildConfig, None)
             self._run_stack_build_command_from_build_config(build_config)
             return

--- a/llama_stack/cli/stack/build.py
+++ b/llama_stack/cli/stack/build.py
@@ -98,7 +98,7 @@ class StackBuild(Subcommand):
             )
 
             cprint(
-                f"Now, let's configure your Llama Stack distribution specs with API providers",
+                f"\n Now, let's configure your Llama Stack distribution specs with API providers",
                 color="green",
             )
 
@@ -113,7 +113,7 @@ class StackBuild(Subcommand):
                 providers[api.value] = api_provider
 
             description = prompt(
-                "> (Optional) Please enter a short description for your Llama Stack distribution: ",
+                "\n > (Optional) Please enter a short description for your Llama Stack distribution: ",
                 default="",
             )
 

--- a/llama_stack/cli/stack/build.py
+++ b/llama_stack/cli/stack/build.py
@@ -82,6 +82,7 @@ class StackBuild(Subcommand):
         )
 
     def _run_stack_build_command(self, args: argparse.Namespace) -> None:
+        from llama_stack.distribution.distribution import Api, api_providers
         from llama_stack.distribution.utils.dynamic import instantiate_class_type
         from llama_stack.distribution.utils.prompt_for_config import prompt_for_config
 
@@ -105,12 +106,26 @@ class StackBuild(Subcommand):
 
             providers = dict()
             for api in Api:
+                all_providers = api_providers()
+                providers_for_api = all_providers[api]
+
                 api_provider = prompt(
                     "> Please enter the API provider for the {} API: (default=meta-reference): ".format(
                         api.value
                     ),
-                    default="meta-reference",
+                    validator=Validator.from_callable(
+                        lambda x: x in providers_for_api,
+                        error_message="Invalid provider, please enter one of the following: {}".format(
+                            providers_for_api.keys()
+                        ),
+                    ),
+                    default=(
+                        "meta-reference"
+                        if "meta-reference" in providers_for_api
+                        else list(providers_for_api.keys())[0]
+                    ),
                 )
+
                 providers[api.value] = api_provider
 
             description = prompt(

--- a/llama_stack/cli/stack/build.py
+++ b/llama_stack/cli/stack/build.py
@@ -34,6 +34,7 @@ class StackBuild(Subcommand):
             "config",
             type=str,
             default=None,
+            nargs="*",
             help="Path to a config file to use for the build. You may find example configs in llama_stack/distribution/example_configs. If not defined, you will be prompted for entering wizard",
         )
 

--- a/llama_stack/cli/stack/build.py
+++ b/llama_stack/cli/stack/build.py
@@ -63,7 +63,10 @@ class StackBuild(Subcommand):
                 llama_stack_path / "configs/distributions" / build_config.image_type
             )
         else:
-            build_dir = Path(os.getenv("CONDA_PREFIX")).parent
+            build_dir = (
+                Path(os.getenv("CONDA_PREFIX")).parent
+                / f"llamastack-{build_config.name}"
+            )
 
         os.makedirs(build_dir, exist_ok=True)
         build_file_path = build_dir / f"{build_config.name}-build.yaml"

--- a/llama_stack/cli/stack/build.py
+++ b/llama_stack/cli/stack/build.py
@@ -27,7 +27,7 @@ class StackBuild(Subcommand):
 
     def _add_arguments(self):
         self.parser.add_argument(
-            "config",
+            "--config",
             type=str,
             help="Path to a config file to use for the build. You may find example configs in llama_stack/distribution/example_configs",
         )
@@ -44,9 +44,10 @@ class StackBuild(Subcommand):
         import json
         import os
 
+        from llama_stack.distribution.build import ApiInput, build_image, ImageType
+
         from llama_stack.distribution.utils.config_dirs import DISTRIBS_BASE_DIR
         from llama_stack.distribution.utils.serialize import EnumEncoder
-        from llama_stack.distribution.build import ApiInput, build_image, ImageType
         from termcolor import cprint
 
         # save build.yaml spec for building same distribution again
@@ -74,13 +75,15 @@ class StackBuild(Subcommand):
         )
 
     def _run_stack_build_command(self, args: argparse.Namespace) -> None:
-        from llama_stack.distribution.utils.prompt_for_config import prompt_for_config
         from llama_stack.distribution.utils.dynamic import instantiate_class_type
+        from llama_stack.distribution.utils.prompt_for_config import prompt_for_config
 
         if not args.config:
-            self.parser.error(
-                "No config file specified. Please use `llama stack build /path/to/*-build.yaml`. Example config files can be found in llama_stack/distribution/example_configs"
-            )
+            # self.parser.error(
+            #     "No config file specified. Please use `llama stack build /path/to/*-build.yaml`. Example config files can be found in llama_stack/distribution/example_configs"
+            # )
+            build_config = prompt_for_config(BuildConfig, None)
+            self._run_stack_build_command_from_build_config(build_config)
             return
 
         with open(args.config, "r") as f:

--- a/llama_stack/cli/stack/build.py
+++ b/llama_stack/cli/stack/build.py
@@ -11,8 +11,6 @@ from llama_stack.distribution.datatypes import *  # noqa: F403
 from pathlib import Path
 
 import yaml
-from prompt_toolkit.validation import Validator
-from termcolor import cprint
 
 
 class StackBuild(Subcommand):
@@ -84,16 +82,18 @@ class StackBuild(Subcommand):
         from llama_stack.distribution.distribution import Api, api_providers
         from llama_stack.distribution.utils.dynamic import instantiate_class_type
         from prompt_toolkit import prompt
+        from prompt_toolkit.validation import Validator
+        from termcolor import cprint
 
         if not args.config:
             name = prompt(
-                "> Enter an unique name for identifying your Llama Stack build distribution (e.g. my-local-stack): "
+                "> Enter a unique name for identifying your Llama Stack build distribution (e.g. my-local-stack): "
             )
             image_type = prompt(
-                "> Enter the image type you want your distribution to be built with (docker or conda): ",
+                "> Enter the image type you want your distribution to be built as (docker or conda): ",
                 validator=Validator.from_callable(
                     lambda x: x in ["docker", "conda"],
-                    error_message="Invalid image type, please enter (conda|docker)",
+                    error_message="Invalid image type, please enter conda or docker",
                 ),
                 default="conda",
             )

--- a/llama_stack/cli/stack/build.py
+++ b/llama_stack/cli/stack/build.py
@@ -76,6 +76,10 @@ class StackBuild(Subcommand):
 
         cprint(
             f"Build spec configuration saved at {str(build_file_path)}",
+            color="blue",
+        )
+        cprint(
+            f"You may now run `llama stack configure {build_config.name}` or `llama stack configure {str(build_file_path)}`",
             color="green",
         )
 

--- a/llama_stack/cli/stack/build.py
+++ b/llama_stack/cli/stack/build.py
@@ -87,10 +87,10 @@ class StackBuild(Subcommand):
 
         if not args.config:
             name = prompt(
-                "> Please enter an unique name for identifying your Llama Stack build distribution (e.g. my-local-stack): "
+                "> Enter an unique name for identifying your Llama Stack build distribution (e.g. my-local-stack): "
             )
             image_type = prompt(
-                "> Please enter the image type you want your distribution to be built with (docker or conda): ",
+                "> Enter the image type you want your distribution to be built with (docker or conda): ",
                 validator=Validator.from_callable(
                     lambda x: x in ["docker", "conda"],
                     error_message="Invalid image type, please enter (conda|docker)",
@@ -109,7 +109,7 @@ class StackBuild(Subcommand):
                 providers_for_api = all_providers[api]
 
                 api_provider = prompt(
-                    "> Please enter the API provider for the {} API: (default=meta-reference): ".format(
+                    "> Enter the API provider for the {} API: (default=meta-reference): ".format(
                         api.value
                     ),
                     validator=Validator.from_callable(
@@ -128,7 +128,7 @@ class StackBuild(Subcommand):
                 providers[api.value] = api_provider
 
             description = prompt(
-                "\n > (Optional) Please enter a short description for your Llama Stack distribution: ",
+                "\n > (Optional) Enter a short description for your Llama Stack distribution: ",
                 default="",
             )
 

--- a/llama_stack/cli/stack/build.py
+++ b/llama_stack/cli/stack/build.py
@@ -31,9 +31,10 @@ class StackBuild(Subcommand):
 
     def _add_arguments(self):
         self.parser.add_argument(
-            "--config",
+            "config",
             type=str,
-            help="Path to a config file to use for the build. You may find example configs in llama_stack/distribution/example_configs",
+            default=None,
+            help="Path to a config file to use for the build. You may find example configs in llama_stack/distribution/example_configs. If not defined, you will be prompted for entering wizard",
         )
 
         self.parser.add_argument(

--- a/llama_stack/cli/stack/build.py
+++ b/llama_stack/cli/stack/build.py
@@ -11,7 +11,6 @@ from llama_stack.distribution.datatypes import *  # noqa: F403
 from pathlib import Path
 
 import yaml
-from llama_stack.distribution.datatypes import Api
 from prompt_toolkit import prompt
 from prompt_toolkit.validation import Validator
 from termcolor import cprint
@@ -35,7 +34,7 @@ class StackBuild(Subcommand):
             type=str,
             default=None,
             nargs="*",
-            help="Path to a config file to use for the build. You may find example configs in llama_stack/distribution/example_configs. If not defined, you will be prompted for entering wizard",
+            help="Path to a config file to use for the build. You can find example configs in llama_stack/distribution/example_configs. If this argument is not provided, you will be prompted to enter information interactively",
         )
 
         self.parser.add_argument(
@@ -87,7 +86,6 @@ class StackBuild(Subcommand):
         from llama_stack.distribution.utils.prompt_for_config import prompt_for_config
 
         if not args.config:
-            # build_config = prompt_for_config(BuildConfig, None)
             name = prompt(
                 "> Please enter an unique name for identifying your Llama Stack build distribution (e.g. my-local-stack): "
             )
@@ -101,7 +99,7 @@ class StackBuild(Subcommand):
             )
 
             cprint(
-                f"\n Now, let's configure your Llama Stack distribution specs with API providers",
+                f"\n Llama Stack is composed of several APIs working together. Let's configure the providers (implementations) you want to use for these APIs.",
                 color="green",
             )
 

--- a/llama_stack/cli/stack/build.py
+++ b/llama_stack/cli/stack/build.py
@@ -87,10 +87,10 @@ class StackBuild(Subcommand):
 
         if not args.config:
             name = prompt(
-                "> Enter a unique name for identifying your Llama Stack build distribution (e.g. my-local-stack): "
+                "> Enter a unique name for identifying your Llama Stack build (e.g. my-local-stack): "
             )
             image_type = prompt(
-                "> Enter the image type you want your distribution to be built as (docker or conda): ",
+                "> Enter the image type you want your Llama Stack to be built as (docker or conda): ",
                 validator=Validator.from_callable(
                     lambda x: x in ["docker", "conda"],
                     error_message="Invalid image type, please enter conda or docker",
@@ -128,7 +128,7 @@ class StackBuild(Subcommand):
                 providers[api.value] = api_provider
 
             description = prompt(
-                "\n > (Optional) Enter a short description for your Llama Stack distribution: ",
+                "\n > (Optional) Enter a short description for your Llama Stack: ",
                 default="",
             )
 

--- a/llama_stack/cli/stack/configure.py
+++ b/llama_stack/cli/stack/configure.py
@@ -135,6 +135,11 @@ class StackConfigure(Subcommand):
             f.write(yaml.dump(to_write, sort_keys=False))
 
         cprint(
-            f"> YAML configuration has been written to {run_config_file}. You can now run `llama stack run {run_config_file}`",
+            f"> YAML configuration has been written to {run_config_file}.",
             color="blue",
+        )
+
+        cprint(
+            f"You can now run `llama stack run {image_name} --port PORT` or `llama stack run {run_config_file} --port PORT`",
+            color="green",
         )

--- a/llama_stack/cli/stack/configure.py
+++ b/llama_stack/cli/stack/configure.py
@@ -9,12 +9,12 @@ import json
 from pathlib import Path
 
 import yaml
-from termcolor import cprint
 
 from llama_stack.cli.subcommand import Subcommand
 from llama_stack.distribution.utils.config_dirs import BUILDS_BASE_DIR
 
 from llama_stack.distribution.utils.exec import run_with_pty
+from termcolor import cprint
 from llama_stack.distribution.datatypes import *  # noqa: F403
 import os
 
@@ -52,7 +52,9 @@ class StackConfigure(Subcommand):
         from llama_stack.distribution.build import ImageType
 
         docker_image = None
-        build_config_file = Path(args.config)
+        conda_dir = Path(os.getenv("CONDA_PREFIX")).parent
+        build_config_file = Path(conda_dir) / f"{args.config}-build.yaml"
+
         if not build_config_file.exists():
             cprint(
                 f"Could not find {build_config_file}. Trying docker image name instead...",

--- a/llama_stack/cli/stack/configure.py
+++ b/llama_stack/cli/stack/configure.py
@@ -81,8 +81,9 @@ class StackConfigure(Subcommand):
                 )
 
             build_name = docker_image.removeprefix("llamastack-")
+            saved_file = str(builds_dir / f"{build_name}-run.yaml")
             cprint(
-                f"YAML configuration has been written to {builds_dir / f'{build_name}-run.yaml'}",
+                f"YAML configuration has been written to {saved_file}. You can now run `llama stack run {saved_file}`",
                 color="green",
             )
             return
@@ -134,6 +135,6 @@ class StackConfigure(Subcommand):
             f.write(yaml.dump(to_write, sort_keys=False))
 
         cprint(
-            f"> YAML configuration has been written to {run_config_file}",
+            f"> YAML configuration has been written to {run_config_file}. You can now run `llama stack run {run_config_file}`",
             color="blue",
         )

--- a/llama_stack/cli/stack/configure.py
+++ b/llama_stack/cli/stack/configure.py
@@ -14,7 +14,6 @@ from llama_stack.cli.subcommand import Subcommand
 from llama_stack.distribution.utils.config_dirs import BUILDS_BASE_DIR
 
 from llama_stack.distribution.utils.exec import run_with_pty
-from termcolor import cprint
 from llama_stack.distribution.datatypes import *  # noqa: F403
 import os
 
@@ -50,6 +49,7 @@ class StackConfigure(Subcommand):
         import pkg_resources
 
         from llama_stack.distribution.build import ImageType
+        from termcolor import cprint
 
         docker_image = None
         conda_dir = Path(os.getenv("CONDA_PREFIX")).parent / f"llamastack-{args.config}"

--- a/llama_stack/cli/stack/configure.py
+++ b/llama_stack/cli/stack/configure.py
@@ -100,6 +100,7 @@ class StackConfigure(Subcommand):
     ):
         from llama_stack.distribution.configure import configure_api_providers
         from llama_stack.distribution.utils.serialize import EnumEncoder
+        from termcolor import cprint
 
         builds_dir = BUILDS_BASE_DIR / build_config.image_type
         if output_dir:

--- a/llama_stack/cli/stack/configure.py
+++ b/llama_stack/cli/stack/configure.py
@@ -52,7 +52,7 @@ class StackConfigure(Subcommand):
         from llama_stack.distribution.build import ImageType
 
         docker_image = None
-        conda_dir = Path(os.getenv("CONDA_PREFIX")).parent
+        conda_dir = Path(os.getenv("CONDA_PREFIX")).parent / f"llamastack-{args.config}"
         build_config_file = Path(conda_dir) / f"{args.config}-build.yaml"
 
         if not build_config_file.exists():

--- a/llama_stack/cli/stack/run.py
+++ b/llama_stack/cli/stack/run.py
@@ -47,6 +47,8 @@ class StackRun(Subcommand):
 
     def _run_stack_run_cmd(self, args: argparse.Namespace) -> None:
         import pkg_resources
+        from llama_stack.distribution.build import ImageType
+        from llama_stack.distribution.utils.config_dirs import BUILDS_BASE_DIR
 
         from llama_stack.distribution.utils.exec import run_with_pty
 
@@ -54,12 +56,22 @@ class StackRun(Subcommand):
             self.parser.error("Must specify a config file to run")
             return
 
-        path = args.config
-        config_file = Path(path)
+        config_file = Path(args.config)
+        if not config_file.exists() and not args.config.endswith(".yaml"):
+            # check if it's a build config saved to conda dir
+            config_file = Path(
+                BUILDS_BASE_DIR / ImageType.conda.value / f"{args.config}-run.yaml"
+            )
+
+        if not config_file.exists() and not args.config.endswith(".yaml"):
+            # check if it's a build config saved to docker dir
+            config_file = Path(
+                BUILDS_BASE_DIR / ImageType.docker.value / f"{args.config}-run.yaml"
+            )
 
         if not config_file.exists():
             self.parser.error(
-                f"File {str(config_file)} does not exist. Did you run `llama stack build`?"
+                f"File {str(config_file)} does not exist. Please run `llama stack build` and `llama stack configure <name>` to generate a run.yaml file"
             )
             return
 

--- a/llama_stack/distribution/datatypes.py
+++ b/llama_stack/distribution/datatypes.py
@@ -184,7 +184,13 @@ class DistributionSpec(BaseModel):
     )
     docker_image: Optional[str] = None
     providers: Dict[str, Union[str, List[str]]] = Field(
-        default_factory=dict,
+        default={
+            "inference": "meta-reference",
+            "memory": "meta-reference",
+            "safety": "meta-reference",
+            "agents": "meta-reference",
+            "telemetry": "meta-reference",
+        },
         description="""
 Provider Types for each of the APIs provided by this distribution. If you
 select multiple providers, you should provide an appropriate 'routing_map'

--- a/llama_stack/distribution/datatypes.py
+++ b/llama_stack/distribution/datatypes.py
@@ -184,13 +184,7 @@ class DistributionSpec(BaseModel):
     )
     docker_image: Optional[str] = None
     providers: Dict[str, Union[str, List[str]]] = Field(
-        default={
-            "inference": "meta-reference",
-            "memory": "meta-reference",
-            "safety": "meta-reference",
-            "agents": "meta-reference",
-            "telemetry": "meta-reference",
-        },
+        default_factory=dict,
         description="""
 Provider Types for each of the APIs provided by this distribution. If you
 select multiple providers, you should provide an appropriate 'routing_map'


### PR DESCRIPTION
✅  add back wizard for `llama stack build`

```
$ llama stack build
> Please enter an unique name for identifying your Llama Stack build distribution (e.g. my-local-stack): stack-1
> Please enter the image type you want your distribution to be built with (docker or conda): conda
Now, let's configure your Llama Stack distribution specs with API providers
> Please enter the API provider for the inference API: (default=meta-reference): meta-reference
> Please enter the API provider for the safety API: (default=meta-reference): meta-reference
> Please enter the API provider for the agents API: (default=meta-reference): meta-reference
> Please enter the API provider for the memory API: (default=meta-reference): meta-reference
> Please enter the API provider for the telemetry API: (default=meta-reference): meta-reference
> (Optional) Please enter a short description for your Llama Stack distribution:
```

✅  configure with conda to take name, save conda build.yaml inside $CONDA_ENVS
```
llama stack configure stack-1

> YAML configuration has been written to ~/.llama/builds/conda/my-stack-name-run.yaml. You can now run `llama stack run ~/.llama/builds/conda/my-stack-name-run.yaml`
```

✅ run with name only
```
llama stack run stack-1
```


✅  polish messages & readme