### PR TITLE
fix prompt with name args

### DIFF
--- a/llama_stack/cli/stack/build.py
+++ b/llama_stack/cli/stack/build.py
@@ -191,7 +191,13 @@ class StackBuild(Subcommand):
             return
 
         if not args.config and not args.template:
-            name = prompt("> Enter a name for your Llama Stack (e.g. my-local-stack): ")
+            if not args.name:
+                name = prompt(
+                    "> Enter a name for your Llama Stack (e.g. my-local-stack): "
+                )
+            else:
+                name = args.name
+
             image_type = prompt(
                 "> Enter the image type you want your Llama Stack to be built as (docker or conda): ",
                 validator=Validator.from_callable(


### PR DESCRIPTION
```
llama stack build --name foo
```
![image](https://github.com/user-attachments/assets/73dc668f-a28b-4675-81a6-05c4bf0fbf11)
