### PR TITLE
Models API with Inference Routing

### DIFF
--- a/llama_stack/apis/inference/client.py
+++ b/llama_stack/apis/inference/client.py
@@ -101,16 +101,17 @@ async def run_main(host: str, port: int, stream: bool):
     async for log in EventLogger().log(iterator):
         log.print()
 
-    cprint(f"User>{message.content}", "green")
-    iterator = client.chat_completion(
-        ChatCompletionRequest(
-            model="Meta-Llama3.1-8B",
-            messages=[message],
-            stream=stream,
-        )
-    )
-    async for log in EventLogger().log(iterator):
-        log.print()
+    # For testing models routing
+    # cprint(f"User>{message.content}", "green")
+    # iterator = client.chat_completion(
+    #     ChatCompletionRequest(
+    #         model="Meta-Llama3.1-8B",
+    #         messages=[message],
+    #         stream=stream,
+    #     )
+    # )
+    # async for log in EventLogger().log(iterator):
+    #     log.print()
 
 
 def main(host: str, port: int, stream: bool = True):

--- a/llama_stack/apis/inference/client.py
+++ b/llama_stack/apis/inference/client.py
@@ -93,7 +93,7 @@ async def run_main(host: str, port: int, stream: bool):
     cprint(f"User>{message.content}", "green")
     iterator = client.chat_completion(
         ChatCompletionRequest(
-            model="Meta-Llama3.1-8B",
+            model="Meta-Llama3.1-8B-Instruct",
             messages=[message],
             stream=stream,
         )
@@ -104,7 +104,7 @@ async def run_main(host: str, port: int, stream: bool):
     cprint(f"User>{message.content}", "green")
     iterator = client.chat_completion(
         ChatCompletionRequest(
-            model="Meta-Llama3.1-8B-Instruct",
+            model="Meta-Llama3.1-8B",
             messages=[message],
             stream=stream,
         )

--- a/llama_stack/apis/inference/client.py
+++ b/llama_stack/apis/inference/client.py
@@ -89,10 +89,11 @@ async def run_main(host: str, port: int, stream: bool):
     message = UserMessage(
         content="hello world, write me a 2 sentence poem about the moon"
     )
+
     cprint(f"User>{message.content}", "green")
     iterator = client.chat_completion(
         ChatCompletionRequest(
-            model="Meta-Llama3.1-8B-Instruct",
+            model="Meta-Llama3.1-8B",
             messages=[message],
             stream=stream,
         )
@@ -103,7 +104,7 @@ async def run_main(host: str, port: int, stream: bool):
     cprint(f"User>{message.content}", "green")
     iterator = client.chat_completion(
         ChatCompletionRequest(
-            model="Meta-Llama3.1-8B",
+            model="Meta-Llama3.1-8B-Instruct",
             messages=[message],
             stream=stream,
         )

--- a/llama_stack/apis/inference/client.py
+++ b/llama_stack/apis/inference/client.py
@@ -100,6 +100,17 @@ async def run_main(host: str, port: int, stream: bool):
     async for log in EventLogger().log(iterator):
         log.print()
 
+    cprint(f"User>{message.content}", "green")
+    iterator = client.chat_completion(
+        ChatCompletionRequest(
+            model="Meta-Llama3.1-8B",
+            messages=[message],
+            stream=stream,
+        )
+    )
+    async for log in EventLogger().log(iterator):
+        log.print()
+
 
 def main(host: str, port: int, stream: bool = True):
     asyncio.run(run_main(host, port, stream))

--- a/llama_stack/apis/models/clients.py
+++ b/llama_stack/apis/models/clients.py
@@ -1,0 +1,72 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import asyncio
+import json
+from pathlib import Path
+
+from typing import Any, Dict, List, Optional
+
+import fire
+import httpx
+
+from llama_stack.distribution.datatypes import RemoteProviderConfig
+from termcolor import cprint
+
+from .models import *  # noqa: F403
+
+
+class ModelsClient(Models):
+    def __init__(self, base_url: str):
+        self.base_url = base_url
+
+    async def initialize(self) -> None:
+        pass
+
+    async def shutdown(self) -> None:
+        pass
+
+    async def list_models(self) -> List[ModelSpec]:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"{self.base_url}/models/list",
+                headers={"Content-Type": "application/json"},
+            )
+            response.raise_for_status()
+            return ModelsListResponse(**response.json())
+
+    async def get_model(self, core_model_id: str) -> List[ModelSpec]:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self.base_url}/models/get",
+                json={
+                    "core_model_id": core_model_id,
+                },
+                headers={"Content-Type": "application/json"},
+            )
+            response.raise_for_status()
+            return ModelsGetResponse(**response.json())
+
+
+async def run_main(host: str, port: int, stream: bool):
+    client = ModelsClient(f"http://{host}:{port}")
+
+    response = await client.list_models()
+    cprint(f"list_models response={response}", "green")
+
+    response = await client.get_model("Meta-Llama3.1-8B-Instruct")
+    cprint(f"get_model response={response}", "blue")
+
+    response = await client.get_model("Llama-Guard-3-8B")
+    cprint(f"get_model response={response}", "red")
+
+
+def main(host: str, port: int, stream: bool = True):
+    asyncio.run(run_main(host, port, stream))
+
+
+if __name__ == "__main__":
+    fire.Fire(main)

--- a/llama_stack/apis/models/models.py
+++ b/llama_stack/apis/models/models.py
@@ -1,14 +1,51 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from typing import Protocol
+from typing import Dict, List, Optional, Protocol
 
-from llama_models.schema_utils import webmethod  # noqa: F401
+from llama_models.llama3.api.datatypes import *  # noqa: F403
 
-from pydantic import BaseModel  # noqa: F401
+from llama_models.schema_utils import json_schema_type, webmethod
+from pydantic import BaseModel, Field
 
 
-class Models(Protocol): ...
+@json_schema_type
+class ModelSpec(BaseModel):
+    llama_model_metadata: Model = Field(
+        description="All metadatas associated with llama model (defined in llama_models.models.sku_list). "
+    )
+    providers_spec: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Map of API to the concrete provider specs. E.g. {}".format(
+            {
+                "inference": {
+                    "provider_type": "remote::8080",
+                    "url": "localhost::5555",
+                    "api_token": "hf_xxx",
+                },
+            }
+        ),
+    )
+
+
+@json_schema_type
+class ModelsListResponse(BaseModel):
+    models_list: List[ModelSpec]
+
+
+@json_schema_type
+class ModelsGetResponse(BaseModel):
+    core_model_spec: Optional[ModelSpec] = None
+
+
+@json_schema_type
+class ModelsRegisterResponse(BaseModel):
+    core_model_spec: Optional[ModelSpec] = None
+
+
+class Models(Protocol):
+    @webmethod(route="/models/list", method="GET")
+    async def list_models(self) -> ModelsListResponse: ...
+
+    @webmethod(route="/models/get", method="POST")
+    async def get_model(self, core_model_id: str) -> ModelsGetResponse: ...

--- a/llama_stack/apis/models/models.py
+++ b/llama_stack/apis/models/models.py
@@ -1,11 +1,12 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from typing import Dict, List, Optional, Protocol
+from typing import Any, Dict, List, Optional, Protocol
 
-from llama_models.llama3.api.datatypes import *  # noqa: F403
+from llama_models.llama3.api.datatypes import Model
 
 from llama_models.schema_utils import json_schema_type, webmethod
+from llama_stack.distribution.datatypes import GenericProviderConfig
 from pydantic import BaseModel, Field
 
 
@@ -14,17 +15,14 @@ class ModelSpec(BaseModel):
     llama_model_metadata: Model = Field(
         description="All metadatas associated with llama model (defined in llama_models.models.sku_list). "
     )
-    providers_spec: Dict[str, Any] = Field(
-        default_factory=dict,
-        description="Map of API to the concrete provider specs. E.g. {}".format(
-            {
-                "inference": {
-                    "provider_type": "remote::8080",
-                    "url": "localhost::5555",
-                    "api_token": "hf_xxx",
-                },
-            }
-        ),
+    provider_id: str = Field(
+        description="API provider that is serving this model (e.g. meta-reference, local)",
+    )
+    api: str = Field(
+        description="API that this model is serving (e.g. inference / safety)",
+    )
+    provider_config: Dict[str, Any] = Field(
+        description="API provider config used for serving this model to the API provider `provider_id`"
     )
 
 

--- a/llama_stack/configs/examples/local-router-run.yaml
+++ b/llama_stack/configs/examples/local-router-run.yaml
@@ -1,0 +1,64 @@
+built_at: '2024-09-18T13:41:17.656743'
+image_name: local
+docker_image: null
+conda_env: local
+apis_to_serve:
+- inference
+- memory
+- safety
+- telemetry
+- agents
+- models
+provider_map:
+  inference: models-router
+  safety:
+    provider_id: meta-reference
+    config:
+      llama_guard_shield:
+        model: Llama-Guard-3-8B
+        excluded_categories: []
+        disable_input_check: false
+        disable_output_check: false
+      prompt_guard_shield:
+        model: Prompt-Guard-86M
+  telemetry:
+    provider_id: meta-reference
+    config: {}
+  agents:
+    provider_id: meta-reference
+    config: {}
+  models:
+    provider_id: builtin
+    config:
+      models_config:
+      - core_model_id: Meta-Llama3.1-8B-Instruct
+        provider_id: meta-reference
+        api: inference
+        config:
+          model: Meta-Llama3.1-8B-Instruct
+          quantization: null
+          torch_seed: null
+          max_seq_len: 4096
+          max_batch_size: 1
+      - core_model_id: Meta-Llama3.1-8B
+        provider_id: meta-reference
+        api: inference
+        config:
+          model: Meta-Llama3.1-8B
+          quantization: null
+          torch_seed: null
+          max_seq_len: 4096
+          max_batch_size: 1
+      - core_model_id: Llama-Guard-3-8B
+        provider_id: meta-reference
+        api: safety
+        config:
+          model: Llama-Guard-3-8B
+          excluded_categories: []
+          disable_input_check: false
+          disable_output_check: false
+      - core_model_id: Prompt-Guard-86M
+        provider_id: meta-reference
+        api: safety
+        config:
+          model: Prompt-Guard-86M

--- a/llama_stack/distribution/datatypes.py
+++ b/llama_stack/distribution/datatypes.py
@@ -20,6 +20,7 @@ class Api(Enum):
     agents = "agents"
     memory = "memory"
     telemetry = "telemetry"
+    models = "models"
 
 
 @json_schema_type

--- a/llama_stack/distribution/datatypes.py
+++ b/llama_stack/distribution/datatypes.py
@@ -198,7 +198,7 @@ class ProviderRoutingEntry(GenericProviderConfig):
     routing_key: str
 
 
-ProviderMapEntry = Union[GenericProviderConfig, List[ProviderRoutingEntry]]
+ProviderMapEntry = Union[GenericProviderConfig, List[ProviderRoutingEntry], str]
 
 
 @json_schema_type

--- a/llama_stack/distribution/distribution.py
+++ b/llama_stack/distribution/distribution.py
@@ -11,6 +11,7 @@ from typing import Dict, List
 from llama_stack.apis.agents import Agents
 from llama_stack.apis.inference import Inference
 from llama_stack.apis.memory import Memory
+from llama_stack.apis.models import Models
 from llama_stack.apis.safety import Safety
 from llama_stack.apis.telemetry import Telemetry
 
@@ -38,6 +39,7 @@ def api_endpoints() -> Dict[Api, List[ApiEndpoint]]:
         Api.agents: Agents,
         Api.memory: Memory,
         Api.telemetry: Telemetry,
+        Api.models: Models,
     }
 
     for api, protocol in protocols.items():

--- a/llama_stack/distribution/server/server.py
+++ b/llama_stack/distribution/server/server.py
@@ -35,9 +35,6 @@ from fastapi import Body, FastAPI, HTTPException, Request, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.routing import APIRoute
-from pydantic import BaseModel, ValidationError
-from termcolor import cprint
-from typing_extensions import Annotated
 
 from llama_stack.providers.utils.telemetry.tracing import (
     end_trace,
@@ -45,6 +42,9 @@ from llama_stack.providers.utils.telemetry.tracing import (
     SpanStatus,
     start_trace,
 )
+from pydantic import BaseModel, ValidationError
+from termcolor import cprint
+from typing_extensions import Annotated
 from llama_stack.distribution.datatypes import *  # noqa: F403
 
 from llama_stack.distribution.distribution import api_endpoints, api_providers
@@ -333,7 +333,9 @@ def main(yaml_config: str, port: int = 5000, disable_ipv6: bool = False):
 
     app = FastAPI()
 
+    print(config)
     impls, specs = asyncio.run(resolve_impls(config.provider_map))
+    print(impls)
     if Api.telemetry in impls:
         setup_logger(impls[Api.telemetry])
 

--- a/llama_stack/distribution/server/server.py
+++ b/llama_stack/distribution/server/server.py
@@ -321,11 +321,9 @@ async def resolve_impls(
                 inner_specs=inner_specs,
             )
 
-    for k, v in specs.items():
-        cprint(k, "blue")
-        cprint(v, "blue")
-
     sorted_specs = topological_sort(specs.values())
+
+    cprint(f"sorted_specs={sorted_specs}", "red")
 
     impls = {}
     for spec in sorted_specs:

--- a/llama_stack/distribution/utils/dynamic.py
+++ b/llama_stack/distribution/utils/dynamic.py
@@ -53,7 +53,8 @@ async def instantiate_provider(
             args = [inner_impls, deps]
         elif isinstance(provider_config, str) and provider_config == "models-router":
             config = None
-            args = [[], deps]
+            assert len(deps) == 1 and Api.models in deps
+            args = [deps[Api.models]]
         else:
             raise ValueError(f"provider_config {provider_config} is not valid")
     else:

--- a/llama_stack/distribution/utils/dynamic.py
+++ b/llama_stack/distribution/utils/dynamic.py
@@ -16,6 +16,10 @@ def instantiate_class_type(fully_qualified_name):
     return getattr(module, class_name)
 
 
+def is_models_router_provider(item: Any):
+    return isinstance(item, str) and item == "models-router"
+
+
 # returns a class implementing the protocol corresponding to the Api
 async def instantiate_provider(
     provider_spec: ProviderSpec,
@@ -51,7 +55,7 @@ async def instantiate_provider(
 
             config = None
             args = [inner_impls, deps]
-        elif isinstance(provider_config, str) and provider_config == "models-router":
+        elif is_models_router_provider(provider_config):
             config = None
             assert len(deps) == 1 and Api.models in deps
             args = [deps[Api.models]]

--- a/llama_stack/distribution/utils/dynamic.py
+++ b/llama_stack/distribution/utils/dynamic.py
@@ -38,19 +38,24 @@ async def instantiate_provider(
     elif isinstance(provider_spec, RouterProviderSpec):
         method = "get_router_impl"
 
-        assert isinstance(provider_config, list)
-        inner_specs = {x.provider_id: x for x in provider_spec.inner_specs}
-        inner_impls = []
-        for routing_entry in provider_config:
-            impl = await instantiate_provider(
-                inner_specs[routing_entry.provider_id],
-                deps,
-                routing_entry,
-            )
-            inner_impls.append((routing_entry.routing_key, impl))
+        if isinstance(provider_config, list):
+            inner_specs = {x.provider_id: x for x in provider_spec.inner_specs}
+            inner_impls = []
+            for routing_entry in provider_config:
+                impl = await instantiate_provider(
+                    inner_specs[routing_entry.provider_id],
+                    deps,
+                    routing_entry,
+                )
+                inner_impls.append((routing_entry.routing_key, impl))
 
-        config = None
-        args = [inner_impls, deps]
+            config = None
+            args = [inner_impls, deps]
+        elif isinstance(provider_config, str) and provider_config == "models-router":
+            config = None
+            args = [[], deps]
+        else:
+            raise ValueError(f"provider_config {provider_config} is not valid")
     else:
         method = "get_provider_impl"
 

--- a/llama_stack/providers/impls/builtin/models/__init__.py
+++ b/llama_stack/providers/impls/builtin/models/__init__.py
@@ -1,0 +1,23 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from typing import Dict
+
+from llama_stack.distribution.datatypes import Api, ProviderSpec
+
+from .config import BuiltinImplConfig  # noqa
+
+
+async def get_provider_impl(config: BuiltinImplConfig, deps: Dict[Api, ProviderSpec]):
+    from .models import BuiltinModelsImpl
+
+    assert isinstance(
+        config, BuiltinImplConfig
+    ), f"Unexpected config type: {type(config)}"
+
+    impl = BuiltinModelsImpl(config)
+    await impl.initialize()
+    return impl

--- a/llama_stack/providers/impls/builtin/models/__init__.py
+++ b/llama_stack/providers/impls/builtin/models/__init__.py
@@ -18,6 +18,8 @@ async def get_provider_impl(config: BuiltinImplConfig, deps: Dict[Api, ProviderS
         config, BuiltinImplConfig
     ), f"Unexpected config type: {type(config)}"
 
+    print(config)
+
     impl = BuiltinModelsImpl(config)
     await impl.initialize()
     return impl

--- a/llama_stack/providers/impls/builtin/models/__init__.py
+++ b/llama_stack/providers/impls/builtin/models/__init__.py
@@ -18,8 +18,6 @@ async def get_provider_impl(config: BuiltinImplConfig, deps: Dict[Api, ProviderS
         config, BuiltinImplConfig
     ), f"Unexpected config type: {type(config)}"
 
-    print(config)
-
     impl = BuiltinModelsImpl(config)
     await impl.initialize()
     return impl

--- a/llama_stack/providers/impls/builtin/models/config.py
+++ b/llama_stack/providers/impls/builtin/models/config.py
@@ -21,4 +21,7 @@ class ModelConfigProviderEntry(GenericProviderConfig):
 
 @json_schema_type
 class BuiltinImplConfig(BaseModel):
-    models_config: List[ModelConfigProviderEntry]
+    models_config: List[ModelConfigProviderEntry] = Field(
+        default_factory=list,
+        description="list of model config entries for each model",
+    )

--- a/llama_stack/providers/impls/builtin/models/config.py
+++ b/llama_stack/providers/impls/builtin/models/config.py
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from typing import Optional
+
+from llama_models.datatypes import ModelFamily
+
+from llama_models.schema_utils import json_schema_type
+from llama_models.sku_list import all_registered_models, resolve_model
+
+from pydantic import BaseModel, Field, field_validator
+
+
+@json_schema_type
+class BuiltinImplConfig(BaseModel): ...

--- a/llama_stack/providers/impls/builtin/models/config.py
+++ b/llama_stack/providers/impls/builtin/models/config.py
@@ -4,15 +4,21 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from typing import Optional
-
-from llama_models.datatypes import ModelFamily
+from typing import Any, List, Optional
 
 from llama_models.schema_utils import json_schema_type
 from llama_models.sku_list import all_registered_models, resolve_model
+from llama_stack.distribution.datatypes import GenericProviderConfig
 
 from pydantic import BaseModel, Field, field_validator
 
 
 @json_schema_type
-class BuiltinImplConfig(BaseModel): ...
+class ModelConfigProviderEntry(GenericProviderConfig):
+    api: str
+    core_model_id: str
+
+
+@json_schema_type
+class BuiltinImplConfig(BaseModel):
+    models_config: List[ModelConfigProviderEntry]

--- a/llama_stack/providers/impls/builtin/models/models.py
+++ b/llama_stack/providers/impls/builtin/models/models.py
@@ -18,16 +18,6 @@ from termcolor import cprint
 
 from .config import BuiltinImplConfig
 
-DUMMY_MODELS_SPEC_1 = ModelSpec(
-    llama_model_metadata=resolve_model("Llama-Guard-3-8B"),
-    providers_spec={"safety": {"provider_type": "meta-reference"}},
-)
-
-DUMMY_MODELS_SPEC_2 = ModelSpec(
-    llama_model_metadata=resolve_model("Meta-Llama3.1-8B-Instruct"),
-    providers_spec={"inference": {"provider_type": "meta-reference"}},
-)
-
 
 class BuiltinModelsImpl(Models):
     def __init__(
@@ -35,19 +25,21 @@ class BuiltinModelsImpl(Models):
         config: BuiltinImplConfig,
     ) -> None:
         self.config = config
-
-        self.models = {
-            x.llama_model_metadata.core_model_id.value: x
-            for x in [DUMMY_MODELS_SPEC_1, DUMMY_MODELS_SPEC_2]
-        }
-
         cprint(self.config, "red")
+        self.models = {
+            entry.core_model_id: ModelSpec(
+                llama_model_metadata=resolve_model(entry.core_model_id),
+                provider_id=entry.provider_id,
+                api=entry.api,
+                provider_config=entry.config,
+            )
+            for entry in self.config.models_config
+        }
 
     async def initialize(self) -> None:
         pass
 
     async def list_models(self) -> ModelsListResponse:
-        print(self.config, "hihihi")
         return ModelsListResponse(models_list=list(self.models.values()))
 
     async def get_model(self, core_model_id: str) -> ModelsGetResponse:

--- a/llama_stack/providers/impls/builtin/models/models.py
+++ b/llama_stack/providers/impls/builtin/models/models.py
@@ -1,0 +1,46 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+import asyncio
+
+from typing import AsyncIterator, Union
+
+from llama_models.llama3.api.datatypes import StopReason
+from llama_models.sku_list import resolve_model
+
+from llama_stack.apis.models import *  # noqa: F403
+from llama_models.llama3.api.datatypes import *  # noqa: F403
+from llama_models.datatypes import CoreModelId, Model
+from llama_models.sku_list import resolve_model
+
+from .config import BuiltinImplConfig
+
+DUMMY_MODELS_SPEC = ModelSpec(
+    llama_model_metadata=resolve_model("Meta-Llama3.1-8B"),
+    providers_spec={"inference": {"provider_type": "meta-reference"}},
+)
+
+
+class BuiltinModelsImpl(Models):
+    def __init__(
+        self,
+        config: BuiltinImplConfig,
+    ) -> None:
+        self.config = config
+        self.models_list = [DUMMY_MODELS_SPEC]
+
+    async def initialize(self) -> None:
+        pass
+
+    async def list_models(self) -> ModelsListResponse:
+        return ModelsListResponse(models_list=self.models_list)
+
+    async def get_model(self, core_model_id: str) -> ModelsGetResponse:
+        return ModelsGetResponse(core_model_spec=DUMMY_MODELS_SPEC)
+
+    async def register_model(
+        self, model_id: str, api: str, provider_spec: Dict[str, str]
+    ) -> ModelsRegisterResponse:
+        return ModelsRegisterResponse()

--- a/llama_stack/providers/impls/builtin/models/models.py
+++ b/llama_stack/providers/impls/builtin/models/models.py
@@ -14,6 +14,7 @@ from llama_stack.apis.models import *  # noqa: F403
 from llama_models.llama3.api.datatypes import *  # noqa: F403
 from llama_models.datatypes import CoreModelId, Model
 from llama_models.sku_list import resolve_model
+from termcolor import cprint
 
 from .config import BuiltinImplConfig
 
@@ -34,21 +35,25 @@ class BuiltinModelsImpl(Models):
         config: BuiltinImplConfig,
     ) -> None:
         self.config = config
+
         self.models = {
             x.llama_model_metadata.core_model_id.value: x
             for x in [DUMMY_MODELS_SPEC_1, DUMMY_MODELS_SPEC_2]
         }
 
+        cprint(self.config, "red")
+
     async def initialize(self) -> None:
         pass
 
     async def list_models(self) -> ModelsListResponse:
+        print(self.config, "hihihi")
         return ModelsListResponse(models_list=list(self.models.values()))
 
     async def get_model(self, core_model_id: str) -> ModelsGetResponse:
         if core_model_id in self.models:
             return ModelsGetResponse(core_model_spec=self.models[core_model_id])
-        raise ValueError(f"Cannot find {core_model_id} in model registry")
+        raise RuntimeError(f"Cannot find {core_model_id} in model registry")
 
     async def register_model(
         self, model_id: str, api: str, provider_spec: Dict[str, str]

--- a/llama_stack/providers/impls/builtin/models/models.py
+++ b/llama_stack/providers/impls/builtin/models/models.py
@@ -25,7 +25,6 @@ class BuiltinModelsImpl(Models):
         config: BuiltinImplConfig,
     ) -> None:
         self.config = config
-        cprint(self.config, "red")
         self.models = {
             entry.core_model_id: ModelSpec(
                 llama_model_metadata=resolve_model(entry.core_model_id),

--- a/llama_stack/providers/registry/models.py
+++ b/llama_stack/providers/registry/models.py
@@ -1,0 +1,22 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from typing import List
+
+from llama_stack.distribution.datatypes import *  # noqa: F403
+
+
+def available_providers() -> List[ProviderSpec]:
+    return [
+        InlineProviderSpec(
+            api=Api.models,
+            provider_id="builtin",
+            pip_packages=[],
+            module="llama_stack.providers.impls.builtin.models",
+            config_class="llama_stack.providers.impls.builtin.models.BuiltinImplConfig",
+            api_dependencies=[],
+        )
+    ]

--- a/llama_stack/providers/routers/inference/__init__.py
+++ b/llama_stack/providers/routers/inference/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from typing import Any, List, Tuple
+
+from llama_stack.distribution.datatypes import Api
+
+
+async def get_router_impl(inner_impls: List[Tuple[str, Any]], deps: List[Api]):
+    from .inference import InferenceRouterImpl
+
+    impl = InferenceRouterImpl(inner_impls, deps)
+    await impl.initialize()
+    return impl

--- a/llama_stack/providers/routers/inference/__init__.py
+++ b/llama_stack/providers/routers/inference/__init__.py
@@ -9,9 +9,9 @@ from typing import Any, List, Tuple
 from llama_stack.distribution.datatypes import Api
 
 
-async def get_router_impl(inner_impls: List[Tuple[str, Any]], deps: List[Api]):
+async def get_router_impl(models_api: Api):
     from .inference import InferenceRouterImpl
 
-    impl = InferenceRouterImpl(inner_impls, deps)
+    impl = InferenceRouterImpl(models_api)
     await impl.initialize()
     return impl

--- a/llama_stack/providers/routers/inference/inference.py
+++ b/llama_stack/providers/routers/inference/inference.py
@@ -55,7 +55,9 @@ class InferenceRouterImpl(Inference):
             core_model_id = model_spec.llama_model_metadata.core_model_id
             self.model2providers[core_model_id.value] = impl
 
-        cprint(self.model2providers, "blue")
+        cprint(f"Initialized inference router: ", "blue")
+        for m, p in self.model2providers.items():
+            cprint(f"- {m} serving using {p}", "blue")
 
     async def shutdown(self) -> None:
         for p in self.model2providers.values():

--- a/llama_stack/providers/routers/inference/inference.py
+++ b/llama_stack/providers/routers/inference/inference.py
@@ -1,0 +1,67 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from typing import Any, AsyncGenerator, Dict, List, Tuple
+
+from llama_stack.distribution.datatypes import Api
+from llama_stack.apis.inference import *  # noqa: F403
+from llama_stack.providers.registry.inference import available_providers
+
+
+class InferenceRouterImpl(Inference):
+    """Routes to an provider based on the memory bank type"""
+
+    def __init__(
+        self,
+        inner_impls: List[Tuple[str, Any]],
+        deps: List[Api],
+    ) -> None:
+        self.inner_impls = inner_impls
+        self.deps = deps
+        print("INIT INFERENCE ROUTER!")
+
+        # self.providers = {}
+        # for routing_key, provider_impl in inner_impls:
+        #     self.providers[routing_key] = provider_impl
+
+    async def initialize(self) -> None:
+        pass
+
+    async def shutdown(self) -> None:
+        pass
+        # for p in self.providers.values():
+        #     await p.shutdown()
+
+    async def chat_completion(
+        self,
+        model: str,
+        messages: List[Message],
+        sampling_params: Optional[SamplingParams] = SamplingParams(),
+        # zero-shot tool definitions as input to the model
+        tools: Optional[List[ToolDefinition]] = list,
+        tool_choice: Optional[ToolChoice] = ToolChoice.auto,
+        tool_prompt_format: Optional[ToolPromptFormat] = ToolPromptFormat.json,
+        stream: Optional[bool] = False,
+        logprobs: Optional[LogProbConfig] = None,
+    ) -> AsyncGenerator:
+        print("router chat_completion")
+        yield ChatCompletionResponseStreamChunk(
+            event=ChatCompletionResponseEvent(
+                event_type=ChatCompletionResponseEventType.progress,
+                delta="router chat completion",
+            )
+        )
+        # async for chunk in self.providers[model].chat_completion(
+        #     model=model,
+        #     messages=messages,
+        #     sampling_params=sampling_params,
+        #     tools=tools,
+        #     tool_choice=tool_choice,
+        #     tool_prompt_format=tool_prompt_format,
+        #     stream=stream,
+        #     logprobs=logprobs,
+        # ):
+        #     yield chunk

--- a/llama_stack/providers/routers/inference/inference.py
+++ b/llama_stack/providers/routers/inference/inference.py
@@ -58,9 +58,8 @@ class InferenceRouterImpl(Inference):
         cprint(self.model2providers, "blue")
 
     async def shutdown(self) -> None:
-        pass
-        # for p in self.providers.values():
-        #     await p.shutdown()
+        for p in self.model2providers.values():
+            await p.shutdown()
 
     async def chat_completion(
         self,
@@ -74,17 +73,11 @@ class InferenceRouterImpl(Inference):
         stream: Optional[bool] = False,
         logprobs: Optional[LogProbConfig] = None,
     ) -> AsyncGenerator:
-        print("router chat_completion")
         if model not in self.model2providers:
             raise ValueError(
                 f"Cannot find model {model} in running distribution. Please use register model first"
             )
-        # yield ChatCompletionResponseStreamChunk(
-        #     event=ChatCompletionResponseEvent(
-        #         event_type=ChatCompletionResponseEventType.progress,
-        #         delta="router chat completion",
-        #     )
-        # )
+
         async for chunk in self.model2providers[model].chat_completion(
             model=model,
             messages=messages,


### PR DESCRIPTION
# Changes
✅  add models api endpoints for querying models distribution
✅  add special router "models-router" for inference endpoints to dynamically route to different models 
✅  configure script to setup models_config for models endpoint, and infer model config
✅  current single adapter based implementation is still in tact

-- not in this PR
🚧  register_model endpoint to add new models
🚧  safety router to run prompt_guard / llama_guard
🚧  client CLI for querying distribution models endpoint --> will be in llama-stack-apps

# run.yaml
```yaml
built_at: '2024-09-18T13:41:17.656743'
image_name: local
docker_image: null
conda_env: local
apis_to_serve:
- inference
- memory
- safety
- telemetry
- agents
- models
provider_map:
  inference: models-router
  safety:
    provider_id: meta-reference
    config:
      llama_guard_shield:
        model: Llama-Guard-3-8B
        excluded_categories: []
        disable_input_check: false
        disable_output_check: false
      prompt_guard_shield:
        model: Prompt-Guard-86M
  telemetry:
    provider_id: meta-reference
    config: {}
  agents:
    provider_id: meta-reference
    config: {}
  memory:
    provider_id: meta-reference
    config: {}
  models:
    provider_id: builtin
    config:
      models_config:
      - core_model_id: Meta-Llama3.1-8B-Instruct
        provider_id: meta-reference
        api: inference
        config:
          model: Meta-Llama3.1-8B-Instruct
          quantization: null
          torch_seed: null
          max_seq_len: 4096
          max_batch_size: 1
      - core_model_id: Meta-Llama3.1-8B
        provider_id: meta-reference
        api: inference
        config:
          model: Meta-Llama3.1-8B
          quantization: null
          torch_seed: null
          max_seq_len: 4096
          max_batch_size: 1
      - core_model_id: Llama-Guard-3-8B
        provider_id: meta-reference
        api: safety
        config:
          model: Llama-Guard-3-8B
          excluded_categories: []
          disable_input_check: false
          disable_output_check: false
      - core_model_id: Prompt-Guard-86M
        provider_id: meta-reference
        api: safety
        config:
          model: Prompt-Guard-86M
```
# Test w/ Client
```
python -m llama_stack.apis.inference.client
```
- Server: local inference with 2 different models

![image](https://github.com/user-attachments/assets/e4680c84-e187-45a3-9554-b510891a1d96)

![image](https://github.com/user-attachments/assets/00399eff-e783-4b54-95ca-27f794bda6d2)

```
python -m llama_stack.apis.models.clients
```
![image](https://github.com/user-attachments/assets/bb36bf2a-0c70-437c-a031-cc04d83d7355)
![image](https://github.com/user-attachments/assets/9aa330cc-283f-45c5-b3ec-10a7616782bd)

# Test w/ SDK
```
python sdk_examples/agents/client.py
```
- agents still works w/ routing

# Test regular simple example support
```
llama stack build
llama stack configure simple-local
```
- configure will generate model_config specs based on inference/safety configurations. 