### PR TITLE
Allow TGI adaptor to have non-standard llama model names

### DIFF
--- a/llama_stack/providers/adapters/inference/tgi/tgi.py
+++ b/llama_stack/providers/adapters/inference/tgi/tgi.py
@@ -18,12 +18,6 @@ from llama_stack.providers.utils.inference.prepare_messages import prepare_messa
 
 from .config import TGIImplConfig
 
-HF_SUPPORTED_MODELS = {
-    "Meta-Llama3.1-8B-Instruct": "meta-llama/Meta-Llama-3.1-8B-Instruct",
-    "Meta-Llama3.1-70B-Instruct": "meta-llama/Meta-Llama-3.1-70B-Instruct",
-    "Meta-Llama3.1-405B-Instruct": "meta-llama/Meta-Llama-3.1-405B-Instruct",
-}
-
 
 class TGIAdapter(Inference):
     def __init__(self, config: TGIImplConfig) -> None:
@@ -50,16 +44,6 @@ class TGIAdapter(Inference):
                 raise RuntimeError("Missing max_total_tokens in model info")
             self.max_tokens = info["max_total_tokens"]
 
-            model_id = info["model_id"]
-            model_name = next(
-                (name for name, id in HF_SUPPORTED_MODELS.items() if id == model_id),
-                None,
-            )
-            if model_name is None:
-                raise RuntimeError(
-                    f"TGI is serving model: {model_id}, use one of the supported models: {', '.join(HF_SUPPORTED_MODELS.values())}"
-                )
-            self.model_name = model_name
             self.inference_url = info["inference_url"]
         except Exception as e:
             import traceback
@@ -115,10 +99,6 @@ class TGIAdapter(Inference):
         )
 
         print(f"Calculated max_new_tokens: {max_new_tokens}")
-
-        assert (
-            request.model == self.model_name
-        ), f"Model mismatch, expected {self.model_name}, got {request.model}"
 
         options = self.get_chat_options(request)
         if not request.stream:


### PR DESCRIPTION
Tested using the following -- 

1. Build conda distribution using `remote::tgi` for inference and meta-reference for rest of apis. 
Here is the run config -- 
```
built_at: '2024-09-19T21:11:18.928309'
image_name: local-dell-tgi
docker_image: null
conda_env: local-dell-tgi
apis_to_serve:
- inference
- safety
- agents
- memory
provider_map:
  inference:
    provider_id: remote::tgi
    config:
      url: http://localhost:2020
      api_token: null
      hf_endpoint_name: null
  safety:
    provider_id: meta-reference
    config:
      llama_guard_shield: null
      prompt_guard_shield: null
  agents:
    provider_id: meta-reference
    config: {}
  memory:
    provider_id: meta-reference
    config: {}
  telemetry:
    provider_id: meta-reference
    config: {}
```
2. Start Dell's custom TGI Adaptor 
```
DOCKER_BINARY=podman DOCKER_OPTS="--network host" with-proxy podman run --network host    -it     --gpus 1     --shm-size 1g     -p 2020:2020     -e NUM_SHARD=1     -e MAX_BATCH_PREFILL_TOKENS=32768     -e MAX_INPUT_TOKENS=8000     -e MAX_TOTAL_TOKENS=8192     registry.dell.huggingface.co/enterprise-dell-inference-meta-llama-meta-llama-3.1-8b-instruct --port 2020
```

3. Run conda distro 
```
 DOCKER_BINARY=podman DOCKER_OPTS="--network host" with-proxy llama stack run /home/hjshah/.llama/builds/conda/local-dell-tgi-run.yaml
```

4. Run Inference Client 
```
python -m llama_stack.apis.inference.client localhost 5000

User>hello world, write me a 2 sentence poem about the moon
Assistant> Silver crescent in the midnight sky,
Luna's gentle light, a beacon passing by.
```