### PR TITLE
Fixed bug with streaming=true always in agents API

### DIFF
--- a/llama_stack/providers/impls/meta_reference/agents/agent_instance.py
+++ b/llama_stack/providers/impls/meta_reference/agents/agent_instance.py
@@ -392,7 +392,7 @@ class ChatAgent(ShieldRunnerMixin):
                 input_messages,
                 tools=self._get_tools(),
                 tool_prompt_format=self.agent_config.tool_prompt_format,
-                stream=True,
+                stream=stream,
                 sampling_params=sampling_params,
             ):
                 event = chunk.event


### PR DESCRIPTION
Previously, because of the `stream=True` in agent_instance.py, all requests were stream=True, even if you sent stream=false on the implementation layer. I've tested this change with the together implementation and it works.