### PR TITLE
Make TGI adapter compatible with HF Inference API

### DIFF
--- a/llama_stack/distribution/templates/local-hf-endpoint-build.yaml
+++ b/llama_stack/distribution/templates/local-hf-endpoint-build.yaml
@@ -1,0 +1,10 @@
+name: local-hf-endpoint
+distribution_spec:
+  description: "Like local, but use Hugging Face Inference Endpoints for running LLM inference.\nSee https://hf.co/docs/api-endpoints."
+  providers:
+    inference: remote::hf::endpoint
+    memory: meta-reference
+    safety: meta-reference
+    agents: meta-reference
+    telemetry: meta-reference
+image_type: conda

--- a/llama_stack/distribution/templates/local-hf-serverless-build.yaml
+++ b/llama_stack/distribution/templates/local-hf-serverless-build.yaml
@@ -1,0 +1,10 @@
+name: local-hf-serverless
+distribution_spec:
+  description: "Like local, but use Hugging Face Inference API (serverless) for running LLM inference.\nSee https://hf.co/docs/api-inference."
+  providers:
+    inference: remote::hf::serverless
+    memory: meta-reference
+    safety: meta-reference
+    agents: meta-reference
+    telemetry: meta-reference
+image_type: conda

--- a/llama_stack/distribution/templates/local-tgi-build.yaml
+++ b/llama_stack/distribution/templates/local-tgi-build.yaml
@@ -1,6 +1,6 @@
 name: local-tgi
 distribution_spec:
-  description: Use TGI (local or with Hugging Face Inference Endpoints for running LLM inference. When using HF Inference Endpoints, you must provide the name of the endpoint).
+  description: Like local, but use a TGI server for running LLM inference.
   providers:
     inference: remote::tgi
     memory: meta-reference

--- a/llama_stack/providers/adapters/inference/tgi/__init__.py
+++ b/llama_stack/providers/adapters/inference/tgi/__init__.py
@@ -4,21 +4,23 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from .config import TGIImplConfig
-from .tgi import InferenceEndpointAdapter, TGIAdapter
+from typing import Union
+
+from .config import InferenceAPIImplConfig, InferenceEndpointImplConfig, TGIImplConfig
+from .tgi import InferenceAPIAdapter, InferenceEndpointAdapter, TGIAdapter
 
 
-async def get_adapter_impl(config: TGIImplConfig, _deps):
-    assert isinstance(config, TGIImplConfig), f"Unexpected config type: {type(config)}"
-
-    if config.url is not None:
-        impl = TGIAdapter(config)
-    elif config.is_inference_endpoint():
-        impl = InferenceEndpointAdapter(config)
+async def get_adapter_impl(config: Union[InferenceAPIImplConfig, InferenceEndpointImplConfig, TGIImplConfig], _deps):
+    if isinstance(config, TGIImplConfig):
+        impl = TGIAdapter()
+    elif isinstance(config, InferenceAPIImplConfig):
+        impl = InferenceAPIAdapter()
+    elif isinstance(config, InferenceEndpointImplConfig):
+        impl = InferenceEndpointAdapter()
     else:
         raise ValueError(
-            "Invalid configuration. Specify either an URL or HF Inference Endpoint details (namespace and endpoint name)."
+            f"Invalid configuration. Expected 'TGIAdapter', 'InferenceAPIImplConfig' or 'InferenceEndpointImplConfig'. Got {type(config)}."
         )
 
-    await impl.initialize()
+    await impl.initialize(config)
     return impl

--- a/llama_stack/providers/adapters/inference/tgi/__init__.py
+++ b/llama_stack/providers/adapters/inference/tgi/__init__.py
@@ -10,7 +10,10 @@ from .config import InferenceAPIImplConfig, InferenceEndpointImplConfig, TGIImpl
 from .tgi import InferenceAPIAdapter, InferenceEndpointAdapter, TGIAdapter
 
 
-async def get_adapter_impl(config: Union[InferenceAPIImplConfig, InferenceEndpointImplConfig, TGIImplConfig], _deps):
+async def get_adapter_impl(
+    config: Union[InferenceAPIImplConfig, InferenceEndpointImplConfig, TGIImplConfig],
+    _deps,
+):
     if isinstance(config, TGIImplConfig):
         impl = TGIAdapter()
     elif isinstance(config, InferenceAPIImplConfig):

--- a/llama_stack/providers/adapters/inference/tgi/config.py
+++ b/llama_stack/providers/adapters/inference/tgi/config.py
@@ -12,18 +12,33 @@ from pydantic import BaseModel, Field
 
 @json_schema_type
 class TGIImplConfig(BaseModel):
-    url: Optional[str] = Field(
-        default=None,
-        description="The URL for the local TGI endpoint (e.g., http://localhost:8080)",
+    url: str = Field(
+        description="The URL for the TGI endpoint (e.g. 'http://localhost:8080')",
     )
     api_token: Optional[str] = Field(
         default=None,
-        description="The HF token for Hugging Face Inference Endpoints (will default to locally saved token if not provided)",
-    )
-    hf_endpoint_name: Optional[str] = Field(
-        default=None,
-        description="The name of the Hugging Face Inference Endpoint : can be either in the format of '{namespace}/{endpoint_name}' (namespace can be the username or organization name) or just '{endpoint_name}' if logged into the same account as the namespace",
+        description="A bearer token if your TGI endpoint is protected.",
     )
 
-    def is_inference_endpoint(self) -> bool:
-        return self.hf_endpoint_name is not None
+@json_schema_type
+class InferenceEndpointImplConfig(BaseModel):
+    endpoint_name: str = Field(
+        description="The name of the Hugging Face Inference Endpoint in the format of '{namespace}/{endpoint_name}' (e.g. 'my-cool-org/meta-llama-3-1-8b-instruct-rce'). Namespace is optional and will default to the user account if not provided.",
+    )
+    api_token: Optional[str] = Field(
+        default=None,
+        description="Your Hugging Face user access token (will default to locally saved token if not provided)",
+    )
+
+
+@json_schema_type
+class InferenceAPIImplConfig(BaseModel):
+    model_id: str = Field(
+        description="The model ID of the model on the Hugging Face Hub (e.g. 'meta-llama/Meta-Llama-3.1-70B-Instruct')",
+    )
+    api_token: Optional[str] = Field(
+        default=None,
+        description="Your Hugging Face user access token (will default to locally saved token if not provided)",
+    )
+
+

--- a/llama_stack/providers/adapters/inference/tgi/config.py
+++ b/llama_stack/providers/adapters/inference/tgi/config.py
@@ -20,6 +20,7 @@ class TGIImplConfig(BaseModel):
         description="A bearer token if your TGI endpoint is protected.",
     )
 
+
 @json_schema_type
 class InferenceEndpointImplConfig(BaseModel):
     endpoint_name: str = Field(
@@ -40,5 +41,3 @@ class InferenceAPIImplConfig(BaseModel):
         default=None,
         description="Your Hugging Face user access token (will default to locally saved token if not provided)",
     )
-
-

--- a/llama_stack/providers/adapters/inference/tgi/tgi.py
+++ b/llama_stack/providers/adapters/inference/tgi/tgi.py
@@ -20,6 +20,7 @@ from .config import InferenceAPIImplConfig, InferenceEndpointImplConfig, TGIImpl
 
 logger = logging.getLogger(__name__)
 
+
 class _HfAdapter(Inference):
     client: AsyncInferenceClient
     max_tokens: int
@@ -214,6 +215,7 @@ class _HfAdapter(Inference):
                 )
             )
 
+
 class TGIAdapter(_HfAdapter):
     async def initialize(self, config: TGIImplConfig) -> None:
         self.client = AsyncInferenceClient(model=config.url, token=config.api_token)
@@ -221,12 +223,16 @@ class TGIAdapter(_HfAdapter):
         self.max_tokens = endpoint_info["max_total_tokens"]
         self.model_id = endpoint_info["model_id"]
 
+
 class InferenceAPIAdapter(_HfAdapter):
     async def initialize(self, config: InferenceAPIImplConfig) -> None:
-        self.client = AsyncInferenceClient(model=config.model_id, token=config.api_token)
+        self.client = AsyncInferenceClient(
+            model=config.model_id, token=config.api_token
+        )
         endpoint_info = await self.client.get_endpoint_info()
         self.max_tokens = endpoint_info["max_total_tokens"]
         self.model_id = endpoint_info["model_id"]
+
 
 class InferenceEndpointAdapter(_HfAdapter):
     async def initialize(self, config: InferenceEndpointImplConfig) -> None:
@@ -240,4 +246,6 @@ class InferenceEndpointAdapter(_HfAdapter):
         # Initialize the adapter
         self.client = endpoint.async_client
         self.model_id = endpoint.repository
-        self.max_tokens = int(endpoint.raw["model"]["image"]["custom"]["env"]["MAX_TOTAL_TOKENS"])
+        self.max_tokens = int(
+            endpoint.raw["model"]["image"]["custom"]["env"]["MAX_TOTAL_TOKENS"]
+        )

--- a/llama_stack/providers/adapters/inference/tgi/tgi.py
+++ b/llama_stack/providers/adapters/inference/tgi/tgi.py
@@ -5,51 +5,29 @@
 # the root directory of this source tree.
 
 
-from typing import Any, AsyncGenerator, Dict
+import logging
+from typing import AsyncGenerator
 
-import requests
-
-from huggingface_hub import HfApi, InferenceClient
+from huggingface_hub import AsyncInferenceClient, HfApi
 from llama_models.llama3.api.chat_format import ChatFormat
 from llama_models.llama3.api.datatypes import StopReason
 from llama_models.llama3.api.tokenizer import Tokenizer
+
 from llama_stack.apis.inference import *  # noqa: F403
 from llama_stack.providers.utils.inference.prepare_messages import prepare_messages
 
-from .config import TGIImplConfig
+from .config import InferenceAPIImplConfig, InferenceEndpointImplConfig, TGIImplConfig
 
+logger = logging.getLogger(__name__)
 
-class TGIAdapter(Inference):
-    def __init__(self, config: TGIImplConfig) -> None:
-        self.config = config
+class _HfAdapter(Inference):
+    client: AsyncInferenceClient
+    max_tokens: int
+    model_id: str
+
+    def __init__(self) -> None:
         self.tokenizer = Tokenizer.get_instance()
         self.formatter = ChatFormat(self.tokenizer)
-
-    @property
-    def client(self) -> InferenceClient:
-        return InferenceClient(model=self.config.url, token=self.config.api_token)
-
-    def _get_endpoint_info(self) -> Dict[str, Any]:
-        return {
-            **self.client.get_endpoint_info(),
-            "inference_url": self.config.url,
-        }
-
-    async def initialize(self) -> None:
-        try:
-            info = self._get_endpoint_info()
-            if "model_id" not in info:
-                raise RuntimeError("Missing model_id in model info")
-            if "max_total_tokens" not in info:
-                raise RuntimeError("Missing max_total_tokens in model info")
-            self.max_tokens = info["max_total_tokens"]
-
-            self.inference_url = info["inference_url"]
-        except Exception as e:
-            import traceback
-
-            traceback.print_exc()
-            raise RuntimeError(f"Error initializing TGIAdapter: {e}") from e
 
     async def shutdown(self) -> None:
         pass
@@ -109,7 +87,7 @@ class TGIAdapter(Inference):
 
         options = self.get_chat_options(request)
         if not request.stream:
-            response = self.client.text_generation(
+            response = await self.client.text_generation(
                 prompt=prompt,
                 stream=False,
                 details=True,
@@ -145,7 +123,7 @@ class TGIAdapter(Inference):
             stop_reason = None
             tokens = []
 
-            for response in self.client.text_generation(
+            async for response in await self.client.text_generation(
                 prompt=prompt,
                 stream=True,
                 details=True,
@@ -236,47 +214,30 @@ class TGIAdapter(Inference):
                 )
             )
 
+class TGIAdapter(_HfAdapter):
+    async def initialize(self, config: TGIImplConfig) -> None:
+        self.client = AsyncInferenceClient(model=config.url, token=config.api_token)
+        endpoint_info = await self.client.get_endpoint_info()
+        self.max_tokens = endpoint_info["max_total_tokens"]
+        self.model_id = endpoint_info["model_id"]
 
-class InferenceEndpointAdapter(TGIAdapter):
-    def __init__(self, config: TGIImplConfig) -> None:
-        super().__init__(config)
-        self.config.url = self._construct_endpoint_url()
+class InferenceAPIAdapter(_HfAdapter):
+    async def initialize(self, config: InferenceAPIImplConfig) -> None:
+        self.client = AsyncInferenceClient(model=config.model_id, token=config.api_token)
+        endpoint_info = await self.client.get_endpoint_info()
+        self.max_tokens = endpoint_info["max_total_tokens"]
+        self.model_id = endpoint_info["model_id"]
 
-    def _construct_endpoint_url(self) -> str:
-        hf_endpoint_name = self.config.hf_endpoint_name
-        assert hf_endpoint_name.count("/") <= 1, (
-            "Endpoint name must be in the format of 'namespace/endpoint_name' "
-            "or 'endpoint_name'"
-        )
-        if "/" not in hf_endpoint_name:
-            hf_namespace: str = self.get_namespace()
-            endpoint_path = f"{hf_namespace}/{hf_endpoint_name}"
-        else:
-            endpoint_path = hf_endpoint_name
-        return f"https://api.endpoints.huggingface.cloud/v2/endpoint/{endpoint_path}"
+class InferenceEndpointAdapter(_HfAdapter):
+    async def initialize(self, config: InferenceEndpointImplConfig) -> None:
+        # Get the inference endpoint details
+        api = HfApi(token=config.api_token)
+        endpoint = api.get_inference_endpoint(config.endpoint_name)
 
-    def get_namespace(self) -> str:
-        return HfApi().whoami()["name"]
+        # Wait for the endpoint to be ready (if not already)
+        endpoint.wait(timeout=60)
 
-    @property
-    def client(self) -> InferenceClient:
-        return InferenceClient(model=self.inference_url, token=self.config.api_token)
-
-    def _get_endpoint_info(self) -> Dict[str, Any]:
-        headers = {
-            "accept": "application/json",
-            "authorization": f"Bearer {self.config.api_token}",
-        }
-        response = requests.get(self.config.url, headers=headers)
-        response.raise_for_status()
-        endpoint_info = response.json()
-        return {
-            "inference_url": endpoint_info["status"]["url"],
-            "model_id": endpoint_info["model"]["repository"],
-            "max_total_tokens": int(
-                endpoint_info["model"]["image"]["custom"]["env"]["MAX_TOTAL_TOKENS"]
-            ),
-        }
-
-    async def initialize(self) -> None:
-        await super().initialize()
+        # Initialize the adapter
+        self.client = endpoint.async_client
+        self.model_id = endpoint.repository
+        self.max_tokens = int(endpoint.raw["model"]["image"]["custom"]["env"]["MAX_TOTAL_TOKENS"])

--- a/llama_stack/providers/registry/inference.py
+++ b/llama_stack/providers/registry/inference.py
@@ -47,9 +47,27 @@ def available_providers() -> List[ProviderSpec]:
             api=Api.inference,
             adapter=AdapterSpec(
                 adapter_id="tgi",
-                pip_packages=["huggingface_hub"],
+                pip_packages=["huggingface_hub", "aiohttp"],
                 module="llama_stack.providers.adapters.inference.tgi",
                 config_class="llama_stack.providers.adapters.inference.tgi.TGIImplConfig",
+            ),
+        ),
+        remote_provider_spec(
+            api=Api.inference,
+            adapter=AdapterSpec(
+                adapter_id="hf::serverless",
+                pip_packages=["huggingface_hub", "aiohttp"],
+                module="llama_stack.providers.adapters.inference.tgi",
+                config_class="llama_stack.providers.adapters.inference.tgi.InferenceAPIImplConfig",
+            ),
+        ),
+        remote_provider_spec(
+            api=Api.inference,
+            adapter=AdapterSpec(
+                adapter_id="hf::endpoint",
+                pip_packages=["huggingface_hub", "aiohttp"],
+                module="llama_stack.providers.adapters.inference.tgi",
+                config_class="llama_stack.providers.adapters.inference.tgi.InferenceEndpointImplConfig",
             ),
         ),
         remote_provider_spec(


### PR DESCRIPTION
Hi there :wave: This is a follow-up PR after @hanouticelina's work in https://github.com/meta-llama/llama-stack/pull/53 and @hardikjshah's PR https://github.com/meta-llama/llama-stack/pull/84. At the moment the TGI Adapter is suitable for either a local TGI deployment or a server deployed on [Inference Endpoint](https://huggingface.co/docs/inference-endpoints/index).

This PR adds a new type of adapter that works with our serverless [Inference API](https://huggingface.co/docs/api-inference/index) as well. In practice, the adapter is the same, only the `await initiliaze(config)` logic changes to set the correct inference URL to call. 

I also took the opportunity to switch from a sync inference client to `AsyncInferenceClient` since llama-stack supports it (inputs/outputs are the same, it just that it uses `asyncio`/`aiohttp` under the hood).

Finally, I also officially added 3 remote providers: `remote::tgi`, `remote::hf::serverless` and `remote::hf::endpoint`. Each of them is linked to the correct config and then uses the same adapter logic. I added a distribution template for each provider.

Please let me know if I need to change anything :)

Cheers,

Wauplin, from :hugs: 


```
> llama stack build --list-templates

+---------------------+------------------------------------------+----------------------------------------------------------------------------------+
| Template Name       | Providers                                | Description                                                                      |
+---------------------+------------------------------------------+----------------------------------------------------------------------------------+
| local-hf-endpoint   | {                                        | Like local, but use Hugging Face Inference Endpoints for running LLM inference.  |
|                     |   "inference": "remote::hf::endpoint",   | See https://hf.co/docs/api-endpoints.                                            |
|                     |   "memory": "meta-reference",            |                                                                                  |
|                     |   "safety": "meta-reference",            |                                                                                  |
|                     |   "agents": "meta-reference",            |                                                                                  |
|                     |   "telemetry": "meta-reference"          |                                                                                  |
|                     | }                                        |                                                                                  |
+---------------------+------------------------------------------+----------------------------------------------------------------------------------+
| local-together      | {                                        | Use Together.ai for running LLM inference                                        |
|                     |   "inference": "remote::together",       |                                                                                  |
|                     |   "memory": "meta-reference",            |                                                                                  |
|                     |   "safety": "remote::together",          |                                                                                  |
|                     |   "agents": "meta-reference",            |                                                                                  |
|                     |   "telemetry": "meta-reference"          |                                                                                  |
|                     | }                                        |                                                                                  |
+---------------------+------------------------------------------+----------------------------------------------------------------------------------+
| local-fireworks     | {                                        | Use Fireworks.ai for running LLM inference                                       |
|                     |   "inference": "remote::fireworks",      |                                                                                  |
|                     |   "memory": "meta-reference",            |                                                                                  |
|                     |   "safety": "meta-reference",            |                                                                                  |
|                     |   "agents": "meta-reference",            |                                                                                  |
|                     |   "telemetry": "meta-reference"          |                                                                                  |
|                     | }                                        |                                                                                  |
+---------------------+------------------------------------------+----------------------------------------------------------------------------------+
| local-hf-serverless | {                                        | Like local, but use Hugging Face Inference API (serverless) for running LLM      |
|                     |   "inference": "remote::hf::serverless", | inference.                                                                       |
|                     |   "memory": "meta-reference",            | See https://hf.co/docs/api-inference.                                            |
|                     |   "safety": "meta-reference",            |                                                                                  |
|                     |   "agents": "meta-reference",            |                                                                                  |
|                     |   "telemetry": "meta-reference"          |                                                                                  |
|                     | }                                        |                                                                                  |
+---------------------+------------------------------------------+----------------------------------------------------------------------------------+
| local               | {                                        | Use code from `llama_stack` itself to serve all llama stack APIs                 |
|                     |   "inference": "meta-reference",         |                                                                                  |
|                     |   "memory": "meta-reference",            |                                                                                  |
|                     |   "safety": "meta-reference",            |                                                                                  |
|                     |   "agents": "meta-reference",            |                                                                                  |
|                     |   "telemetry": "meta-reference"          |                                                                                  |
|                     | }                                        |                                                                                  |
+---------------------+------------------------------------------+----------------------------------------------------------------------------------+
| local-ollama        | {                                        | Like local, but use ollama for running LLM inference                             |
|                     |   "inference": "remote::ollama",         |                                                                                  |
|                     |   "memory": "meta-reference",            |                                                                                  |
|                     |   "safety": "meta-reference",            |                                                                                  |
|                     |   "agents": "meta-reference",            |                                                                                  |
|                     |   "telemetry": "meta-reference"          |                                                                                  |
|                     | }                                        |                                                                                  |
+---------------------+------------------------------------------+----------------------------------------------------------------------------------+
| local-tgi           | {                                        | Like local, but use a TGI server for running LLM inference.                      |
|                     |   "inference": "remote::tgi",            |                                                                                  |
|                     |   "memory": "meta-reference",            |                                                                                  |
|                     |   "safety": "meta-reference",            |                                                                                  |
|                     |   "agents": "meta-reference",            |                                                                                  |
|                     |   "telemetry": "meta-reference"          |                                                                                  |
|                     | }                                        |                                                                                  |
+---------------------+------------------------------------------+----------------------------------------------------------------------------------+
```

