### PR TITLE
Fixes typo for setup instruction for starting Llama Stack Server section 

### DIFF
--- a/docs/getting_started.ipynb
+++ b/docs/getting_started.ipynb
@@ -50,7 +50,7 @@
     "```\n",
     "$ git clone https://github.com/meta-llama/llama-stack-apps.git\n",
     "\n",
-    "$ cd llama-stack\n",
+    "$ cd llama-stack-apps\n",
     "$ yes | conda create -n stack-test python=3.10 \n",
     "$ conda activate stack-test\n",
     "\n",


### PR DESCRIPTION
Fixes typo for setup instruction for starting Llama Stack Server section after cloning the git repo
Before:
> $ cd llama-stack

After
> $ cd llama-stack-apps

