### PR TITLE
Validate `name` in `llama stack build`

### DIFF
--- a/llama_stack/cli/stack/build.py
+++ b/llama_stack/cli/stack/build.py
@@ -199,7 +199,11 @@ class StackBuild(Subcommand):
         if not args.config and not args.template:
             if not args.name:
                 name = prompt(
-                    "> Enter a name for your Llama Stack (e.g. my-local-stack): "
+                    "> Enter a name for your Llama Stack (e.g. my-local-stack): ",
+                    validator=Validator.from_callable(
+                        lambda x: len(x) > 0,
+                        error_message="Name cannot be empty, please enter a name",
+                    ),
                 )
             else:
                 name = args.name


### PR DESCRIPTION
The first time I ran `llama stack build`, I quickly hit enter at the
first prompt asking for a name, assuming it would use the default
given in the help text. This caused a failure later on that wasn't
very obvious. I was using the `docker` format and a blank name caused
an invalid tag format that failed the image build.

This change adds validation for the `name` parameter to ensure it's
not empty before proceeding.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
