### PR TITLE
docs: Note how to use podman

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -267,6 +267,9 @@ llama stack build --config llama_stack/distribution/templates/local-ollama-build
 
 #### How to build distribution with Docker image
 
+> [!TIP]
+> Podman is supported as an alternative to Docker. Set `DOCKER_BINARY` to `podman` in your environment to use Podman.
+
 To build a docker image, you may start off from a template and use the `--image-type docker` flag to specify `docker` as the build image type.
 
 ```


### PR DESCRIPTION
Podman works as an alternative to Docker, but it wasn't immediately
obvious going through the quickstart how to enable it aside from
installing the docker alias. Add a note that points users to the
correct env var to use podman.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
