### PR TITLE
configure: Fix a error msg typo

### DIFF
--- a/llama_stack/cli/stack/configure.py
+++ b/llama_stack/cli/stack/configure.py
@@ -99,7 +99,7 @@ class StackConfigure(Subcommand):
         # we have regenerated the build config file with script, now check if it exists
         if return_code != 0:
             self.parser.error(
-                f"Failed to configure container {docker_image} with return code {return_code}. Please run `llama stack build first`. "
+                f"Failed to configure container {docker_image} with return code {return_code}. Please run `llama stack build` first. "
             )
             return
 


### PR DESCRIPTION
I got this error message and noticed the typo in the message. It
directed the user to run `llama stack build first`, which is not a
valid command.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
