### PR TITLE
Fix podman+selinux compatibility

### DIFF
--- a/llama_stack/distribution/build_container.sh
+++ b/llama_stack/distribution/build_container.sh
@@ -117,6 +117,9 @@ if [ -n "$LLAMA_MODELS_DIR" ]; then
   mounts="$mounts -v $(readlink -f $LLAMA_MODELS_DIR):$models_mount"
 fi
 
+# Disable SELinux labels -- we don't want to relabel the llama-stack source dir
+DOCKER_OPTS="$DOCKER_OPTS --security-opt label=disable"
+
 set -x
 $DOCKER_BINARY build $DOCKER_OPTS -t $image_name -f "$TEMP_DIR/Dockerfile" "$REPO_DIR" $mounts
 set +x

--- a/llama_stack/distribution/configure_container.sh
+++ b/llama_stack/distribution/configure_container.sh
@@ -27,6 +27,9 @@ docker_image="$1"
 host_build_dir="$2"
 container_build_dir="/app/builds"
 
+# Disable SELinux labels
+DOCKER_OPTS="$DOCKER_OPTS --security-opt label=disable"
+
 set -x
 $DOCKER_BINARY run $DOCKER_OPTS -it \
   -v $host_build_dir:$container_build_dir \

--- a/llama_stack/distribution/start_container.sh
+++ b/llama_stack/distribution/start_container.sh
@@ -39,6 +39,9 @@ shift
 
 set -x
 
+# Disable SELinux labels
+DOCKER_OPTS="$DOCKER_OPTS --security-opt label=disable"
+
 if [ -n "$LLAMA_CHECKPOINT_DIR" ]; then
   $DOCKER_BINARY run $DOCKER_OPTS -it \
     -p $port:$port \


### PR DESCRIPTION

commit c39ba235087291b3901cf2ddd68f5526e97ab67f
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Sep 27 14:05:18 2024 +0000

    Fix podman+selinux compatibility
    
    When I ran `llama stack configure` for my `docker` based stack on my
    system using podman + SELinux (CentOS Stream 9), The `podman run`
    command failed due to SELinux blocking access to the volume mount.
    
    As a simple fix, disable SELinux label checking.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
