### PR TITLE
inference: Fix download command in error msg

### DIFF
--- a/llama_stack/providers/impls/meta_reference/inference/generation.py
+++ b/llama_stack/providers/impls/meta_reference/inference/generation.py
@@ -53,7 +53,7 @@ def model_checkpoint_dir(model) -> str:
 
     assert checkpoint_dir.exists(), (
         f"Could not find checkpoint dir: {checkpoint_dir}."
-        f"Please download model using `llama download {model.descriptor()}`"
+        f"Please download model using `llama download --model-id {model.descriptor()}`"
     )
     return str(checkpoint_dir)
 


### PR DESCRIPTION
I got this error message and tried to the run the command presented
and it didn't work. The model needs to be give with `--model-id`
instead of as a positional argument.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
