### PR TITLE
Fix broken links in RFC-0001-llama-stack.md

### DIFF
--- a/rfcs/RFC-0001-llama-stack.md
+++ b/rfcs/RFC-0001-llama-stack.md
@@ -65,7 +65,7 @@ We define the Llama Stack as a layer cake shown below.
 
 
 
-The API is defined in the [YAML](../docs/llama-stack-spec.yaml) and [HTML](../docs/llama-stack-spec.html) files. These files were generated using the Pydantic definitions in (api/datatypes.py and api/endpoints.py) files that are in the llama-models, llama-stack, and llama-agentic-system repositories.
+The API is defined in the [YAML](../docs/resources/llama-stack-spec.yaml) and [HTML](../docs/resources/llama-stack-spec.html) files. These files were generated using the Pydantic definitions in (api/datatypes.py and api/endpoints.py) files that are in the llama-models, llama-stack, and llama-agentic-system repositories.
 
 
 
@@ -75,7 +75,7 @@ The API is defined in the [YAML](../docs/llama-stack-spec.yaml) and [HTML](../do
 
 To prove out the API, we implemented a handful of use cases to make things more concrete. The [llama-stack-apps](https://github.com/meta-llama/llama-stack-apps) repository contains [6 different examples](https://github.com/meta-llama/llama-stack-apps/tree/main/examples) ranging from very basic to a multi turn agent.
 
-There is also a sample inference endpoint implementation in the [llama-stack](https://github.com/meta-llama/llama-stack/blob/main/llama_stack/inference/server.py) repository.
+There is also a sample inference endpoint implementation in the [llama-stack](https://github.com/meta-llama/llama-stack/blob/main/llama_stack/distribution/server/server.py) repository.
 
 
 ## Limitations


### PR DESCRIPTION
## What does this PR do ?
This PR fixes the broken links for the following three items: 
- [llama-stack-spec.yaml](https://github.com/meta-llama/llama-stack/blob/main/docs/resources/llama-stack-spec.yaml)
- [llama-stack-spec.html](https://github.com/meta-llama/llama-stack/blob/main/docs/resources/llama-stack-spec.html)
- sample inference endpoint implementation -> [`server.py`](https://github.com/meta-llama/llama-stack/blob/main/llama_stack/distribution/server/server.py)