### PR TITLE
Add sambanova provider

### DIFF
--- a/llama_stack/distribution/templates/local-sambanova-build.yaml
+++ b/llama_stack/distribution/templates/local-sambanova-build.yaml
@@ -1,0 +1,10 @@
+name: local-sambanova
+distribution_spec:
+  description: Use SambaNova Cloud API for running LLM inference
+  providers:
+    inference: remote::sambanova
+    memory: meta-reference
+    safety: meta-reference
+    agents: meta-reference
+    telemetry: meta-reference
+image_type: conda

--- a/llama_stack/providers/adapters/inference/sambanova/__init__.py
+++ b/llama_stack/providers/adapters/inference/sambanova/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from .config import SambaNovaImplConfig
+from .sambanova import SambaNovaInferenceAdapter
+
+async def get_adapter_impl(config: SambaNovaImplConfig, _deps):
+    assert isinstance(
+        config, SambaNovaImplConfig
+    ), f"Unexpected config type: {type(config)}"
+    impl = SambaNovaInferenceAdapter(config)
+    await impl.initialize()
+    return impl

--- a/llama_stack/providers/adapters/inference/sambanova/config.py
+++ b/llama_stack/providers/adapters/inference/sambanova/config.py
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from llama_models.schema_utils import json_schema_type
+from pydantic import BaseModel, Field
+
+
+@json_schema_type
+class SambaNovaImplConfig(BaseModel):
+    url: str = Field(
+        default="https://api.sambanova.ai/v1",
+        description="The URL for the SambaNova Cloud AI server",
+    )
+    api_key: str = Field(
+        default="",
+        description="The SambaNova AI API Key",
+    )

--- a/llama_stack/providers/adapters/inference/sambanova/sambanova.py
+++ b/llama_stack/providers/adapters/inference/sambanova/sambanova.py
@@ -1,0 +1,254 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from typing import AsyncGenerator
+
+import openai
+from openai import OpenAI
+
+from llama_models.llama3.api.chat_format import ChatFormat
+
+from llama_models.llama3.api.datatypes import Message, StopReason
+from llama_models.llama3.api.tokenizer import Tokenizer
+from llama_models.sku_list import resolve_model
+
+from llama_stack.apis.inference import *  # noqa: F403
+from llama_stack.providers.utils.inference.augment_messages import (
+    augment_messages_for_tools,
+)
+
+from .config import SambaNovaImplConfig
+
+SAMBANOVA_SUPPORTED_MODELS = {
+    "Llama3.1-8B-Instruct": "Meta-Llama-3.1-8B-Instruct",
+    "Llama3.1-70B-Instruct": "Meta-Llama-3.1-70B-Instruct",
+    "Llama3.1-405B-Instruct": "Meta-Llama-3.1-405B-Instruct",
+}
+
+
+class SambaNovaInferenceAdapter(Inference):
+    def __init__(self, config: SambaNovaImplConfig) -> None:
+        self.config = config
+        tokenizer = Tokenizer.get_instance()
+        self.formatter = ChatFormat(tokenizer)
+
+    @property
+    def client(self) -> OpenAI:
+        return OpenAI(
+            base_url=self.config.url, 
+            api_key=self.config.api_key
+        )
+
+    async def initialize(self) -> None:
+        return
+
+    async def shutdown(self) -> None:
+        pass
+
+    async def completion(self, request: CompletionRequest) -> AsyncGenerator:
+        raise NotImplementedError()
+
+    def _messages_to_sambanova_messages(self, messages: list[Message]) -> list:
+        sambanova_messages = []
+        for message in messages:
+            if message.role == "ipython":
+                role = "tool"
+            else:
+                role = message.role
+            sambanova_messages.append({"role": role, "content": message.content})
+
+        return sambanova_messages
+
+    def resolve_sambanova_model(self, model_name: str) -> str:
+        model = resolve_model(model_name)
+        assert (
+            model is not None
+            and model.descriptor(shorten_default_variant=True)
+            in SAMBANOVA_SUPPORTED_MODELS
+        ), f"Unsupported model: {model_name}, use one of the supported models: {','.join(SAMBANOVA_SUPPORTED_MODELS.keys())}"
+
+        return SAMBANOVA_SUPPORTED_MODELS.get(
+            model.descriptor(shorten_default_variant=True)
+        )
+
+    def get_sambanova_chat_options(self, request: ChatCompletionRequest) -> dict:
+        options = {}
+        if request.sampling_params is not None:
+            for attr in {"temperature", "top_p", "top_k", "max_tokens"}:
+                if getattr(request.sampling_params, attr):
+                    options[attr] = getattr(request.sampling_params, attr)
+
+        return options
+
+    async def chat_completion(
+        self,
+        model: str,
+        messages: List[Message],
+        sampling_params: Optional[SamplingParams] = SamplingParams(),
+        tools: Optional[List[ToolDefinition]] = None,
+        tool_choice: Optional[ToolChoice] = ToolChoice.auto,
+        tool_prompt_format: Optional[ToolPromptFormat] = ToolPromptFormat.json,
+        stream: Optional[bool] = False,
+        logprobs: Optional[LogProbConfig] = None,
+    ) -> AsyncGenerator:
+        request = ChatCompletionRequest(
+            model=model,
+            messages=messages,
+            sampling_params=sampling_params,
+            tools=tools or [],
+            tool_choice=tool_choice,
+            tool_prompt_format=tool_prompt_format,
+            stream=stream,
+            logprobs=logprobs,
+        )
+
+        messages = augment_messages_for_tools(request)
+        options = self.get_sambanova_chat_options(request)
+        sambanova_model = self.resolve_sambanova_model(request.model)
+
+        if not request.stream:
+            
+            r = self.client.chat.completions.create(
+                model=sambanova_model,
+                messages=self._messages_to_sambanova_messages(messages),
+                stream=False,
+                **options,
+            )
+
+            stop_reason = None
+            if r.choices[0].finish_reason:
+                if r.choices[0].finish_reason == "stop":
+                    stop_reason = StopReason.end_of_turn
+                elif r.choices[0].finish_reason == "length":
+                    stop_reason = StopReason.out_of_tokens
+
+            completion_message = self.formatter.decode_assistant_message_from_content(
+                r.choices[0].message.content, stop_reason
+            )
+            yield ChatCompletionResponse(
+                completion_message=completion_message,
+                logprobs=None,
+            )
+        else:
+            yield ChatCompletionResponseStreamChunk(
+                event=ChatCompletionResponseEvent(
+                    event_type=ChatCompletionResponseEventType.start,
+                    delta="",
+                )
+            )
+
+            buffer = ""
+            ipython = False
+            stop_reason = None
+
+            for chunk in self.client.chat.completions.create(
+                model=sambanova_model,
+                messages=self._messages_to_sambanova_messages(messages),
+                stream=True,
+                **options,
+            ):
+                if chunk.choices[0].finish_reason:
+                    if (
+                        stop_reason is None
+                        and chunk.choices[0].finish_reason == "stop"
+                    ):
+                        stop_reason = StopReason.end_of_turn
+                    elif (
+                        stop_reason is None
+                        and chunk.choices[0].finish_reason == "length"
+                    ):
+                        stop_reason = StopReason.out_of_tokens
+                    break
+
+                text = chunk.choices[0].delta.content
+
+                if text is None:
+                    continue
+
+                # check if its a tool call ( aka starts with <|python_tag|> )
+                if not ipython and text.startswith("<|python_tag|>"):
+                    ipython = True
+                    yield ChatCompletionResponseStreamChunk(
+                        event=ChatCompletionResponseEvent(
+                            event_type=ChatCompletionResponseEventType.progress,
+                            delta=ToolCallDelta(
+                                content="",
+                                parse_status=ToolCallParseStatus.started,
+                            ),
+                        )
+                    )
+                    buffer += text
+                    continue
+
+                if ipython:
+                    if text == "<|eot_id|>":
+                        stop_reason = StopReason.end_of_turn
+                        text = ""
+                        continue
+                    elif text == "<|eom_id|>":
+                        stop_reason = StopReason.end_of_message
+                        text = ""
+                        continue
+
+                    buffer += text
+                    delta = ToolCallDelta(
+                        content=text,
+                        parse_status=ToolCallParseStatus.in_progress,
+                    )
+
+                    yield ChatCompletionResponseStreamChunk(
+                        event=ChatCompletionResponseEvent(
+                            event_type=ChatCompletionResponseEventType.progress,
+                            delta=delta,
+                            stop_reason=stop_reason,
+                        )
+                    )
+                else:
+                    buffer += text
+                    yield ChatCompletionResponseStreamChunk(
+                        event=ChatCompletionResponseEvent(
+                            event_type=ChatCompletionResponseEventType.progress,
+                            delta=text,
+                            stop_reason=stop_reason,
+                        )
+                    )
+
+            # parse tool calls and report errors
+            message = self.formatter.decode_assistant_message_from_content(
+                buffer, stop_reason
+            )
+            parsed_tool_calls = len(message.tool_calls) > 0
+            if ipython and not parsed_tool_calls:
+                yield ChatCompletionResponseStreamChunk(
+                    event=ChatCompletionResponseEvent(
+                        event_type=ChatCompletionResponseEventType.progress,
+                        delta=ToolCallDelta(
+                            content="",
+                            parse_status=ToolCallParseStatus.failure,
+                        ),
+                        stop_reason=stop_reason,
+                    )
+                )
+
+            for tool_call in message.tool_calls:
+                yield ChatCompletionResponseStreamChunk(
+                    event=ChatCompletionResponseEvent(
+                        event_type=ChatCompletionResponseEventType.progress,
+                        delta=ToolCallDelta(
+                            content=tool_call,
+                            parse_status=ToolCallParseStatus.success,
+                        ),
+                        stop_reason=stop_reason,
+                    )
+                )
+
+            yield ChatCompletionResponseStreamChunk(
+                event=ChatCompletionResponseEvent(
+                    event_type=ChatCompletionResponseEventType.complete,
+                    delta="",
+                    stop_reason=stop_reason,
+                )
+            )

--- a/llama_stack/providers/adapters/inference/sambanova/sambanova.py
+++ b/llama_stack/providers/adapters/inference/sambanova/sambanova.py
@@ -6,7 +6,6 @@
 
 from typing import AsyncGenerator
 
-import openai
 from openai import OpenAI
 
 from llama_models.llama3.api.chat_format import ChatFormat

--- a/llama_stack/providers/registry/inference.py
+++ b/llama_stack/providers/registry/inference.py
@@ -94,4 +94,15 @@ def available_providers() -> List[ProviderSpec]:
                 header_extractor_class="llama_stack.providers.adapters.inference.together.TogetherHeaderExtractor",
             ),
         ),
+        remote_provider_spec(
+            api=Api.inference,
+            adapter=AdapterSpec(
+                adapter_id="sambanova",
+                pip_packages=[
+                    "openai",
+                ],
+                module="llama_stack.providers.adapters.inference.sambanova",
+                config_class="llama_stack.providers.adapters.inference.sambanova.SambaNovaImplConfig",
+            ),
+        ),
     ]


### PR DESCRIPTION
### Why this PR
We want to setup SambaNova as a remote inference provider for llama-stack.

### What is in the PR
Integration with distribution
OpenAI as a client

### How I tested
1. Start the distribution
```
llama stack run remote_sambanova --port 12345
```
2. Invoke the call (non-streaming)
```
curl -X POST http://localhost:12345/inference/chat_completion -H "Content-Type: application/json" -d {"model":"Llama3.1-8B-Instruct","messages":[{"content":"hello world, write me a 2 sentence poem about the moon", "role": "user"}],"stream":false}'
```
and the response is 
```
data: {"completion_message":{"role":"assistant","content":"Here's a 2-sentence poem about the moon:\n\nThe moon glows softly in the midnight sky,\nA beacon of wonder, as it passes by.","stop_reason":"end_of_turn","tool_calls":[]},"logprobs":null}
```
3. Invoke the call (streaming)
```
curl -X POST http://localhost:12345/inference/chat_completion -H "Content-Type: application/json" -d '{"model":"Llama3.1-8B-Instruct","messages":[{"content":"hello world, write me a 2 sentence poem about the moon", "role": "user"}],"stream":true}'
```
and the response is
```
data: {"event":{"event_type":"start","delta":"","logprobs":null,"stop_reason":null}}

data: {"event":{"event_type":"progress","delta":"","logprobs":null,"stop_reason":null}}

data: {"event":{"event_type":"progress","delta":"","logprobs":null,"stop_reason":null}}

data: {"event":{"event_type":"progress","delta":"Here's a 2-sentence poem about the moon:\n\nThe moon glows softly in the ","logprobs":null,"stop_reason":null}}

data: {"event":{"event_type":"progress","delta":"midnight sky,\nA beacon of wonder, as it ","logprobs":null,"stop_reason":null}}

data: {"event":{"event_type":"progress","delta":"passes by.","logprobs":null,"stop_reason":null}}

data: {"event":{"event_type":"progress","delta":"","logprobs":null,"stop_reason":null}}

data: {"event":{"event_type":"complete","delta":"","logprobs":null,"stop_reason":"end_of_turn"}}
```