### PR TITLE
add env for LLAMA_STACK_CONFIG_DIR

### DIFF
--- a/llama_stack/distribution/utils/config_dirs.py
+++ b/llama_stack/distribution/utils/config_dirs.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 
 
-LLAMA_STACK_CONFIG_DIR = Path(os.path.expanduser("~/.llama/"))
+LLAMA_STACK_CONFIG_DIR = Path(os.getenv("LLAMA_STACK_CONFIG_DIR", os.path.expanduser("~/.llama/")))
 
 DISTRIBS_BASE_DIR = LLAMA_STACK_CONFIG_DIR / "distributions"
 


### PR DESCRIPTION
Support for https://github.com/meta-llama/llama-stack/issues/129 & https://github.com/meta-llama/llama-stack/issues/111 to specify download directory through env var. 

```
export LLAMA_STACK_CONFIG_DIR=/custom/path/to/.llama

llama download --source meta --model-id Llama3.2-1B
```