### PR TITLE
for agents API, provider data from the header is not parsed as for ag…

### DIFF
--- a/llama_stack/distribution/request_headers.py
+++ b/llama_stack/distribution/request_headers.py
@@ -18,6 +18,7 @@ def get_request_provider_data() -> Any:
 
 
 def set_request_provider_data(headers: Dict[str, str], validator_classes: List[str]):
+
     if not validator_classes:
         return
 

--- a/llama_stack/providers/adapters/inference/together/together.py
+++ b/llama_stack/providers/adapters/inference/together/together.py
@@ -3,7 +3,6 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
-
 from typing import AsyncGenerator
 
 from llama_models.llama3.api.chat_format import ChatFormat
@@ -61,6 +60,20 @@ class TogetherInferenceAdapter(Inference):
                 role = "tool"
             else:
                 role = message.role
+
+            if role == "user" and type(message.content) == list:
+                contents = []
+                for content in message.content:
+                    if type(content) == str:
+                        contents.append({"type": "text", "text": content})
+                    elif type(content) == ImageMedia:
+                        contents.append(
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": content.image.uri},
+                            }
+                        )
+                message.content = contents
             together_messages.append({"role": role, "content": message.content})
 
         return together_messages

--- a/llama_stack/providers/impls/meta_reference/agents/agent_instance.py
+++ b/llama_stack/providers/impls/meta_reference/agents/agent_instance.py
@@ -541,6 +541,7 @@ class ChatAgent(ShieldRunnerMixin):
                             )
                         )
                     )
+
                     yield AgentTurnResponseStreamChunk(
                         event=AgentTurnResponseEvent(
                             payload=AgentTurnResponseStepProgressPayload(

--- a/llama_stack/providers/registry/agents.py
+++ b/llama_stack/providers/registry/agents.py
@@ -29,6 +29,7 @@ def available_providers() -> List[ProviderSpec]:
                 Api.safety,
                 Api.memory,
             ],
+            provider_data_validator="llama_stack.providers.adapters.safety.together.TogetherProviderDataValidator",
         ),
         remote_provider_spec(
             api=Api.agents,


### PR DESCRIPTION
…ents there is no provider_data_validator meta-reference implementation. Added Together data validator as the provider_data_validator for now. Did some code changes accordingly.

Tested it by running local instance of the llama-stack and running multi-turn agent for vision models.