### PR TITLE
[CLI] remove dependency on CONDA_PREFIX in CLI

### DIFF
--- a/llama_stack/cli/stack/build.py
+++ b/llama_stack/cli/stack/build.py
@@ -100,10 +100,7 @@ class StackBuild(Subcommand):
                 llama_stack_path / "tmp/configs/"
             )
         else:
-            build_dir = (
-                Path(os.getenv("CONDA_PREFIX")).parent
-                / f"llamastack-{build_config.name}"
-            )
+            build_dir = DISTRIBS_BASE_DIR / f"llamastack-{build_config.name}"
 
         os.makedirs(build_dir, exist_ok=True)
         build_file_path = build_dir / f"{build_config.name}-build.yaml"
@@ -115,11 +112,6 @@ class StackBuild(Subcommand):
         return_code = build_image(build_config, build_file_path)
         if return_code != 0:
             return
-
-        cprint(
-            f"Build spec configuration saved at {str(build_file_path)}",
-            color="blue",
-        )
 
         configure_name = (
             build_config.name

--- a/llama_stack/cli/stack/configure.py
+++ b/llama_stack/cli/stack/configure.py
@@ -65,7 +65,7 @@ class StackConfigure(Subcommand):
             f"Could not find {build_config_file}. Trying conda build name instead...",
             color="green",
         )
-        if os.getenv("CONDA_PREFIX"):
+        if os.getenv("CONDA_PREFIX", ""):
             conda_dir = (
                 Path(os.getenv("CONDA_PREFIX")).parent / f"llamastack-{args.config}"
             )

--- a/llama_stack/cli/stack/configure.py
+++ b/llama_stack/cli/stack/configure.py
@@ -69,14 +69,23 @@ class StackConfigure(Subcommand):
             conda_dir = (
                 Path(os.getenv("CONDA_PREFIX")).parent / f"llamastack-{args.config}"
             )
-            build_config_file = Path(conda_dir) / f"{args.config}-build.yaml"
+        else:
+            cprint(
+                "Cannot find CONDA_PREFIX. Trying default conda path ~/.conda/envs...",
+                color="green",
+            )
+            conda_dir = (
+                Path(os.path.expanduser("~/.conda/envs")) / f"llamastack-{args.config}"
+            )
 
-            if build_config_file.exists():
-                with open(build_config_file, "r") as f:
-                    build_config = BuildConfig(**yaml.safe_load(f))
+        build_config_file = Path(conda_dir) / f"{args.config}-build.yaml"
 
-                self._configure_llama_distribution(build_config, args.output_dir)
-                return
+        if build_config_file.exists():
+            with open(build_config_file, "r") as f:
+                build_config = BuildConfig(**yaml.safe_load(f))
+
+            self._configure_llama_distribution(build_config, args.output_dir)
+            return
 
         # if we get here, we need to try to find the docker image
         cprint(

--- a/llama_stack/distribution/build.py
+++ b/llama_stack/distribution/build.py
@@ -92,6 +92,7 @@ def build_image(build_config: BuildConfig, build_file_path: Path):
         args = [
             script,
             build_config.name,
+            str(build_file_path),
             " ".join(deps),
         ]
 

--- a/llama_stack/distribution/build_conda_env.sh
+++ b/llama_stack/distribution/build_conda_env.sh
@@ -17,9 +17,9 @@ if [ -n "$LLAMA_MODELS_DIR" ]; then
   echo "Using llama-models-dir=$LLAMA_MODELS_DIR"
 fi
 
-if [ "$#" -lt 2 ]; then
-  echo "Usage: $0 <distribution_type> <build_name> <pip_dependencies> [<special_pip_deps>]" >&2
-  echo "Example: $0 <distribution_type> mybuild 'numpy pandas scipy'" >&2
+if [ "$#" -lt 3 ]; then
+  echo "Usage: $0 <distribution_type> <build_name> <build_file_path> <pip_dependencies> [<special_pip_deps>]" >&2
+  echo "Example: $0 <distribution_type> mybuild ./my-stack-run.yaml 'numpy pandas scipy'" >&2
   exit 1
 fi
 
@@ -29,7 +29,8 @@ set -euo pipefail
 
 build_name="$1"
 env_name="llamastack-$build_name"
-pip_dependencies="$2"
+build_file_path="$2"
+pip_dependencies="$3"
 
 # Define color codes
 RED='\033[0;31m'
@@ -123,6 +124,9 @@ ensure_conda_env_python310() {
       done
     fi
   fi
+
+  mv $build_file_path $CONDA_PREFIX/
+  echo "Build spec configuration saved at $CONDA_PREFIX/$build_name-build.yaml"
 }
 
 ensure_conda_env_python310 "$env_name" "$pip_dependencies" "$special_pip_deps"

--- a/llama_stack/distribution/build_conda_env.sh
+++ b/llama_stack/distribution/build_conda_env.sh
@@ -19,7 +19,7 @@ fi
 
 if [ "$#" -lt 3 ]; then
   echo "Usage: $0 <distribution_type> <build_name> <build_file_path> <pip_dependencies> [<special_pip_deps>]" >&2
-  echo "Example: $0 <distribution_type> mybuild ./my-stack-run.yaml 'numpy pandas scipy'" >&2
+  echo "Example: $0 <distribution_type> mybuild ./my-stack-build.yaml 'numpy pandas scipy'" >&2
   exit 1
 fi
 


### PR DESCRIPTION
1. `build` --> get $CONDA_PREFIX in `build_conda_env.sh` instead of looking for $CONDA_PREFIX at CLI runtime. 
2. `configure` --> add option for looking at $CONDA_PREFIX while searching for build files

# Test
```
llama stack build
> Enter a name for your Llama Stack (e.g. my-local-stack): c-7
> Enter the image type you want your Llama Stack to be built as (docker or conda): conda

llama stack configure <name>
llama stack run <name>
```
