### PR TITLE
Fix TypeError when CONDA_PREFIX is not set

### DIFF
--- a/llama_stack/cli/stack/build.py
+++ b/llama_stack/cli/stack/build.py
@@ -101,7 +101,7 @@ class StackBuild(Subcommand):
             )
         else:
             build_dir = (
-                Path(os.getenv("CONDA_PREFIX")).parent
+                Path(os.getenv("CONDA_PREFIX", "")).parent
                 / f"llamastack-{build_config.name}"
             )
 

--- a/llama_stack/cli/stack/configure.py
+++ b/llama_stack/cli/stack/configure.py
@@ -67,7 +67,7 @@ class StackConfigure(Subcommand):
         )
         if os.getenv("CONDA_PREFIX"):
             conda_dir = (
-                Path(os.getenv("CONDA_PREFIX")).parent / f"llamastack-{args.config}"
+                Path(os.getenv("CONDA_PREFIX", "")).parent / f"llamastack-{args.config}"
             )
             build_config_file = Path(conda_dir) / f"{args.config}-build.yaml"
 


### PR DESCRIPTION
I ran a build with the mode set to `conda` by accident and did not
have the `CONDA_PREFIX` env var set. In that case, `os.getenv` returns
`None`, and passing `None` to create an `os.Path` is not valid. It
will raise a `TypeError`.

> TypeError: expected str, bytes or os.PathLike object, not NoneType

Signed-off-by: Russell Bryant <rbryant@redhat.com>
