### PR TITLE
Extract provider data properly (attempt 2)

### DIFF
--- a/llama_stack/providers/adapters/inference/together/together.py
+++ b/llama_stack/providers/adapters/inference/together/together.py
@@ -15,7 +15,7 @@ from llama_models.sku_list import resolve_model
 from together import Together
 
 from llama_stack.apis.inference import *  # noqa: F403
-from llama_stack.distribution.request_headers import get_request_provider_data
+from llama_stack.distribution.request_headers import NeedsRequestProviderData
 from llama_stack.providers.utils.inference.augment_messages import (
     augment_messages_for_tools,
 )
@@ -32,7 +32,7 @@ TOGETHER_SUPPORTED_MODELS = {
 }
 
 
-class TogetherInferenceAdapter(Inference):
+class TogetherInferenceAdapter(Inference, NeedsRequestProviderData):
     def __init__(self, config: TogetherImplConfig) -> None:
         self.config = config
         tokenizer = Tokenizer.get_instance()
@@ -103,7 +103,7 @@ class TogetherInferenceAdapter(Inference):
     ) -> AsyncGenerator:
 
         together_api_key = None
-        provider_data = get_request_provider_data()
+        provider_data = self.get_request_provider_data()
         if provider_data is None or not provider_data.together_api_key:
             raise ValueError(
                 'Pass Together API Key in the header X-LlamaStack-ProviderData as { "together_api_key": <your api key>}'

--- a/llama_stack/providers/adapters/safety/together/together.py
+++ b/llama_stack/providers/adapters/safety/together/together.py
@@ -13,7 +13,7 @@ from llama_stack.apis.safety import (
     SafetyViolation,
     ViolationLevel,
 )
-from llama_stack.distribution.request_headers import get_request_provider_data
+from llama_stack.distribution.request_headers import NeedsRequestProviderData
 
 from .config import TogetherSafetyConfig
 
@@ -40,7 +40,7 @@ def shield_type_to_model_name(shield_type: str) -> str:
     return SAFETY_SHIELD_TYPES.get(model.descriptor(shorten_default_variant=True))
 
 
-class TogetherSafetyImpl(Safety):
+class TogetherSafetyImpl(Safety, NeedsRequestProviderData):
     def __init__(self, config: TogetherSafetyConfig) -> None:
         self.config = config
 
@@ -52,7 +52,7 @@ class TogetherSafetyImpl(Safety):
     ) -> RunShieldResponse:
 
         together_api_key = None
-        provider_data = get_request_provider_data()
+        provider_data = self.get_request_provider_data()
         if provider_data is None or not provider_data.together_api_key:
             raise ValueError(
                 'Pass Together API Key in the header X-LlamaStack-ProviderData as { "together_api_key": <your api key>}'


### PR DESCRIPTION
In the previous design, the server endpoint at the top-most level extracted the headers from the request and set provider data (e.g., private keys) that the implementations could retrieve using `get_request_provider_data()`. 

However, as Yogish has shown in #138, this is not sufficient. Consider the `/agents` API -- Together uses the standard "meta-reference" implementation for it but the inference provider is set to be Together. When an incoming request arrives, no "provider data validator" is registered for Agents because Agents isn't using the Together provider at all. However, when the agent calls inference as its dependency, the inference implementation _does_ need the Together API key. 

The solution is straightforward:
- the server at the top-level does not have the correct context to validate the headers. what it should only do is extract them, json-decode them and stash the resulting dict into a thread-local.
- the provider implementation when it needs the data, queries it using an **instance** method on the implementation. The instance method works via a utility mixin (`NeedsRequestProviderData`).
- this mixin is able to query the underlying provider spec, get to it the required validator class and parse the correct keys from there.

This design is more general and also allows for multiple providers needing multiple private keys to co-exist peacefully with each other.