### PR TITLE
Add timeout to requests calls

### DIFF
--- a/llama_stack/providers/impls/meta_reference/agents/tools/builtin.py
+++ b/llama_stack/providers/impls/meta_reference/agents/tools/builtin.py
@@ -117,7 +117,7 @@ class BingSearch:
             "q": query,
         }
 
-        response = requests.get(url=url, params=params, headers=headers)
+        response = requests.get(url=url, params=params, headers=headers, timeout=60)
         response.raise_for_status()
         clean = self._clean_response(response.json())
         return json.dumps(clean)
@@ -156,7 +156,7 @@ class BraveSearch:
             "Accept": "application/json",
         }
         payload = {"q": query}
-        response = requests.get(url=url, params=payload, headers=headers)
+        response = requests.get(url=url, params=payload, headers=headers, timeout=60)
         return json.dumps(self._clean_brave_response(response.json()))
 
     def _clean_brave_response(self, search_response, top_k=3):
@@ -275,7 +275,7 @@ class WolframAlphaTool(SingleMessageBuiltinTool):
         response = requests.get(
             self.url,
             params=params,
-        )
+        timeout=60)
 
         return json.dumps(self._clean_wolfram_alpha_response(response.json()))
 


### PR DESCRIPTION
Many developers will be surprised to learn that `requests` library calls do not include timeouts by default. This means that an attempted request could hang indefinitely if no connection is established or if no data is received from the server. 

The [requests documentation](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts) suggests that most calls should explicitly include a `timeout` parameter. This codemod adds a default timeout value in order to set an upper bound on connection times and ensure that requests connect or fail in a timely manner. This value also ensures the connection will timeout if the server does not respond with data within a reasonable amount of time. 

While timeout values will be application dependent, we believe that this codemod adds a reasonable default that serves as an appropriate ceiling for most situations. 

Our changes look like the following:
```diff
 import requests
 
- requests.get("http://example.com")
+ requests.get("http://example.com", timeout=60)
```

<details>
  <summary>More reading</summary>

  * [https://docs.python-requests.org/en/master/user/quickstart/#timeouts](https://docs.python-requests.org/en/master/user/quickstart/#timeouts)
</details>

I have additional improvements ready for this repo! If you want to see them, install our plugin (Github Marketplace [download](https://github.com/apps/pixeebot)) & leave the comment:
```
@pixeebot next
```
... and I will open a new PR right away!


🧚🤖  Powered by Pixeebot  

[Feedback](https://ask.pixee.ai/feedback) | [Community](https://pixee-community.slack.com/signup#/domain-signup) | [Docs](https://docs.pixee.ai/) | Codemod ID: pixee:python/add-requests-timeouts ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2Fllama-stack%7Cd66d4297795e61a219bb01415fc1d77071ebb198)


<!--{"type":"DRIP","codemod":"pixee:python/add-requests-timeouts"}-->