### PR TITLE
fix broken bedrock inference provider

### DIFF
--- a/llama_stack/providers/registry/inference.py
+++ b/llama_stack/providers/registry/inference.py
@@ -94,4 +94,15 @@ def available_providers() -> List[ProviderSpec]:
                 provider_data_validator="llama_stack.providers.adapters.safety.together.TogetherProviderDataValidator",
             ),
         ),
+        remote_provider_spec(
+            api=Api.inference,
+            adapter=AdapterSpec(
+                adapter_id="bedrock",
+                pip_packages=[
+                    "boto3"
+                ],
+                module="llama_stack.providers.adapters.inference.bedrock",
+                config_class="llama_stack.providers.adapters.inference.bedrock.BedrockConfig",
+            ),
+        ),
     ]


### PR DESCRIPTION
Support for Bedrock inference providers has been applied with the following merges:

https://github.com/meta-llama/llama-stack/commit/95abbf576b4b078e72b779f534cbaf696e30ecab

However, it was overwritten in the next merge.

https://github.com/meta-llama/llama-stack/commit/56aed59eb4c9915676c6fc7aac009dad97e7ead2

As a result, Bedrock is not displayed as an inference provider.

```
llama stack list-providers inference
```

```
+------------------------+----------------------------------------------------------------------------------+
| Provider Type          | PIP Package Dependencies                                                         |
+------------------------+----------------------------------------------------------------------------------+
| remote                 |                                                                                  |
+------------------------+----------------------------------------------------------------------------------+
| meta-reference         | accelerate,blobfile,fairscale,fbgemm-                                            |
|                        | gpu==0.8.0,torch,torchvision,transformers,zmq                                    |
+------------------------+----------------------------------------------------------------------------------+
| remote::sample         |                                                                                  |
+------------------------+----------------------------------------------------------------------------------+
| remote::ollama         | ollama                                                                           |
+------------------------+----------------------------------------------------------------------------------+
| remote::tgi            | huggingface_hub,aiohttp                                                          |
+------------------------+----------------------------------------------------------------------------------+
| remote::hf::serverless | huggingface_hub,aiohttp                                                          |
+------------------------+----------------------------------------------------------------------------------+
| remote::hf::endpoint   | huggingface_hub,aiohttp                                                          |
+------------------------+----------------------------------------------------------------------------------+
| remote::fireworks      | fireworks-ai                                                                     |
+------------------------+----------------------------------------------------------------------------------+
| remote::together       | together                                                                         |
+------------------------+----------------------------------------------------------------------------------+
```

I fix it.

```
+------------------------+----------------------------------------------------------------------------------+
| remote::bedrock        | boto3                                                                            |
+------------------------+----------------------------------------------------------------------------------+
```
