### PR TITLE
docker: Install in editable mode for dev purposes

### DIFF
--- a/llama_stack/distribution/build_container.sh
+++ b/llama_stack/distribution/build_container.sh
@@ -65,7 +65,11 @@ if [ -n "$LLAMA_STACK_DIR" ]; then
     echo "${RED}Warning: LLAMA_STACK_DIR is set but directory does not exist: $LLAMA_STACK_DIR${NC}" >&2
     exit 1
   fi
-  add_to_docker "RUN pip install $stack_mount"
+
+  # Install in editable format. We will mount the source code into the container
+  # so that changes will be reflected in the container without having to do a
+  # rebuild. This is just for development convenience.
+  add_to_docker "RUN pip install -e $stack_mount"
 else
   add_to_docker "RUN pip install llama-stack"
 fi

--- a/llama_stack/distribution/configure_container.sh
+++ b/llama_stack/distribution/configure_container.sh
@@ -8,6 +8,7 @@
 
 DOCKER_BINARY=${DOCKER_BINARY:-docker}
 DOCKER_OPTS=${DOCKER_OPTS:-}
+LLAMA_STACK_DIR=${LLAMA_STACK_DIR:-}
 
 set -euo pipefail
 
@@ -30,8 +31,14 @@ container_build_dir="/app/builds"
 # Disable SELinux labels
 DOCKER_OPTS="$DOCKER_OPTS --security-opt label=disable"
 
+mounts=""
+if [ -n "$LLAMA_STACK_DIR" ]; then
+  mounts="$mounts -v $(readlink -f $LLAMA_STACK_DIR):/app/llama-stack-source"
+fi
+
 set -x
 $DOCKER_BINARY run $DOCKER_OPTS -it \
   -v $host_build_dir:$container_build_dir \
+  $mounts \
   $docker_image \
   llama stack configure ./llamastack-build.yaml --output-dir $container_build_dir


### PR DESCRIPTION

da33fa0 docker: Install in editable mode for dev purposes

commit da33fa0f80967490bd14e9fbf5cd917c873cac0d
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Sep 30 16:30:04 2024 +0000

    docker: Install in editable mode for dev purposes
    
    While rebuilding a stack using the `docker` image type and having
    `LLAMA_STACK_DIR` set so it installs `llama_stack` from my local
    source, I noticed that once built, it just used the image build cache
    and didn't pull in changes to my source.
    
    1. Install in editable mode (`pip install -e`) for dev purposes.
    
    2. Mount the source into the container for `configure` and `run` so
       that the editable install works.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
