### PR TITLE
docker: Check for selinux before using `--security-opt`

### DIFF
--- a/llama_stack/distribution/build_container.sh
+++ b/llama_stack/distribution/build_container.sh
@@ -125,8 +125,10 @@ if [ -n "$LLAMA_MODELS_DIR" ]; then
   mounts="$mounts -v $(readlink -f $LLAMA_MODELS_DIR):$models_mount"
 fi
 
-# Disable SELinux labels -- we don't want to relabel the llama-stack source dir
-DOCKER_OPTS="$DOCKER_OPTS --security-opt label=disable"
+if command -v selinuxenabled &> /dev/null && selinuxenabled; then
+  # Disable SELinux labels -- we don't want to relabel the llama-stack source dir
+  DOCKER_OPTS="$DOCKER_OPTS --security-opt label=disable"
+fi
 
 set -x
 $DOCKER_BINARY build $DOCKER_OPTS -t $image_name -f "$TEMP_DIR/Dockerfile" "$REPO_DIR" $mounts

--- a/llama_stack/distribution/configure_container.sh
+++ b/llama_stack/distribution/configure_container.sh
@@ -28,8 +28,10 @@ docker_image="$1"
 host_build_dir="$2"
 container_build_dir="/app/builds"
 
-# Disable SELinux labels
-DOCKER_OPTS="$DOCKER_OPTS --security-opt label=disable"
+if command -v selinuxenabled &> /dev/null && selinuxenabled; then
+  # Disable SELinux labels
+  DOCKER_OPTS="$DOCKER_OPTS --security-opt label=disable"
+fi
 
 mounts=""
 if [ -n "$LLAMA_STACK_DIR" ]; then

--- a/llama_stack/distribution/start_container.sh
+++ b/llama_stack/distribution/start_container.sh
@@ -40,8 +40,10 @@ shift
 
 set -x
 
-# Disable SELinux labels
-DOCKER_OPTS="$DOCKER_OPTS --security-opt label=disable"
+if command -v selinuxenabled &> /dev/null && selinuxenabled; then
+  # Disable SELinux labels
+  DOCKER_OPTS="$DOCKER_OPTS --security-opt label=disable"
+fi
 
 mounts=""
 if [ -n "$LLAMA_STACK_DIR" ]; then


### PR DESCRIPTION
Before using `--security-opt label=disable`, check that SELinux is
enabled. Otherwise, the option is not relevant.

This fixes errors on Mac.

Closes #166

Signed-off-by: Russell Bryant <rbryant@redhat.com>
