### PR TITLE
ci: Run pre-commit checks in CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -21,11 +21,11 @@ ignore =
 optional-ascii-coding = True
 exclude =
     ./.git,
-    ./docs
-    ./build
+    ./docs,
+    ./build,
     ./scripts,
     ./venv,
-    *.pyi
-    .pre-commit-config.yaml
-    *.md
+    *.pyi,
+    .pre-commit-config.yaml,
+    *.md,
     .flake8

--- a/.flake8
+++ b/.flake8
@@ -21,7 +21,7 @@ ignore =
 optional-ascii-coding = True
 exclude =
     ./.git,
-    ./docs,
+    ./docs/*,
     ./build,
     ./scripts,
     ./venv,

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,6 +1,6 @@
 name: Pre-commit
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   pre-commit:
@@ -24,5 +24,22 @@ jobs:
           python -m pip install --upgrade pip
           pip install pre-commit
 
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
+
+      - name: Fetch head commit from PR
+        run: git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-${{ github.event.pull_request.number }}
+
+      - name: Get changed files
+        id: changed-files
+        run: |
+          git diff --name-only origin/${{ github.event.pull_request.base.ref }} pr-${{ github.event.pull_request.number }} > changed_files.txt
+          cat changed_files.txt
+
       - name: Run pre-commit
-        run: pre-commit run --all-files
+        run: |
+          if [ -s changed_files.txt ]; then
+            pre-commit run --files $(cat changed_files.txt | tr '\n' ' ')
+          else
+            echo "No changed files to run pre-commit on."
+          fi

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,28 @@
+name: Pre-commit
+
+on: [push, pull_request]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
+      - name: Set up Python
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: |
+            **/requirements*.txt
+            .pre-commit-config.yaml
+
+      - name: Install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+
+      - name: Run pre-commit
+        run: pre-commit run --all-files


### PR DESCRIPTION
Closes #172 

e6c3a4b ci: Run pre-commit checks in CI
adeee1e flake8: Fix config formatting error

commit e6c3a4b162ab1690cc0a196fbb45acc39313b280
Author: Russell Bryant <rbryant@redhat.com>
Date:   Thu Oct 3 13:52:24 2024 +0000

    ci: Run pre-commit checks in CI
    
    Run the pre-commit checks in a github workflow to validate that a PR
    or a direct push to the repo does not introduce new errors.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit adeee1eb5022fc59257180964b48130931ddfe20
Author: Russell Bryant <rbryant@redhat.com>
Date:   Thu Oct 3 14:00:20 2024 +0000

    flake8: Fix config formatting error
    
    The list of paths under `exclude` had a formatting error. Entries must
    be separated by commas.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
