### PR TITLE
Check that the model is found before use.

### DIFF
--- a/llama_stack/cli/download.py
+++ b/llama_stack/cli/download.py
@@ -158,11 +158,10 @@ def run_download_cmd(args: argparse.Namespace, parser: argparse.ArgumentParser):
         info = prompt_guard_download_info()
     else:
         model = resolve_model(args.model_id)
+        if model is None:
+            parser.error(f"Model {args.model_id} not found")
+            return
         info = llama_meta_net_info(model)
-
-    if model is None:
-        parser.error(f"Model {args.model_id} not found")
-        return
 
     if args.source == "huggingface":
         _hf_download(model, args.hf_token, args.ignore_patterns, parser)


### PR DESCRIPTION
A misspelled model name on download emits a verbose exception stack without a clear error message. The fix is to move the the intended model `None` check up before first use of model.

Example failing command: `llama download --source huggingface --model-id unknown`

Testing...

Note, below uses 'Llama-3.1-8B' as the invalid model name, and 'Llama3.1-8B' (no dash after 'Llama') as the correct model name.

#### Select `main` branch without fix:
```
$ git branch
  download-check-model-found-before-use
* main
```

#### Download using valid model name:  no issues.
```
$ llama download --source huggingface --model-id Llama3.1-8B
Fetching 13 files: 100%|███...███| 13/13 [00:00<00:00, 16860.22it/s]
Successfully downloaded model to /home/dev/.llama/checkpoints/Llama3.1-8B
```

#### Download using invalid model name: fail with _unclear_ verbose exception.
```
$ llama download --source huggingface --model-id Llama-3.1-8B
Traceback (most recent call last):
  File "/home/dev/py3.11.10-venv/bin/llama", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/dev/src/llama-stack-fork/llama_stack/cli/llama.py", line 44, in main
    parser.run(args)
  File "/home/dev/src/llama-stack-fork/llama_stack/cli/llama.py", line 38, in run
    args.func(args)
  File "/home/dev/src/llama-stack-fork/llama_stack/cli/download.py", line 161, in run_download_cmd
    info = llama_meta_net_info(model)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dev/py3.11.10-venv/lib/python3.11/site-packages/llama_models/sku_list.py", line 831, in llama_meta_net_info
    pth_count = model.pth_file_count
                ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'pth_file_count'
```

#### Checkout branch with fix:
```
$ git checkout download-check-model-found-before-use
Switched to branch 'download-check-model-found-before-use'
```

#### Download using invalid model name: fail with user-friendly message.
```
$ llama download --source huggingface --model-id Llama-3.1-8B
usage: llama download [-h] [--source {meta,huggingface}] [--model-id MODEL_ID] [--hf-token HF_TOKEN] [--meta-url META_URL]
                      [--ignore-patterns IGNORE_PATTERNS] [--manifest-file MANIFEST_FILE]
llama download: error: Model Llama-3.1-8B not found
```

#### Check other working cases...

#### Download using valid model name: no issues.
```
$ llama download --source huggingface --model-id Llama3.1-8B
Fetching 13 files: 100%|███...███| 13/13 [00:00<00:00, 44366.11it/s]
Successfully downloaded model to /home/dev/.llama/checkpoints/Llama3.1-8B
```

#### Validate prompt guard code path: no issues.
```
$ llama download --source huggingface --model-id Prompt-Guard-86M
Fetching 10 files: 100%|███...███| 10/10 [00:00<00:00, 20078.05it/s]
Successfully downloaded model to /home/dev/.llama/checkpoints/Prompt-Guard-86M
```

In addition to the above, a debugger was used to visually step through each code path: valid model name, invalid model name, and the prompt guard model name.