### PR TITLE
Fix ValueError in case chunks are empty

### DIFF
--- a/llama_stack/providers/impls/meta_reference/agents/agent_instance.py
+++ b/llama_stack/providers/impls/meta_reference/agents/agent_instance.py
@@ -673,7 +673,7 @@ class ChatAgent(ShieldRunnerMixin):
 
     async def _retrieve_context(
         self, session_id: str, messages: List[Message], attachments: List[Attachment]
-    ) -> Tuple[List[str], List[int]]:  # (rag_context, bank_ids)
+    ) -> Tuple[Optional[List[str]], Optional[List[int]]]:  # (rag_context, bank_ids)
         bank_ids = []
 
         memory = self._memory_tool_definition()
@@ -722,12 +722,13 @@ class ChatAgent(ShieldRunnerMixin):
         chunks = [c for r in results for c in r.chunks]
         scores = [s for r in results for s in r.scores]
 
+        if not chunks:
+            return None, bank_ids
+
         # sort by score
         chunks, scores = zip(
             *sorted(zip(chunks, scores), key=lambda x: x[1], reverse=True)
         )
-        if not chunks:
-            return None, bank_ids
 
         tokens = 0
         picked = []


### PR DESCRIPTION
If I have an empty memory bank I get following ValueError:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/llama_stack/distribution/server/server.py", line 215, in sse_generator
    async for item in event_gen:
  File "/usr/local/lib/python3.10/site-packages/llama_stack/providers/impls/meta_reference/agents/agents.py", line 127, in create_agent_turn
    async for event in agent.create_and_execute_turn(request):
  File "/usr/local/lib/python3.10/site-packages/llama_stack/providers/impls/meta_reference/agents/agent_instance.py", line 174, in create_and_execute_turn
    async for chunk in self.run(
  File "/usr/local/lib/python3.10/site-packages/llama_stack/providers/impls/meta_reference/agents/agent_instance.py", line 247, in run
    async for res in self._run(
  File "/usr/local/lib/python3.10/site-packages/llama_stack/providers/impls/meta_reference/agents/agent_instance.py", line 356, in _run
    rag_context, bank_ids = await self._retrieve_context(
  File "/usr/local/lib/python3.10/site-packages/llama_stack/providers/impls/meta_reference/agents/agent_instance.py", line 726, in _retrieve_context
    chunks, scores = zip(
ValueError: not enough values to unpack (expected 2, got 0)
```