### PR TITLE
Add function for stopping inference

### DIFF
--- a/llama_stack/providers/impls/ios/inference/LocalInferenceImpl/LocalInference.swift
+++ b/llama_stack/providers/impls/ios/inference/LocalInferenceImpl/LocalInference.swift
@@ -34,6 +34,10 @@ public class LocalInference: Inference {
     }
   }
 
+  public func stop() {
+    runnerHolder.runner?.stop()
+  }
+
   public func chatCompletion(request: Components.Schemas.ChatCompletionRequest) -> AsyncStream<Components.Schemas.ChatCompletionResponseStreamChunk> {
     return AsyncStream { continuation in
       runnerQueue.async {


### PR DESCRIPTION
Making llama runner's `stop()` function accessible to the world