### PR TITLE
Add --disable-ipv6 when starting container to avoid `httpx.ReadError`

### DIFF
--- a/llama_stack/distribution/start_container.sh
+++ b/llama_stack/distribution/start_container.sh
@@ -61,4 +61,5 @@ $DOCKER_BINARY run $DOCKER_OPTS -it \
   $docker_image \
   python -m llama_stack.distribution.server.server \
   --yaml_config /app/config.yaml \
+  --disable-ipv6 \
   --port $port "$@"


### PR DESCRIPTION
This fixes the following issue:
```
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.10/3.10.15/Frameworks/Python.framework/Versions/3.10/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/homebrew/Cellar/python@3.10/3.10.15/Frameworks/Python.framework/Versions/3.10/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/Users/yutang/repos/llama-stack/llama_stack/apis/inference/client.py", line 163, in <module>
    fire.Fire(main)
  File "/Users/yutang/repos/llama-stack/venv/lib/python3.10/site-packages/fire/core.py", line 135, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
  File "/Users/yutang/repos/llama-stack/venv/lib/python3.10/site-packages/fire/core.py", line 468, in _Fire
    component, remaining_args = _CallAndUpdateTrace(
  File "/Users/yutang/repos/llama-stack/venv/lib/python3.10/site-packages/fire/core.py", line 684, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
  File "/Users/yutang/repos/llama-stack/llama_stack/apis/inference/client.py", line 159, in main
    asyncio.run(run_main(host, port, stream, model))
  File "/opt/homebrew/Cellar/python@3.10/3.10.15/Frameworks/Python.framework/Versions/3.10/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/opt/homebrew/Cellar/python@3.10/3.10.15/Frameworks/Python.framework/Versions/3.10/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/Users/yutang/repos/llama-stack/llama_stack/apis/inference/client.py", line 120, in run_main
    async for log in EventLogger().log(iterator):
  File "/Users/yutang/repos/llama-stack/llama_stack/apis/inference/event_logger.py", line 32, in log
    async for chunk in event_generator:
  File "/Users/yutang/repos/llama-stack/llama_stack/apis/inference/client.py", line 71, in chat_completion
    async with client.stream(
  File "/opt/homebrew/Cellar/python@3.10/3.10.15/Frameworks/Python.framework/Versions/3.10/lib/python3.10/contextlib.py", line 199, in __aenter__
    return await anext(self.gen)
  File "/Users/yutang/repos/llama-stack/venv/lib/python3.10/site-packages/httpx/_client.py", line 1628, in stream
    response = await self.send(
  File "/Users/yutang/repos/llama-stack/venv/lib/python3.10/site-packages/httpx/_client.py", line 1674, in send
    response = await self._send_handling_auth(
  File "/Users/yutang/repos/llama-stack/venv/lib/python3.10/site-packages/httpx/_client.py", line 1702, in _send_handling_auth
    response = await self._send_handling_redirects(
  File "/Users/yutang/repos/llama-stack/venv/lib/python3.10/site-packages/httpx/_client.py", line 1739, in _send_handling_redirects
    response = await self._send_single_request(request)
  File "/Users/yutang/repos/llama-stack/venv/lib/python3.10/site-packages/httpx/_client.py", line 1776, in _send_single_request
    response = await transport.handle_async_request(request)
  File "/Users/yutang/repos/llama-stack/venv/lib/python3.10/site-packages/httpx/_transports/default.py", line 376, in handle_async_request
    with map_httpcore_exceptions():
  File "/opt/homebrew/Cellar/python@3.10/3.10.15/Frameworks/Python.framework/Versions/3.10/lib/python3.10/contextlib.py", line 153, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/Users/yutang/repos/llama-stack/venv/lib/python3.10/site-packages/httpx/_transports/default.py", line 89, in map_httpcore_exceptions
    raise mapped_exc(message) from exc
httpx.ReadError

```