### PR TITLE
Add an option to not use elastic agents for meta-reference inference

### DIFF
--- a/llama_stack/providers/impls/meta_reference/inference/config.py
+++ b/llama_stack/providers/impls/meta_reference/inference/config.py
@@ -27,7 +27,7 @@ class MetaReferenceInferenceConfig(BaseModel):
     # when this is False, we assume that the distributed process group is setup by someone
     # outside of this code (e.g., when run inside `torchrun`). that is useful for clients
     # (including our testing code) who might be using llama-stack as a library.
-    use_elastic_agent: bool = True
+    create_distributed_process_group: bool = True
 
     @field_validator("model")
     @classmethod

--- a/llama_stack/providers/impls/meta_reference/inference/config.py
+++ b/llama_stack/providers/impls/meta_reference/inference/config.py
@@ -17,12 +17,17 @@ from llama_stack.providers.utils.inference import supported_inference_models
 
 class MetaReferenceInferenceConfig(BaseModel):
     model: str = Field(
-        default="Llama3.1-8B-Instruct",
+        default="Llama3.2-3B-Instruct",
         description="Model descriptor from `llama model list`",
     )
     torch_seed: Optional[int] = None
     max_seq_len: int = 4096
     max_batch_size: int = 1
+
+    # when this is False, we assume that the distributed process group is setup by someone
+    # outside of this code (e.g., when run inside `torchrun`). that is useful for clients
+    # (including our testing code) who might be using llama-stack as a library.
+    use_elastic_agent: bool = True
 
     @field_validator("model")
     @classmethod

--- a/llama_stack/providers/impls/meta_reference/inference/inference.py
+++ b/llama_stack/providers/impls/meta_reference/inference/inference.py
@@ -37,7 +37,7 @@ class MetaReferenceInferenceImpl(Inference, ModelsProtocolPrivate):
 
     async def initialize(self) -> None:
         print(f"Loading model `{self.model.descriptor()}`")
-        if self.config.use_elastic_agent:
+        if self.config.create_distributed_process_group:
             self.generator = LlamaModelParallelGenerator(self.config)
             self.generator.start()
         else:
@@ -55,7 +55,7 @@ class MetaReferenceInferenceImpl(Inference, ModelsProtocolPrivate):
         ]
 
     async def shutdown(self) -> None:
-        if self.config.use_elastic_agent:
+        if self.config.create_distributed_process_group:
             self.generator.stop()
 
     def completion(
@@ -104,7 +104,7 @@ class MetaReferenceInferenceImpl(Inference, ModelsProtocolPrivate):
                 f"Model mismatch: {request.model} != {self.model.descriptor()}"
             )
 
-        if self.config.use_elastic_agent:
+        if self.config.create_distributed_process_group:
             if SEMAPHORE.locked():
                 raise RuntimeError("Only one concurrent request is supported")
 
@@ -160,7 +160,7 @@ class MetaReferenceInferenceImpl(Inference, ModelsProtocolPrivate):
                 logprobs=logprobs if request.logprobs else None,
             )
 
-        if self.config.use_elastic_agent:
+        if self.config.create_distributed_process_group:
             async with SEMAPHORE:
                 return impl()
         else:
@@ -284,7 +284,7 @@ class MetaReferenceInferenceImpl(Inference, ModelsProtocolPrivate):
                 )
             )
 
-        if self.config.use_elastic_agent:
+        if self.config.create_distributed_process_group:
             async with SEMAPHORE:
                 for x in impl():
                     yield x


### PR DESCRIPTION
Sometimes llama-stack is used as a library (and not as a server) -- in some of these cases, the client code can wish to take control of setting up the distributed process group. This can happen in test cases (run via `torchrun`) or in eval harnesses. This PR adds an option to make this possible.

**Test Plan** 

```
MODEL_IDS=Llama3.2-3B-Instruct \
  PROVIDER_ID=meta-reference \
  PROVIDER_CONFIG=~/.llama/tests/inf_providers.yaml \
  torchrun ~/.conda/envs/quant/bin/pytest -s llama_stack/providers/tests/inference/test_inference.py --tb=short --disable-warnings
```

with the following config for meta-reference provider:

```
providers:
  - provider_id: meta-reference
    provider_type: meta-reference
    config:
      model: Llama3.2-3B-Instruct
      create_distributed_process_group: false
```