### PR TITLE
[bug] Fix import conflict for SamplingParams

### DIFF
--- a/llama_stack/providers/impls/vllm/vllm.py
+++ b/llama_stack/providers/impls/vllm/vllm.py
@@ -7,7 +7,7 @@
 import logging
 import os
 import uuid
-from typing import Any
+from typing import Any, AsyncGenerator
 
 from llama_models.llama3.api.chat_format import ChatFormat
 from llama_models.llama3.api.datatypes import *  # noqa: F403
@@ -15,7 +15,7 @@ from llama_models.llama3.api.tokenizer import Tokenizer
 
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine
-from vllm.sampling_params import SamplingParams
+from vllm.sampling_params import SamplingParams as VLLMSamplingParams
 
 from llama_stack.apis.inference import *  # noqa: F403
 
@@ -40,10 +40,10 @@ def _random_uuid() -> str:
     return str(uuid.uuid4().hex)
 
 
-def _vllm_sampling_params(sampling_params: Any) -> SamplingParams:
+def _vllm_sampling_params(sampling_params: Any) -> VLLMSamplingParams:
     """Convert sampling params to vLLM sampling params."""
     if sampling_params is None:
-        return SamplingParams()
+        return VLLMSamplingParams()
 
     # TODO convert what I saw in my first test ... but surely there's more to do here
     kwargs = {
@@ -58,7 +58,7 @@ def _vllm_sampling_params(sampling_params: Any) -> SamplingParams:
     if sampling_params.repetition_penalty > 0:
         kwargs["repetition_penalty"] = sampling_params.repetition_penalty
 
-    return SamplingParams(**kwargs)
+    return VLLMSamplingParams(**kwargs)
 
 
 class VLLMInferenceImpl(ModelRegistryHelper, Inference):


### PR DESCRIPTION
Conflict between llama_models.llama3.api.datatypes.SamplingParams and vllm.sampling_params.SamplingParams results in errors while processing VLLM engine requests. The PR aliases vllm samplingparams to resolve the conflict.

The problem really occurs due to the blanket import `from llama_models.llama3.api.datatypes import *` in `vllm.py`. If we can update that to import specific modules instead of the entire namespace, the proposed fix here is not necessary.

## Test-plan

Before:
```
curl http://localhost:5000/inference/chat_completion -H "Content-Type: application/json" -d '{"model": "Llama3.1-8B-Instruct", "messages": [{"role": "system", "content": "You are a helpful assistant."}, {"role": "user", "content": "Write me a 2 sentence poem about the moon"}], "sampling_params": {"temperature": 0.7, "seed": 42, "max_tokens": 512}}'

Stacktrace:
INFO:     Uvicorn running on http://[::]:5000 (Press CTRL+C to quit)
18:56:22.799 [INFO] [chat_completion] vLLM chat completion
18:56:22.800 [INFO] [chat_completion] Sampling params: strategy=<SamplingStrategy.greedy: 'greedy'> temperature=0.7 top_p=0.95 top_k=0 max_tokens=512 repetition_penalty=1.0
INFO 10-22 18:56:22 async_llm_engine.py:207] Added request 0b8f72db356c403790e0f5fe11d84efe.
INFO 10-22 18:56:22 async_llm_engine.py:184] Finished request 0b8f72db356c403790e0f5fe11d84efe.
INFO 10-22 18:56:22 metrics.py:349] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 0.0%, CPU KV cache usage: 0.0%.
Traceback (most recent call last):
  File "/home/ubuntu/subramen/llama32/llama-stack/llama_stack/distribution/server/server.py", line 240, in endpoint
    return await maybe_await(value)
  File "/home/ubuntu/subramen/llama32/llama-stack/llama_stack/distribution/server/server.py", line 200, in maybe_await
    return await value
  File "/home/ubuntu/subramen/llama32/llama-stack/llama_stack/distribution/routers/routers.py", line 98, in chat_completion
    return await provider.chat_completion(**params)
  File "/home/ubuntu/subramen/llama32/llama-stack/llama_stack/providers/impls/vllm/vllm.py", line 193, in chat_completion
    return await self._nonstream_chat_completion(request, results_generator)
  File "/home/ubuntu/subramen/llama32/llama-stack/llama_stack/providers/impls/vllm/vllm.py", line 198, in _nonstream_chat_completion
    outputs = [o async for o in results_generator]
  File "/home/ubuntu/subramen/llama32/llama-stack/llama_stack/providers/impls/vllm/vllm.py", line 198, in <listcomp>
    outputs = [o async for o in results_generator]
  File "/opt/conda/envs/llamastack-vllm-stack/lib/python3.10/site-packages/vllm/engine/async_llm_engine.py", line 1029, in generate
    async for output in await self.add_request(
  File "/opt/conda/envs/llamastack-vllm-stack/lib/python3.10/site-packages/vllm/engine/async_llm_engine.py", line 112, in generator
    raise result
  File "/opt/conda/envs/llamastack-vllm-stack/lib/python3.10/site-packages/vllm/engine/async_llm_engine.py", line 762, in engine_step
    await self.engine.add_request_async(**new_request)
  File "/opt/conda/envs/llamastack-vllm-stack/lib/python3.10/site-packages/vllm/engine/async_llm_engine.py", line 495, in add_request_async
    self._add_processed_request(
  File "/opt/conda/envs/llamastack-vllm-stack/lib/python3.10/site-packages/vllm/engine/llm_engine.py", line 689, in _add_processed_request
    raise ValueError(
ValueError: Either SamplingParams or PoolingParams must be provided.
```
The ValueError is raised because it fails the `isinstance(params, vllm.sampling_params.SamplingParams)` check.

After:
```
curl http://localhost:5000/inference/chat_completion -H "Content-Type: application/json" -d '{"model": "Llama3.1-8B-Instruct", "messages": [{"role": "system", "content": "You are a helpful assistant."}, {"role": "user", "content": "Write me a 2 sentence poem about the moon"}], "sampling_params": {"temperature": 0.7, "seed": 42, "max_tokens": 512}}'

{"completion_message":{"role":"assistant","content":"The moon glows softly in the mid night sky, \nA beacon of wonder, as it catches the eye.","stop_reason":"out_of_tokens  ","tool_calls":[]},"logprobs":null}
```