### PR TITLE
Support structured output for Together

### DIFF
--- a/llama_stack/providers/adapters/inference/together/together.py
+++ b/llama_stack/providers/adapters/inference/together/together.py
@@ -111,7 +111,6 @@ class TogetherInferenceAdapter(
     ) -> ChatCompletionResponse:
         params = self._get_params(request)
         r = client.completions.create(**params)
-        print(r)
         return process_chat_completion_response(r, self.formatter)
 
     async def _stream_chat_completion(
@@ -135,7 +134,7 @@ class TogetherInferenceAdapter(
         options = get_sampling_options(request)
         if fmt := request.response_format:
             if fmt.type == ResponseFormatType.json_schema.value:
-                options["respose_format"] = {
+                options["response_format"] = {
                     "type": "json_object",
                     "schema": fmt.schema,
                 }

--- a/llama_stack/providers/adapters/inference/together/together.py
+++ b/llama_stack/providers/adapters/inference/together/together.py
@@ -70,10 +70,10 @@ class TogetherInferenceAdapter(
         model: str,
         messages: List[Message],
         sampling_params: Optional[SamplingParams] = SamplingParams(),
-        response_format: Optional[ResponseFormat] = None,
         tools: Optional[List[ToolDefinition]] = None,
         tool_choice: Optional[ToolChoice] = ToolChoice.auto,
         tool_prompt_format: Optional[ToolPromptFormat] = ToolPromptFormat.json,
+        response_format: Optional[ResponseFormat] = None,
         stream: Optional[bool] = False,
         logprobs: Optional[LogProbConfig] = None,
     ) -> AsyncGenerator:
@@ -96,6 +96,7 @@ class TogetherInferenceAdapter(
             tools=tools or [],
             tool_choice=tool_choice,
             tool_prompt_format=tool_prompt_format,
+            response_format=response_format,
             stream=stream,
             logprobs=logprobs,
         )
@@ -110,6 +111,7 @@ class TogetherInferenceAdapter(
     ) -> ChatCompletionResponse:
         params = self._get_params(request)
         r = client.completions.create(**params)
+        print(r)
         return process_chat_completion_response(r, self.formatter)
 
     async def _stream_chat_completion(
@@ -130,11 +132,23 @@ class TogetherInferenceAdapter(
             yield chunk
 
     def _get_params(self, request: ChatCompletionRequest) -> dict:
+        options = get_sampling_options(request)
+        if fmt := request.response_format:
+            if fmt.type == ResponseFormatType.json_schema.value:
+                options["respose_format"] = {
+                    "type": "json_object",
+                    "schema": fmt.schema,
+                }
+            elif fmt.type == ResponseFormatType.grammar.value:
+                raise NotImplementedError("Grammar response format not supported yet")
+            else:
+                raise ValueError(f"Unknown response format {fmt.type}")
+
         return {
             "model": self.map_to_provider_model(request.model),
             "prompt": chat_completion_request_to_prompt(request, self.formatter),
             "stream": request.stream,
-            **get_sampling_options(request),
+            **options,
         }
 
     async def embeddings(

--- a/llama_stack/providers/tests/inference/test_inference.py
+++ b/llama_stack/providers/tests/inference/test_inference.py
@@ -195,6 +195,7 @@ async def test_structured_output(inference_settings):
         "meta-reference",
         "remote::fireworks",
         "remote::tgi",
+        "remote::together",
     ):
         pytest.skip("Other inference providers don't support structured output yet")
 


### PR DESCRIPTION
As title. 

**Test Plan:**
```
MODEL_IDS=Llama3.1-8B-Instruct \
  PROVIDER_ID=together \
  PROVIDER_CONFIG=providers.yaml \
  $CONDA_PREFIX/bin/pytest -s llama_stack/providers/tests/inference/test_inference.py::test_structured_output --tb=short --disable-warnings
```

The providers.yaml file above will look like:

```
providers:
  - provider_id: together
    provider_type: remote::together
    config: {}
provider_data:
  together:
    together_api_key: <TOGETHER_API_KEY>
```