### PR TITLE
completion() for together

### DIFF
--- a/llama_stack/providers/tests/inference/test_inference.py
+++ b/llama_stack/providers/tests/inference/test_inference.py
@@ -143,7 +143,7 @@ async def test_completion(inference_settings):
         pytest.skip("Other inference providers don't support completion() yet")
 
     response = await inference_impl.completion(
-        content="Roses are red,",
+        content="Micheael Jordan is born in ",
         stream=False,
         model=params["model"],
         sampling_params=SamplingParams(
@@ -152,7 +152,7 @@ async def test_completion(inference_settings):
     )
 
     assert isinstance(response, CompletionResponse)
-    assert "violets are blue" in response.content
+    assert "1963" in response.content
 
     chunks = [
         r
@@ -181,6 +181,7 @@ async def test_completions_structured_output(inference_settings):
     if provider.__provider_spec__.provider_type not in (
         "meta-reference",
         "remote::tgi",
+        "remote::together",
     ):
         pytest.skip(
             "Other inference providers don't support structured output in completions yet"

--- a/llama_stack/providers/tests/inference/test_inference.py
+++ b/llama_stack/providers/tests/inference/test_inference.py
@@ -138,6 +138,7 @@ async def test_completion(inference_settings):
         "meta-reference",
         "remote::ollama",
         "remote::tgi",
+        "remote::together",
     ):
         pytest.skip("Other inference providers don't support completion() yet")
 


### PR DESCRIPTION
# What does this PR do?

Implements completion() API for together 
Addresses #168

## Feature/Issue validation/testing/test plan
Tested completion for both stream and non streaming cases for non structured output  and non streaming case for structured output
- [x] Test 
PROVIDER_ID=test-together PROVIDER_CONFIG=../configs/provider_config_example.yaml with-proxy pytest -s tests/inference/test_inference.py --tb=short --disable-warnings -rs

```
 PROVIDER_ID=test-together MODEL_IDS="Llama3.1-8B-Instruct" PROVIDER_CONFIG=../configs/provider_config_example.yaml with-proxy pytest -s tests/inference/test_inference.py --tb=short --disable-warnings -rs
/home/dineshyv/.conda/envs/stack/lib/python3.10/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.15, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/dineshyv/local/llama-stack
configfile: pyproject.toml
plugins: asyncio-0.24.0, anyio-4.6.2.post1
asyncio: mode=strict, default_loop_scope=None
collected 8 items

tests/inference/test_inference.py Resolved 4 providers
 inner-inference => test-together
 models => __routing_table__
 inference => __autorouted__
 inspect => __builtin__

........

======================================================================================== 8 passed, 20 warnings in 15.88s =========================================================================================

```


