### PR TITLE
add dynamic clients for all APIs

### DIFF
--- a/docs/resources/llama-stack-spec.html
+++ b/docs/resources/llama-stack-spec.html
@@ -21,7 +21,7 @@
     "info": {
         "title": "[DRAFT] Llama Stack Specification",
         "version": "0.0.1",
-        "description": "This is the specification of the llama stack that provides\n                a set of endpoints and their corresponding interfaces that are tailored to\n                best leverage Llama Models. The specification is still in draft and subject to change.\n                Generated at 2024-10-31 10:35:38.305313"
+        "description": "This is the specification of the llama stack that provides\n                a set of endpoints and their corresponding interfaces that are tailored to\n                best leverage Llama Models. The specification is still in draft and subject to change.\n                Generated at 2024-10-31 14:28:52.128905"
     },
     "servers": [
         {
@@ -320,11 +320,18 @@
             "post": {
                 "responses": {
                     "200": {
-                        "description": "A single turn in an interaction with an Agentic System.",
+                        "description": "A single turn in an interaction with an Agentic System. **OR** streamed agent turn completion response.",
                         "content": {
                             "text/event-stream": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Turn"
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/components/schemas/Turn"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/AgentTurnResponseStreamChunk"
+                                        }
+                                    ]
                                 }
                             }
                         }
@@ -3832,6 +3839,215 @@
                     "messages"
                 ]
             },
+            "AgentTurnResponseEvent": {
+                "type": "object",
+                "properties": {
+                    "payload": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/AgentTurnResponseStepStartPayload"
+                            },
+                            {
+                                "$ref": "#/components/schemas/AgentTurnResponseStepProgressPayload"
+                            },
+                            {
+                                "$ref": "#/components/schemas/AgentTurnResponseStepCompletePayload"
+                            },
+                            {
+                                "$ref": "#/components/schemas/AgentTurnResponseTurnStartPayload"
+                            },
+                            {
+                                "$ref": "#/components/schemas/AgentTurnResponseTurnCompletePayload"
+                            }
+                        ]
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "payload"
+                ],
+                "title": "Streamed agent execution response."
+            },
+            "AgentTurnResponseStepCompletePayload": {
+                "type": "object",
+                "properties": {
+                    "event_type": {
+                        "type": "string",
+                        "const": "step_complete",
+                        "default": "step_complete"
+                    },
+                    "step_type": {
+                        "type": "string",
+                        "enum": [
+                            "inference",
+                            "tool_execution",
+                            "shield_call",
+                            "memory_retrieval"
+                        ]
+                    },
+                    "step_details": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/InferenceStep"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ToolExecutionStep"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ShieldCallStep"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MemoryRetrievalStep"
+                            }
+                        ]
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "event_type",
+                    "step_type",
+                    "step_details"
+                ]
+            },
+            "AgentTurnResponseStepProgressPayload": {
+                "type": "object",
+                "properties": {
+                    "event_type": {
+                        "type": "string",
+                        "const": "step_progress",
+                        "default": "step_progress"
+                    },
+                    "step_type": {
+                        "type": "string",
+                        "enum": [
+                            "inference",
+                            "tool_execution",
+                            "shield_call",
+                            "memory_retrieval"
+                        ]
+                    },
+                    "step_id": {
+                        "type": "string"
+                    },
+                    "model_response_text_delta": {
+                        "type": "string"
+                    },
+                    "tool_call_delta": {
+                        "$ref": "#/components/schemas/ToolCallDelta"
+                    },
+                    "tool_response_text_delta": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "event_type",
+                    "step_type",
+                    "step_id"
+                ]
+            },
+            "AgentTurnResponseStepStartPayload": {
+                "type": "object",
+                "properties": {
+                    "event_type": {
+                        "type": "string",
+                        "const": "step_start",
+                        "default": "step_start"
+                    },
+                    "step_type": {
+                        "type": "string",
+                        "enum": [
+                            "inference",
+                            "tool_execution",
+                            "shield_call",
+                            "memory_retrieval"
+                        ]
+                    },
+                    "step_id": {
+                        "type": "string"
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "type": "boolean"
+                                },
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "event_type",
+                    "step_type",
+                    "step_id"
+                ]
+            },
+            "AgentTurnResponseStreamChunk": {
+                "type": "object",
+                "properties": {
+                    "event": {
+                        "$ref": "#/components/schemas/AgentTurnResponseEvent"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "event"
+                ],
+                "title": "streamed agent turn completion response."
+            },
+            "AgentTurnResponseTurnCompletePayload": {
+                "type": "object",
+                "properties": {
+                    "event_type": {
+                        "type": "string",
+                        "const": "turn_complete",
+                        "default": "turn_complete"
+                    },
+                    "turn": {
+                        "$ref": "#/components/schemas/Turn"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "event_type",
+                    "turn"
+                ]
+            },
+            "AgentTurnResponseTurnStartPayload": {
+                "type": "object",
+                "properties": {
+                    "event_type": {
+                        "type": "string",
+                        "const": "turn_start",
+                        "default": "turn_start"
+                    },
+                    "turn_id": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "event_type",
+                    "turn_id"
+                ]
+            },
             "InferenceStep": {
                 "type": "object",
                 "properties": {
@@ -6847,55 +7063,55 @@
     ],
     "tags": [
         {
-            "name": "Safety"
-        },
-        {
-            "name": "Scoring"
-        },
-        {
-            "name": "BatchInference"
-        },
-        {
-            "name": "DatasetIO"
-        },
-        {
-            "name": "Models"
-        },
-        {
-            "name": "Eval"
-        },
-        {
-            "name": "Telemetry"
-        },
-        {
-            "name": "Shields"
-        },
-        {
-            "name": "Datasets"
-        },
-        {
             "name": "Memory"
-        },
-        {
-            "name": "PostTraining"
-        },
-        {
-            "name": "ScoringFunctions"
-        },
-        {
-            "name": "SyntheticDataGeneration"
-        },
-        {
-            "name": "Inspect"
-        },
-        {
-            "name": "MemoryBanks"
         },
         {
             "name": "Inference"
         },
         {
+            "name": "Eval"
+        },
+        {
+            "name": "MemoryBanks"
+        },
+        {
+            "name": "Models"
+        },
+        {
+            "name": "BatchInference"
+        },
+        {
+            "name": "PostTraining"
+        },
+        {
             "name": "Agents"
+        },
+        {
+            "name": "Shields"
+        },
+        {
+            "name": "Telemetry"
+        },
+        {
+            "name": "Inspect"
+        },
+        {
+            "name": "DatasetIO"
+        },
+        {
+            "name": "SyntheticDataGeneration"
+        },
+        {
+            "name": "Datasets"
+        },
+        {
+            "name": "Scoring"
+        },
+        {
+            "name": "ScoringFunctions"
+        },
+        {
+            "name": "Safety"
         },
         {
             "name": "BuiltinTool",
@@ -7080,6 +7296,34 @@
         {
             "name": "CreateAgentTurnRequest",
             "description": "<SchemaDefinition schemaRef=\"#/components/schemas/CreateAgentTurnRequest\" />"
+        },
+        {
+            "name": "AgentTurnResponseEvent",
+            "description": "Streamed agent execution response.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseEvent\" />"
+        },
+        {
+            "name": "AgentTurnResponseStepCompletePayload",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseStepCompletePayload\" />"
+        },
+        {
+            "name": "AgentTurnResponseStepProgressPayload",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseStepProgressPayload\" />"
+        },
+        {
+            "name": "AgentTurnResponseStepStartPayload",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseStepStartPayload\" />"
+        },
+        {
+            "name": "AgentTurnResponseStreamChunk",
+            "description": "streamed agent turn completion response.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseStreamChunk\" />"
+        },
+        {
+            "name": "AgentTurnResponseTurnCompletePayload",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseTurnCompletePayload\" />"
+        },
+        {
+            "name": "AgentTurnResponseTurnStartPayload",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseTurnStartPayload\" />"
         },
         {
             "name": "InferenceStep",
@@ -7429,6 +7673,13 @@
                 "AgentCreateResponse",
                 "AgentSessionCreateResponse",
                 "AgentStepResponse",
+                "AgentTurnResponseEvent",
+                "AgentTurnResponseStepCompletePayload",
+                "AgentTurnResponseStepProgressPayload",
+                "AgentTurnResponseStepStartPayload",
+                "AgentTurnResponseStreamChunk",
+                "AgentTurnResponseTurnCompletePayload",
+                "AgentTurnResponseTurnStartPayload",
                 "Attachment",
                 "BatchChatCompletionRequest",
                 "BatchChatCompletionResponse",

--- a/docs/resources/llama-stack-spec.html
+++ b/docs/resources/llama-stack-spec.html
@@ -21,7 +21,7 @@
     "info": {
         "title": "[DRAFT] Llama Stack Specification",
         "version": "0.0.1",
-        "description": "This is the specification of the llama stack that provides\n                a set of endpoints and their corresponding interfaces that are tailored to\n                best leverage Llama Models. The specification is still in draft and subject to change.\n                Generated at 2024-10-30 16:17:03.919702"
+        "description": "This is the specification of the llama stack that provides\n                a set of endpoints and their corresponding interfaces that are tailored to\n                best leverage Llama Models. The specification is still in draft and subject to change.\n                Generated at 2024-10-31 10:35:38.305313"
     },
     "servers": [
         {
@@ -320,11 +320,11 @@
             "post": {
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "A single turn in an interaction with an Agentic System.",
                         "content": {
                             "text/event-stream": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/AgentTurnResponseStreamChunk"
+                                    "$ref": "#/components/schemas/Turn"
                                 }
                             }
                         }
@@ -3832,214 +3832,6 @@
                     "messages"
                 ]
             },
-            "AgentTurnResponseEvent": {
-                "type": "object",
-                "properties": {
-                    "payload": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/AgentTurnResponseStepStartPayload"
-                            },
-                            {
-                                "$ref": "#/components/schemas/AgentTurnResponseStepProgressPayload"
-                            },
-                            {
-                                "$ref": "#/components/schemas/AgentTurnResponseStepCompletePayload"
-                            },
-                            {
-                                "$ref": "#/components/schemas/AgentTurnResponseTurnStartPayload"
-                            },
-                            {
-                                "$ref": "#/components/schemas/AgentTurnResponseTurnCompletePayload"
-                            }
-                        ]
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "payload"
-                ],
-                "title": "Streamed agent execution response."
-            },
-            "AgentTurnResponseStepCompletePayload": {
-                "type": "object",
-                "properties": {
-                    "event_type": {
-                        "type": "string",
-                        "const": "step_complete",
-                        "default": "step_complete"
-                    },
-                    "step_type": {
-                        "type": "string",
-                        "enum": [
-                            "inference",
-                            "tool_execution",
-                            "shield_call",
-                            "memory_retrieval"
-                        ]
-                    },
-                    "step_details": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/InferenceStep"
-                            },
-                            {
-                                "$ref": "#/components/schemas/ToolExecutionStep"
-                            },
-                            {
-                                "$ref": "#/components/schemas/ShieldCallStep"
-                            },
-                            {
-                                "$ref": "#/components/schemas/MemoryRetrievalStep"
-                            }
-                        ]
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "event_type",
-                    "step_type",
-                    "step_details"
-                ]
-            },
-            "AgentTurnResponseStepProgressPayload": {
-                "type": "object",
-                "properties": {
-                    "event_type": {
-                        "type": "string",
-                        "const": "step_progress",
-                        "default": "step_progress"
-                    },
-                    "step_type": {
-                        "type": "string",
-                        "enum": [
-                            "inference",
-                            "tool_execution",
-                            "shield_call",
-                            "memory_retrieval"
-                        ]
-                    },
-                    "step_id": {
-                        "type": "string"
-                    },
-                    "model_response_text_delta": {
-                        "type": "string"
-                    },
-                    "tool_call_delta": {
-                        "$ref": "#/components/schemas/ToolCallDelta"
-                    },
-                    "tool_response_text_delta": {
-                        "type": "string"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "event_type",
-                    "step_type",
-                    "step_id"
-                ]
-            },
-            "AgentTurnResponseStepStartPayload": {
-                "type": "object",
-                "properties": {
-                    "event_type": {
-                        "type": "string",
-                        "const": "step_start",
-                        "default": "step_start"
-                    },
-                    "step_type": {
-                        "type": "string",
-                        "enum": [
-                            "inference",
-                            "tool_execution",
-                            "shield_call",
-                            "memory_retrieval"
-                        ]
-                    },
-                    "step_id": {
-                        "type": "string"
-                    },
-                    "metadata": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "oneOf": [
-                                {
-                                    "type": "null"
-                                },
-                                {
-                                    "type": "boolean"
-                                },
-                                {
-                                    "type": "number"
-                                },
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "object"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "event_type",
-                    "step_type",
-                    "step_id"
-                ]
-            },
-            "AgentTurnResponseStreamChunk": {
-                "type": "object",
-                "properties": {
-                    "event": {
-                        "$ref": "#/components/schemas/AgentTurnResponseEvent"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "event"
-                ]
-            },
-            "AgentTurnResponseTurnCompletePayload": {
-                "type": "object",
-                "properties": {
-                    "event_type": {
-                        "type": "string",
-                        "const": "turn_complete",
-                        "default": "turn_complete"
-                    },
-                    "turn": {
-                        "$ref": "#/components/schemas/Turn"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "event_type",
-                    "turn"
-                ]
-            },
-            "AgentTurnResponseTurnStartPayload": {
-                "type": "object",
-                "properties": {
-                    "event_type": {
-                        "type": "string",
-                        "const": "turn_start",
-                        "default": "turn_start"
-                    },
-                    "turn_id": {
-                        "type": "string"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "event_type",
-                    "turn_id"
-                ]
-            },
             "InferenceStep": {
                 "type": "object",
                 "properties": {
@@ -7055,43 +6847,19 @@
     ],
     "tags": [
         {
-            "name": "Inference"
-        },
-        {
-            "name": "Memory"
-        },
-        {
-            "name": "Inspect"
-        },
-        {
-            "name": "PostTraining"
-        },
-        {
-            "name": "Models"
+            "name": "Safety"
         },
         {
             "name": "Scoring"
         },
         {
-            "name": "DatasetIO"
-        },
-        {
             "name": "BatchInference"
         },
         {
-            "name": "Agents"
+            "name": "DatasetIO"
         },
         {
-            "name": "Shields"
-        },
-        {
-            "name": "MemoryBanks"
-        },
-        {
-            "name": "Datasets"
-        },
-        {
-            "name": "SyntheticDataGeneration"
+            "name": "Models"
         },
         {
             "name": "Eval"
@@ -7100,10 +6868,34 @@
             "name": "Telemetry"
         },
         {
+            "name": "Shields"
+        },
+        {
+            "name": "Datasets"
+        },
+        {
+            "name": "Memory"
+        },
+        {
+            "name": "PostTraining"
+        },
+        {
             "name": "ScoringFunctions"
         },
         {
-            "name": "Safety"
+            "name": "SyntheticDataGeneration"
+        },
+        {
+            "name": "Inspect"
+        },
+        {
+            "name": "MemoryBanks"
+        },
+        {
+            "name": "Inference"
+        },
+        {
+            "name": "Agents"
         },
         {
             "name": "BuiltinTool",
@@ -7288,34 +7080,6 @@
         {
             "name": "CreateAgentTurnRequest",
             "description": "<SchemaDefinition schemaRef=\"#/components/schemas/CreateAgentTurnRequest\" />"
-        },
-        {
-            "name": "AgentTurnResponseEvent",
-            "description": "Streamed agent execution response.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseEvent\" />"
-        },
-        {
-            "name": "AgentTurnResponseStepCompletePayload",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseStepCompletePayload\" />"
-        },
-        {
-            "name": "AgentTurnResponseStepProgressPayload",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseStepProgressPayload\" />"
-        },
-        {
-            "name": "AgentTurnResponseStepStartPayload",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseStepStartPayload\" />"
-        },
-        {
-            "name": "AgentTurnResponseStreamChunk",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseStreamChunk\" />"
-        },
-        {
-            "name": "AgentTurnResponseTurnCompletePayload",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseTurnCompletePayload\" />"
-        },
-        {
-            "name": "AgentTurnResponseTurnStartPayload",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseTurnStartPayload\" />"
         },
         {
             "name": "InferenceStep",
@@ -7665,13 +7429,6 @@
                 "AgentCreateResponse",
                 "AgentSessionCreateResponse",
                 "AgentStepResponse",
-                "AgentTurnResponseEvent",
-                "AgentTurnResponseStepCompletePayload",
-                "AgentTurnResponseStepProgressPayload",
-                "AgentTurnResponseStepStartPayload",
-                "AgentTurnResponseStreamChunk",
-                "AgentTurnResponseTurnCompletePayload",
-                "AgentTurnResponseTurnStartPayload",
                 "Attachment",
                 "BatchChatCompletionRequest",
                 "BatchChatCompletionResponse",

--- a/docs/resources/llama-stack-spec.yaml
+++ b/docs/resources/llama-stack-spec.yaml
@@ -86,6 +86,138 @@ components:
       required:
       - step
       type: object
+    AgentTurnResponseEvent:
+      additionalProperties: false
+      properties:
+        payload:
+          oneOf:
+          - $ref: '#/components/schemas/AgentTurnResponseStepStartPayload'
+          - $ref: '#/components/schemas/AgentTurnResponseStepProgressPayload'
+          - $ref: '#/components/schemas/AgentTurnResponseStepCompletePayload'
+          - $ref: '#/components/schemas/AgentTurnResponseTurnStartPayload'
+          - $ref: '#/components/schemas/AgentTurnResponseTurnCompletePayload'
+      required:
+      - payload
+      title: Streamed agent execution response.
+      type: object
+    AgentTurnResponseStepCompletePayload:
+      additionalProperties: false
+      properties:
+        event_type:
+          const: step_complete
+          default: step_complete
+          type: string
+        step_details:
+          oneOf:
+          - $ref: '#/components/schemas/InferenceStep'
+          - $ref: '#/components/schemas/ToolExecutionStep'
+          - $ref: '#/components/schemas/ShieldCallStep'
+          - $ref: '#/components/schemas/MemoryRetrievalStep'
+        step_type:
+          enum:
+          - inference
+          - tool_execution
+          - shield_call
+          - memory_retrieval
+          type: string
+      required:
+      - event_type
+      - step_type
+      - step_details
+      type: object
+    AgentTurnResponseStepProgressPayload:
+      additionalProperties: false
+      properties:
+        event_type:
+          const: step_progress
+          default: step_progress
+          type: string
+        model_response_text_delta:
+          type: string
+        step_id:
+          type: string
+        step_type:
+          enum:
+          - inference
+          - tool_execution
+          - shield_call
+          - memory_retrieval
+          type: string
+        tool_call_delta:
+          $ref: '#/components/schemas/ToolCallDelta'
+        tool_response_text_delta:
+          type: string
+      required:
+      - event_type
+      - step_type
+      - step_id
+      type: object
+    AgentTurnResponseStepStartPayload:
+      additionalProperties: false
+      properties:
+        event_type:
+          const: step_start
+          default: step_start
+          type: string
+        metadata:
+          additionalProperties:
+            oneOf:
+            - type: 'null'
+            - type: boolean
+            - type: number
+            - type: string
+            - type: array
+            - type: object
+          type: object
+        step_id:
+          type: string
+        step_type:
+          enum:
+          - inference
+          - tool_execution
+          - shield_call
+          - memory_retrieval
+          type: string
+      required:
+      - event_type
+      - step_type
+      - step_id
+      type: object
+    AgentTurnResponseStreamChunk:
+      additionalProperties: false
+      properties:
+        event:
+          $ref: '#/components/schemas/AgentTurnResponseEvent'
+      required:
+      - event
+      title: streamed agent turn completion response.
+      type: object
+    AgentTurnResponseTurnCompletePayload:
+      additionalProperties: false
+      properties:
+        event_type:
+          const: turn_complete
+          default: turn_complete
+          type: string
+        turn:
+          $ref: '#/components/schemas/Turn'
+      required:
+      - event_type
+      - turn
+      type: object
+    AgentTurnResponseTurnStartPayload:
+      additionalProperties: false
+      properties:
+        event_type:
+          const: turn_start
+          default: turn_start
+          type: string
+        turn_id:
+          type: string
+      required:
+      - event_type
+      - turn_id
+      type: object
     Attachment:
       additionalProperties: false
       properties:
@@ -2866,7 +2998,7 @@ info:
   description: "This is the specification of the llama stack that provides\n     \
     \           a set of endpoints and their corresponding interfaces that are tailored\
     \ to\n                best leverage Llama Models. The specification is still in\
-    \ draft and subject to change.\n                Generated at 2024-10-31 10:35:38.305313"
+    \ draft and subject to change.\n                Generated at 2024-10-31 14:28:52.128905"
   title: '[DRAFT] Llama Stack Specification'
   version: 0.0.1
 jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
@@ -3059,8 +3191,11 @@ paths:
           content:
             text/event-stream:
               schema:
-                $ref: '#/components/schemas/Turn'
-          description: A single turn in an interaction with an Agentic System.
+                oneOf:
+                - $ref: '#/components/schemas/Turn'
+                - $ref: '#/components/schemas/AgentTurnResponseStreamChunk'
+          description: A single turn in an interaction with an Agentic System. **OR**
+            streamed agent turn completion response.
       tags:
       - Agents
   /agents/turn/get:
@@ -4145,23 +4280,23 @@ security:
 servers:
 - url: http://any-hosted-llama-stack.com
 tags:
-- name: Safety
-- name: Scoring
-- name: BatchInference
-- name: DatasetIO
-- name: Models
-- name: Eval
-- name: Telemetry
-- name: Shields
-- name: Datasets
 - name: Memory
-- name: PostTraining
-- name: ScoringFunctions
-- name: SyntheticDataGeneration
-- name: Inspect
-- name: MemoryBanks
 - name: Inference
+- name: Eval
+- name: MemoryBanks
+- name: Models
+- name: BatchInference
+- name: PostTraining
 - name: Agents
+- name: Shields
+- name: Telemetry
+- name: Inspect
+- name: DatasetIO
+- name: SyntheticDataGeneration
+- name: Datasets
+- name: Scoring
+- name: ScoringFunctions
+- name: Safety
 - description: <SchemaDefinition schemaRef="#/components/schemas/BuiltinTool" />
   name: BuiltinTool
 - description: <SchemaDefinition schemaRef="#/components/schemas/CompletionMessage"
@@ -4306,6 +4441,32 @@ tags:
 - description: <SchemaDefinition schemaRef="#/components/schemas/CreateAgentTurnRequest"
     />
   name: CreateAgentTurnRequest
+- description: 'Streamed agent execution response.
+
+
+    <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseEvent" />'
+  name: AgentTurnResponseEvent
+- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepCompletePayload"
+    />
+  name: AgentTurnResponseStepCompletePayload
+- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepProgressPayload"
+    />
+  name: AgentTurnResponseStepProgressPayload
+- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepStartPayload"
+    />
+  name: AgentTurnResponseStepStartPayload
+- description: 'streamed agent turn completion response.
+
+
+    <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStreamChunk"
+    />'
+  name: AgentTurnResponseStreamChunk
+- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseTurnCompletePayload"
+    />
+  name: AgentTurnResponseTurnCompletePayload
+- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseTurnStartPayload"
+    />
+  name: AgentTurnResponseTurnStartPayload
 - description: <SchemaDefinition schemaRef="#/components/schemas/InferenceStep" />
   name: InferenceStep
 - description: <SchemaDefinition schemaRef="#/components/schemas/MemoryRetrievalStep"
@@ -4566,6 +4727,13 @@ x-tagGroups:
   - AgentCreateResponse
   - AgentSessionCreateResponse
   - AgentStepResponse
+  - AgentTurnResponseEvent
+  - AgentTurnResponseStepCompletePayload
+  - AgentTurnResponseStepProgressPayload
+  - AgentTurnResponseStepStartPayload
+  - AgentTurnResponseStreamChunk
+  - AgentTurnResponseTurnCompletePayload
+  - AgentTurnResponseTurnStartPayload
   - Attachment
   - BatchChatCompletionRequest
   - BatchChatCompletionResponse

--- a/docs/resources/llama-stack-spec.yaml
+++ b/docs/resources/llama-stack-spec.yaml
@@ -86,137 +86,6 @@ components:
       required:
       - step
       type: object
-    AgentTurnResponseEvent:
-      additionalProperties: false
-      properties:
-        payload:
-          oneOf:
-          - $ref: '#/components/schemas/AgentTurnResponseStepStartPayload'
-          - $ref: '#/components/schemas/AgentTurnResponseStepProgressPayload'
-          - $ref: '#/components/schemas/AgentTurnResponseStepCompletePayload'
-          - $ref: '#/components/schemas/AgentTurnResponseTurnStartPayload'
-          - $ref: '#/components/schemas/AgentTurnResponseTurnCompletePayload'
-      required:
-      - payload
-      title: Streamed agent execution response.
-      type: object
-    AgentTurnResponseStepCompletePayload:
-      additionalProperties: false
-      properties:
-        event_type:
-          const: step_complete
-          default: step_complete
-          type: string
-        step_details:
-          oneOf:
-          - $ref: '#/components/schemas/InferenceStep'
-          - $ref: '#/components/schemas/ToolExecutionStep'
-          - $ref: '#/components/schemas/ShieldCallStep'
-          - $ref: '#/components/schemas/MemoryRetrievalStep'
-        step_type:
-          enum:
-          - inference
-          - tool_execution
-          - shield_call
-          - memory_retrieval
-          type: string
-      required:
-      - event_type
-      - step_type
-      - step_details
-      type: object
-    AgentTurnResponseStepProgressPayload:
-      additionalProperties: false
-      properties:
-        event_type:
-          const: step_progress
-          default: step_progress
-          type: string
-        model_response_text_delta:
-          type: string
-        step_id:
-          type: string
-        step_type:
-          enum:
-          - inference
-          - tool_execution
-          - shield_call
-          - memory_retrieval
-          type: string
-        tool_call_delta:
-          $ref: '#/components/schemas/ToolCallDelta'
-        tool_response_text_delta:
-          type: string
-      required:
-      - event_type
-      - step_type
-      - step_id
-      type: object
-    AgentTurnResponseStepStartPayload:
-      additionalProperties: false
-      properties:
-        event_type:
-          const: step_start
-          default: step_start
-          type: string
-        metadata:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        step_id:
-          type: string
-        step_type:
-          enum:
-          - inference
-          - tool_execution
-          - shield_call
-          - memory_retrieval
-          type: string
-      required:
-      - event_type
-      - step_type
-      - step_id
-      type: object
-    AgentTurnResponseStreamChunk:
-      additionalProperties: false
-      properties:
-        event:
-          $ref: '#/components/schemas/AgentTurnResponseEvent'
-      required:
-      - event
-      type: object
-    AgentTurnResponseTurnCompletePayload:
-      additionalProperties: false
-      properties:
-        event_type:
-          const: turn_complete
-          default: turn_complete
-          type: string
-        turn:
-          $ref: '#/components/schemas/Turn'
-      required:
-      - event_type
-      - turn
-      type: object
-    AgentTurnResponseTurnStartPayload:
-      additionalProperties: false
-      properties:
-        event_type:
-          const: turn_start
-          default: turn_start
-          type: string
-        turn_id:
-          type: string
-      required:
-      - event_type
-      - turn_id
-      type: object
     Attachment:
       additionalProperties: false
       properties:
@@ -2997,7 +2866,7 @@ info:
   description: "This is the specification of the llama stack that provides\n     \
     \           a set of endpoints and their corresponding interfaces that are tailored\
     \ to\n                best leverage Llama Models. The specification is still in\
-    \ draft and subject to change.\n                Generated at 2024-10-30 16:17:03.919702"
+    \ draft and subject to change.\n                Generated at 2024-10-31 10:35:38.305313"
   title: '[DRAFT] Llama Stack Specification'
   version: 0.0.1
 jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
@@ -3190,8 +3059,8 @@ paths:
           content:
             text/event-stream:
               schema:
-                $ref: '#/components/schemas/AgentTurnResponseStreamChunk'
-          description: OK
+                $ref: '#/components/schemas/Turn'
+          description: A single turn in an interaction with an Agentic System.
       tags:
       - Agents
   /agents/turn/get:
@@ -4276,23 +4145,23 @@ security:
 servers:
 - url: http://any-hosted-llama-stack.com
 tags:
-- name: Inference
-- name: Memory
-- name: Inspect
-- name: PostTraining
-- name: Models
+- name: Safety
 - name: Scoring
-- name: DatasetIO
 - name: BatchInference
-- name: Agents
-- name: Shields
-- name: MemoryBanks
-- name: Datasets
-- name: SyntheticDataGeneration
+- name: DatasetIO
+- name: Models
 - name: Eval
 - name: Telemetry
+- name: Shields
+- name: Datasets
+- name: Memory
+- name: PostTraining
 - name: ScoringFunctions
-- name: Safety
+- name: SyntheticDataGeneration
+- name: Inspect
+- name: MemoryBanks
+- name: Inference
+- name: Agents
 - description: <SchemaDefinition schemaRef="#/components/schemas/BuiltinTool" />
   name: BuiltinTool
 - description: <SchemaDefinition schemaRef="#/components/schemas/CompletionMessage"
@@ -4437,29 +4306,6 @@ tags:
 - description: <SchemaDefinition schemaRef="#/components/schemas/CreateAgentTurnRequest"
     />
   name: CreateAgentTurnRequest
-- description: 'Streamed agent execution response.
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseEvent" />'
-  name: AgentTurnResponseEvent
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepCompletePayload"
-    />
-  name: AgentTurnResponseStepCompletePayload
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepProgressPayload"
-    />
-  name: AgentTurnResponseStepProgressPayload
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepStartPayload"
-    />
-  name: AgentTurnResponseStepStartPayload
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStreamChunk"
-    />
-  name: AgentTurnResponseStreamChunk
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseTurnCompletePayload"
-    />
-  name: AgentTurnResponseTurnCompletePayload
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseTurnStartPayload"
-    />
-  name: AgentTurnResponseTurnStartPayload
 - description: <SchemaDefinition schemaRef="#/components/schemas/InferenceStep" />
   name: InferenceStep
 - description: <SchemaDefinition schemaRef="#/components/schemas/MemoryRetrievalStep"
@@ -4720,13 +4566,6 @@ x-tagGroups:
   - AgentCreateResponse
   - AgentSessionCreateResponse
   - AgentStepResponse
-  - AgentTurnResponseEvent
-  - AgentTurnResponseStepCompletePayload
-  - AgentTurnResponseStepProgressPayload
-  - AgentTurnResponseStepStartPayload
-  - AgentTurnResponseStreamChunk
-  - AgentTurnResponseTurnCompletePayload
-  - AgentTurnResponseTurnStartPayload
   - Attachment
   - BatchChatCompletionRequest
   - BatchChatCompletionResponse

--- a/llama_stack/apis/agents/agents.py
+++ b/llama_stack/apis/agents/agents.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from enum import Enum
 from typing import (
     Any,
+    AsyncIterator,
     Dict,
     List,
     Literal,
@@ -434,7 +435,7 @@ class Agents(Protocol):
         ],
         attachments: Optional[List[Attachment]] = None,
         stream: Optional[bool] = False,
-    ) -> AgentTurnResponseStreamChunk: ...
+    ) -> Union[Turn, AsyncIterator[AgentTurnResponseStreamChunk]]: ...
 
     @webmethod(route="/agents/turn/get")
     async def get_agents_turn(

--- a/llama_stack/apis/agents/agents.py
+++ b/llama_stack/apis/agents/agents.py
@@ -406,6 +406,8 @@ class AgentTurnCreateRequest(AgentConfigOverridablePerTurn):
 
 @json_schema_type
 class AgentTurnResponseStreamChunk(BaseModel):
+    """streamed agent turn completion response."""
+
     event: AgentTurnResponseEvent
 
 

--- a/llama_stack/apis/inference/inference.py
+++ b/llama_stack/apis/inference/inference.py
@@ -6,7 +6,15 @@
 
 from enum import Enum
 
-from typing import List, Literal, Optional, Protocol, runtime_checkable, Union
+from typing import (
+    AsyncIterator,
+    List,
+    Literal,
+    Optional,
+    Protocol,
+    runtime_checkable,
+    Union,
+)
 
 from llama_models.schema_utils import json_schema_type, webmethod
 
@@ -224,7 +232,7 @@ class Inference(Protocol):
         response_format: Optional[ResponseFormat] = None,
         stream: Optional[bool] = False,
         logprobs: Optional[LogProbConfig] = None,
-    ) -> Union[CompletionResponse, CompletionResponseStreamChunk]: ...
+    ) -> Union[CompletionResponse, AsyncIterator[CompletionResponseStreamChunk]]: ...
 
     @webmethod(route="/inference/chat_completion")
     async def chat_completion(
@@ -239,7 +247,9 @@ class Inference(Protocol):
         response_format: Optional[ResponseFormat] = None,
         stream: Optional[bool] = False,
         logprobs: Optional[LogProbConfig] = None,
-    ) -> Union[ChatCompletionResponse, ChatCompletionResponseStreamChunk]: ...
+    ) -> Union[
+        ChatCompletionResponse, AsyncIterator[ChatCompletionResponseStreamChunk]
+    ]: ...
 
     @webmethod(route="/inference/embeddings")
     async def embeddings(

--- a/llama_stack/distribution/client.py
+++ b/llama_stack/distribution/client.py
@@ -1,0 +1,183 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import inspect
+
+import json
+from collections.abc import AsyncIterator
+from typing import Any, get_args, get_origin, Type, Union
+
+import httpx
+
+from llama_models.schema_utils import WebMethod
+from pydantic import BaseModel, parse_obj_as
+from termcolor import cprint
+
+
+def extract_non_async_iterator_type(type_hint):
+    if get_origin(type_hint) is Union:
+        args = get_args(type_hint)
+        for arg in args:
+            if not issubclass(get_origin(arg) or arg, AsyncIterator):
+                return arg
+    return None
+
+
+def extract_async_iterator_type(type_hint):
+    if get_origin(type_hint) is Union:
+        args = get_args(type_hint)
+        for arg in args:
+            if issubclass(get_origin(arg) or arg, AsyncIterator):
+                inner_args = get_args(arg)
+                return inner_args[0]
+    return None
+
+
+def create_api_client_class(protocol) -> Type:
+    class APIClient:
+        def __init__(self, base_url: str):
+            self.base_url = base_url.rstrip("/")
+            self.routes = {}
+
+            # Store routes for this protocol
+            for name, method in inspect.getmembers(protocol):
+                if hasattr(method, "__webmethod__"):
+                    sig = inspect.signature(method)
+                    self.routes[name] = (method.__webmethod__, sig)
+
+        async def __acall__(self, method_name: str, *args, **kwargs) -> Any:
+            assert method_name in self.routes, f"Unknown endpoint: {method_name}"
+
+            # TODO: make this more precise, same thing needs to happen in server.py
+            is_streaming = kwargs.get("stream", False)
+            if is_streaming:
+                return self._call_streaming(method_name, *args, **kwargs)
+            else:
+                return await self._call_non_streaming(method_name, *args, **kwargs)
+
+        async def _call_non_streaming(self, method_name: str, *args, **kwargs) -> Any:
+            webmethod, sig = self.routes[method_name]
+
+            return_type = extract_non_async_iterator_type(sig.return_annotation)
+            assert (
+                return_type
+            ), f"Could not extract return type for {sig.return_annotation}"
+            cprint(f"{return_type=}", "yellow")
+
+            async with httpx.AsyncClient() as client:
+                params = self.httpx_request_params(webmethod, **kwargs)
+                response = await client.request(**params)
+                response.raise_for_status()
+
+                j = response.json()
+                if not j:
+                    return None
+                return parse_obj_as(return_type, j)
+
+        async def _call_streaming(self, method_name: str, *args, **kwargs) -> Any:
+            webmethod, sig = self.routes[method_name]
+
+            return_type = extract_async_iterator_type(sig.return_annotation)
+            assert (
+                return_type
+            ), f"Could not extract return type for {sig.return_annotation}"
+            cprint(f"{return_type=}", "yellow")
+
+            async with httpx.AsyncClient() as client:
+                params = self.httpx_request_params(webmethod, **kwargs)
+                async with client.stream(**params) as response:
+                    response.raise_for_status()
+
+                    async for line in response.aiter_lines():
+                        if line.startswith("data:"):
+                            data = line[len("data: ") :]
+                            try:
+                                if "error" in data:
+                                    cprint(data, "red")
+                                    continue
+
+                                yield parse_obj_as(return_type, json.loads(data))
+                            except Exception as e:
+                                print(data)
+                                print(f"Error with parsing or validation: {e}")
+
+        def httpx_request_params(self, webmethod: WebMethod, **kwargs) -> dict:
+            url = f"{self.base_url}{webmethod.route}"
+
+            def convert(value):
+                if isinstance(value, list):
+                    return [convert(v) for v in value]
+                elif isinstance(value, dict):
+                    return {k: convert(v) for k, v in value.items()}
+                elif isinstance(value, BaseModel):
+                    return json.loads(value.json())
+                else:
+                    return value
+
+            params = {}
+            data = {}
+            if webmethod.method == "GET":
+                params.update(kwargs)
+            else:
+                data.update(convert(kwargs))
+
+            print(f"{data=}")
+            return dict(
+                method=webmethod.method or "POST",
+                url=url,
+                headers={"Content-Type": "application/json"},
+                params=params,
+                json=data,
+                timeout=30,
+            )
+
+    # Add protocol methods to the wrapper
+    for name, method in inspect.getmembers(protocol):
+        if hasattr(method, "__webmethod__"):
+
+            async def method_impl(self, *args, method_name=name, **kwargs):
+                return await self.__acall__(method_name, *args, **kwargs)
+
+            method_impl.__name__ = name
+            method_impl.__qualname__ = f"APIClient.{name}"
+            method_impl.__signature__ = inspect.signature(method)
+            setattr(APIClient, name, method_impl)
+
+    # Name the class after the protocol
+    APIClient.__name__ = f"{protocol.__name__}Client"
+    return APIClient
+
+
+async def example(model: str = None):
+    from llama_stack.apis.inference import Inference, UserMessage  # noqa: F403
+    from llama_stack.apis.inference.event_logger import EventLogger
+
+    client_class = create_api_client_class(Inference)
+    client = client_class("http://localhost:5003")
+
+    if not model:
+        model = "Llama3.2-3B-Instruct"
+
+    message = UserMessage(
+        content="hello world, write me a 2 sentence poem about the moon"
+    )
+    cprint(f"User>{message.content}", "green")
+
+    stream = True
+    iterator = await client.chat_completion(
+        model=model,
+        messages=[message],
+        stream=stream,
+    )
+
+    async for log in EventLogger().log(iterator):
+        log.print()
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(example())

--- a/llama_stack/distribution/client.py
+++ b/llama_stack/distribution/client.py
@@ -36,7 +36,13 @@ def extract_async_iterator_type(type_hint):
     return None
 
 
+_CLIENT_CLASSES = {}
+
+
 def create_api_client_class(protocol) -> Type:
+    if protocol in _CLIENT_CLASSES:
+        return _CLIENT_CLASSES[protocol]
+
     class APIClient:
         def __init__(self, base_url: str):
             self.base_url = base_url.rstrip("/")
@@ -124,7 +130,6 @@ def create_api_client_class(protocol) -> Type:
             else:
                 data.update(convert(kwargs))
 
-            print(f"{data=}")
             return dict(
                 method=webmethod.method or "POST",
                 url=url,
@@ -148,6 +153,7 @@ def create_api_client_class(protocol) -> Type:
 
     # Name the class after the protocol
     APIClient.__name__ = f"{protocol.__name__}Client"
+    _CLIENT_CLASSES[protocol] = APIClient
     return APIClient
 
 

--- a/llama_stack/distribution/client.py
+++ b/llama_stack/distribution/client.py
@@ -8,51 +8,51 @@ import inspect
 
 import json
 from collections.abc import AsyncIterator
+from enum import Enum
 from typing import Any, get_args, get_origin, Type, Union
 
 import httpx
-
-from llama_models.schema_utils import WebMethod
 from pydantic import BaseModel, parse_obj_as
 from termcolor import cprint
 
-
-def extract_non_async_iterator_type(type_hint):
-    if get_origin(type_hint) is Union:
-        args = get_args(type_hint)
-        for arg in args:
-            if not issubclass(get_origin(arg) or arg, AsyncIterator):
-                return arg
-    return None
-
-
-def extract_async_iterator_type(type_hint):
-    if get_origin(type_hint) is Union:
-        args = get_args(type_hint)
-        for arg in args:
-            if issubclass(get_origin(arg) or arg, AsyncIterator):
-                inner_args = get_args(arg)
-                return inner_args[0]
-    return None
-
+from llama_stack.providers.datatypes import RemoteProviderConfig
 
 _CLIENT_CLASSES = {}
 
 
-def create_api_client_class(protocol) -> Type:
+async def get_client_impl(
+    protocol, additional_protocol, config: RemoteProviderConfig, _deps: Any
+):
+    client_class = create_api_client_class(protocol, additional_protocol)
+    impl = client_class(config.url)
+    await impl.initialize()
+    return impl
+
+
+def create_api_client_class(protocol, additional_protocol) -> Type:
     if protocol in _CLIENT_CLASSES:
         return _CLIENT_CLASSES[protocol]
 
+    protocols = [protocol, additional_protocol] if additional_protocol else [protocol]
+
     class APIClient:
         def __init__(self, base_url: str):
+            print(f"({protocol.__name__}) Connecting to {base_url}")
             self.base_url = base_url.rstrip("/")
             self.routes = {}
 
             # Store routes for this protocol
-            for name, method in inspect.getmembers(protocol):
-                if hasattr(method, "__webmethod__"):
-                    sig = inspect.signature(method)
-                    self.routes[name] = (method.__webmethod__, sig)
+            for p in protocols:
+                for name, method in inspect.getmembers(p):
+                    if hasattr(method, "__webmethod__"):
+                        sig = inspect.signature(method)
+                        self.routes[name] = (method.__webmethod__, sig)
+
+        async def initialize(self):
+            pass
+
+        async def shutdown(self):
+            pass
 
         async def __acall__(self, method_name: str, *args, **kwargs) -> Any:
             assert method_name in self.routes, f"Unknown endpoint: {method_name}"
@@ -65,21 +65,23 @@ def create_api_client_class(protocol) -> Type:
                 return await self._call_non_streaming(method_name, *args, **kwargs)
 
         async def _call_non_streaming(self, method_name: str, *args, **kwargs) -> Any:
-            webmethod, sig = self.routes[method_name]
+            _, sig = self.routes[method_name]
 
-            return_type = extract_non_async_iterator_type(sig.return_annotation)
-            assert (
-                return_type
-            ), f"Could not extract return type for {sig.return_annotation}"
-            cprint(f"{return_type=}", "yellow")
+            if sig.return_annotation is None:
+                return_type = None
+            else:
+                return_type = extract_non_async_iterator_type(sig.return_annotation)
+                assert (
+                    return_type
+                ), f"Could not extract return type for {sig.return_annotation}"
 
             async with httpx.AsyncClient() as client:
-                params = self.httpx_request_params(webmethod, **kwargs)
+                params = self.httpx_request_params(method_name, *args, **kwargs)
                 response = await client.request(**params)
                 response.raise_for_status()
 
                 j = response.json()
-                if not j:
+                if j is None:
                     return None
                 return parse_obj_as(return_type, j)
 
@@ -90,10 +92,9 @@ def create_api_client_class(protocol) -> Type:
             assert (
                 return_type
             ), f"Could not extract return type for {sig.return_annotation}"
-            cprint(f"{return_type=}", "yellow")
 
             async with httpx.AsyncClient() as client:
-                params = self.httpx_request_params(webmethod, **kwargs)
+                params = self.httpx_request_params(method_name, *args, **kwargs)
                 async with client.stream(**params) as response:
                     response.raise_for_status()
 
@@ -110,7 +111,15 @@ def create_api_client_class(protocol) -> Type:
                                 print(data)
                                 print(f"Error with parsing or validation: {e}")
 
-        def httpx_request_params(self, webmethod: WebMethod, **kwargs) -> dict:
+        def httpx_request_params(self, method_name: str, *args, **kwargs) -> dict:
+            webmethod, sig = self.routes[method_name]
+
+            parameters = list(sig.parameters.values())[1:]  # skip `self`
+            for i, param in enumerate(parameters):
+                if i >= len(args):
+                    break
+                kwargs[param.name] = args[i]
+
             url = f"{self.base_url}{webmethod.route}"
 
             def convert(value):
@@ -119,7 +128,9 @@ def create_api_client_class(protocol) -> Type:
                 elif isinstance(value, dict):
                     return {k: convert(v) for k, v in value.items()}
                 elif isinstance(value, BaseModel):
-                    return json.loads(value.json())
+                    return json.loads(value.model_dump_json())
+                elif isinstance(value, Enum):
+                    return value.value
                 else:
                     return value
 
@@ -140,21 +151,42 @@ def create_api_client_class(protocol) -> Type:
             )
 
     # Add protocol methods to the wrapper
-    for name, method in inspect.getmembers(protocol):
-        if hasattr(method, "__webmethod__"):
+    for p in protocols:
+        for name, method in inspect.getmembers(p):
+            if hasattr(method, "__webmethod__"):
 
-            async def method_impl(self, *args, method_name=name, **kwargs):
-                return await self.__acall__(method_name, *args, **kwargs)
+                async def method_impl(self, *args, method_name=name, **kwargs):
+                    return await self.__acall__(method_name, *args, **kwargs)
 
-            method_impl.__name__ = name
-            method_impl.__qualname__ = f"APIClient.{name}"
-            method_impl.__signature__ = inspect.signature(method)
-            setattr(APIClient, name, method_impl)
+                method_impl.__name__ = name
+                method_impl.__qualname__ = f"APIClient.{name}"
+                method_impl.__signature__ = inspect.signature(method)
+                setattr(APIClient, name, method_impl)
 
     # Name the class after the protocol
     APIClient.__name__ = f"{protocol.__name__}Client"
     _CLIENT_CLASSES[protocol] = APIClient
     return APIClient
+
+
+# not quite general these methods are
+def extract_non_async_iterator_type(type_hint):
+    if get_origin(type_hint) is Union:
+        args = get_args(type_hint)
+        for arg in args:
+            if not issubclass(get_origin(arg) or arg, AsyncIterator):
+                return arg
+    return type_hint
+
+
+def extract_async_iterator_type(type_hint):
+    if get_origin(type_hint) is Union:
+        args = get_args(type_hint)
+        for arg in args:
+            if issubclass(get_origin(arg) or arg, AsyncIterator):
+                inner_args = get_args(arg)
+                return inner_args[0]
+    return None
 
 
 async def example(model: str = None):

--- a/llama_stack/providers/datatypes.py
+++ b/llama_stack/providers/datatypes.py
@@ -60,7 +60,7 @@ class MemoryBanksProtocolPrivate(Protocol):
 class DatasetsProtocolPrivate(Protocol):
     async def list_datasets(self) -> List[DatasetDef]: ...
 
-    async def register_datasets(self, dataset_def: DatasetDef) -> None: ...
+    async def register_dataset(self, dataset_def: DatasetDef) -> None: ...
 
 
 class ScoringFunctionsProtocolPrivate(Protocol):
@@ -171,7 +171,7 @@ as being "Llama Stack compatible"
     def module(self) -> str:
         if self.adapter:
             return self.adapter.module
-        return f"llama_stack.apis.{self.api.value}.client"
+        return "llama_stack.distribution.client"
 
     @property
     def pip_packages(self) -> List[str]:

--- a/llama_stack/providers/tests/agents/test_agents.py
+++ b/llama_stack/providers/tests/agents/test_agents.py
@@ -26,6 +26,7 @@ from dotenv import load_dotenv
 #
 # ```bash
 # PROVIDER_ID=<your_provider> \
+#   MODEL_ID=<your_model> \
 #   PROVIDER_CONFIG=provider_config.yaml \
 #   pytest -s llama_stack/providers/tests/agents/test_agents.py \
 #   --tb=short --disable-warnings
@@ -44,7 +45,7 @@ async def agents_settings():
         "impl": impls[Api.agents],
         "memory_impl": impls[Api.memory],
         "common_params": {
-            "model": "Llama3.1-8B-Instruct",
+            "model": os.environ["MODEL_ID"] or "Llama3.1-8B-Instruct",
             "instructions": "You are a helpful assistant.",
         },
     }

--- a/llama_stack/providers/tests/memory/test_memory.py
+++ b/llama_stack/providers/tests/memory/test_memory.py
@@ -3,7 +3,6 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
-import os
 
 import pytest
 import pytest_asyncio
@@ -73,7 +72,6 @@ async def register_memory_bank(banks_impl: MemoryBanks):
         embedding_model="all-MiniLM-L6-v2",
         chunk_size_in_tokens=512,
         overlap_size_in_tokens=64,
-        provider_id=os.environ["PROVIDER_ID"],
     )
 
     await banks_impl.register_memory_bank(bank)


### PR DESCRIPTION
# What does this PR do?

We have frequently bit-rotten (apis/<api>/client.py) files. They have two drawbacks:
- we need to hand-write these client implementations (work!)
- they often are poorly written and untested
- they are accompanied with some useful testing code which is useful for developers but not intended for end users.

This PR is the first step towards killing these hand-written implementations. It dynamically creates Client classes for each API protocol and registers appropriate methods based on type introspection.

### Test Plan 
First, I ran an ollama server (`ollama run llama3.2:3b-instruct-fp16`) and then started a Llama Stack using `--template ollama` on port 5003.

Then I set up the following yaml for testing:
```yaml
providers:
 - provider_id: remote
   provider_type: remote
   config: 
     host: localhost
     port: 5003
```

Then I ran the following set of tests:
```bash
MODEL_IDS=Llama3.2-3B-Instruct \
PROVIDER_ID=remote \
PROVIDER_CONFIG=config.yaml \
$CONDA_PREFIX/bin/pytest -s llama_stack/providers/tests/inference/test_inference.py

PROVIDER_ID=remote \
PROVIDER_CONFIG=config.yaml \
$CONDA_PREFIX/bin/pytest -s llama_stack/providers/tests/memory/test_memory.py
```

Then I modified the config.yaml to be: 
```yaml
providers:
  inference:
  - provider_id: remote
    provider_type: remote
    config:
      host: localhost
      port: 5003
  safety:
  - provider_id: remote
    provider_type: remote
    config:
      host: localhost
      port: 5003
  memory:
  - provider_id: remote
    provider_type: remote
    config:
      host: localhost
      port: 5003
  agents:
  - provider_id: remote
    provider_type: remote
    config:
      host: localhost
      port: 5003
```

And ran the following tests:
```
MODEL_ID=Llama3.2-3B-Instruct \
PROVIDER_ID=remote \
PROVIDER_CONFIG=config.yaml \
$CONDA_PREFIX/bin/pytest -s llama_stack/providers/tests/agents/test_agents.py
```
This test did not fully pass due to an unexpected model response from the ollama 3b-instruct llama model w.r.t. tool calling but tests which didn't exercise tool calling passed.
