### PR TITLE
fix bedrock impl

### DIFF
--- a/llama_stack/providers/adapters/inference/bedrock/bedrock.py
+++ b/llama_stack/providers/adapters/inference/bedrock/bedrock.py
@@ -295,7 +295,9 @@ class BedrockInferenceAdapter(ModelRegistryHelper, Inference):
         tool_prompt_format: Optional[ToolPromptFormat] = ToolPromptFormat.json,
         stream: Optional[bool] = False,
         logprobs: Optional[LogProbConfig] = None,
-    ) -> AsyncGenerator:
+    ) -> Union[
+        ChatCompletionResponse, AsyncIterator[ChatCompletionResponseStreamChunk]
+    ]:
         request = ChatCompletionRequest(
             model=model,
             messages=messages,
@@ -316,7 +318,6 @@ class BedrockInferenceAdapter(ModelRegistryHelper, Inference):
     async def _nonstream_chat_completion(
         self, request: ChatCompletionRequest
     ) -> ChatCompletionResponse:
-        print("non-streaming chat completion")
         params = self._get_params_for_chat_completion(request)
         converse_api_res = self.client.converse(**params)
 
@@ -332,7 +333,6 @@ class BedrockInferenceAdapter(ModelRegistryHelper, Inference):
     async def _stream_chat_completion(
         self, request: ChatCompletionRequest
     ) -> AsyncGenerator:
-        print("streaming chat completion")
         params = self._get_params_for_chat_completion(request)
         converse_stream_api_res = self.client.converse_stream(**params)
         event_stream = converse_stream_api_res["stream"]

--- a/llama_stack/providers/adapters/inference/bedrock/bedrock.py
+++ b/llama_stack/providers/adapters/inference/bedrock/bedrock.py
@@ -57,7 +57,7 @@ class BedrockInferenceAdapter(ModelRegistryHelper, Inference):
         logprobs: Optional[LogProbConfig] = None,
     ) -> AsyncGenerator:
         raise NotImplementedError()
- 
+
     @staticmethod
     def _bedrock_stop_reason_to_stop_reason(bedrock_stop_reason: str) -> StopReason:
         if bedrock_stop_reason == "max_tokens":
@@ -352,7 +352,9 @@ class BedrockInferenceAdapter(ModelRegistryHelper, Inference):
                         delta=ToolCallDelta(
                             content=ToolCall(
                                 tool_name=chunk["contentBlockStart"]["toolUse"]["name"],
-                                call_id=chunk["contentBlockStart"]["toolUse"]["toolUseId"],
+                                call_id=chunk["contentBlockStart"]["toolUse"][
+                                    "toolUseId"
+                                ],
                             ),
                             parse_status=ToolCallParseStatus.started,
                         ),
@@ -364,7 +366,9 @@ class BedrockInferenceAdapter(ModelRegistryHelper, Inference):
                 else:
                     delta = ToolCallDelta(
                         content=ToolCall(
-                            arguments=chunk["contentBlockDelta"]["delta"]["toolUse"]["input"]
+                            arguments=chunk["contentBlockDelta"]["delta"]["toolUse"][
+                                "input"
+                            ]
                         ),
                         parse_status=ToolCallParseStatus.success,
                     )
@@ -379,8 +383,10 @@ class BedrockInferenceAdapter(ModelRegistryHelper, Inference):
                 # Ignored
                 pass
             elif "messageStop" in chunk:
-                stop_reason = BedrockInferenceAdapter._bedrock_stop_reason_to_stop_reason(
-                    chunk["messageStop"]["stopReason"]
+                stop_reason = (
+                    BedrockInferenceAdapter._bedrock_stop_reason_to_stop_reason(
+                        chunk["messageStop"]["stopReason"]
+                    )
                 )
 
                 yield ChatCompletionResponseStreamChunk(


### PR DESCRIPTION
This is needed after the async refactor.
testplan:
* llama stack build --template bedrock --image-type conda
* llama stack run bedrock --port 5000
*  python examples/inference/client.py localhost 5000 
```
User>hello world, write me a 2 sentence poem about the moon
Assistant>

Here is a 2-sentence poem about the moon:

The moon glows bright in the midnight sky,
A beacon of wonder, as it passes by.
[ModelDefWithProvider(identifier='Llama3.1-8B-Instruct', llama_model='Llama3.1-8B-Instruct', metadata={}, provider_id='remote::bedrock'), ModelDefWithProvider(identifier='Llama3.1-70B-Instruct', llama_model='Llama3.1-70B-Instruct', metadata={}, provider_id='remote::bedrock'), ModelDefWithProvider(identifier='Llama3.1-405B-Instruct', llama_model='Llama3.1-405B-Instruct', metadata={}, provider_id='remote::bedrock')]
```