### PR TITLE
Correct a traceback in vllm

### DIFF
--- a/llama_stack/providers/adapters/inference/vllm/vllm.py
+++ b/llama_stack/providers/adapters/inference/vllm/vllm.py
@@ -134,7 +134,7 @@ class VLLMInferenceAdapter(Inference, ModelsProtocolPrivate):
 
         stream = _to_async_generator()
         async for chunk in process_chat_completion_stream_response(
-            request, stream, self.formatter
+            stream, self.formatter
         ):
             yield chunk
 


### PR DESCRIPTION
# What does this PR do?
We get this traceback:

File "/usr/local/lib/python3.10/site-packages/llama_stack/providers/adapters/inference/vllm/vllm.py", line 136, in _stream_chat_completion async for chunk in process_chat_completion_stream_response( TypeError: process_chat_completion_stream_response() takes 2 positional arguments but 3 were given

This corrects the error by deleting the "request" variable to match other inference adapters.
Mentioned in  #357 

## Feature/Issue validation/testing/test plan

Please describe the tests that you ran to verify your changes and relevant result summary. 
python -m llama_stack.apis.safety.client localhost 5000

