### PR TITLE
[LlamaStack] Fix pydantic issue for instance method

### DIFF
--- a/llama_stack/providers/utils/kvstore/config.py
+++ b/llama_stack/providers/utils/kvstore/config.py
@@ -55,7 +55,8 @@ class PostgresKVStoreConfig(CommonConfig):
     table_name: str = "llamastack_kvstore"
 
     @field_validator("table_name")
-    def validate_table_name(self, v: str) -> str:
+    @classmethod
+    def validate_table_name(cls, v: str) -> str:
         # PostgreSQL identifiers rules:
         # - Must start with a letter or underscore
         # - Can contain letters, numbers, and underscores


### PR DESCRIPTION
# What does this PR do?

PostgresKVStore config triggered a new pydantic error, since you cannot apply field validator on instance method

## Feature/Issue validation/testing/test plan

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration or test plan.

- [x] Running it locally before and after
before
```
(stack) bchen@dev-modeling:~/llama-stack/llama-stack(main)$ llama stack
Traceback (most recent call last):
  File "/home/bchen/miniconda3/envs/stack/bin/llama", line 5, in <module>
    from llama_stack.cli.llama import main
  File "/home/bchen/llama-stack/llama-stack/llama_stack/cli/llama.py", line 11, in <module>
    from .stack import StackParser
  File "/home/bchen/llama-stack/llama-stack/llama_stack/cli/stack/__init__.py", line 7, in <module>
    from .stack import StackParser  # noqa
  File "/home/bchen/llama-stack/llama-stack/llama_stack/cli/stack/stack.py", line 11, in <module>
    from .build import StackBuild
  File "/home/bchen/llama-stack/llama-stack/llama_stack/cli/stack/build.py", line 10, in <module>
    from llama_stack.distribution.datatypes import *  # noqa: F403
  File "/home/bchen/llama-stack/llama-stack/llama_stack/distribution/datatypes.py", line 24, in <module>
    from llama_stack.providers.utils.kvstore.config import KVStoreConfig
  File "/home/bchen/llama-stack/llama-stack/llama_stack/providers/utils/kvstore/__init__.py", line 7, in <module>
    from .kvstore import *  # noqa: F401, F403
  File "/home/bchen/llama-stack/llama-stack/llama_stack/providers/utils/kvstore/kvstore.py", line 8, in <module>
    from .config import *  # noqa: F403
  File "/home/bchen/llama-stack/llama-stack/llama_stack/providers/utils/kvstore/config.py", line 48, in <module>
    class PostgresKVStoreConfig(CommonConfig):
  File "/home/bchen/llama-stack/llama-stack/llama_stack/providers/utils/kvstore/config.py", line 59, in PostgresKVStoreConfig
    def validate_table_name(self, v: str) -> str:
  File "/home/bchen/.local/lib/python3.10/site-packages/pydantic/functional_validators.py", line 484, in dec
    raise PydanticUserError(
pydantic.errors.PydanticUserError: `@field_validator` cannot be applied to instance methods

For further information visit https://errors.pydantic.dev/2.9/u/validator-instance-method

```
after
```
(stack) bchen@dev-modeling:~/llama-stack/llama-stack(main)$ llama stack
usage: llama [-h] {download,model,stack} ...

Welcome to the Llama CLI

options:
  -h, --help            show this help message and exit

subcommands:
  {download,model,stack}
```


## Sources

Please link relevant resources if necessary.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

Thanks for contributing 🎉!
