### PR TITLE
Enable remote::vllm

### DIFF
--- a/llama_stack/providers/adapters/inference/vllm/__init__.py
+++ b/llama_stack/providers/adapters/inference/vllm/__init__.py
@@ -4,12 +4,15 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from .config import VLLMImplConfig
-from .vllm import VLLMInferenceAdapter
+from .config import VLLMInferenceAdapterConfig
 
 
-async def get_adapter_impl(config: VLLMImplConfig, _deps):
-    assert isinstance(config, VLLMImplConfig), f"Unexpected config type: {type(config)}"
+async def get_adapter_impl(config: VLLMInferenceAdapterConfig, _deps):
+    from .vllm import VLLMInferenceAdapter
+
+    assert isinstance(
+        config, VLLMInferenceAdapterConfig
+    ), f"Unexpected config type: {type(config)}"
     impl = VLLMInferenceAdapter(config)
     await impl.initialize()
     return impl

--- a/llama_stack/providers/adapters/inference/vllm/config.py
+++ b/llama_stack/providers/adapters/inference/vllm/config.py
@@ -11,12 +11,16 @@ from pydantic import BaseModel, Field
 
 
 @json_schema_type
-class VLLMImplConfig(BaseModel):
+class VLLMInferenceAdapterConfig(BaseModel):
     url: Optional[str] = Field(
         default=None,
         description="The URL for the vLLM model serving endpoint",
     )
+    max_tokens: int = Field(
+        default=4096,
+        description="Maximum number of tokens to generate.",
+    )
     api_token: Optional[str] = Field(
-        default=None,
+        default="fake",
         description="The API token",
     )

--- a/llama_stack/providers/registry/inference.py
+++ b/llama_stack/providers/registry/inference.py
@@ -61,15 +61,15 @@ def available_providers() -> List[ProviderSpec]:
                 module="llama_stack.providers.adapters.inference.ollama",
             ),
         ),
-        # remote_provider_spec(
-        #     api=Api.inference,
-        #     adapter=AdapterSpec(
-        #         adapter_type="vllm",
-        #         pip_packages=["openai"],
-        #         module="llama_stack.providers.adapters.inference.vllm",
-        #         config_class="llama_stack.providers.adapters.inference.vllm.VLLMImplConfig",
-        #     ),
-        # ),
+        remote_provider_spec(
+            api=Api.inference,
+            adapter=AdapterSpec(
+                adapter_type="vllm",
+                pip_packages=["openai"],
+                module="llama_stack.providers.adapters.inference.vllm",
+                config_class="llama_stack.providers.adapters.inference.vllm.VLLMInferenceAdapterConfig",
+            ),
+        ),
         remote_provider_spec(
             api=Api.inference,
             adapter=AdapterSpec(

--- a/llama_stack/providers/tests/inference/fixtures.py
+++ b/llama_stack/providers/tests/inference/fixtures.py
@@ -14,6 +14,7 @@ from llama_stack.distribution.datatypes import Api, Provider
 from llama_stack.providers.adapters.inference.fireworks import FireworksImplConfig
 from llama_stack.providers.adapters.inference.ollama import OllamaImplConfig
 from llama_stack.providers.adapters.inference.together import TogetherImplConfig
+from llama_stack.providers.adapters.inference.vllm import VLLMInferenceAdapterConfig
 from llama_stack.providers.impls.meta_reference.inference import (
     MetaReferenceInferenceConfig,
 )
@@ -79,6 +80,21 @@ def inference_ollama(inference_model) -> ProviderFixture:
 
 
 @pytest.fixture(scope="session")
+def inference_vllm_remote() -> ProviderFixture:
+    return ProviderFixture(
+        providers=[
+            Provider(
+                provider_id="remote::vllm",
+                provider_type="remote::vllm",
+                config=VLLMInferenceAdapterConfig(
+                    url=get_env_or_fail("VLLM_URL"),
+                ).model_dump(),
+            )
+        ],
+    )
+
+
+@pytest.fixture(scope="session")
 def inference_fireworks() -> ProviderFixture:
     return ProviderFixture(
         providers=[
@@ -109,7 +125,14 @@ def inference_together() -> ProviderFixture:
     )
 
 
-INFERENCE_FIXTURES = ["meta_reference", "ollama", "fireworks", "together", "remote"]
+INFERENCE_FIXTURES = [
+    "meta_reference",
+    "ollama",
+    "fireworks",
+    "together",
+    "vllm_remote",
+    "remote",
+]
 
 
 @pytest_asyncio.fixture(scope="session")


### PR DESCRIPTION
# What does this PR do?

Enables support for `remote::vllm` adapter for inference. That is, you can run `vllm` server independently outside the llama stack distribution and be able to connect to it and work with everything else on top.

### Test Plan

Added a fixture. Tested as:

```bash
pytest -v -s -m "vllm_remote and llama_3b" test_inference.py --env VLLM_URL=http://localhost:5101/v1
```

(after starting a vllm container serving Llama3.2-3B-Instruct)
