### PR TITLE
Use the list endpoint instead of ps to get ollama's models

### DIFF
--- a/llama_stack/providers/remote/inference/ollama/ollama.py
+++ b/llama_stack/providers/remote/inference/ollama/ollama.py
@@ -72,7 +72,7 @@ class OllamaInferenceAdapter(Inference, ModelsProtocolPrivate):
         ollama_to_llama = {v: k for k, v in OLLAMA_SUPPORTED_MODELS.items()}
 
         ret = []
-        res = await self.client.ps()
+        res = await self.client.list()
         for r in res["models"]:
             if r["model"] not in ollama_to_llama:
                 print(f"Ollama is running a model unknown to Llama Stack: {r['model']}")


### PR DESCRIPTION
# What does this PR do?

Change the endpoint used to determine what models are available in ollama from `/api/ps` to `/api/tags`

- [x] Addresses issue #332 

## Feature/Issue validation/testing/test plan

To reproduce the problem observed in the issue above:
 - Start the `ollama` server (ensure there are compatible models installed)
 - Ensure there is no current process running any model with `ollama ps`
 - Start the llama-stack server and no model will be found, although the models are usable in ollama

After the change, there is no need to have a process running the models in Ollama. It'll pick them up anyway.


## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Ran pre-commit to handle lint / formatting issues.
- [x] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [x] Updated relevant documentation.
- [ ] Wrote necessary unit or integration tests.
