### PR TITLE
migrate evals to resource

### DIFF
--- a/llama_stack/apis/eval_tasks/eval_tasks.py
+++ b/llama_stack/apis/eval_tasks/eval_tasks.py
@@ -7,12 +7,14 @@ from typing import Any, Dict, List, Literal, Optional, Protocol, runtime_checkab
 
 from llama_models.schema_utils import json_schema_type, webmethod
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from llama_stack.apis.resource import Resource
 
 
 @json_schema_type
-class EvalTaskDef(BaseModel):
-    identifier: str
+class EvalTask(Resource):
+    type: Literal["eval_task"] = "eval_task"
     dataset_id: str
     scoring_functions: List[str]
     metadata: Dict[str, Any] = Field(
@@ -21,23 +23,21 @@ class EvalTaskDef(BaseModel):
     )
 
 
-@json_schema_type
-class EvalTaskDefWithProvider(EvalTaskDef):
-    type: Literal["eval_task"] = "eval_task"
-    provider_id: str = Field(
-        description="ID of the provider which serves this dataset",
-    )
-
-
 @runtime_checkable
 class EvalTasks(Protocol):
     @webmethod(route="/eval_tasks/list", method="GET")
-    async def list_eval_tasks(self) -> List[EvalTaskDefWithProvider]: ...
+    async def list_eval_tasks(self) -> List[EvalTask]: ...
 
     @webmethod(route="/eval_tasks/get", method="GET")
-    async def get_eval_task(self, name: str) -> Optional[EvalTaskDefWithProvider]: ...
+    async def get_eval_task(self, name: str) -> Optional[EvalTask]: ...
 
     @webmethod(route="/eval_tasks/register", method="POST")
     async def register_eval_task(
-        self, eval_task_def: EvalTaskDefWithProvider
+        self,
+        eval_task_id: str,
+        dataset_id: str,
+        scoring_functions: List[str],
+        provider_id: Optional[str] = None,
+        provider_eval_task_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> None: ...

--- a/llama_stack/apis/eval_tasks/eval_tasks.py
+++ b/llama_stack/apis/eval_tasks/eval_tasks.py
@@ -37,7 +37,7 @@ class EvalTasks(Protocol):
         eval_task_id: str,
         dataset_id: str,
         scoring_functions: List[str],
-        provider_id: Optional[str] = None,
         provider_eval_task_id: Optional[str] = None,
+        provider_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> None: ...

--- a/llama_stack/distribution/routers/routing_tables.py
+++ b/llama_stack/distribution/routers/routing_tables.py
@@ -367,8 +367,8 @@ class EvalTasksRoutingTable(CommonRoutingTableImpl, EvalTasks):
         dataset_id: str,
         scoring_functions: List[str],
         metadata: Optional[Dict[str, Any]] = None,
-        provider_id: Optional[str] = None,
         provider_eval_task_id: Optional[str] = None,
+        provider_id: Optional[str] = None,
     ) -> None:
         if metadata is None:
             metadata = {}

--- a/llama_stack/distribution/routers/routing_tables.py
+++ b/llama_stack/distribution/routers/routing_tables.py
@@ -105,8 +105,6 @@ class CommonRoutingTableImpl(RoutingTable):
 
             elif api == Api.eval:
                 p.eval_task_store = self
-                eval_tasks = await p.list_eval_tasks()
-                await add_objects(eval_tasks, pid, EvalTaskDefWithProvider)
 
     async def shutdown(self) -> None:
         for p in self.impls_by_provider_id.values():
@@ -357,11 +355,38 @@ class ScoringFunctionsRoutingTable(CommonRoutingTableImpl, ScoringFunctions):
 
 
 class EvalTasksRoutingTable(CommonRoutingTableImpl, EvalTasks):
-    async def list_eval_tasks(self) -> List[ScoringFnDefWithProvider]:
+    async def list_eval_tasks(self) -> List[EvalTask]:
         return await self.get_all_with_type("eval_task")
 
-    async def get_eval_task(self, name: str) -> Optional[EvalTaskDefWithProvider]:
+    async def get_eval_task(self, name: str) -> Optional[EvalTask]:
         return await self.get_object_by_identifier(name)
 
-    async def register_eval_task(self, eval_task_def: EvalTaskDefWithProvider) -> None:
-        await self.register_object(eval_task_def)
+    async def register_eval_task(
+        self,
+        eval_task_id: str,
+        dataset_id: str,
+        scoring_functions: List[str],
+        metadata: Optional[Dict[str, Any]] = None,
+        provider_id: Optional[str] = None,
+        provider_eval_task_id: Optional[str] = None,
+    ) -> None:
+        if metadata is None:
+            metadata = {}
+        if provider_id is None:
+            if len(self.impls_by_provider_id) == 1:
+                provider_id = list(self.impls_by_provider_id.keys())[0]
+            else:
+                raise ValueError(
+                    "No provider specified and multiple providers available. Please specify a provider_id."
+                )
+        if provider_eval_task_id is None:
+            provider_eval_task_id = eval_task_id
+        eval_task = EvalTask(
+            identifier=eval_task_id,
+            dataset_id=dataset_id,
+            scoring_functions=scoring_functions,
+            metadata=metadata,
+            provider_id=provider_id,
+            provider_resource_id=provider_eval_task_id,
+        )
+        await self.register_object(eval_task)

--- a/llama_stack/providers/datatypes.py
+++ b/llama_stack/providers/datatypes.py
@@ -12,8 +12,8 @@ from llama_models.schema_utils import json_schema_type
 from pydantic import BaseModel, Field
 
 from llama_stack.apis.datasets import Dataset
-from llama_stack.apis.eval_tasks import EvalTaskDef
 from llama_stack.apis.memory_banks.memory_banks import MemoryBank
+from llama_stack.apis.eval_tasks import EvalTask
 from llama_stack.apis.models import Model
 from llama_stack.apis.scoring_functions import ScoringFnDef
 from llama_stack.apis.shields import Shield
@@ -67,9 +67,9 @@ class ScoringFunctionsProtocolPrivate(Protocol):
 
 
 class EvalTasksProtocolPrivate(Protocol):
-    async def list_eval_tasks(self) -> List[EvalTaskDef]: ...
+    async def list_eval_tasks(self) -> List[EvalTask]: ...
 
-    async def register_eval_task(self, eval_task_def: EvalTaskDef) -> None: ...
+    async def register_eval_task(self, eval_task: EvalTask) -> None: ...
 
 
 @json_schema_type

--- a/llama_stack/providers/datatypes.py
+++ b/llama_stack/providers/datatypes.py
@@ -67,8 +67,6 @@ class ScoringFunctionsProtocolPrivate(Protocol):
 
 
 class EvalTasksProtocolPrivate(Protocol):
-    async def list_eval_tasks(self) -> List[EvalTask]: ...
-
     async def register_eval_task(self, eval_task: EvalTask) -> None: ...
 
 

--- a/llama_stack/providers/datatypes.py
+++ b/llama_stack/providers/datatypes.py
@@ -12,8 +12,8 @@ from llama_models.schema_utils import json_schema_type
 from pydantic import BaseModel, Field
 
 from llama_stack.apis.datasets import Dataset
-from llama_stack.apis.memory_banks.memory_banks import MemoryBank
 from llama_stack.apis.eval_tasks import EvalTask
+from llama_stack.apis.memory_banks.memory_banks import MemoryBank
 from llama_stack.apis.models import Model
 from llama_stack.apis.scoring_functions import ScoringFnDef
 from llama_stack.apis.shields import Shield

--- a/llama_stack/providers/inline/eval/meta_reference/eval.py
+++ b/llama_stack/providers/inline/eval/meta_reference/eval.py
@@ -56,9 +56,6 @@ class MetaReferenceEvalImpl(Eval, EvalTasksProtocolPrivate):
     async def register_eval_task(self, task_def: EvalTask) -> None:
         self.eval_tasks[task_def.identifier] = task_def
 
-    async def list_eval_tasks(self) -> List[EvalTask]:
-        return list(self.eval_tasks.values())
-
     async def validate_eval_input_dataset_schema(self, dataset_id: str) -> None:
         dataset_def = await self.datasets_api.get_dataset(dataset_identifier=dataset_id)
         if not dataset_def.dataset_schema or len(dataset_def.dataset_schema) == 0:

--- a/llama_stack/providers/inline/eval/meta_reference/eval.py
+++ b/llama_stack/providers/inline/eval/meta_reference/eval.py
@@ -11,7 +11,7 @@ from .....apis.eval.eval import Eval, EvalTaskConfig, EvaluateResponse, JobStatu
 from llama_stack.apis.common.type_system import *  # noqa: F403
 from llama_stack.apis.datasetio import DatasetIO
 from llama_stack.apis.datasets import Datasets
-from llama_stack.apis.eval_tasks import EvalTaskDef
+from llama_stack.apis.eval_tasks import EvalTask
 from llama_stack.apis.inference import Inference
 from llama_stack.apis.scoring import Scoring
 from llama_stack.providers.datatypes import EvalTasksProtocolPrivate
@@ -53,10 +53,10 @@ class MetaReferenceEvalImpl(Eval, EvalTasksProtocolPrivate):
 
     async def shutdown(self) -> None: ...
 
-    async def register_eval_task(self, task_def: EvalTaskDef) -> None:
+    async def register_eval_task(self, task_def: EvalTask) -> None:
         self.eval_tasks[task_def.identifier] = task_def
 
-    async def list_eval_tasks(self) -> List[EvalTaskDef]:
+    async def list_eval_tasks(self) -> List[EvalTask]:
         return list(self.eval_tasks.values())
 
     async def validate_eval_input_dataset_schema(self, dataset_id: str) -> None:

--- a/llama_stack/providers/inline/eval/meta_reference/eval.py
+++ b/llama_stack/providers/inline/eval/meta_reference/eval.py
@@ -57,8 +57,8 @@ class MetaReferenceEvalImpl(Eval, EvalTasksProtocolPrivate):
         self.eval_tasks[task_def.identifier] = task_def
 
     async def validate_eval_input_dataset_schema(self, dataset_id: str) -> None:
-        dataset_def = await self.datasets_api.get_dataset(dataset_identifier=dataset_id)
-        if not dataset_def.dataset_schema or len(dataset_def.dataset_schema) == 0:
+        dataset_def = await self.datasets_api.get_dataset(dataset_id=dataset_id)
+        if not dataset_def.schema or len(dataset_def.schema) == 0:
             raise ValueError(f"Dataset {dataset_id} does not have a schema defined.")
 
         expected_schemas = [
@@ -74,7 +74,7 @@ class MetaReferenceEvalImpl(Eval, EvalTasksProtocolPrivate):
             },
         ]
 
-        if dataset_def.dataset_schema not in expected_schemas:
+        if dataset_def.schema not in expected_schemas:
             raise ValueError(
                 f"Dataset {dataset_id} does not have a correct input schema in {expected_schemas}"
             )

--- a/llama_stack/providers/tests/eval/test_eval.py
+++ b/llama_stack/providers/tests/eval/test_eval.py
@@ -11,8 +11,6 @@ from llama_models.llama3.api import SamplingParams, URL
 
 from llama_stack.apis.common.type_system import ChatCompletionInputType, StringType
 
-from llama_stack.apis.datasetio.datasetio import DatasetDefWithProvider
-
 from llama_stack.apis.eval.eval import (
     AppEvalTaskConfig,
     BenchmarkEvalTaskConfig,
@@ -164,24 +162,21 @@ class Testeval:
             pytest.skip(
                 "Only huggingface provider supports pre-registered remote datasets"
             )
-        # register dataset
-        mmlu = DatasetDefWithProvider(
-            identifier="mmlu",
-            url=URL(uri="https://huggingface.co/datasets/llamastack/evals"),
-            dataset_schema={
+
+        await datasets_impl.register_dataset(
+            dataset_id="mmlu",
+            schema={
                 "input_query": StringType(),
                 "expected_answer": StringType(),
                 "chat_completion_input": ChatCompletionInputType(),
             },
+            url=URL(uri="https://huggingface.co/datasets/llamastack/evals"),
             metadata={
                 "path": "llamastack/evals",
                 "name": "evals__mmlu__details",
                 "split": "train",
             },
-            provider_id="",
         )
-
-        await datasets_impl.register_dataset(mmlu)
 
         # register eval task
         await eval_tasks_impl.register_eval_task(

--- a/llama_stack/providers/tests/eval/test_eval.py
+++ b/llama_stack/providers/tests/eval/test_eval.py
@@ -16,7 +16,6 @@ from llama_stack.apis.datasetio.datasetio import DatasetDefWithProvider
 from llama_stack.apis.eval.eval import (
     AppEvalTaskConfig,
     BenchmarkEvalTaskConfig,
-    EvalTaskDefWithProvider,
     ModelCandidate,
 )
 from llama_stack.apis.scoring_functions import LLMAsJudgeScoringFnParams
@@ -70,13 +69,11 @@ class Testeval:
             "meta-reference::equality",
         ]
         task_id = "meta-reference::app_eval"
-        task_def = EvalTaskDefWithProvider(
-            identifier=task_id,
+        await eval_tasks_impl.register_eval_task(
+            eval_task_id=task_id,
             dataset_id="test_dataset_for_eval",
             scoring_functions=scoring_functions,
-            provider_id="meta-reference",
         )
-        await eval_tasks_impl.register_eval_task(task_def)
         response = await eval_impl.evaluate_rows(
             task_id=task_id,
             input_rows=rows.rows,
@@ -125,13 +122,11 @@ class Testeval:
         ]
 
         task_id = "meta-reference::app_eval-2"
-        task_def = EvalTaskDefWithProvider(
-            identifier=task_id,
+        await eval_tasks_impl.register_eval_task(
+            eval_task_id=task_id,
             dataset_id="test_dataset_for_eval",
             scoring_functions=scoring_functions,
-            provider_id="meta-reference",
         )
-        await eval_tasks_impl.register_eval_task(task_def)
         response = await eval_impl.run_eval(
             task_id=task_id,
             task_config=AppEvalTaskConfig(
@@ -189,14 +184,11 @@ class Testeval:
         await datasets_impl.register_dataset(mmlu)
 
         # register eval task
-        meta_reference_mmlu = EvalTaskDefWithProvider(
-            identifier="meta-reference-mmlu",
+        await eval_tasks_impl.register_eval_task(
+            eval_task_id="meta-reference-mmlu",
             dataset_id="mmlu",
             scoring_functions=["meta-reference::regex_parser_multiple_choice_answer"],
-            provider_id="",
         )
-
-        await eval_tasks_impl.register_eval_task(meta_reference_mmlu)
 
         # list benchmarks
         response = await eval_tasks_impl.list_eval_tasks()


### PR DESCRIPTION
Tests: 
```
pytest -v -s -m meta_reference_eval_together_inference_huggingface_datasetio llama_stack/providers/tests/eval/test_eval.py --env TOGETHER_API_KEY=<KEY>

/Users/dineshyv/miniconda3/envs/stack/lib/python3.10/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
=========================================================================================================== test session starts ============================================================================================================
platform darwin -- Python 3.10.15, pytest-8.3.3, pluggy-1.5.0 -- /Users/dineshyv/miniconda3/envs/stack/bin/python
cachedir: .pytest_cache
rootdir: /Users/dineshyv/code/llama-stack
configfile: pyproject.toml
plugins: asyncio-0.24.0, anyio-4.6.2.post1
asyncio: mode=strict, default_loop_scope=None
collected 12 items / 8 deselected / 4 selected

llama_stack/providers/tests/eval/test_eval.py::Testeval::test_eval_tasks_list[meta_reference_eval_together_inference_huggingface_datasetio] Resolved 13 providers
 inner-datasetio => huggingface
 datasets => __routing_table__
 datasetio => __autorouted__
 inner-inference => together
 models => __routing_table__
 inference => __autorouted__
 inner-scoring => meta-reference
 scoring_functions => __routing_table__
 scoring => __autorouted__
 inner-eval => meta-reference
 eval_tasks => __routing_table__
 eval => __autorouted__
 inspect => __builtin__

PASSED
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:04<00:00,  1.65s/it]
PASSED
llama_stack/providers/tests/eval/test_eval.py::Testeval::test_eval_run_eval[meta_reference_eval_together_inference_huggingface_datasetio] `Llama3.2-3B-Instruct` already registered with `together`
`Llama3.1-8B-Instruct` already registered with `together`
`test_dataset_for_eval` already registered with `huggingface`
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:08<00:00,  1.71s/it]
PASSED
llama_stack/providers/tests/eval/test_eval.py::Testeval::test_eval_run_benchmark_eval[meta_reference_eval_together_inference_huggingface_datasetio] `Llama3.2-3B-Instruct` already registered with `together`
`Llama3.1-8B-Instruct` already registered with `together`
README.md: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 879/879 [00:00<00:00, 4.80MB/s]
train-00000-of-00001.parquet: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7.64M/7.64M [00:00<00:00, 12.0MB/s]
Generating train split: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14042/14042 [00:00<00:00, 272553.77 examples/s]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:03<00:00,  1.31s/it]
PASSED

=============================================================================================== 4 passed, 8 deselected, 6 warnings in 33.12s ===============================================================================================
❯ git status
```