### PR TITLE
migrate scoring fns to resource

### DIFF
--- a/llama_stack/apis/scoring/scoring.py
+++ b/llama_stack/apis/scoring/scoring.py
@@ -37,7 +37,7 @@ class ScoreResponse(BaseModel):
 
 
 class ScoringFunctionStore(Protocol):
-    def get_scoring_function(self, name: str) -> ScoringFnDefWithProvider: ...
+    def get_scoring_function(self, scoring_fn_id: str) -> ScoringFn: ...
 
 
 @runtime_checkable

--- a/llama_stack/distribution/datatypes.py
+++ b/llama_stack/distribution/datatypes.py
@@ -35,7 +35,7 @@ RoutableObject = Union[
     Shield,
     MemoryBank,
     Dataset,
-    ScoringFnDef,
+    ScoringFn,
 ]
 
 
@@ -45,7 +45,7 @@ RoutableObjectWithProvider = Annotated[
         Shield,
         MemoryBank,
         Dataset,
-        ScoringFnDefWithProvider,
+        ScoringFn,
     ],
     Field(discriminator="type"),
 ]

--- a/llama_stack/providers/datatypes.py
+++ b/llama_stack/providers/datatypes.py
@@ -15,7 +15,7 @@ from llama_stack.apis.datasets import Dataset
 from llama_stack.apis.eval_tasks import EvalTask
 from llama_stack.apis.memory_banks.memory_banks import MemoryBank
 from llama_stack.apis.models import Model
-from llama_stack.apis.scoring_functions import ScoringFnDef
+from llama_stack.apis.scoring_functions import ScoringFn
 from llama_stack.apis.shields import Shield
 
 
@@ -61,9 +61,9 @@ class DatasetsProtocolPrivate(Protocol):
 
 
 class ScoringFunctionsProtocolPrivate(Protocol):
-    async def list_scoring_functions(self) -> List[ScoringFnDef]: ...
+    async def list_scoring_functions(self) -> List[ScoringFn]: ...
 
-    async def register_scoring_function(self, function_def: ScoringFnDef) -> None: ...
+    async def register_scoring_function(self, scoring_fn: ScoringFn) -> None: ...
 
 
 class EvalTasksProtocolPrivate(Protocol):

--- a/llama_stack/providers/inline/scoring/braintrust/braintrust.py
+++ b/llama_stack/providers/inline/scoring/braintrust/braintrust.py
@@ -48,7 +48,7 @@ class BraintrustScoringImpl(Scoring, ScoringFunctionsProtocolPrivate):
 
     async def shutdown(self) -> None: ...
 
-    async def list_scoring_functions(self) -> List[ScoringFnDef]:
+    async def list_scoring_functions(self) -> List[ScoringFn]:
         scoring_fn_defs_list = [x for x in self.supported_fn_defs_registry.values()]
         for f in scoring_fn_defs_list:
             assert f.identifier.startswith(
@@ -57,7 +57,7 @@ class BraintrustScoringImpl(Scoring, ScoringFunctionsProtocolPrivate):
 
         return scoring_fn_defs_list
 
-    async def register_scoring_function(self, function_def: ScoringFnDef) -> None:
+    async def register_scoring_function(self, scoring_fn: ScoringFn) -> None:
         raise NotImplementedError(
             "Registering scoring function not allowed for braintrust provider"
         )

--- a/llama_stack/providers/inline/scoring/braintrust/scoring_fn/fn_defs/answer_correctness.py
+++ b/llama_stack/providers/inline/scoring/braintrust/scoring_fn/fn_defs/answer_correctness.py
@@ -5,12 +5,14 @@
 # the root directory of this source tree.
 
 from llama_stack.apis.common.type_system import NumberType
-from llama_stack.apis.scoring_functions import ScoringFnDef
+from llama_stack.apis.scoring_functions import ScoringFn
 
 
-answer_correctness_fn_def = ScoringFnDef(
+answer_correctness_fn_def = ScoringFn(
     identifier="braintrust::answer-correctness",
     description="Test whether an output is factual, compared to an original (`expected`) value. One of Braintrust LLM basd scorer https://github.com/braintrustdata/autoevals/blob/main/py/autoevals/llm.py",
-    parameters=[],
+    params=None,
+    provider_id="braintrust",
+    provider_resource_id="answer-correctness",
     return_type=NumberType(),
 )

--- a/llama_stack/providers/inline/scoring/braintrust/scoring_fn/fn_defs/factuality.py
+++ b/llama_stack/providers/inline/scoring/braintrust/scoring_fn/fn_defs/factuality.py
@@ -5,12 +5,14 @@
 # the root directory of this source tree.
 
 from llama_stack.apis.common.type_system import NumberType
-from llama_stack.apis.scoring_functions import ScoringFnDef
+from llama_stack.apis.scoring_functions import ScoringFn
 
 
-factuality_fn_def = ScoringFnDef(
+factuality_fn_def = ScoringFn(
     identifier="braintrust::factuality",
     description="Test whether an output is factual, compared to an original (`expected`) value. One of Braintrust LLM basd scorer https://github.com/braintrustdata/autoevals/blob/main/py/autoevals/llm.py",
-    parameters=[],
+    params=None,
+    provider_id="braintrust",
+    provider_resource_id="factuality",
     return_type=NumberType(),
 )

--- a/llama_stack/providers/inline/scoring/meta_reference/scoring.py
+++ b/llama_stack/providers/inline/scoring/meta_reference/scoring.py
@@ -52,7 +52,7 @@ class MetaReferenceScoringImpl(Scoring, ScoringFunctionsProtocolPrivate):
 
     async def shutdown(self) -> None: ...
 
-    async def list_scoring_functions(self) -> List[ScoringFnDef]:
+    async def list_scoring_functions(self) -> List[ScoringFn]:
         scoring_fn_defs_list = [
             fn_def
             for impl in self.scoring_fn_id_impls.values()
@@ -66,7 +66,7 @@ class MetaReferenceScoringImpl(Scoring, ScoringFunctionsProtocolPrivate):
 
         return scoring_fn_defs_list
 
-    async def register_scoring_function(self, function_def: ScoringFnDef) -> None:
+    async def register_scoring_function(self, function_def: ScoringFn) -> None:
         raise NotImplementedError("Register scoring function not implemented yet")
 
     async def validate_scoring_input_dataset_schema(self, dataset_id: str) -> None:

--- a/llama_stack/providers/inline/scoring/meta_reference/scoring_fn/base_scoring_fn.py
+++ b/llama_stack/providers/inline/scoring/meta_reference/scoring_fn/base_scoring_fn.py
@@ -24,15 +24,15 @@ class BaseScoringFn(ABC):
     def __str__(self) -> str:
         return self.__class__.__name__
 
-    def get_supported_scoring_fn_defs(self) -> List[ScoringFnDef]:
+    def get_supported_scoring_fn_defs(self) -> List[ScoringFn]:
         return [x for x in self.supported_fn_defs_registry.values()]
 
-    def register_scoring_fn_def(self, scoring_fn_def: ScoringFnDef) -> None:
-        if scoring_fn_def.identifier in self.supported_fn_defs_registry:
+    def register_scoring_fn_def(self, scoring_fn: ScoringFn) -> None:
+        if scoring_fn.identifier in self.supported_fn_defs_registry:
             raise ValueError(
-                f"Scoring function def with identifier {scoring_fn_def.identifier} already exists."
+                f"Scoring function def with identifier {scoring_fn.identifier} already exists."
             )
-        self.supported_fn_defs_registry[scoring_fn_def.identifier] = scoring_fn_def
+        self.supported_fn_defs_registry[scoring_fn.identifier] = scoring_fn
 
     @abstractmethod
     async def score_row(

--- a/llama_stack/providers/inline/scoring/meta_reference/scoring_fn/fn_defs/equality.py
+++ b/llama_stack/providers/inline/scoring/meta_reference/scoring_fn/fn_defs/equality.py
@@ -5,11 +5,14 @@
 # the root directory of this source tree.
 
 from llama_stack.apis.common.type_system import NumberType
-from llama_stack.apis.scoring_functions import ScoringFnDef
+from llama_stack.apis.scoring_functions import ScoringFn
 
 
-equality = ScoringFnDef(
+equality = ScoringFn(
     identifier="meta-reference::equality",
     description="Returns 1.0 if the input is equal to the target, 0.0 otherwise.",
+    params=None,
+    provider_id="meta-reference",
+    provider_resource_id="equality",
     return_type=NumberType(),
 )

--- a/llama_stack/providers/inline/scoring/meta_reference/scoring_fn/fn_defs/llm_as_judge_base.py
+++ b/llama_stack/providers/inline/scoring/meta_reference/scoring_fn/fn_defs/llm_as_judge_base.py
@@ -5,11 +5,13 @@
 # the root directory of this source tree.
 
 from llama_stack.apis.common.type_system import NumberType
-from llama_stack.apis.scoring_functions import ScoringFnDef
+from llama_stack.apis.scoring_functions import ScoringFn
 
 
-llm_as_judge_base = ScoringFnDef(
+llm_as_judge_base = ScoringFn(
     identifier="meta-reference::llm_as_judge_base",
     description="Llm As Judge Scoring Function",
     return_type=NumberType(),
+    provider_id="meta-reference",
+    provider_resource_id="llm-as-judge-base",
 )

--- a/llama_stack/providers/inline/scoring/meta_reference/scoring_fn/fn_defs/regex_parser_multiple_choice_answer.py
+++ b/llama_stack/providers/inline/scoring/meta_reference/scoring_fn/fn_defs/regex_parser_multiple_choice_answer.py
@@ -56,10 +56,12 @@ MULTILINGUAL_ANSWER_PATTERN_TEMPLATE = (
     r"(?i){}\s*([A-D]|[أ-د]|[অ]|[ব]|[ড]|[ঢ]|[Ａ]|[Ｂ]|[Ｃ]|[Ｄ])"
 )
 
-regex_parser_multiple_choice_answer = ScoringFnDef(
+regex_parser_multiple_choice_answer = ScoringFn(
     identifier="meta-reference::regex_parser_multiple_choice_answer",
     description="Extract answer from response matching Answer: [the_answer_letter], and compare with expected result",
     return_type=NumberType(),
+    provider_id="meta-reference",
+    provider_resource_id="regex-parser-multiple-choice-answer",
     params=RegexParserScoringFnParams(
         parsing_regexes=[
             MULTILINGUAL_ANSWER_PATTERN_TEMPLATE.format(x)

--- a/llama_stack/providers/inline/scoring/meta_reference/scoring_fn/fn_defs/subset_of.py
+++ b/llama_stack/providers/inline/scoring/meta_reference/scoring_fn/fn_defs/subset_of.py
@@ -5,12 +5,13 @@
 # the root directory of this source tree.
 
 from llama_stack.apis.common.type_system import NumberType
-from llama_stack.apis.scoring_functions import ScoringFnDef
+from llama_stack.apis.scoring_functions import ScoringFn
 
 
-subset_of = ScoringFnDef(
+subset_of = ScoringFn(
     identifier="meta-reference::subset_of",
     description="Returns 1.0 if the expected is included in generated, 0.0 otherwise.",
-    parameters=[],
     return_type=NumberType(),
+    provider_id="meta-reference",
+    provider_resource_id="subset-of",
 )

--- a/llama_stack/providers/inline/scoring/meta_reference/scoring_fn/regex_parser_scoring_fn.py
+++ b/llama_stack/providers/inline/scoring/meta_reference/scoring_fn/regex_parser_scoring_fn.py
@@ -42,7 +42,7 @@ class RegexParserScoringFn(BaseScoringFn):
 
         assert (
             fn_def.params is not None
-            and fn_def.params.type == ScoringConfigType.regex_parser.value
+            and fn_def.params.type == ScoringFnParamsType.regex_parser.value
         ), f"RegexParserScoringFnParams not found for {fn_def}."
 
         expected_answer = input_row["expected_answer"]

--- a/llama_stack/providers/tests/scoring/fixtures.py
+++ b/llama_stack/providers/tests/scoring/fixtures.py
@@ -66,7 +66,6 @@ async def scoring_stack(request, inference_model):
     )
 
     provider_id = providers["inference"][0].provider_id
-    print(f"Registering model {inference_model} with provider {provider_id}")
     await impls[Api.models].register_model(
         model_id=inference_model,
         provider_id=provider_id,

--- a/llama_stack/providers/tests/scoring/fixtures.py
+++ b/llama_stack/providers/tests/scoring/fixtures.py
@@ -48,7 +48,7 @@ SCORING_FIXTURES = ["meta_reference", "remote", "braintrust"]
 
 
 @pytest_asyncio.fixture(scope="session")
-async def scoring_stack(request):
+async def scoring_stack(request, inference_model):
     fixture_dict = request.param
 
     providers = {}
@@ -63,6 +63,21 @@ async def scoring_stack(request):
         [Api.scoring, Api.datasetio, Api.inference],
         providers,
         provider_data,
+    )
+
+    provider_id = providers["inference"][0].provider_id
+    print(f"Registering model {inference_model} with provider {provider_id}")
+    await impls[Api.models].register_model(
+        model_id=inference_model,
+        provider_id=provider_id,
+    )
+    await impls[Api.models].register_model(
+        model_id="Llama3.1-405B-Instruct",
+        provider_id=provider_id,
+    )
+    await impls[Api.models].register_model(
+        model_id="Llama3.1-8B-Instruct",
+        provider_id=provider_id,
     )
 
     return impls


### PR DESCRIPTION
tests:
```
pytest -v -s -m meta_reference_scoring_fireworks_inference llama_stack/providers/tests/scoring/test_scoring.py --env FIREWORKS_API_KEY=<KEY>

/Users/dineshyv/miniconda3/envs/stack/lib/python3.10/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
=========================================================================================================== test session starts ============================================================================================================
platform darwin -- Python 3.10.15, pytest-8.3.3, pluggy-1.5.0 -- /Users/dineshyv/miniconda3/envs/stack/bin/python
cachedir: .pytest_cache
rootdir: /Users/dineshyv/code/llama-stack
configfile: pyproject.toml
plugins: asyncio-0.24.0, anyio-4.6.2.post1
asyncio: mode=strict, default_loop_scope=None
collected 6 items / 3 deselected / 3 selected

llama_stack/providers/tests/scoring/test_scoring.py::TestScoring::test_scoring_functions_list[meta_reference_scoring_fireworks_inference] Resolved 10 providers
 inner-datasetio => meta-reference
 datasets => __routing_table__
 datasetio => __autorouted__
 inner-inference => fireworks
 models => __routing_table__
 inference => __autorouted__
 inner-scoring => meta-reference
 scoring_functions => __routing_table__
 scoring => __autorouted__
 inspect => __builtin__

Registering model Llama3.2-3B-Instruct with provider fireworks
PASSED
llama_stack/providers/tests/scoring/test_scoring.py::TestScoring::test_scoring_score[meta_reference_scoring_fireworks_inference] PASSED
llama_stack/providers/tests/scoring/test_scoring.py::TestScoring::test_scoring_score_with_params[meta_reference_scoring_fireworks_inference] `test_dataset` already registered with `meta-reference`
PASSED

=============================================================================================== 3 passed, 3 deselected, 8 warnings in 9.45s ================================================================================================



Braintrust:
pytest -v -s -m braintrust_scoring_together_inference scoring/test_scoring.py --env TOGETHER_API_KEY=<KEY>
/Users/dineshyv/miniconda3/envs/stack/lib/python3.10/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
=========================================================================================================== test session starts ============================================================================================================
platform darwin -- Python 3.10.15, pytest-8.3.3, pluggy-1.5.0 -- /Users/dineshyv/miniconda3/envs/stack/bin/python
cachedir: .pytest_cache
rootdir: /Users/dineshyv/code/llama-stack
configfile: pyproject.toml
plugins: asyncio-0.24.0, anyio-4.6.2.post1
asyncio: mode=strict, default_loop_scope=None
collected 9 items / 6 deselected / 3 selected

scoring/test_scoring.py::TestScoring::test_scoring_functions_list[braintrust_scoring_together_inference] Resolved 10 providers
 inner-datasetio => localfs
 datasets => __routing_table__
 datasetio => __autorouted__
 inner-scoring => braintrust
 inner-inference => together
 models => __routing_table__
 inference => __autorouted__
 scoring_functions => __routing_table__
 scoring => __autorouted__
 inspect => __builtin__

Registering model Llama3.2-3B-Instruct with provider together
PASSED
scoring/test_scoring.py::TestScoring::test_scoring_score[braintrust_scoring_together_inference] `Llama3.2-3B-Instruct` already registered with `together`
`Llama3.1-8B-Instruct` already registered with `together`
PASSED
scoring/test_scoring.py::TestScoring::test_scoring_score_with_params[braintrust_scoring_together_inference] `test_dataset` already registered with `localfs`
`Llama3.1-405B-Instruct` already registered with `together`
SKIPPED (Braintrust provider does not support scoring with params)

========================================================================================== 2 passed, 1 skipped, 6 deselected, 6 warnings in 4.15s ==========================================================================================
❯ git status