### PR TITLE
Inference to use provider resource id to register and validate

### DIFF
--- a/docs/resources/llama-stack-spec.html
+++ b/docs/resources/llama-stack-spec.html
@@ -21,7 +21,7 @@
     "info": {
         "title": "[DRAFT] Llama Stack Specification",
         "version": "0.0.1",
-        "description": "This is the specification of the llama stack that provides\n                a set of endpoints and their corresponding interfaces that are tailored to\n                best leverage Llama Models. The specification is still in draft and subject to change.\n                Generated at 2024-11-12 11:39:48.665782"
+        "description": "This is the specification of the llama stack that provides\n                a set of endpoints and their corresponding interfaces that are tailored to\n                best leverage Llama Models. The specification is still in draft and subject to change.\n                Generated at 2024-11-12 15:47:15.607543"
     },
     "servers": [
         {
@@ -2856,7 +2856,7 @@
             "ChatCompletionRequest": {
                 "type": "object",
                 "properties": {
-                    "model": {
+                    "model_id": {
                         "type": "string"
                     },
                     "messages": {
@@ -2993,7 +2993,7 @@
                 },
                 "additionalProperties": false,
                 "required": [
-                    "model",
+                    "model_id",
                     "messages"
                 ]
             },
@@ -3120,7 +3120,7 @@
             "CompletionRequest": {
                 "type": "object",
                 "properties": {
-                    "model": {
+                    "model_id": {
                         "type": "string"
                     },
                     "content": {
@@ -3249,7 +3249,7 @@
                 },
                 "additionalProperties": false,
                 "required": [
-                    "model",
+                    "model_id",
                     "content"
                 ]
             },
@@ -4552,7 +4552,7 @@
             "EmbeddingsRequest": {
                 "type": "object",
                 "properties": {
-                    "model": {
+                    "model_id": {
                         "type": "string"
                     },
                     "contents": {
@@ -4584,7 +4584,7 @@
                 },
                 "additionalProperties": false,
                 "required": [
-                    "model",
+                    "model_id",
                     "contents"
                 ]
             },
@@ -7837,34 +7837,10 @@
     ],
     "tags": [
         {
-            "name": "MemoryBanks"
+            "name": "Safety"
         },
         {
-            "name": "BatchInference"
-        },
-        {
-            "name": "Agents"
-        },
-        {
-            "name": "Inference"
-        },
-        {
-            "name": "DatasetIO"
-        },
-        {
-            "name": "Eval"
-        },
-        {
-            "name": "Models"
-        },
-        {
-            "name": "PostTraining"
-        },
-        {
-            "name": "ScoringFunctions"
-        },
-        {
-            "name": "Datasets"
+            "name": "EvalTasks"
         },
         {
             "name": "Shields"
@@ -7873,22 +7849,46 @@
             "name": "Telemetry"
         },
         {
-            "name": "Inspect"
-        },
-        {
-            "name": "Safety"
-        },
-        {
-            "name": "SyntheticDataGeneration"
-        },
-        {
             "name": "Memory"
         },
         {
             "name": "Scoring"
         },
         {
-            "name": "EvalTasks"
+            "name": "ScoringFunctions"
+        },
+        {
+            "name": "SyntheticDataGeneration"
+        },
+        {
+            "name": "Models"
+        },
+        {
+            "name": "Agents"
+        },
+        {
+            "name": "MemoryBanks"
+        },
+        {
+            "name": "DatasetIO"
+        },
+        {
+            "name": "Inference"
+        },
+        {
+            "name": "Datasets"
+        },
+        {
+            "name": "PostTraining"
+        },
+        {
+            "name": "BatchInference"
+        },
+        {
+            "name": "Eval"
+        },
+        {
+            "name": "Inspect"
         },
         {
             "name": "BuiltinTool",

--- a/docs/resources/llama-stack-spec.yaml
+++ b/docs/resources/llama-stack-spec.yaml
@@ -396,7 +396,7 @@ components:
             - $ref: '#/components/schemas/ToolResponseMessage'
             - $ref: '#/components/schemas/CompletionMessage'
           type: array
-        model:
+        model_id:
           type: string
         response_format:
           oneOf:
@@ -453,7 +453,7 @@ components:
             $ref: '#/components/schemas/ToolDefinition'
           type: array
       required:
-      - model
+      - model_id
       - messages
       type: object
     ChatCompletionResponse:
@@ -577,7 +577,7 @@ components:
               default: 0
               type: integer
           type: object
-        model:
+        model_id:
           type: string
         response_format:
           oneOf:
@@ -626,7 +626,7 @@ components:
         stream:
           type: boolean
       required:
-      - model
+      - model_id
       - content
       type: object
     CompletionResponse:
@@ -903,10 +903,10 @@ components:
                 - $ref: '#/components/schemas/ImageMedia'
               type: array
           type: array
-        model:
+        model_id:
           type: string
       required:
-      - model
+      - model_id
       - contents
       type: object
     EmbeddingsResponse:
@@ -3384,7 +3384,7 @@ info:
   description: "This is the specification of the llama stack that provides\n     \
     \           a set of endpoints and their corresponding interfaces that are tailored\
     \ to\n                best leverage Llama Models. The specification is still in\
-    \ draft and subject to change.\n                Generated at 2024-11-12 11:39:48.665782"
+    \ draft and subject to change.\n                Generated at 2024-11-12 15:47:15.607543"
   title: '[DRAFT] Llama Stack Specification'
   version: 0.0.1
 jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
@@ -4748,24 +4748,24 @@ security:
 servers:
 - url: http://any-hosted-llama-stack.com
 tags:
-- name: MemoryBanks
-- name: BatchInference
-- name: Agents
-- name: Inference
-- name: DatasetIO
-- name: Eval
-- name: Models
-- name: PostTraining
-- name: ScoringFunctions
-- name: Datasets
+- name: Safety
+- name: EvalTasks
 - name: Shields
 - name: Telemetry
-- name: Inspect
-- name: Safety
-- name: SyntheticDataGeneration
 - name: Memory
 - name: Scoring
-- name: EvalTasks
+- name: ScoringFunctions
+- name: SyntheticDataGeneration
+- name: Models
+- name: Agents
+- name: MemoryBanks
+- name: DatasetIO
+- name: Inference
+- name: Datasets
+- name: PostTraining
+- name: BatchInference
+- name: Eval
+- name: Inspect
 - description: <SchemaDefinition schemaRef="#/components/schemas/BuiltinTool" />
   name: BuiltinTool
 - description: <SchemaDefinition schemaRef="#/components/schemas/CompletionMessage"

--- a/docs/source/getting_started/index.md
+++ b/docs/source/getting_started/index.md
@@ -538,7 +538,7 @@ Once the server is set up, we can test it with a client to verify it's working c
 $ curl http://localhost:5000/inference/chat_completion \
 -H "Content-Type: application/json" \
 -d '{
-    "model": "Llama3.1-8B-Instruct",
+    "model_id": "Llama3.1-8B-Instruct",
     "messages": [
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "Write me a 2 sentence poem about the moon"}

--- a/llama_stack/apis/inference/inference.py
+++ b/llama_stack/apis/inference/inference.py
@@ -226,7 +226,7 @@ class Inference(Protocol):
     @webmethod(route="/inference/completion")
     async def completion(
         self,
-        model: str,
+        model_id: str,
         content: InterleavedTextMedia,
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
@@ -237,7 +237,7 @@ class Inference(Protocol):
     @webmethod(route="/inference/chat_completion")
     async def chat_completion(
         self,
-        model: str,
+        model_id: str,
         messages: List[Message],
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         # zero-shot tool definitions as input to the model
@@ -254,6 +254,6 @@ class Inference(Protocol):
     @webmethod(route="/inference/embeddings")
     async def embeddings(
         self,
-        model: str,
+        model_id: str,
         contents: List[InterleavedTextMedia],
     ) -> EmbeddingsResponse: ...

--- a/llama_stack/distribution/routers/routers.py
+++ b/llama_stack/distribution/routers/routers.py
@@ -95,7 +95,7 @@ class InferenceRouter(Inference):
 
     async def chat_completion(
         self,
-        model: str,
+        model_id: str,
         messages: List[Message],
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
@@ -105,8 +105,9 @@ class InferenceRouter(Inference):
         stream: Optional[bool] = False,
         logprobs: Optional[LogProbConfig] = None,
     ) -> AsyncGenerator:
+        model = await self.routing_table.get_model(model_id)
         params = dict(
-            model=model,
+            model_id=model.provider_resource_id,
             messages=messages,
             sampling_params=sampling_params,
             tools=tools or [],
@@ -116,7 +117,7 @@ class InferenceRouter(Inference):
             stream=stream,
             logprobs=logprobs,
         )
-        provider = self.routing_table.get_provider_impl(model)
+        provider = self.routing_table.get_provider_impl(model_id)
         if stream:
             return (chunk async for chunk in await provider.chat_completion(**params))
         else:
@@ -124,16 +125,17 @@ class InferenceRouter(Inference):
 
     async def completion(
         self,
-        model: str,
+        model_id: str,
         content: InterleavedTextMedia,
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
         stream: Optional[bool] = False,
         logprobs: Optional[LogProbConfig] = None,
     ) -> AsyncGenerator:
-        provider = self.routing_table.get_provider_impl(model)
+        model = await self.routing_table.get_model(model_id)
+        provider = self.routing_table.get_provider_impl(model_id)
         params = dict(
-            model=model,
+            model_id=model.provider_resource_id,
             content=content,
             sampling_params=sampling_params,
             response_format=response_format,
@@ -147,11 +149,12 @@ class InferenceRouter(Inference):
 
     async def embeddings(
         self,
-        model: str,
+        model_id: str,
         contents: List[InterleavedTextMedia],
     ) -> EmbeddingsResponse:
-        return await self.routing_table.get_provider_impl(model).embeddings(
-            model=model,
+        model = await self.routing_table.get_model(model_id)
+        return await self.routing_table.get_provider_impl(model_id).embeddings(
+            model_id=model.provider_resource_id,
             contents=contents,
         )
 

--- a/llama_stack/distribution/routers/routers.py
+++ b/llama_stack/distribution/routers/routers.py
@@ -105,9 +105,8 @@ class InferenceRouter(Inference):
         stream: Optional[bool] = False,
         logprobs: Optional[LogProbConfig] = None,
     ) -> AsyncGenerator:
-        model = await self.routing_table.get_model(model_id)
         params = dict(
-            model_id=model.provider_resource_id,
+            model_id=model_id,
             messages=messages,
             sampling_params=sampling_params,
             tools=tools or [],
@@ -132,10 +131,9 @@ class InferenceRouter(Inference):
         stream: Optional[bool] = False,
         logprobs: Optional[LogProbConfig] = None,
     ) -> AsyncGenerator:
-        model = await self.routing_table.get_model(model_id)
         provider = self.routing_table.get_provider_impl(model_id)
         params = dict(
-            model_id=model.provider_resource_id,
+            model_id=model_id,
             content=content,
             sampling_params=sampling_params,
             response_format=response_format,
@@ -152,9 +150,8 @@ class InferenceRouter(Inference):
         model_id: str,
         contents: List[InterleavedTextMedia],
     ) -> EmbeddingsResponse:
-        model = await self.routing_table.get_model(model_id)
         return await self.routing_table.get_provider_impl(model_id).embeddings(
-            model_id=model.provider_resource_id,
+            model_id=model_id,
             contents=contents,
         )
 

--- a/llama_stack/providers/inline/eval/meta_reference/eval.py
+++ b/llama_stack/providers/inline/eval/meta_reference/eval.py
@@ -150,7 +150,7 @@ class MetaReferenceEvalImpl(Eval, EvalTasksProtocolPrivate):
                     messages.append(candidate.system_message)
                 messages += input_messages
                 response = await self.inference_api.chat_completion(
-                    model=candidate.model,
+                    model_id=candidate.model,
                     messages=messages,
                     sampling_params=candidate.sampling_params,
                 )

--- a/llama_stack/providers/inline/inference/meta_reference/inference.py
+++ b/llama_stack/providers/inline/inference/meta_reference/inference.py
@@ -46,7 +46,7 @@ class MetaReferenceInferenceImpl(Inference, ModelsProtocolPrivate):
             self.generator = Llama.build(self.config)
 
     async def register_model(self, model: Model) -> None:
-        if model.identifier != self.model.descriptor():
+        if model.provider_resource_id != self.model.descriptor():
             raise ValueError(
                 f"Model mismatch: {model.identifier} != {self.model.descriptor()}"
             )
@@ -68,7 +68,7 @@ class MetaReferenceInferenceImpl(Inference, ModelsProtocolPrivate):
 
     async def completion(
         self,
-        model: str,
+        model_id: str,
         content: InterleavedTextMedia,
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
@@ -79,7 +79,7 @@ class MetaReferenceInferenceImpl(Inference, ModelsProtocolPrivate):
             assert logprobs.top_k == 1, f"Unexpected top_k={logprobs.top_k}"
 
         request = CompletionRequest(
-            model=model,
+            model=model_id,
             content=content,
             sampling_params=sampling_params,
             response_format=response_format,
@@ -186,7 +186,7 @@ class MetaReferenceInferenceImpl(Inference, ModelsProtocolPrivate):
 
     async def chat_completion(
         self,
-        model: str,
+        model_id: str,
         messages: List[Message],
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
@@ -201,7 +201,7 @@ class MetaReferenceInferenceImpl(Inference, ModelsProtocolPrivate):
 
         # wrapper request to make it easier to pass around (internal only, not exposed to API)
         request = ChatCompletionRequest(
-            model=model,
+            model=model_id,
             messages=messages,
             sampling_params=sampling_params,
             tools=tools or [],
@@ -386,7 +386,7 @@ class MetaReferenceInferenceImpl(Inference, ModelsProtocolPrivate):
 
     async def embeddings(
         self,
-        model: str,
+        model_id: str,
         contents: List[InterleavedTextMedia],
     ) -> EmbeddingsResponse:
         raise NotImplementedError()

--- a/llama_stack/providers/inline/inference/meta_reference/inference.py
+++ b/llama_stack/providers/inline/inference/meta_reference/inference.py
@@ -39,7 +39,7 @@ class MetaReferenceInferenceImpl(Inference, ModelRegistryHelper, ModelsProtocolP
             [
                 build_model_alias(
                     model.descriptor(),
-                    model.core_model_id,
+                    model.core_model_id.value,
                 )
             ],
         )
@@ -55,12 +55,6 @@ class MetaReferenceInferenceImpl(Inference, ModelRegistryHelper, ModelsProtocolP
             self.generator.start()
         else:
             self.generator = Llama.build(self.config)
-
-    async def register_model(self, model: Model) -> None:
-        if model.provider_resource_id != self.model.descriptor():
-            raise ValueError(
-                f"Model mismatch: {model.identifier} != {self.model.descriptor()}"
-            )
 
     async def shutdown(self) -> None:
         if self.config.create_distributed_process_group:

--- a/llama_stack/providers/inline/inference/vllm/vllm.py
+++ b/llama_stack/providers/inline/inference/vllm/vllm.py
@@ -110,7 +110,7 @@ class VLLMInferenceImpl(Inference, ModelsProtocolPrivate):
 
     async def completion(
         self,
-        model: str,
+        model_id: str,
         content: InterleavedTextMedia,
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
@@ -120,7 +120,7 @@ class VLLMInferenceImpl(Inference, ModelsProtocolPrivate):
         log.info("vLLM completion")
         messages = [UserMessage(content=content)]
         return self.chat_completion(
-            model=model,
+            model=model_id,
             messages=messages,
             sampling_params=sampling_params,
             stream=stream,
@@ -129,7 +129,7 @@ class VLLMInferenceImpl(Inference, ModelsProtocolPrivate):
 
     async def chat_completion(
         self,
-        model: str,
+        model_id: str,
         messages: List[Message],
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         tools: Optional[List[ToolDefinition]] = None,
@@ -144,7 +144,7 @@ class VLLMInferenceImpl(Inference, ModelsProtocolPrivate):
         assert self.engine is not None
 
         request = ChatCompletionRequest(
-            model=model,
+            model=model_id,
             messages=messages,
             sampling_params=sampling_params,
             tools=tools or [],
@@ -215,7 +215,7 @@ class VLLMInferenceImpl(Inference, ModelsProtocolPrivate):
             yield chunk
 
     async def embeddings(
-        self, model: str, contents: list[InterleavedTextMedia]
+        self, model_id: str, contents: list[InterleavedTextMedia]
     ) -> EmbeddingsResponse:
         log.info("vLLM embeddings")
         # TODO

--- a/llama_stack/providers/inline/scoring/llm_as_judge/scoring_fn/llm_as_judge_scoring_fn.py
+++ b/llama_stack/providers/inline/scoring/llm_as_judge/scoring_fn/llm_as_judge_scoring_fn.py
@@ -62,7 +62,7 @@ class LlmAsJudgeScoringFn(BaseScoringFn):
         )
 
         judge_response = await self.inference_api.chat_completion(
-            model=fn_def.params.judge_model,
+            model_id=fn_def.params.judge_model,
             messages=[
                 {
                     "role": "user",

--- a/llama_stack/providers/remote/inference/bedrock/bedrock.py
+++ b/llama_stack/providers/remote/inference/bedrock/bedrock.py
@@ -26,15 +26,15 @@ from llama_stack.providers.utils.bedrock.client import create_bedrock_client
 model_aliases = [
     build_model_alias(
         "meta.llama3-1-8b-instruct-v1:0",
-        CoreModelId.llama3_1_8b_instruct,
+        CoreModelId.llama3_1_8b_instruct.value,
     ),
     build_model_alias(
         "meta.llama3-1-70b-instruct-v1:0",
-        CoreModelId.llama3_1_70b_instruct,
+        CoreModelId.llama3_1_70b_instruct.value,
     ),
     build_model_alias(
         "meta.llama3-1-405b-instruct-v1:0",
-        CoreModelId.llama3_1_405b_instruct,
+        CoreModelId.llama3_1_405b_instruct.value,
     ),
 ]
 

--- a/llama_stack/providers/remote/inference/bedrock/bedrock.py
+++ b/llama_stack/providers/remote/inference/bedrock/bedrock.py
@@ -7,6 +7,7 @@
 from typing import *  # noqa: F403
 
 from botocore.client import BaseClient
+from llama_models.datatypes import CoreModelId
 
 from llama_models.llama3.api.chat_format import ChatFormat
 from llama_models.llama3.api.tokenizer import Tokenizer
@@ -25,15 +26,18 @@ from llama_stack.providers.utils.bedrock.client import create_bedrock_client
 model_aliases = [
     ModelAlias(
         provider_model_id="meta.llama3-1-8b-instruct-v1:0",
-        aliases=["Llama3.1-8B"],
+        aliases=["Llama3.1-8B-Instruct"],
+        llama_model=CoreModelId.llama3_1_8b_instruct,
     ),
     ModelAlias(
         provider_model_id="meta.llama3-1-70b-instruct-v1:0",
-        aliases=["Llama3.1-70B"],
+        aliases=["Llama3.1-70B-Instruct"],
+        llama_model=CoreModelId.llama3_1_70b_instruct,
     ),
     ModelAlias(
         provider_model_id="meta.llama3-1-405b-instruct-v1:0",
-        aliases=["Llama3.1-405B"],
+        aliases=["Llama3.1-405B-Instruct"],
+        llama_model=CoreModelId.llama3_1_405b_instruct,
     ),
 ]
 
@@ -308,8 +312,9 @@ class BedrockInferenceAdapter(ModelRegistryHelper, Inference):
     ) -> Union[
         ChatCompletionResponse, AsyncIterator[ChatCompletionResponseStreamChunk]
     ]:
+        model = await self.model_store.get_model(model_id)
         request = ChatCompletionRequest(
-            model=model_id,
+            model=model.provider_resource_id,
             messages=messages,
             sampling_params=sampling_params,
             tools=tools or [],
@@ -414,7 +419,7 @@ class BedrockInferenceAdapter(ModelRegistryHelper, Inference):
                 pass
 
     def _get_params_for_chat_completion(self, request: ChatCompletionRequest) -> Dict:
-        bedrock_model = self.map_to_provider_model(request.model)
+        bedrock_model = request.model
         inference_config = BedrockInferenceAdapter.get_bedrock_inference_config(
             request.sampling_params
         )

--- a/llama_stack/providers/remote/inference/bedrock/bedrock.py
+++ b/llama_stack/providers/remote/inference/bedrock/bedrock.py
@@ -11,7 +11,10 @@ from botocore.client import BaseClient
 from llama_models.llama3.api.chat_format import ChatFormat
 from llama_models.llama3.api.tokenizer import Tokenizer
 
-from llama_stack.providers.utils.inference.model_registry import ModelRegistryHelper
+from llama_stack.providers.utils.inference.model_registry import (
+    ModelAlias,
+    ModelRegistryHelper,
+)
 
 from llama_stack.apis.inference import *  # noqa: F403
 
@@ -19,19 +22,26 @@ from llama_stack.providers.remote.inference.bedrock.config import BedrockConfig
 from llama_stack.providers.utils.bedrock.client import create_bedrock_client
 
 
-BEDROCK_SUPPORTED_MODELS = {
-    "Llama3.1-8B-Instruct": "meta.llama3-1-8b-instruct-v1:0",
-    "Llama3.1-70B-Instruct": "meta.llama3-1-70b-instruct-v1:0",
-    "Llama3.1-405B-Instruct": "meta.llama3-1-405b-instruct-v1:0",
-}
+model_aliases = [
+    ModelAlias(
+        provider_model_id="meta.llama3-1-8b-instruct-v1:0",
+        aliases=["Llama3.1-8B"],
+    ),
+    ModelAlias(
+        provider_model_id="meta.llama3-1-70b-instruct-v1:0",
+        aliases=["Llama3.1-70B"],
+    ),
+    ModelAlias(
+        provider_model_id="meta.llama3-1-405b-instruct-v1:0",
+        aliases=["Llama3.1-405B"],
+    ),
+]
 
 
 # NOTE: this is not quite tested after the recent refactors
 class BedrockInferenceAdapter(ModelRegistryHelper, Inference):
     def __init__(self, config: BedrockConfig) -> None:
-        ModelRegistryHelper.__init__(
-            self, stack_to_provider_models_map=BEDROCK_SUPPORTED_MODELS
-        )
+        ModelRegistryHelper.__init__(self, model_aliases)
         self._config = config
 
         self._client = create_bedrock_client(config)

--- a/llama_stack/providers/remote/inference/bedrock/bedrock.py
+++ b/llama_stack/providers/remote/inference/bedrock/bedrock.py
@@ -13,7 +13,7 @@ from llama_models.llama3.api.chat_format import ChatFormat
 from llama_models.llama3.api.tokenizer import Tokenizer
 
 from llama_stack.providers.utils.inference.model_registry import (
-    ModelAlias,
+    build_model_alias,
     ModelRegistryHelper,
 )
 
@@ -24,20 +24,17 @@ from llama_stack.providers.utils.bedrock.client import create_bedrock_client
 
 
 model_aliases = [
-    ModelAlias(
-        provider_model_id="meta.llama3-1-8b-instruct-v1:0",
-        aliases=["Llama3.1-8B-Instruct"],
-        llama_model=CoreModelId.llama3_1_8b_instruct,
+    build_model_alias(
+        "meta.llama3-1-8b-instruct-v1:0",
+        CoreModelId.llama3_1_8b_instruct,
     ),
-    ModelAlias(
-        provider_model_id="meta.llama3-1-70b-instruct-v1:0",
-        aliases=["Llama3.1-70B-Instruct"],
-        llama_model=CoreModelId.llama3_1_70b_instruct,
+    build_model_alias(
+        "meta.llama3-1-70b-instruct-v1:0",
+        CoreModelId.llama3_1_70b_instruct,
     ),
-    ModelAlias(
-        provider_model_id="meta.llama3-1-405b-instruct-v1:0",
-        aliases=["Llama3.1-405B-Instruct"],
-        llama_model=CoreModelId.llama3_1_405b_instruct,
+    build_model_alias(
+        "meta.llama3-1-405b-instruct-v1:0",
+        CoreModelId.llama3_1_405b_instruct,
     ),
 ]
 

--- a/llama_stack/providers/remote/inference/bedrock/bedrock.py
+++ b/llama_stack/providers/remote/inference/bedrock/bedrock.py
@@ -49,7 +49,7 @@ class BedrockInferenceAdapter(ModelRegistryHelper, Inference):
 
     async def completion(
         self,
-        model: str,
+        model_id: str,
         content: InterleavedTextMedia,
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
@@ -286,7 +286,7 @@ class BedrockInferenceAdapter(ModelRegistryHelper, Inference):
 
     async def chat_completion(
         self,
-        model: str,
+        model_id: str,
         messages: List[Message],
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
@@ -299,7 +299,7 @@ class BedrockInferenceAdapter(ModelRegistryHelper, Inference):
         ChatCompletionResponse, AsyncIterator[ChatCompletionResponseStreamChunk]
     ]:
         request = ChatCompletionRequest(
-            model=model,
+            model=model_id,
             messages=messages,
             sampling_params=sampling_params,
             tools=tools or [],
@@ -433,7 +433,7 @@ class BedrockInferenceAdapter(ModelRegistryHelper, Inference):
 
     async def embeddings(
         self,
-        model: str,
+        model_id: str,
         contents: List[InterleavedTextMedia],
     ) -> EmbeddingsResponse:
         raise NotImplementedError()

--- a/llama_stack/providers/remote/inference/databricks/databricks.py
+++ b/llama_stack/providers/remote/inference/databricks/databricks.py
@@ -18,7 +18,7 @@ from openai import OpenAI
 from llama_stack.apis.inference import *  # noqa: F403
 
 from llama_stack.providers.utils.inference.model_registry import (
-    ModelAlias,
+    build_model_alias,
     ModelRegistryHelper,
 )
 from llama_stack.providers.utils.inference.openai_compat import (
@@ -34,15 +34,13 @@ from .config import DatabricksImplConfig
 
 
 model_aliases = [
-    ModelAlias(
-        provider_model_id="databricks-meta-llama-3-1-70b-instruct",
-        aliases=["Llama3.1-70B-Instruct"],
-        llama_model=CoreModelId.llama3_1_70b_instruct.value,
+    build_model_alias(
+        "databricks-meta-llama-3-1-70b-instruct",
+        CoreModelId.llama3_1_70b_instruct,
     ),
-    ModelAlias(
-        provider_model_id="databricks-meta-llama-3-1-405b-instruct",
-        aliases=["Llama3.1-405B-Instruct"],
-        llama_model=CoreModelId.llama3_1_405b_instruct.value,
+    build_model_alias(
+        "databricks-meta-llama-3-1-405b-instruct",
+        CoreModelId.llama3_1_405b_instruct,
     ),
 ]
 

--- a/llama_stack/providers/remote/inference/databricks/databricks.py
+++ b/llama_stack/providers/remote/inference/databricks/databricks.py
@@ -37,7 +37,7 @@ DATABRICKS_SUPPORTED_MODELS = {
 class DatabricksInferenceAdapter(ModelRegistryHelper, Inference):
     def __init__(self, config: DatabricksImplConfig) -> None:
         ModelRegistryHelper.__init__(
-            self, stack_to_provider_models_map=DATABRICKS_SUPPORTED_MODELS
+            self, provider_to_common_model_aliases_map=DATABRICKS_SUPPORTED_MODELS
         )
         self.config = config
         self.formatter = ChatFormat(Tokenizer.get_instance())

--- a/llama_stack/providers/remote/inference/databricks/databricks.py
+++ b/llama_stack/providers/remote/inference/databricks/databricks.py
@@ -6,6 +6,8 @@
 
 from typing import AsyncGenerator
 
+from llama_models.datatypes import CoreModelId
+
 from llama_models.llama3.api.chat_format import ChatFormat
 
 from llama_models.llama3.api.datatypes import Message
@@ -15,7 +17,10 @@ from openai import OpenAI
 
 from llama_stack.apis.inference import *  # noqa: F403
 
-from llama_stack.providers.utils.inference.model_registry import ModelRegistryHelper
+from llama_stack.providers.utils.inference.model_registry import (
+    ModelAlias,
+    ModelRegistryHelper,
+)
 from llama_stack.providers.utils.inference.openai_compat import (
     get_sampling_options,
     process_chat_completion_response,
@@ -28,16 +33,25 @@ from llama_stack.providers.utils.inference.prompt_adapter import (
 from .config import DatabricksImplConfig
 
 
-DATABRICKS_SUPPORTED_MODELS = {
-    "Llama3.1-70B-Instruct": "databricks-meta-llama-3-1-70b-instruct",
-    "Llama3.1-405B-Instruct": "databricks-meta-llama-3-1-405b-instruct",
-}
+model_aliases = [
+    ModelAlias(
+        provider_model_id="databricks-meta-llama-3-1-70b-instruct",
+        aliases=["Llama3.1-70B-Instruct"],
+        llama_model=CoreModelId.llama3_1_70b_instruct.value,
+    ),
+    ModelAlias(
+        provider_model_id="databricks-meta-llama-3-1-405b-instruct",
+        aliases=["Llama3.1-405B-Instruct"],
+        llama_model=CoreModelId.llama3_1_405b_instruct.value,
+    ),
+]
 
 
 class DatabricksInferenceAdapter(ModelRegistryHelper, Inference):
     def __init__(self, config: DatabricksImplConfig) -> None:
         ModelRegistryHelper.__init__(
-            self, provider_to_common_model_aliases_map=DATABRICKS_SUPPORTED_MODELS
+            self,
+            model_aliases=model_aliases,
         )
         self.config = config
         self.formatter = ChatFormat(Tokenizer.get_instance())
@@ -113,8 +127,10 @@ class DatabricksInferenceAdapter(ModelRegistryHelper, Inference):
 
     def _get_params(self, request: ChatCompletionRequest) -> dict:
         return {
-            "model": self.map_to_provider_model(request.model),
-            "prompt": chat_completion_request_to_prompt(request, self.formatter),
+            "model": request.model,
+            "prompt": chat_completion_request_to_prompt(
+                request, self.get_llama_model(request.model), self.formatter
+            ),
             "stream": request.stream,
             **get_sampling_options(request.sampling_params),
         }

--- a/llama_stack/providers/remote/inference/databricks/databricks.py
+++ b/llama_stack/providers/remote/inference/databricks/databricks.py
@@ -36,11 +36,11 @@ from .config import DatabricksImplConfig
 model_aliases = [
     build_model_alias(
         "databricks-meta-llama-3-1-70b-instruct",
-        CoreModelId.llama3_1_70b_instruct,
+        CoreModelId.llama3_1_70b_instruct.value,
     ),
     build_model_alias(
         "databricks-meta-llama-3-1-405b-instruct",
-        CoreModelId.llama3_1_405b_instruct,
+        CoreModelId.llama3_1_405b_instruct.value,
     ),
 ]
 

--- a/llama_stack/providers/remote/inference/fireworks/fireworks.py
+++ b/llama_stack/providers/remote/inference/fireworks/fireworks.py
@@ -74,7 +74,7 @@ class FireworksInferenceAdapter(
 
     async def completion(
         self,
-        model: str,
+        model_id: str,
         content: InterleavedTextMedia,
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
@@ -82,7 +82,7 @@ class FireworksInferenceAdapter(
         logprobs: Optional[LogProbConfig] = None,
     ) -> AsyncGenerator:
         request = CompletionRequest(
-            model=model,
+            model=model_id,
             content=content,
             sampling_params=sampling_params,
             response_format=response_format,
@@ -138,7 +138,7 @@ class FireworksInferenceAdapter(
 
     async def chat_completion(
         self,
-        model: str,
+        model_id: str,
         messages: List[Message],
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         tools: Optional[List[ToolDefinition]] = None,
@@ -149,7 +149,7 @@ class FireworksInferenceAdapter(
         logprobs: Optional[LogProbConfig] = None,
     ) -> AsyncGenerator:
         request = ChatCompletionRequest(
-            model=model,
+            model=model_id,
             messages=messages,
             sampling_params=sampling_params,
             tools=tools or [],
@@ -229,7 +229,7 @@ class FireworksInferenceAdapter(
 
     async def embeddings(
         self,
-        model: str,
+        model_id: str,
         contents: List[InterleavedTextMedia],
     ) -> EmbeddingsResponse:
         raise NotImplementedError()

--- a/llama_stack/providers/remote/inference/fireworks/fireworks.py
+++ b/llama_stack/providers/remote/inference/fireworks/fireworks.py
@@ -7,14 +7,17 @@
 from typing import AsyncGenerator
 
 from fireworks.client import Fireworks
+from llama_models.datatypes import CoreModelId
 
 from llama_models.llama3.api.chat_format import ChatFormat
 from llama_models.llama3.api.datatypes import Message
 from llama_models.llama3.api.tokenizer import Tokenizer
-
 from llama_stack.apis.inference import *  # noqa: F403
 from llama_stack.distribution.request_headers import NeedsRequestProviderData
-from llama_stack.providers.utils.inference.model_registry import ModelRegistryHelper
+from llama_stack.providers.utils.inference.model_registry import (
+    ModelAlias,
+    ModelRegistryHelper,
+)
 from llama_stack.providers.utils.inference.openai_compat import (
     get_sampling_options,
     process_chat_completion_response,
@@ -31,25 +34,61 @@ from llama_stack.providers.utils.inference.prompt_adapter import (
 
 from .config import FireworksImplConfig
 
-FIREWORKS_SUPPORTED_MODELS = {
-    "Llama3.1-8B-Instruct": "fireworks/llama-v3p1-8b-instruct",
-    "Llama3.1-70B-Instruct": "fireworks/llama-v3p1-70b-instruct",
-    "Llama3.1-405B-Instruct": "fireworks/llama-v3p1-405b-instruct",
-    "Llama3.2-1B-Instruct": "fireworks/llama-v3p2-1b-instruct",
-    "Llama3.2-3B-Instruct": "fireworks/llama-v3p2-3b-instruct",
-    "Llama3.2-11B-Vision-Instruct": "fireworks/llama-v3p2-11b-vision-instruct",
-    "Llama3.2-90B-Vision-Instruct": "fireworks/llama-v3p2-90b-vision-instruct",
-    "Llama-Guard-3-8B": "fireworks/llama-guard-3-8b",
-}
+
+model_aliases = [
+    ModelAlias(
+        provider_model_id="fireworks/llama-v3p1-8b-instruct",
+        aliases=["Llama3.1-8B-Instruct"],
+        llama_model=CoreModelId.llama3_1_8b_instruct.value,
+    ),
+    ModelAlias(
+        provider_model_id="fireworks/llama-v3p1-70b-instruct",
+        aliases=["Llama3.1-70B-Instruct"],
+        llama_model=CoreModelId.llama3_1_70b_instruct.value,
+    ),
+    ModelAlias(
+        provider_model_id="fireworks/llama-v3p1-405b-instruct",
+        aliases=["Llama3.1-405B-Instruct"],
+        llama_model=CoreModelId.llama3_1_405b_instruct.value,
+    ),
+    ModelAlias(
+        provider_model_id="fireworks/llama-v3p2-1b-instruct",
+        aliases=["Llama3.2-1B-Instruct"],
+        llama_model=CoreModelId.llama3_2_3b_instruct.value,
+    ),
+    ModelAlias(
+        provider_model_id="fireworks/llama-v3p2-3b-instruct",
+        aliases=["Llama3.2-3B-Instruct"],
+        llama_model=CoreModelId.llama3_2_11b_vision_instruct.value,
+    ),
+    ModelAlias(
+        provider_model_id="fireworks/llama-v3p2-11b-vision-instruct",
+        aliases=["Llama3.2-11B-Vision-Instruct"],
+        llama_model=CoreModelId.llama3_2_11b_vision_instruct.value,
+    ),
+    ModelAlias(
+        provider_model_id="fireworks/llama-v3p2-90b-vision-instruct",
+        aliases=["Llama3.2-90B-Vision-Instruct"],
+        llama_model=CoreModelId.llama3_2_90b_vision_instruct.value,
+    ),
+    ModelAlias(
+        provider_model_id="fireworks/llama-guard-3-8b",
+        aliases=["Llama-Guard-3-8B"],
+        llama_model=CoreModelId.llama_guard_3_8b.value,
+    ),
+    ModelAlias(
+        provider_model_id="fireworks/llama-guard-3-11b-vision",
+        aliases=["Llama-Guard-3-11B-Vision"],
+        llama_model=CoreModelId.llama_guard_3_11b_vision.value,
+    ),
+]
 
 
 class FireworksInferenceAdapter(
     ModelRegistryHelper, Inference, NeedsRequestProviderData
 ):
     def __init__(self, config: FireworksImplConfig) -> None:
-        ModelRegistryHelper.__init__(
-            self, stack_to_provider_models_map=FIREWORKS_SUPPORTED_MODELS
-        )
+        ModelRegistryHelper.__init__(self, model_aliases)
         self.config = config
         self.formatter = ChatFormat(Tokenizer.get_instance())
 
@@ -81,8 +120,9 @@ class FireworksInferenceAdapter(
         stream: Optional[bool] = False,
         logprobs: Optional[LogProbConfig] = None,
     ) -> AsyncGenerator:
+        model = await self.model_store.get_model(model_id)
         request = CompletionRequest(
-            model=model_id,
+            model=model.provider_resource_id,
             content=content,
             sampling_params=sampling_params,
             response_format=response_format,
@@ -148,8 +188,9 @@ class FireworksInferenceAdapter(
         stream: Optional[bool] = False,
         logprobs: Optional[LogProbConfig] = None,
     ) -> AsyncGenerator:
+        model = await self.model_store.get_model(model_id)
         request = ChatCompletionRequest(
-            model=model_id,
+            model=model.provider_resource_id,
             messages=messages,
             sampling_params=sampling_params,
             tools=tools or [],
@@ -207,7 +248,7 @@ class FireworksInferenceAdapter(
                 ]
             else:
                 input_dict["prompt"] = chat_completion_request_to_prompt(
-                    request, self.formatter
+                    request, self.get_llama_model(request.model), self.formatter
                 )
         else:
             assert (
@@ -221,7 +262,7 @@ class FireworksInferenceAdapter(
                 input_dict["prompt"] = input_dict["prompt"][len("<|begin_of_text|>") :]
 
         return {
-            "model": self.map_to_provider_model(request.model),
+            "model": request.model,
             **input_dict,
             "stream": request.stream,
             **self._build_options(request.sampling_params, request.response_format),

--- a/llama_stack/providers/remote/inference/fireworks/fireworks.py
+++ b/llama_stack/providers/remote/inference/fireworks/fireworks.py
@@ -15,7 +15,7 @@ from llama_models.llama3.api.tokenizer import Tokenizer
 from llama_stack.apis.inference import *  # noqa: F403
 from llama_stack.distribution.request_headers import NeedsRequestProviderData
 from llama_stack.providers.utils.inference.model_registry import (
-    ModelAlias,
+    build_model_alias,
     ModelRegistryHelper,
 )
 from llama_stack.providers.utils.inference.openai_compat import (
@@ -36,50 +36,41 @@ from .config import FireworksImplConfig
 
 
 model_aliases = [
-    ModelAlias(
-        provider_model_id="fireworks/llama-v3p1-8b-instruct",
-        aliases=["Llama3.1-8B-Instruct"],
-        llama_model=CoreModelId.llama3_1_8b_instruct.value,
+    build_model_alias(
+        "fireworks/llama-v3p1-8b-instruct",
+        CoreModelId.llama3_1_8b_instruct,
     ),
-    ModelAlias(
-        provider_model_id="fireworks/llama-v3p1-70b-instruct",
-        aliases=["Llama3.1-70B-Instruct"],
-        llama_model=CoreModelId.llama3_1_70b_instruct.value,
+    build_model_alias(
+        "fireworks/llama-v3p1-70b-instruct",
+        CoreModelId.llama3_1_70b_instruct,
     ),
-    ModelAlias(
-        provider_model_id="fireworks/llama-v3p1-405b-instruct",
-        aliases=["Llama3.1-405B-Instruct"],
-        llama_model=CoreModelId.llama3_1_405b_instruct.value,
+    build_model_alias(
+        "fireworks/llama-v3p1-405b-instruct",
+        CoreModelId.llama3_1_405b_instruct,
     ),
-    ModelAlias(
-        provider_model_id="fireworks/llama-v3p2-1b-instruct",
-        aliases=["Llama3.2-1B-Instruct"],
-        llama_model=CoreModelId.llama3_2_3b_instruct.value,
+    build_model_alias(
+        "fireworks/llama-v3p2-1b-instruct",
+        CoreModelId.llama3_2_3b_instruct,
     ),
-    ModelAlias(
-        provider_model_id="fireworks/llama-v3p2-3b-instruct",
-        aliases=["Llama3.2-3B-Instruct"],
-        llama_model=CoreModelId.llama3_2_11b_vision_instruct.value,
+    build_model_alias(
+        "fireworks/llama-v3p2-3b-instruct",
+        CoreModelId.llama3_2_11b_vision_instruct,
     ),
-    ModelAlias(
-        provider_model_id="fireworks/llama-v3p2-11b-vision-instruct",
-        aliases=["Llama3.2-11B-Vision-Instruct"],
-        llama_model=CoreModelId.llama3_2_11b_vision_instruct.value,
+    build_model_alias(
+        "fireworks/llama-v3p2-11b-vision-instruct",
+        CoreModelId.llama3_2_11b_vision_instruct,
     ),
-    ModelAlias(
-        provider_model_id="fireworks/llama-v3p2-90b-vision-instruct",
-        aliases=["Llama3.2-90B-Vision-Instruct"],
-        llama_model=CoreModelId.llama3_2_90b_vision_instruct.value,
+    build_model_alias(
+        "fireworks/llama-v3p2-90b-vision-instruct",
+        CoreModelId.llama3_2_90b_vision_instruct,
     ),
-    ModelAlias(
-        provider_model_id="fireworks/llama-guard-3-8b",
-        aliases=["Llama-Guard-3-8B"],
-        llama_model=CoreModelId.llama_guard_3_8b.value,
+    build_model_alias(
+        "fireworks/llama-guard-3-8b",
+        CoreModelId.llama_guard_3_8b,
     ),
-    ModelAlias(
-        provider_model_id="fireworks/llama-guard-3-11b-vision",
-        aliases=["Llama-Guard-3-11B-Vision"],
-        llama_model=CoreModelId.llama_guard_3_11b_vision.value,
+    build_model_alias(
+        "fireworks/llama-guard-3-11b-vision",
+        CoreModelId.llama_guard_3_11b_vision,
     ),
 ]
 

--- a/llama_stack/providers/remote/inference/fireworks/fireworks.py
+++ b/llama_stack/providers/remote/inference/fireworks/fireworks.py
@@ -38,39 +38,39 @@ from .config import FireworksImplConfig
 model_aliases = [
     build_model_alias(
         "fireworks/llama-v3p1-8b-instruct",
-        CoreModelId.llama3_1_8b_instruct,
+        CoreModelId.llama3_1_8b_instruct.value,
     ),
     build_model_alias(
         "fireworks/llama-v3p1-70b-instruct",
-        CoreModelId.llama3_1_70b_instruct,
+        CoreModelId.llama3_1_70b_instruct.value,
     ),
     build_model_alias(
         "fireworks/llama-v3p1-405b-instruct",
-        CoreModelId.llama3_1_405b_instruct,
+        CoreModelId.llama3_1_405b_instruct.value,
     ),
     build_model_alias(
         "fireworks/llama-v3p2-1b-instruct",
-        CoreModelId.llama3_2_3b_instruct,
+        CoreModelId.llama3_2_3b_instruct.value,
     ),
     build_model_alias(
         "fireworks/llama-v3p2-3b-instruct",
-        CoreModelId.llama3_2_11b_vision_instruct,
+        CoreModelId.llama3_2_11b_vision_instruct.value,
     ),
     build_model_alias(
         "fireworks/llama-v3p2-11b-vision-instruct",
-        CoreModelId.llama3_2_11b_vision_instruct,
+        CoreModelId.llama3_2_11b_vision_instruct.value,
     ),
     build_model_alias(
         "fireworks/llama-v3p2-90b-vision-instruct",
-        CoreModelId.llama3_2_90b_vision_instruct,
+        CoreModelId.llama3_2_90b_vision_instruct.value,
     ),
     build_model_alias(
         "fireworks/llama-guard-3-8b",
-        CoreModelId.llama_guard_3_8b,
+        CoreModelId.llama_guard_3_8b.value,
     ),
     build_model_alias(
         "fireworks/llama-guard-3-11b-vision",
-        CoreModelId.llama_guard_3_11b_vision,
+        CoreModelId.llama_guard_3_11b_vision.value,
     ),
 ]
 

--- a/llama_stack/providers/remote/inference/ollama/ollama.py
+++ b/llama_stack/providers/remote/inference/ollama/ollama.py
@@ -15,7 +15,7 @@ from llama_models.llama3.api.tokenizer import Tokenizer
 from ollama import AsyncClient
 
 from llama_stack.providers.utils.inference.model_registry import (
-    ModelAlias,
+    build_model_alias,
     ModelRegistryHelper,
 )
 
@@ -40,40 +40,33 @@ from llama_stack.providers.utils.inference.prompt_adapter import (
 
 
 model_aliases = [
-    ModelAlias(
-        provider_model_id="llama3.1:8b-instruct-fp16",
-        aliases=["Llama3.1-8B-Instruct"],
-        llama_model=CoreModelId.llama3_1_8b_instruct.value,
+    build_model_alias(
+        "llama3.1:8b-instruct-fp16",
+        CoreModelId.llama3_1_8b_instruct,
     ),
-    ModelAlias(
-        provider_model_id="llama3.1:70b-instruct-fp16",
-        aliases=["Llama3.1-70B-Instruct"],
-        llama_model=CoreModelId.llama3_1_70b_instruct.value,
+    build_model_alias(
+        "llama3.1:70b-instruct-fp16",
+        CoreModelId.llama3_1_70b_instruct,
     ),
-    ModelAlias(
-        provider_model_id="llama3.2:1b-instruct-fp16",
-        aliases=["Llama3.2-1B-Instruct"],
-        llama_model=CoreModelId.llama3_2_1b_instruct.value,
+    build_model_alias(
+        "llama3.2:1b-instruct-fp16",
+        CoreModelId.llama3_2_1b_instruct,
     ),
-    ModelAlias(
-        provider_model_id="llama3.2:3b-instruct-fp16",
-        aliases=["Llama3.2-3B-Instruct"],
-        llama_model=CoreModelId.llama3_2_3b_instruct.value,
+    build_model_alias(
+        "llama3.2:3b-instruct-fp16",
+        CoreModelId.llama3_2_3b_instruct,
     ),
-    ModelAlias(
-        provider_model_id="llama-guard3:8b",
-        aliases=["Llama-Guard-3-8B"],
-        llama_model=CoreModelId.llama_guard_3_8b.value,
+    build_model_alias(
+        "llama-guard3:8b",
+        CoreModelId.llama_guard_3_8b,
     ),
-    ModelAlias(
-        provider_model_id="llama-guard3:1b",
-        aliases=["Llama-Guard-3-1B"],
-        llama_model=CoreModelId.llama_guard_3_1b.value,
+    build_model_alias(
+        "llama-guard3:1b",
+        CoreModelId.llama_guard_3_1b,
     ),
-    ModelAlias(
-        provider_model_id="x/llama3.2-vision:11b-instruct-fp16",
-        aliases=["Llama3.2-11B-Vision-Instruct"],
-        llama_model=CoreModelId.llama3_2_11b_vision_instruct.value,
+    build_model_alias(
+        "x/llama3.2-vision:11b-instruct-fp16",
+        CoreModelId.llama3_2_11b_vision_instruct,
     ),
 ]
 

--- a/llama_stack/providers/remote/inference/ollama/ollama.py
+++ b/llama_stack/providers/remote/inference/ollama/ollama.py
@@ -20,7 +20,7 @@ from llama_stack.providers.utils.inference.model_registry import (
 )
 
 from llama_stack.apis.inference import *  # noqa: F403
-from llama_stack.providers.datatypes import Model, ModelsProtocolPrivate
+from llama_stack.providers.datatypes import ModelsProtocolPrivate
 
 from llama_stack.providers.utils.inference.openai_compat import (
     get_sampling_options,
@@ -102,29 +102,6 @@ class OllamaInferenceAdapter(Inference, ModelRegistryHelper, ModelsProtocolPriva
 
     async def shutdown(self) -> None:
         pass
-
-    async def list_models(self) -> List[Model]:
-        ollama_to_llama = {v: k for k, v in OLLAMA_SUPPORTED_MODELS.items()}
-
-        ret = []
-        res = await self.client.ps()
-        for r in res["models"]:
-            if r["model"] not in ollama_to_llama:
-                print(f"Ollama is running a model unknown to Llama Stack: {r['model']}")
-                continue
-
-            llama_model = ollama_to_llama[r["model"]]
-            print(f"Found model {llama_model} in Ollama")
-            ret.append(
-                Model(
-                    identifier=llama_model,
-                    metadata={
-                        "ollama_model": r["model"],
-                    },
-                )
-            )
-
-        return ret
 
     async def completion(
         self,
@@ -243,7 +220,7 @@ class OllamaInferenceAdapter(Inference, ModelRegistryHelper, ModelsProtocolPriva
             input_dict["raw"] = True
 
         return {
-            "model": OLLAMA_SUPPORTED_MODELS[request.model],
+            "model": request.model,
             **input_dict,
             "options": sampling_options,
             "stream": request.stream,

--- a/llama_stack/providers/remote/inference/ollama/ollama.py
+++ b/llama_stack/providers/remote/inference/ollama/ollama.py
@@ -66,8 +66,10 @@ class OllamaInferenceAdapter(Inference, ModelsProtocolPrivate):
         pass
 
     async def register_model(self, model: Model) -> None:
-        if model.identifier not in OLLAMA_SUPPORTED_MODELS:
-            raise ValueError(f"Model {model.identifier} is not supported by Ollama")
+        if model.provider_resource_id not in OLLAMA_SUPPORTED_MODELS:
+            raise ValueError(
+                f"Model {model.provider_resource_id} is not supported by Ollama"
+            )
 
     async def list_models(self) -> List[Model]:
         ollama_to_llama = {v: k for k, v in OLLAMA_SUPPORTED_MODELS.items()}
@@ -94,7 +96,7 @@ class OllamaInferenceAdapter(Inference, ModelsProtocolPrivate):
 
     async def completion(
         self,
-        model: str,
+        model_id: str,
         content: InterleavedTextMedia,
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
@@ -102,7 +104,7 @@ class OllamaInferenceAdapter(Inference, ModelsProtocolPrivate):
         logprobs: Optional[LogProbConfig] = None,
     ) -> AsyncGenerator:
         request = CompletionRequest(
-            model=model,
+            model=model_id,
             content=content,
             sampling_params=sampling_params,
             stream=stream,
@@ -148,7 +150,7 @@ class OllamaInferenceAdapter(Inference, ModelsProtocolPrivate):
 
     async def chat_completion(
         self,
-        model: str,
+        model_id: str,
         messages: List[Message],
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
@@ -159,7 +161,7 @@ class OllamaInferenceAdapter(Inference, ModelsProtocolPrivate):
         logprobs: Optional[LogProbConfig] = None,
     ) -> AsyncGenerator:
         request = ChatCompletionRequest(
-            model=model,
+            model=model_id,
             messages=messages,
             sampling_params=sampling_params,
             tools=tools or [],
@@ -271,7 +273,7 @@ class OllamaInferenceAdapter(Inference, ModelsProtocolPrivate):
 
     async def embeddings(
         self,
-        model: str,
+        model_id: str,
         contents: List[InterleavedTextMedia],
     ) -> EmbeddingsResponse:
         raise NotImplementedError()

--- a/llama_stack/providers/remote/inference/ollama/ollama.py
+++ b/llama_stack/providers/remote/inference/ollama/ollama.py
@@ -42,31 +42,31 @@ from llama_stack.providers.utils.inference.prompt_adapter import (
 model_aliases = [
     build_model_alias(
         "llama3.1:8b-instruct-fp16",
-        CoreModelId.llama3_1_8b_instruct,
+        CoreModelId.llama3_1_8b_instruct.value,
     ),
     build_model_alias(
         "llama3.1:70b-instruct-fp16",
-        CoreModelId.llama3_1_70b_instruct,
+        CoreModelId.llama3_1_70b_instruct.value,
     ),
     build_model_alias(
         "llama3.2:1b-instruct-fp16",
-        CoreModelId.llama3_2_1b_instruct,
+        CoreModelId.llama3_2_1b_instruct.value,
     ),
     build_model_alias(
         "llama3.2:3b-instruct-fp16",
-        CoreModelId.llama3_2_3b_instruct,
+        CoreModelId.llama3_2_3b_instruct.value,
     ),
     build_model_alias(
         "llama-guard3:8b",
-        CoreModelId.llama_guard_3_8b,
+        CoreModelId.llama_guard_3_8b.value,
     ),
     build_model_alias(
         "llama-guard3:1b",
-        CoreModelId.llama_guard_3_1b,
+        CoreModelId.llama_guard_3_1b.value,
     ),
     build_model_alias(
         "x/llama3.2-vision:11b-instruct-fp16",
-        CoreModelId.llama3_2_11b_vision_instruct,
+        CoreModelId.llama3_2_11b_vision_instruct.value,
     ),
 ]
 
@@ -164,6 +164,7 @@ class OllamaInferenceAdapter(Inference, ModelRegistryHelper, ModelsProtocolPriva
         logprobs: Optional[LogProbConfig] = None,
     ) -> AsyncGenerator:
         model = await self.model_store.get_model(model_id)
+        print(f"model={model}")
         request = ChatCompletionRequest(
             model=model.provider_resource_id,
             messages=messages,

--- a/llama_stack/providers/remote/inference/together/together.py
+++ b/llama_stack/providers/remote/inference/together/together.py
@@ -63,7 +63,7 @@ class TogetherInferenceAdapter(
 
     async def completion(
         self,
-        model: str,
+        model_id: str,
         content: InterleavedTextMedia,
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
@@ -71,7 +71,7 @@ class TogetherInferenceAdapter(
         logprobs: Optional[LogProbConfig] = None,
     ) -> AsyncGenerator:
         request = CompletionRequest(
-            model=model,
+            model=model_id,
             content=content,
             sampling_params=sampling_params,
             response_format=response_format,
@@ -135,7 +135,7 @@ class TogetherInferenceAdapter(
 
     async def chat_completion(
         self,
-        model: str,
+        model_id: str,
         messages: List[Message],
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         tools: Optional[List[ToolDefinition]] = None,
@@ -146,7 +146,7 @@ class TogetherInferenceAdapter(
         logprobs: Optional[LogProbConfig] = None,
     ) -> AsyncGenerator:
         request = ChatCompletionRequest(
-            model=model,
+            model=model_id,
             messages=messages,
             sampling_params=sampling_params,
             tools=tools or [],
@@ -221,7 +221,7 @@ class TogetherInferenceAdapter(
 
     async def embeddings(
         self,
-        model: str,
+        model_id: str,
         contents: List[InterleavedTextMedia],
     ) -> EmbeddingsResponse:
         raise NotImplementedError()

--- a/llama_stack/providers/remote/inference/together/together.py
+++ b/llama_stack/providers/remote/inference/together/together.py
@@ -18,7 +18,7 @@ from together import Together
 from llama_stack.apis.inference import *  # noqa: F403
 from llama_stack.distribution.request_headers import NeedsRequestProviderData
 from llama_stack.providers.utils.inference.model_registry import (
-    ModelAlias,
+    build_model_alias,
     ModelRegistryHelper,
 )
 from llama_stack.providers.utils.inference.openai_compat import (
@@ -39,45 +39,37 @@ from .config import TogetherImplConfig
 
 
 model_aliases = [
-    ModelAlias(
-        provider_model_id="meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
-        aliases=["Llama3.1-8B-Instruct"],
-        llama_model=CoreModelId.llama3_1_8b_instruct.value,
+    build_model_alias(
+        "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
+        CoreModelId.llama3_1_8b_instruct,
     ),
-    ModelAlias(
-        provider_model_id="meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
-        aliases=["Llama3.1-70B-Instruct"],
-        llama_model=CoreModelId.llama3_1_70b_instruct.value,
+    build_model_alias(
+        "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
+        CoreModelId.llama3_1_70b_instruct,
     ),
-    ModelAlias(
-        provider_model_id="meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo",
-        aliases=["Llama3.1-405B-Instruct"],
-        llama_model=CoreModelId.llama3_1_405b_instruct.value,
+    build_model_alias(
+        "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo",
+        CoreModelId.llama3_1_405b_instruct,
     ),
-    ModelAlias(
-        provider_model_id="meta-llama/Llama-3.2-3B-Instruct-Turbo",
-        aliases=["Llama3.2-3B-Instruct"],
-        llama_model=CoreModelId.llama3_2_3b_instruct.value,
+    build_model_alias(
+        "meta-llama/Llama-3.2-3B-Instruct-Turbo",
+        CoreModelId.llama3_2_3b_instruct,
     ),
-    ModelAlias(
-        provider_model_id="meta-llama/Llama-3.2-11B-Vision-Instruct-Turbo",
-        aliases=["Llama3.2-11B-Vision-Instruct"],
-        llama_model=CoreModelId.llama3_2_11b_vision_instruct.value,
+    build_model_alias(
+        "meta-llama/Llama-3.2-11B-Vision-Instruct-Turbo",
+        CoreModelId.llama3_2_11b_vision_instruct,
     ),
-    ModelAlias(
-        provider_model_id="meta-llama/Llama-3.2-90B-Vision-Instruct-Turbo",
-        aliases=["Llama3.2-90B-Vision-Instruct"],
-        llama_model=CoreModelId.llama3_2_90b_vision_instruct.value,
+    build_model_alias(
+        "meta-llama/Llama-3.2-90B-Vision-Instruct-Turbo",
+        CoreModelId.llama3_2_90b_vision_instruct,
     ),
-    ModelAlias(
-        provider_model_id="meta-llama/Meta-Llama-Guard-3-8B",
-        aliases=["Llama-Guard-3-8B"],
-        llama_model=CoreModelId.llama_guard_3_8b.value,
+    build_model_alias(
+        "meta-llama/Meta-Llama-Guard-3-8B",
+        CoreModelId.llama_guard_3_8b,
     ),
-    ModelAlias(
-        provider_model_id="meta-llama/Llama-Guard-3-11B-Vision-Turbo",
-        aliases=["Llama-Guard-3-11B-Vision"],
-        llama_model=CoreModelId.llama_guard_3_11b_vision.value,
+    build_model_alias(
+        "meta-llama/Llama-Guard-3-11B-Vision-Turbo",
+        CoreModelId.llama_guard_3_11b_vision,
     ),
 ]
 

--- a/llama_stack/providers/remote/inference/together/together.py
+++ b/llama_stack/providers/remote/inference/together/together.py
@@ -41,35 +41,35 @@ from .config import TogetherImplConfig
 model_aliases = [
     build_model_alias(
         "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
-        CoreModelId.llama3_1_8b_instruct,
+        CoreModelId.llama3_1_8b_instruct.value,
     ),
     build_model_alias(
         "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
-        CoreModelId.llama3_1_70b_instruct,
+        CoreModelId.llama3_1_70b_instruct.value,
     ),
     build_model_alias(
         "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo",
-        CoreModelId.llama3_1_405b_instruct,
+        CoreModelId.llama3_1_405b_instruct.value,
     ),
     build_model_alias(
         "meta-llama/Llama-3.2-3B-Instruct-Turbo",
-        CoreModelId.llama3_2_3b_instruct,
+        CoreModelId.llama3_2_3b_instruct.value,
     ),
     build_model_alias(
         "meta-llama/Llama-3.2-11B-Vision-Instruct-Turbo",
-        CoreModelId.llama3_2_11b_vision_instruct,
+        CoreModelId.llama3_2_11b_vision_instruct.value,
     ),
     build_model_alias(
         "meta-llama/Llama-3.2-90B-Vision-Instruct-Turbo",
-        CoreModelId.llama3_2_90b_vision_instruct,
+        CoreModelId.llama3_2_90b_vision_instruct.value,
     ),
     build_model_alias(
         "meta-llama/Meta-Llama-Guard-3-8B",
-        CoreModelId.llama_guard_3_8b,
+        CoreModelId.llama_guard_3_8b.value,
     ),
     build_model_alias(
         "meta-llama/Llama-Guard-3-11B-Vision-Turbo",
-        CoreModelId.llama_guard_3_11b_vision,
+        CoreModelId.llama_guard_3_11b_vision.value,
     ),
 ]
 

--- a/llama_stack/providers/remote/inference/vllm/vllm.py
+++ b/llama_stack/providers/remote/inference/vllm/vllm.py
@@ -85,7 +85,6 @@ class VLLMInferenceAdapter(Inference, ModelRegistryHelper, ModelsProtocolPrivate
         logprobs: Optional[LogProbConfig] = None,
     ) -> AsyncGenerator:
         model = await self.model_store.get_model(model_id)
-        print(f"model={model}")
         request = ChatCompletionRequest(
             model=model.provider_resource_id,
             messages=messages,

--- a/llama_stack/providers/remote/inference/vllm/vllm.py
+++ b/llama_stack/providers/remote/inference/vllm/vllm.py
@@ -16,7 +16,7 @@ from llama_stack.apis.inference import *  # noqa: F403
 from llama_stack.providers.datatypes import ModelsProtocolPrivate
 
 from llama_stack.providers.utils.inference.model_registry import (
-    ModelAlias,
+    build_model_alias,
     ModelRegistryHelper,
 )
 from llama_stack.providers.utils.inference.openai_compat import (
@@ -36,10 +36,9 @@ from .config import VLLMInferenceAdapterConfig
 
 def build_model_aliases():
     return [
-        ModelAlias(
-            provider_model_id=model.huggingface_repo,
-            aliases=[model.descriptor()],
-            llama_model=model.descriptor(),
+        build_model_alias(
+            model.huggingface_repo,
+            model.core_model_id,
         )
         for model in all_registered_models()
         if model.huggingface_repo
@@ -55,11 +54,6 @@ class VLLMInferenceAdapter(Inference, ModelRegistryHelper, ModelsProtocolPrivate
         self.config = config
         self.formatter = ChatFormat(Tokenizer.get_instance())
         self.client = None
-        self.huggingface_repo_to_llama_model_id = {
-            model.huggingface_repo: model.descriptor()
-            for model in all_registered_models()
-            if model.huggingface_repo
-        }
 
     async def initialize(self) -> None:
         self.client = OpenAI(base_url=self.config.url, api_key=self.config.api_token)

--- a/llama_stack/providers/remote/inference/vllm/vllm.py
+++ b/llama_stack/providers/remote/inference/vllm/vllm.py
@@ -45,8 +45,15 @@ class VLLMInferenceAdapter(Inference, ModelsProtocolPrivate):
         self.client = OpenAI(base_url=self.config.url, api_key=self.config.api_token)
 
     async def register_model(self, model: Model) -> None:
-        for running_model in self.client.models.list():
-            repo = running_model.id
+        pass
+
+    async def shutdown(self) -> None:
+        pass
+
+    async def list_models(self) -> List[Model]:
+        models = []
+        for model in self.client.models.list():
+            repo = model.id
             if repo not in self.huggingface_repo_to_llama_model_id:
                 print(f"Unknown model served by vllm: {repo}")
                 continue
@@ -67,7 +74,7 @@ class VLLMInferenceAdapter(Inference, ModelsProtocolPrivate):
 
     async def completion(
         self,
-        model: str,
+        model_id: str,
         content: InterleavedTextMedia,
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
@@ -78,7 +85,7 @@ class VLLMInferenceAdapter(Inference, ModelsProtocolPrivate):
 
     async def chat_completion(
         self,
-        model: str,
+        model_id: str,
         messages: List[Message],
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
@@ -89,7 +96,7 @@ class VLLMInferenceAdapter(Inference, ModelsProtocolPrivate):
         logprobs: Optional[LogProbConfig] = None,
     ) -> AsyncGenerator:
         request = ChatCompletionRequest(
-            model=model,
+            model=model_id,
             messages=messages,
             sampling_params=sampling_params,
             tools=tools or [],
@@ -173,7 +180,7 @@ class VLLMInferenceAdapter(Inference, ModelsProtocolPrivate):
 
     async def embeddings(
         self,
-        model: str,
+        model_id: str,
         contents: List[InterleavedTextMedia],
     ) -> EmbeddingsResponse:
         raise NotImplementedError()

--- a/llama_stack/providers/remote/inference/vllm/vllm.py
+++ b/llama_stack/providers/remote/inference/vllm/vllm.py
@@ -38,7 +38,7 @@ def build_model_aliases():
     return [
         build_model_alias(
             model.huggingface_repo,
-            model.core_model_id,
+            model.descriptor(),
         )
         for model in all_registered_models()
         if model.huggingface_repo
@@ -85,6 +85,7 @@ class VLLMInferenceAdapter(Inference, ModelRegistryHelper, ModelsProtocolPrivate
         logprobs: Optional[LogProbConfig] = None,
     ) -> AsyncGenerator:
         model = await self.model_store.get_model(model_id)
+        print(f"model={model}")
         request = ChatCompletionRequest(
             model=model.provider_resource_id,
             messages=messages,

--- a/llama_stack/providers/tests/inference/fixtures.py
+++ b/llama_stack/providers/tests/inference/fixtures.py
@@ -49,7 +49,7 @@ def inference_meta_reference(inference_model) -> ProviderFixture:
         providers=[
             Provider(
                 provider_id=f"meta-reference-{i}",
-                provider_type="meta-reference",
+                provider_type="inline::meta-reference",
                 config=MetaReferenceInferenceConfig(
                     model=m,
                     max_seq_len=4096,

--- a/llama_stack/providers/tests/inference/fixtures.py
+++ b/llama_stack/providers/tests/inference/fixtures.py
@@ -179,7 +179,7 @@ INFERENCE_FIXTURES = [
 
 
 @pytest_asyncio.fixture(scope="session")
-async def inference_stack(request, inference_model, model_id):
+async def inference_stack(request, inference_model):
     fixture_name = request.param
     inference_fixture = request.getfixturevalue(f"inference_{fixture_name}")
     impls = await resolve_impls_for_test_v2(
@@ -188,7 +188,7 @@ async def inference_stack(request, inference_model, model_id):
         inference_fixture.provider_data,
         models=[
             ModelInput(
-                model_id=model_id,
+                model_id=inference_model,
             )
         ],
     )

--- a/llama_stack/providers/tests/inference/test_text_inference.py
+++ b/llama_stack/providers/tests/inference/test_text_inference.py
@@ -64,7 +64,7 @@ def sample_tool_definition():
 
 class TestInference:
     @pytest.mark.asyncio
-    async def test_model_list(self, inference_model, inference_stack):
+    async def test_model_list(self, inference_model, inference_stack, model_id):
         _, models_impl = inference_stack
         response = await models_impl.list_models()
         assert isinstance(response, list)
@@ -73,17 +73,16 @@ class TestInference:
 
         model_def = None
         for model in response:
-            if model.identifier == inference_model:
+            if model.identifier == model_id:
                 model_def = model
                 break
 
         assert model_def is not None
 
     @pytest.mark.asyncio
-    async def test_completion(self, inference_model, inference_stack):
+    async def test_completion(self, inference_model, inference_stack, model_id):
         inference_impl, _ = inference_stack
-
-        provider = inference_impl.routing_table.get_provider_impl(inference_model)
+        provider = inference_impl.routing_table.get_provider_impl(model_id)
         if provider.__provider_spec__.provider_type not in (
             "meta-reference",
             "remote::ollama",
@@ -96,7 +95,7 @@ class TestInference:
         response = await inference_impl.completion(
             content="Micheael Jordan is born in ",
             stream=False,
-            model=inference_model,
+            model_id=model_id,
             sampling_params=SamplingParams(
                 max_tokens=50,
             ),
@@ -110,7 +109,7 @@ class TestInference:
             async for r in await inference_impl.completion(
                 content="Roses are red,",
                 stream=True,
-                model=inference_model,
+                model_id=model_id,
                 sampling_params=SamplingParams(
                     max_tokens=50,
                 ),
@@ -125,11 +124,11 @@ class TestInference:
     @pytest.mark.asyncio
     @pytest.mark.skip("This test is not quite robust")
     async def test_completions_structured_output(
-        self, inference_model, inference_stack
+        self, inference_model, inference_stack, model_id
     ):
         inference_impl, _ = inference_stack
 
-        provider = inference_impl.routing_table.get_provider_impl(inference_model)
+        provider = inference_impl.routing_table.get_provider_impl(model_id)
         if provider.__provider_spec__.provider_type not in (
             "meta-reference",
             "remote::tgi",
@@ -149,7 +148,7 @@ class TestInference:
         response = await inference_impl.completion(
             content=user_input,
             stream=False,
-            model=inference_model,
+            model_id=model_id,
             sampling_params=SamplingParams(
                 max_tokens=50,
             ),
@@ -167,11 +166,11 @@ class TestInference:
 
     @pytest.mark.asyncio
     async def test_chat_completion_non_streaming(
-        self, inference_model, inference_stack, common_params, sample_messages
+        self, inference_model, inference_stack, common_params, sample_messages, model_id
     ):
         inference_impl, _ = inference_stack
         response = await inference_impl.chat_completion(
-            model=inference_model,
+            model_id=model_id,
             messages=sample_messages,
             stream=False,
             **common_params,
@@ -184,11 +183,11 @@ class TestInference:
 
     @pytest.mark.asyncio
     async def test_structured_output(
-        self, inference_model, inference_stack, common_params
+        self, inference_model, inference_stack, common_params, model_id
     ):
         inference_impl, _ = inference_stack
 
-        provider = inference_impl.routing_table.get_provider_impl(inference_model)
+        provider = inference_impl.routing_table.get_provider_impl(model_id)
         if provider.__provider_spec__.provider_type not in (
             "meta-reference",
             "remote::fireworks",
@@ -204,7 +203,7 @@ class TestInference:
             num_seasons_in_nba: int
 
         response = await inference_impl.chat_completion(
-            model=inference_model,
+            model_id=model_id,
             messages=[
                 SystemMessage(content="You are a helpful assistant."),
                 UserMessage(content="Please give me information about Michael Jordan."),
@@ -227,7 +226,7 @@ class TestInference:
         assert answer.num_seasons_in_nba == 15
 
         response = await inference_impl.chat_completion(
-            model=inference_model,
+            model_id=model_id,
             messages=[
                 SystemMessage(content="You are a helpful assistant."),
                 UserMessage(content="Please give me information about Michael Jordan."),
@@ -244,13 +243,13 @@ class TestInference:
 
     @pytest.mark.asyncio
     async def test_chat_completion_streaming(
-        self, inference_model, inference_stack, common_params, sample_messages
+        self, inference_model, inference_stack, common_params, sample_messages, model_id
     ):
         inference_impl, _ = inference_stack
         response = [
             r
             async for r in await inference_impl.chat_completion(
-                model=inference_model,
+                model_id=model_id,
                 messages=sample_messages,
                 stream=True,
                 **common_params,
@@ -277,6 +276,7 @@ class TestInference:
         common_params,
         sample_messages,
         sample_tool_definition,
+        model_id,
     ):
         inference_impl, _ = inference_stack
         messages = sample_messages + [
@@ -286,7 +286,7 @@ class TestInference:
         ]
 
         response = await inference_impl.chat_completion(
-            model=inference_model,
+            model_id=model_id,
             messages=messages,
             tools=[sample_tool_definition],
             stream=False,
@@ -316,6 +316,7 @@ class TestInference:
         common_params,
         sample_messages,
         sample_tool_definition,
+        model_id,
     ):
         inference_impl, _ = inference_stack
         messages = sample_messages + [
@@ -327,7 +328,7 @@ class TestInference:
         response = [
             r
             async for r in await inference_impl.chat_completion(
-                model=inference_model,
+                model_id=model_id,
                 messages=messages,
                 tools=[sample_tool_definition],
                 stream=True,

--- a/llama_stack/providers/utils/inference/model_registry.py
+++ b/llama_stack/providers/utils/inference/model_registry.py
@@ -29,7 +29,7 @@ class ModelRegistryHelper(ModelsProtocolPrivate):
         return self.stack_to_provider_models_map[identifier]
 
     async def register_model(self, model: Model) -> None:
-        if model.identifier not in self.stack_to_provider_models_map:
+        if model.provider_resource_id not in self.stack_to_provider_models_map:
             raise ValueError(
-                f"Unsupported model {model.identifier}. Supported models: {self.stack_to_provider_models_map.keys()}"
+                f"Unsupported model {model.provider_resource_id}. Supported models: {self.stack_to_provider_models_map.keys()}"
             )

--- a/llama_stack/providers/utils/inference/model_registry.py
+++ b/llama_stack/providers/utils/inference/model_registry.py
@@ -5,11 +5,33 @@
 # the root directory of this source tree.
 
 from collections import namedtuple
-from typing import List
+from typing import List, Optional
+
+from llama_models.datatypes import CoreModelId
+from llama_models.sku_list import all_registered_models
 
 from llama_stack.providers.datatypes import Model, ModelsProtocolPrivate
 
 ModelAlias = namedtuple("ModelAlias", ["provider_model_id", "aliases", "llama_model"])
+
+
+def get_huggingface_repo(core_model_id: CoreModelId) -> Optional[str]:
+    """Get the Hugging Face repository for a given CoreModelId."""
+    for model in all_registered_models():
+        if model.core_model_id == core_model_id:
+            return model.huggingface_repo
+    return None
+
+
+def build_model_alias(provider_model_id: str, core_model_id: CoreModelId) -> ModelAlias:
+    return ModelAlias(
+        provider_model_id=provider_model_id,
+        aliases=[
+            core_model_id.value,
+            get_huggingface_repo(core_model_id),
+        ],
+        llama_model=core_model_id.value,
+    )
 
 
 class ModelLookup:

--- a/llama_stack/providers/utils/inference/model_registry.py
+++ b/llama_stack/providers/utils/inference/model_registry.py
@@ -4,32 +4,54 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from typing import Dict
-
-from llama_models.sku_list import resolve_model
+from collections import namedtuple
+from typing import List
 
 from llama_stack.providers.datatypes import Model, ModelsProtocolPrivate
+
+ModelAlias = namedtuple("ModelAlias", ["provider_model_id", "aliases", "llama_model"])
+
+
+class ModelLookup:
+    def __init__(
+        self,
+        model_aliases: List[ModelAlias],
+    ):
+        self.alias_to_provider_id_map = {}
+        self.provider_id_to_llama_model_map = {}
+        for alias_obj in model_aliases:
+            for alias in alias_obj.aliases:
+                self.alias_to_provider_id_map[alias] = alias_obj.provider_model_id
+            # also add a mapping from provider model id to itself for easy lookup
+            self.alias_to_provider_id_map[alias_obj.provider_model_id] = (
+                alias_obj.provider_model_id
+            )
+            self.provider_id_to_llama_model_map[alias_obj.provider_model_id] = (
+                alias_obj.llama_model
+            )
+
+    def get_provider_model_id(self, identifier: str) -> str:
+        if identifier in self.alias_to_provider_id_map:
+            return self.alias_to_provider_id_map[identifier]
+        else:
+            raise ValueError(f"Unknown model: `{identifier}`")
 
 
 class ModelRegistryHelper(ModelsProtocolPrivate):
 
-    def __init__(self, stack_to_provider_models_map: Dict[str, str]):
-        self.stack_to_provider_models_map = stack_to_provider_models_map
+    def __init__(self, model_aliases: List[ModelAlias]):
+        self.model_lookup = ModelLookup(model_aliases)
 
-    def map_to_provider_model(self, identifier: str) -> str:
-        model = resolve_model(identifier)
-        if not model:
-            raise ValueError(f"Unknown model: `{identifier}`")
+    def get_llama_model(self, provider_model_id: str) -> str:
+        return self.model_lookup.provider_id_to_llama_model_map[provider_model_id]
 
-        if identifier not in self.stack_to_provider_models_map:
-            raise ValueError(
-                f"Model {identifier} not found in map {self.stack_to_provider_models_map}"
-            )
+    async def register_model(self, model: Model) -> Model:
+        provider_model_id = self.model_lookup.get_provider_model_id(
+            model.provider_resource_id
+        )
+        if not provider_model_id:
+            raise ValueError(f"Unknown model: `{model.provider_resource_id}`")
 
-        return self.stack_to_provider_models_map[identifier]
+        model.provider_resource_id = provider_model_id
 
-    async def register_model(self, model: Model) -> None:
-        if model.provider_resource_id not in self.stack_to_provider_models_map:
-            raise ValueError(
-                f"Unsupported model {model.provider_resource_id}. Supported models: {self.stack_to_provider_models_map.keys()}"
-            )
+        return model

--- a/llama_stack/providers/utils/inference/model_registry.py
+++ b/llama_stack/providers/utils/inference/model_registry.py
@@ -7,7 +7,6 @@
 from collections import namedtuple
 from typing import List, Optional
 
-from llama_models.datatypes import CoreModelId
 from llama_models.sku_list import all_registered_models
 
 from llama_stack.providers.datatypes import Model, ModelsProtocolPrivate
@@ -15,22 +14,22 @@ from llama_stack.providers.datatypes import Model, ModelsProtocolPrivate
 ModelAlias = namedtuple("ModelAlias", ["provider_model_id", "aliases", "llama_model"])
 
 
-def get_huggingface_repo(core_model_id: CoreModelId) -> Optional[str]:
+def get_huggingface_repo(model_descriptor: str) -> Optional[str]:
     """Get the Hugging Face repository for a given CoreModelId."""
     for model in all_registered_models():
-        if model.core_model_id == core_model_id:
+        if model.descriptor() == model_descriptor:
             return model.huggingface_repo
     return None
 
 
-def build_model_alias(provider_model_id: str, core_model_id: CoreModelId) -> ModelAlias:
+def build_model_alias(provider_model_id: str, model_descriptor: str) -> ModelAlias:
     return ModelAlias(
         provider_model_id=provider_model_id,
         aliases=[
-            core_model_id.value,
-            get_huggingface_repo(core_model_id),
+            model_descriptor,
+            get_huggingface_repo(model_descriptor),
         ],
-        llama_model=core_model_id.value,
+        llama_model=model_descriptor,
     )
 
 

--- a/llama_stack/providers/utils/inference/prompt_adapter.py
+++ b/llama_stack/providers/utils/inference/prompt_adapter.py
@@ -147,17 +147,17 @@ def augment_content_with_response_format_prompt(response_format, content):
 
 
 def chat_completion_request_to_prompt(
-    request: ChatCompletionRequest, formatter: ChatFormat
+    request: ChatCompletionRequest, llama_model: str, formatter: ChatFormat
 ) -> str:
-    messages = chat_completion_request_to_messages(request)
+    messages = chat_completion_request_to_messages(request, llama_model)
     model_input = formatter.encode_dialog_prompt(messages)
     return formatter.tokenizer.decode(model_input.tokens)
 
 
 def chat_completion_request_to_model_input_info(
-    request: ChatCompletionRequest, formatter: ChatFormat
+    request: ChatCompletionRequest, llama_model: str, formatter: ChatFormat
 ) -> Tuple[str, int]:
-    messages = chat_completion_request_to_messages(request)
+    messages = chat_completion_request_to_messages(request, llama_model)
     model_input = formatter.encode_dialog_prompt(messages)
     return (
         formatter.tokenizer.decode(model_input.tokens),
@@ -167,14 +167,15 @@ def chat_completion_request_to_model_input_info(
 
 def chat_completion_request_to_messages(
     request: ChatCompletionRequest,
+    llama_model: str,
 ) -> List[Message]:
     """Reads chat completion request and augments the messages to handle tools.
     For eg. for llama_3_1, add system message with the appropriate tools or
     add user messsage for custom tools, etc.
     """
-    model = resolve_model(request.model)
+    model = resolve_model(llama_model)
     if model is None:
-        cprint(f"Could not resolve model {request.model}", color="red")
+        cprint(f"Could not resolve model {llama_model}", color="red")
         return request.messages
 
     if model.descriptor() not in supported_inference_models():


### PR DESCRIPTION
This PR changes the way model id gets translated to the final model name that gets passed through the provider. 
Major changes include:
1) Providers are responsible for registering an object and as part of the registration returning the object with the correct provider specific name of the model provider_resource_id
2) To help with the common look ups different names a new ModelLookup class is created.



Tested all inference providers including together, fireworks, vllm, ollama, meta reference and bedrock