### PR TITLE
add inline:: prefix for localfs provider

### DIFF
--- a/llama_stack/providers/registry/datasetio.py
+++ b/llama_stack/providers/registry/datasetio.py
@@ -13,7 +13,7 @@ def available_providers() -> List[ProviderSpec]:
     return [
         InlineProviderSpec(
             api=Api.datasetio,
-            provider_type="localfs",
+            provider_type="inline::localfs",
             pip_packages=["pandas"],
             module="llama_stack.providers.inline.datasetio.localfs",
             config_class="llama_stack.providers.inline.datasetio.localfs.LocalFSDatasetIOConfig",

--- a/llama_stack/providers/tests/datasetio/fixtures.py
+++ b/llama_stack/providers/tests/datasetio/fixtures.py
@@ -24,7 +24,7 @@ def datasetio_localfs() -> ProviderFixture:
         providers=[
             Provider(
                 provider_id="localfs",
-                provider_type="localfs",
+                provider_type="inline::localfs",
                 config={},
             )
         ],


### PR DESCRIPTION
# What does this PR do?

- add inline:: prefix for localfs provider

## Test Plan

```
llama stack run

datasetio:
  - provider_id: localfs-0
    provider_type: inline::localfs
    config: {}
```

```
pytest -v -s -m meta_reference_eval_fireworks_inference eval/test_eval.py
pytest -v -s -m localfs datasetio/test_datasetio.py
```

## Sources

Please link relevant resources if necessary.


## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Ran pre-commit to handle lint / formatting issues.
- [ ] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Updated relevant documentation.
- [ ] Wrote necessary unit or integration tests.
