### PR TITLE
init registry once

### DIFF
--- a/llama_stack/distribution/routers/routing_tables.py
+++ b/llama_stack/distribution/routers/routing_tables.py
@@ -64,8 +64,6 @@ class CommonRoutingTableImpl(RoutingTable):
         self.dist_registry = dist_registry
 
     async def initialize(self) -> None:
-        # Initialize the registry if not already done
-        await self.dist_registry.initialize()
 
         async def add_objects(
             objs: List[RoutableObjectWithProvider], provider_id: str, cls

--- a/llama_stack/distribution/store/registry.py
+++ b/llama_stack/distribution/store/registry.py
@@ -220,5 +220,6 @@ async def create_dist_registry(
                 db_path=(DISTRIBS_BASE_DIR / image_name / "kvstore.db").as_posix()
             )
         )
-
-    return CachedDiskDistributionRegistry(dist_kvstore), dist_kvstore
+    dist_registry = CachedDiskDistributionRegistry(dist_kvstore)
+    await dist_registry.initialize()
+    return dist_registry, dist_kvstore


### PR DESCRIPTION
We are calling the initialize function on the registery in the common routing table impl, which is incorrect as the common routing table is the base class inherited by each resource's routing table. this change moves remove that and add the initialize to the creation, where it inits once server run.