### PR TITLE
Fix build configure deprecation message

### DIFF
--- a/llama_stack/cli/stack/configure.py
+++ b/llama_stack/cli/stack/configure.py
@@ -40,7 +40,7 @@ class StackConfigure(Subcommand):
         self.parser.error(
             """
             DEPRECATED! llama stack configure has been deprecated.
-            Please use llama stack run --config <path/to/run.yaml> instead.
+            Please use llama stack run <path/to/run.yaml> instead.
             Please see example run.yaml in /distributions folder.
             """
         )


### PR DESCRIPTION
# What does this PR do?

Removes from the `llama build configure` deprecation message the `--configure` flag because the `llama stack run` command does not support this flag.