### PR TITLE
Fix conda env names in distribution example run files

### DIFF
--- a/distributions/bedrock/run.yaml
+++ b/distributions/bedrock/run.yaml
@@ -3,7 +3,7 @@ built_at: '2024-11-01T17:40:45.325529'
 image_name: local
 name: bedrock
 docker_image: null
-conda_env: local
+conda_env: bedrock
 apis:
 - shields
 - agents

--- a/distributions/fireworks/run.yaml
+++ b/distributions/fireworks/run.yaml
@@ -2,7 +2,7 @@ version: '2'
 built_at: '2024-10-08T17:40:45.325529'
 image_name: local
 docker_image: null
-conda_env: local
+conda_env: fireworks
 apis:
 - shields
 - agents

--- a/distributions/meta-reference-gpu/run.yaml
+++ b/distributions/meta-reference-gpu/run.yaml
@@ -2,7 +2,7 @@ version: '2'
 built_at: '2024-10-08T17:40:45.325529'
 image_name: local
 docker_image: null
-conda_env: local
+conda_env: meta-reference-gpu
 apis:
 - shields
 - agents

--- a/distributions/meta-reference-quantized-gpu/run.yaml
+++ b/distributions/meta-reference-quantized-gpu/run.yaml
@@ -2,7 +2,7 @@ version: '2'
 built_at: '2024-10-08T17:40:45.325529'
 image_name: local
 docker_image: null
-conda_env: local
+conda_env: meta-reference-quantized-gpu 
 apis:
 - shields
 - agents

--- a/distributions/ollama/run.yaml
+++ b/distributions/ollama/run.yaml
@@ -2,7 +2,7 @@ version: '2'
 built_at: '2024-10-08T17:40:45.325529'
 image_name: local
 docker_image: null
-conda_env: local
+conda_env: ollama
 apis:
 - shields
 - agents

--- a/distributions/tgi/run.yaml
+++ b/distributions/tgi/run.yaml
@@ -2,7 +2,7 @@ version: '2'
 built_at: '2024-10-08T17:40:45.325529'
 image_name: local
 docker_image: null
-conda_env: local
+conda_env: tgi
 apis:
 - shields
 - agents

--- a/distributions/together/run.yaml
+++ b/distributions/together/run.yaml
@@ -2,7 +2,7 @@ version: '2'
 built_at: '2024-10-08T17:40:45.325529'
 image_name: local
 docker_image: null
-conda_env: local
+conda_env: together
 apis:
 - shields
 - agents


### PR DESCRIPTION
# What does this PR do?

The [Self-Hosted Distribution documentation](https://llama-stack.readthedocs.io/en/latest/getting_started/distributions/self_hosted_distro/index.html) contain steps to start llama server via conda environment. If the user generates the conda environment using `llaama build` command with `--template` flag, it generate an environment with name of the distribution and not default name of` local` as per the example run yaml files. It will therefore fail when user tried to run the server because the `local` conda env does not exist.

Error similar to the following:

```command
$ llama stack run run.yaml

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(

EnvironmentNameNotFound: Could not find conda environment: llamastack-local
You can list all discoverable environments with `conda info --envs`.
```

This PR fixes the conda env names in the distribution example run yaml files.
