### PR TITLE
remove pydantic namespace warnings using model_config

### DIFF
--- a/llama_stack/apis/models/models.py
+++ b/llama_stack/apis/models/models.py
@@ -31,6 +31,8 @@ class Model(CommonModelFields, Resource):
     def provider_model_id(self) -> str:
         return self.provider_resource_id
 
+    model_config = ConfigDict(protected_namespaces=())
+
 
 class ModelInput(CommonModelFields):
     model_id: str

--- a/llama_stack/cli/download.py
+++ b/llama_stack/cli/download.py
@@ -19,7 +19,7 @@ import httpx
 
 from llama_models.datatypes import Model
 from llama_models.sku_list import LlamaDownloadInfo
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from rich.console import Console
 from rich.progress import (
@@ -293,8 +293,8 @@ class ParallelDownloader:
 
             if free_space < required_space:
                 self.console.print(
-                    f"[red]Not enough disk space. Required: {required_space // (1024*1024)} MB, "
-                    f"Available: {free_space // (1024*1024)} MB[/red]"
+                    f"[red]Not enough disk space. Required: {required_space // (1024 * 1024)} MB, "
+                    f"Available: {free_space // (1024 * 1024)} MB[/red]"
                 )
                 return False
             return True
@@ -413,8 +413,7 @@ class ModelEntry(BaseModel):
     model_id: str
     files: Dict[str, str]
 
-    class Config:
-        protected_namespaces = ()
+    model_config = ConfigDict(protected_namespaces=())
 
 
 class Manifest(BaseModel):


### PR DESCRIPTION
# What does this PR do?

remove another model_ pydantic namespace warning and convert old-style 'class Config' to new-style 'model_config' workaround.

also a whitespace change to get past -

flake8...................................................................Failed
llama_stack/cli/download.py:296:85: E226 missing whitespace around arithmetic operator
llama_stack/cli/download.py:297:54: E226 missing whitespace around arithmetic operator


## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Ran pre-commit to handle lint / formatting issues.
- [x] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Updated relevant documentation.
- [x] Wrote necessary unit or integration tests.
