### PR TITLE
Fix incorrect ollama port in ollama run.yaml template

### DIFF
--- a/distributions/ollama/run.yaml
+++ b/distributions/ollama/run.yaml
@@ -16,7 +16,7 @@ providers:
   - provider_id: ollama0
     provider_type: remote::ollama
     config:
-      url: http://127.0.0.1:14343
+      url: http://127.0.0.1:11434
   safety:
   - provider_id: meta0
     provider_type: inline::llama-guard


### PR DESCRIPTION

Summary:
Default port number was not correct ollama port number 11434.
