### PR TITLE
register with provider even if present in stack

### DIFF
--- a/llama_stack/distribution/routers/routing_tables.py
+++ b/llama_stack/distribution/routers/routing_tables.py
@@ -170,13 +170,6 @@ class CommonRoutingTableImpl(RoutingTable):
         # Get existing objects from registry
         existing_obj = await self.dist_registry.get(obj.type, obj.identifier)
 
-        # Check for existing registration
-        if existing_obj and existing_obj.provider_id == obj.provider_id:
-            print(
-                f"`{obj.identifier}` already registered with `{existing_obj.provider_id}`"
-            )
-            return existing_obj
-
         # if provider_id is not specified, pick an arbitrary one from existing entries
         if not obj.provider_id and len(self.impls_by_provider_id) > 0:
             obj.provider_id = list(self.impls_by_provider_id.keys())[0]


### PR DESCRIPTION
# What does this PR do?

Remove a check which skips provider registration if a resource is already in stack registry. Since we do not reconcile state with provider, register should always call into provider's register endpoint.


## Test Plan
```
# stack run
╰─❯ llama stack run /Users/dineshyv/.llama/distributions/llamastack-together/together-run.yaml

#register memory bank
❯ llama-stack-client memory_banks register your_memory_bank_name --type vector --provider-id inline::faiss-0

Memory Bank Configuration:
{
│   'memory_bank_type': 'vector',
│   'chunk_size_in_tokens': 512,
│   'embedding_model': 'all-MiniLM-L6-v2',
│   'overlap_size_in_tokens': 64
}

#register again
❯ llama-stack-client memory_banks register your_memory_bank_name --type vector --provider-id inline::faiss-0

Memory Bank Configuration:
{
│   'memory_bank_type': 'vector',
│   'chunk_size_in_tokens': 512,
│   'embedding_model': 'all-MiniLM-L6-v2',
│   'overlap_size_in_tokens': 64
}
```