### PR TITLE
Make run yaml optional so dockers can start with just --env

### DIFF
--- a/llama_stack/distribution/build_container.sh
+++ b/llama_stack/distribution/build_container.sh
@@ -122,7 +122,7 @@ add_to_docker <<EOF
 # This would be good in production but for debugging flexibility lets not add it right now
 # We need a more solid production ready entrypoint.sh anyway
 #
-ENTRYPOINT ["python", "-m", "llama_stack.distribution.server.server"]
+ENTRYPOINT ["python", "-m", "llama_stack.distribution.server.server", "--template", "$build_name"]
 
 EOF
 

--- a/llama_stack/distribution/server/server.py
+++ b/llama_stack/distribution/server/server.py
@@ -16,6 +16,7 @@ import traceback
 import warnings
 
 from contextlib import asynccontextmanager
+from pathlib import Path
 from ssl import SSLError
 from typing import Any, Dict, Optional
 
@@ -47,6 +48,9 @@ from llama_stack.distribution.stack import (
 )
 
 from .endpoints import get_all_api_endpoints
+
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
 
 
 def warn_with_traceback(message, category, filename, lineno, file=None, line=None):
@@ -279,8 +283,11 @@ def main():
     parser = argparse.ArgumentParser(description="Start the LlamaStack server.")
     parser.add_argument(
         "--yaml-config",
-        default="llamastack-run.yaml",
         help="Path to YAML configuration file",
+    )
+    parser.add_argument(
+        "--template",
+        help="One of the template names in llama_stack/templates (e.g., tgi, fireworks, remote-vllm, etc.)",
     )
     parser.add_argument("--port", type=int, default=5000, help="Port to listen on")
     parser.add_argument(
@@ -303,9 +310,27 @@ def main():
                 print(f"Error: {str(e)}")
                 sys.exit(1)
 
-    with open(args.yaml_config, "r") as fp:
+    if args.yaml_config:
+        # if the user provided a config file, use it, even if template was specified
+        config_file = Path(args.yaml_config)
+        if not config_file.exists():
+            raise ValueError(f"Config file {config_file} does not exist")
+
+    elif args.template:
+        config_file = (
+            Path(REPO_ROOT) / "llama_stack" / "templates" / args.template / "run.yaml"
+        )
+        if not config_file.exists():
+            raise ValueError(f"Template {args.template} does not exist")
+    else:
+        raise ValueError("Either --yaml-config or --template must be provided")
+
+    with open(config_file, "r") as fp:
         config = replace_env_vars(yaml.safe_load(fp))
         config = StackRunConfig(**config)
+
+    print(f"Using config file: {config_file}")
+    print(f"Config: {yaml.dump(config.model_dump(), indent=2)}")
 
     app = FastAPI()
 

--- a/llama_stack/distribution/server/server.py
+++ b/llama_stack/distribution/server/server.py
@@ -315,13 +315,14 @@ def main():
         config_file = Path(args.yaml_config)
         if not config_file.exists():
             raise ValueError(f"Config file {config_file} does not exist")
-
+        print(f"Using config file: {config_file}")
     elif args.template:
         config_file = (
             Path(REPO_ROOT) / "llama_stack" / "templates" / args.template / "run.yaml"
         )
         if not config_file.exists():
             raise ValueError(f"Template {args.template} does not exist")
+        print(f"Using template {args.template} config file: {config_file}")
     else:
         raise ValueError("Either --yaml-config or --template must be provided")
 
@@ -329,8 +330,8 @@ def main():
         config = replace_env_vars(yaml.safe_load(fp))
         config = StackRunConfig(**config)
 
-    print(f"Using config file: {config_file}")
-    print(f"Config: {yaml.dump(config.model_dump(), indent=2)}")
+    print("Run configuration:")
+    print(yaml.dump(config.model_dump(), indent=2))
 
     app = FastAPI()
 


### PR DESCRIPTION
When running with dockers, the idea is that users be able to work purely with the `llama stack` CLI. They should not need to know about the existence of any YAMLs unless they need to. This PR enables it.

The docker command now doesn't need to volume mount a yaml and can simply be:
```bash
docker run -v ~/.llama/:/root/.llama \
  --env A=a --env B=b
```

## Test Plan

Check with conda first (no regressions):
```bash
LLAMA_STACK_DIR=. llama stack build --template ollama
llama stack run ollama --port 5001

# server starts up correctly
```

Check with docker
```bash
# build the docker
LLAMA_STACK_DIR=. llama stack build --template ollama --image-type docker

export INFERENCE_MODEL="meta-llama/Llama-3.2-3B-Instruct"

docker run -it  -p 5001:5001 \
  -v ~/.llama:/root/.llama \
  -v $PWD:/app/llama-stack-source \
  localhost/distribution-ollama:dev \
  --port 5001 \
  --env INFERENCE_MODEL=$INFERENCE_MODEL \
  --env OLLAMA_URL=http://host.docker.internal:11434
```

Note that volume mounting to `/app/llama-stack-source` is only needed because we built the docker with uncommitted source code.