### PR TITLE
use logging instead of prints

### DIFF
--- a/llama_stack/distribution/build.py
+++ b/llama_stack/distribution/build.py
@@ -4,13 +4,12 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import logging
 from enum import Enum
 from typing import List
 
 import pkg_resources
 from pydantic import BaseModel
-
-from termcolor import cprint
 
 from llama_stack.distribution.utils.exec import run_with_pty
 
@@ -21,6 +20,8 @@ from llama_stack.distribution.distribution import get_provider_registry
 
 from llama_stack.distribution.utils.config_dirs import BUILDS_BASE_DIR
 
+
+log = logging.getLogger(__name__)
 
 # These are the dependencies needed by the distribution server.
 # `llama-stack` is automatically installed by the installation script.
@@ -89,12 +90,12 @@ def get_provider_dependencies(
 def print_pip_install_help(providers: Dict[str, List[Provider]]):
     normal_deps, special_deps = get_provider_dependencies(providers)
 
-    print(
+    log.info(
         f"Please install needed dependencies using the following commands:\n\n\tpip install {' '.join(normal_deps)}"
     )
     for special_dep in special_deps:
-        print(f"\tpip install {special_dep}")
-    print()
+        log.info(f"\tpip install {special_dep}")
+    log.info()
 
 
 def build_image(build_config: BuildConfig, build_file_path: Path):
@@ -133,9 +134,8 @@ def build_image(build_config: BuildConfig, build_file_path: Path):
 
     return_code = run_with_pty(args)
     if return_code != 0:
-        cprint(
+        log.error(
             f"Failed to build target {build_config.name} with return code {return_code}",
-            color="red",
         )
 
     return return_code

--- a/llama_stack/distribution/configure.py
+++ b/llama_stack/distribution/configure.py
@@ -3,12 +3,12 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
+import logging
 import textwrap
 
 from typing import Any
 
 from llama_stack.distribution.datatypes import *  # noqa: F403
-from termcolor import cprint
 
 from llama_stack.distribution.distribution import (
     builtin_automatically_routed_apis,
@@ -21,6 +21,8 @@ from llama_stack.distribution.utils.prompt_for_config import prompt_for_config
 from llama_stack.apis.models import *  # noqa: F403
 from llama_stack.apis.shields import *  # noqa: F403
 from llama_stack.apis.memory_banks import *  # noqa: F403
+
+logger = logging.getLogger(__name__)
 
 
 def configure_single_provider(
@@ -50,7 +52,7 @@ def configure_api_providers(
     is_nux = len(config.providers) == 0
 
     if is_nux:
-        print(
+        logger.info(
             textwrap.dedent(
                 """
         Llama Stack is composed of several APIs working together. For each API served by the Stack,
@@ -76,18 +78,18 @@ def configure_api_providers(
 
         existing_providers = config.providers.get(api_str, [])
         if existing_providers:
-            cprint(
+            logger.info(
                 f"Re-configuring existing providers for API `{api_str}`...",
                 "green",
                 attrs=["bold"],
             )
             updated_providers = []
             for p in existing_providers:
-                print(f"> Configuring provider `({p.provider_type})`")
+                logger.info(f"> Configuring provider `({p.provider_type})`")
                 updated_providers.append(
                     configure_single_provider(provider_registry[api], p)
                 )
-                print("")
+                logger.info("")
         else:
             # we are newly configuring this API
             plist = build_spec.providers.get(api_str, [])
@@ -96,17 +98,17 @@ def configure_api_providers(
             if not plist:
                 raise ValueError(f"No provider configured for API {api_str}?")
 
-            cprint(f"Configuring API `{api_str}`...", "green", attrs=["bold"])
+            logger.info(f"Configuring API `{api_str}`...", "green", attrs=["bold"])
             updated_providers = []
             for i, provider_type in enumerate(plist):
                 if i >= 1:
                     others = ", ".join(plist[i:])
-                    print(
+                    logger.info(
                         f"Not configuring other providers ({others}) interactively. Please edit the resulting YAML directly.\n"
                     )
                     break
 
-                print(f"> Configuring provider `({provider_type})`")
+                logger.info(f"> Configuring provider `({provider_type})`")
                 updated_providers.append(
                     configure_single_provider(
                         provider_registry[api],
@@ -121,7 +123,7 @@ def configure_api_providers(
                         ),
                     )
                 )
-                print("")
+                logger.info("")
 
         config.providers[api_str] = updated_providers
 
@@ -182,7 +184,7 @@ def parse_and_maybe_upgrade_config(config_dict: Dict[str, Any]) -> StackRunConfi
         return StackRunConfig(**config_dict)
 
     if "routing_table" in config_dict:
-        print("Upgrading config...")
+        logger.info("Upgrading config...")
         config_dict = upgrade_from_routing_table(config_dict)
 
     config_dict["version"] = LLAMA_STACK_RUN_CONFIG_VERSION

--- a/llama_stack/distribution/request_headers.py
+++ b/llama_stack/distribution/request_headers.py
@@ -5,10 +5,13 @@
 # the root directory of this source tree.
 
 import json
+import logging
 import threading
 from typing import Any, Dict
 
 from .utils.dynamic import instantiate_class_type
+
+log = logging.getLogger(__name__)
 
 _THREAD_LOCAL = threading.local()
 
@@ -32,7 +35,7 @@ class NeedsRequestProviderData:
             provider_data = validator(**val)
             return provider_data
         except Exception as e:
-            print("Error parsing provider data", e)
+            log.error("Error parsing provider data", e)
 
 
 def set_request_provider_data(headers: Dict[str, str]):
@@ -51,7 +54,7 @@ def set_request_provider_data(headers: Dict[str, str]):
     try:
         val = json.loads(val)
     except json.JSONDecodeError:
-        print("Provider data not encoded as a JSON object!", val)
+        log.error("Provider data not encoded as a JSON object!", val)
         return
 
     _THREAD_LOCAL.provider_data_header_value = val

--- a/llama_stack/distribution/resolver.py
+++ b/llama_stack/distribution/resolver.py
@@ -8,10 +8,11 @@ import inspect
 
 from typing import Any, Dict, List, Set
 
-from termcolor import cprint
 
 from llama_stack.providers.datatypes import *  # noqa: F403
 from llama_stack.distribution.datatypes import *  # noqa: F403
+
+import logging
 
 from llama_stack.apis.agents import Agents
 from llama_stack.apis.datasetio import DatasetIO
@@ -32,6 +33,8 @@ from llama_stack.distribution.client import get_client_impl
 from llama_stack.distribution.distribution import builtin_automatically_routed_apis
 from llama_stack.distribution.store import DistributionRegistry
 from llama_stack.distribution.utils.dynamic import instantiate_class_type
+
+log = logging.getLogger(__name__)
 
 
 class InvalidProviderError(Exception):
@@ -115,11 +118,11 @@ async def resolve_impls(
 
             p = provider_registry[api][provider.provider_type]
             if p.deprecation_error:
-                cprint(p.deprecation_error, "red", attrs=["bold"])
+                log.error(p.deprecation_error, "red", attrs=["bold"])
                 raise InvalidProviderError(p.deprecation_error)
 
             elif p.deprecation_warning:
-                cprint(
+                log.warning(
                     f"Provider `{provider.provider_type}` for API `{api}` is deprecated and will be removed in a future release: {p.deprecation_warning}",
                     "yellow",
                     attrs=["bold"],
@@ -199,10 +202,10 @@ async def resolve_impls(
         )
     )
 
-    print(f"Resolved {len(sorted_providers)} providers")
+    log.info(f"Resolved {len(sorted_providers)} providers")
     for api_str, provider in sorted_providers:
-        print(f" {api_str} => {provider.provider_id}")
-    print("")
+        log.info(f" {api_str} => {provider.provider_id}")
+    log.info("")
 
     impls = {}
     inner_impls_by_provider_id = {f"inner-{x.value}": {} for x in router_apis}
@@ -339,7 +342,7 @@ def check_protocol_compliance(obj: Any, protocol: Any) -> None:
                 obj_params = set(obj_sig.parameters)
                 obj_params.discard("self")
                 if not (proto_params <= obj_params):
-                    print(
+                    log.error(
                         f"Method {name} incompatible proto: {proto_params} vs. obj: {obj_params}"
                     )
                     missing_methods.append((name, "signature_mismatch"))

--- a/llama_stack/distribution/server/server.py
+++ b/llama_stack/distribution/server/server.py
@@ -46,6 +46,10 @@ from llama_stack.distribution.stack import (
     replace_env_vars,
     validate_env_pair,
 )
+from llama_stack.providers.inline.meta_reference.telemetry.console import (
+    ConsoleConfig,
+    ConsoleTelemetryImpl,
+)
 
 from .endpoints import get_all_api_endpoints
 
@@ -342,6 +346,8 @@ def main():
 
     if Api.telemetry in impls:
         setup_logger(impls[Api.telemetry])
+    else:
+        setup_logger(ConsoleTelemetryImpl(ConsoleConfig()))
 
     all_endpoints = get_all_api_endpoints()
 

--- a/llama_stack/distribution/server/server.py
+++ b/llama_stack/distribution/server/server.py
@@ -196,7 +196,6 @@ def handle_sigint(app, *args, **kwargs):
 async def lifespan(app: FastAPI):
     print("Starting up")
     yield
-
     print("Shutting down")
     for impl in app.__llama_stack_impls__.values():
         await impl.shutdown()
@@ -214,6 +213,7 @@ async def maybe_await(value):
 
 
 async def sse_generator(event_gen):
+    await start_trace("sse_generator")
     try:
         event_gen = await event_gen
         async for item in event_gen:
@@ -333,7 +333,7 @@ def main():
     print("Run configuration:")
     print(yaml.dump(config.model_dump(), indent=2))
 
-    app = FastAPI()
+    app = FastAPI(lifespan=lifespan)
 
     try:
         impls = asyncio.run(construct_stack(config))

--- a/llama_stack/distribution/stack.py
+++ b/llama_stack/distribution/stack.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import logging
 import os
 from pathlib import Path
 from typing import Any, Dict
@@ -39,6 +40,8 @@ from llama_stack.distribution.resolver import ProviderRegistry, resolve_impls
 from llama_stack.distribution.store.registry import create_dist_registry
 from llama_stack.providers.datatypes import Api
 
+
+log = logging.getLogger(__name__)
 
 LLAMA_STACK_API_VERSION = "alpha"
 
@@ -93,11 +96,11 @@ async def register_resources(run_config: StackRunConfig, impls: Dict[Api, Any]):
 
         method = getattr(impls[api], list_method)
         for obj in await method():
-            print(
+            log.info(
                 f"{rsrc.capitalize()}: {colored(obj.identifier, 'white', attrs=['bold'])} served by {colored(obj.provider_id, 'white', attrs=['bold'])}",
             )
 
-    print("")
+    log.info("")
 
 
 class EnvVarError(Exception):

--- a/llama_stack/distribution/utils/exec.py
+++ b/llama_stack/distribution/utils/exec.py
@@ -5,6 +5,7 @@
 # the root directory of this source tree.
 
 import errno
+import logging
 import os
 import pty
 import select
@@ -13,7 +14,7 @@ import subprocess
 import sys
 import termios
 
-from termcolor import cprint
+log = logging.getLogger(__name__)
 
 
 # run a command in a pseudo-terminal, with interrupt handling,
@@ -29,7 +30,7 @@ def run_with_pty(command):
     def sigint_handler(signum, frame):
         nonlocal ctrl_c_pressed
         ctrl_c_pressed = True
-        cprint("\nCtrl-C detected. Aborting...", "white", attrs=["bold"])
+        log.info("\nCtrl-C detected. Aborting...")
 
     try:
         # Set up the signal handler
@@ -100,6 +101,6 @@ def run_command(command):
     process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output, error = process.communicate()
     if process.returncode != 0:
-        print(f"Error: {error.decode('utf-8')}")
+        log.error(f"Error: {error.decode('utf-8')}")
         sys.exit(1)
     return output.decode("utf-8")

--- a/llama_stack/providers/inline/agents/meta_reference/persistence.py
+++ b/llama_stack/providers/inline/agents/meta_reference/persistence.py
@@ -5,7 +5,7 @@
 # the root directory of this source tree.
 
 import json
-
+import logging
 import uuid
 from datetime import datetime
 
@@ -14,6 +14,8 @@ from llama_stack.apis.agents import *  # noqa: F403
 from pydantic import BaseModel
 
 from llama_stack.providers.utils.kvstore import KVStore
+
+log = logging.getLogger(__name__)
 
 
 class AgentSessionInfo(BaseModel):
@@ -78,7 +80,7 @@ class AgentPersistence:
                 turn = Turn(**json.loads(value))
                 turns.append(turn)
             except Exception as e:
-                print(f"Error parsing turn: {e}")
+                log.error(f"Error parsing turn: {e}")
                 continue
         turns.sort(key=lambda x: (x.completed_at or datetime.min))
         return turns

--- a/llama_stack/providers/inline/agents/meta_reference/rag/context_retriever.py
+++ b/llama_stack/providers/inline/agents/meta_reference/rag/context_retriever.py
@@ -10,8 +10,6 @@ from jinja2 import Template
 from llama_models.llama3.api import *  # noqa: F403
 
 
-from termcolor import cprint  # noqa: F401
-
 from llama_stack.apis.agents import (
     DefaultMemoryQueryGeneratorConfig,
     LLMMemoryQueryGeneratorConfig,
@@ -36,7 +34,6 @@ async def generate_rag_query(
         query = await llm_rag_query_generator(config, messages, **kwargs)
     else:
         raise NotImplementedError(f"Unsupported memory query generator {config.type}")
-    # cprint(f"Generated query >>>: {query}", color="green")
     return query
 
 

--- a/llama_stack/providers/inline/agents/meta_reference/safety.py
+++ b/llama_stack/providers/inline/agents/meta_reference/safety.py
@@ -5,13 +5,15 @@
 # the root directory of this source tree.
 
 import asyncio
+import logging
 
 from typing import List
 
 from llama_models.llama3.api.datatypes import Message
-from termcolor import cprint
 
 from llama_stack.apis.safety import *  # noqa: F403
+
+log = logging.getLogger(__name__)
 
 
 class SafetyException(Exception):  # noqa: N818
@@ -51,7 +53,4 @@ class ShieldRunnerMixin:
             if violation.violation_level == ViolationLevel.ERROR:
                 raise SafetyException(violation)
             elif violation.violation_level == ViolationLevel.WARN:
-                cprint(
-                    f"[Warn]{identifier} raised a warning",
-                    color="red",
-                )
+                log.warning(f"[Warn]{identifier} raised a warning")

--- a/llama_stack/providers/inline/agents/meta_reference/tools/builtin.py
+++ b/llama_stack/providers/inline/agents/meta_reference/tools/builtin.py
@@ -5,6 +5,7 @@
 # the root directory of this source tree.
 
 import json
+import logging
 import re
 import tempfile
 
@@ -12,7 +13,6 @@ from abc import abstractmethod
 from typing import List, Optional
 
 import requests
-from termcolor import cprint
 
 from .ipython_tool.code_execution import (
     CodeExecutionContext,
@@ -25,6 +25,9 @@ from llama_stack.apis.inference import *  # noqa: F403
 from llama_stack.apis.agents import *  # noqa: F403
 
 from .base import BaseTool
+
+
+log = logging.getLogger(__name__)
 
 
 def interpret_content_as_attachment(content: str) -> Optional[Attachment]:
@@ -383,7 +386,7 @@ class CodeInterpreterTool(BaseTool):
             if res_out != "":
                 pieces.extend([f"[{out_type}]", res_out, f"[/{out_type}]"])
                 if out_type == "stderr":
-                    cprint(f"ipython tool error: ↓\n{res_out}", color="red")
+                    log.error(f"ipython tool error: ↓\n{res_out}")
 
         message = ToolResponseMessage(
             call_id=tool_call.call_id,

--- a/llama_stack/providers/inline/agents/meta_reference/tools/ipython_tool/matplotlib_custom_backend.py
+++ b/llama_stack/providers/inline/agents/meta_reference/tools/ipython_tool/matplotlib_custom_backend.py
@@ -11,12 +11,15 @@ A custom Matplotlib backend that overrides the show method to return image bytes
 import base64
 import io
 import json as _json
+import logging
 
 import matplotlib
 from matplotlib.backend_bases import FigureManagerBase
 
 # Import necessary components from Matplotlib
 from matplotlib.backends.backend_agg import FigureCanvasAgg
+
+log = logging.getLogger(__name__)
 
 
 class CustomFigureCanvas(FigureCanvasAgg):
@@ -80,7 +83,7 @@ def show():
     )
     req_con.send_bytes(_json_dump.encode("utf-8"))
     resp = _json.loads(resp_con.recv_bytes().decode("utf-8"))
-    print(resp)
+    log.info(resp)
 
 
 FigureCanvas = CustomFigureCanvas

--- a/llama_stack/providers/inline/inference/meta_reference/inference.py
+++ b/llama_stack/providers/inline/inference/meta_reference/inference.py
@@ -5,6 +5,7 @@
 # the root directory of this source tree.
 
 import asyncio
+import logging
 
 from typing import AsyncGenerator, List
 
@@ -25,6 +26,7 @@ from .config import MetaReferenceInferenceConfig
 from .generation import Llama
 from .model_parallel import LlamaModelParallelGenerator
 
+log = logging.getLogger(__name__)
 # there's a single model parallel process running serving the model. for now,
 # we don't support multiple concurrent requests to this process.
 SEMAPHORE = asyncio.Semaphore(1)
@@ -49,7 +51,7 @@ class MetaReferenceInferenceImpl(Inference, ModelRegistryHelper, ModelsProtocolP
         # verify that the checkpoint actually is for this model lol
 
     async def initialize(self) -> None:
-        print(f"Loading model `{self.model.descriptor()}`")
+        log.info(f"Loading model `{self.model.descriptor()}`")
         if self.config.create_distributed_process_group:
             self.generator = LlamaModelParallelGenerator(self.config)
             self.generator.start()

--- a/llama_stack/providers/inline/inference/meta_reference/parallel_utils.py
+++ b/llama_stack/providers/inline/inference/meta_reference/parallel_utils.py
@@ -194,10 +194,8 @@ def retrieve_requests(reply_socket_url: str):
                 if mp_rank_0():
                     send_obj(EndSentinel())
             except Exception as e:
-                log.error(f"[debug] got exception {e}")
-                import traceback
+                log.exception("exception in generation loop")
 
-                traceback.print_exc()
                 if mp_rank_0():
                     send_obj(ExceptionResponse(error=str(e)))
 

--- a/llama_stack/providers/inline/inference/meta_reference/quantization/fp8_impls.py
+++ b/llama_stack/providers/inline/inference/meta_reference/quantization/fp8_impls.py
@@ -8,14 +8,20 @@
 # This software may be used and distributed in accordance with the terms of the Llama 3 Community License Agreement.
 
 import collections
+
+import logging
 from typing import Optional, Type
+
+log = logging.getLogger(__name__)
 
 try:
     import fbgemm_gpu.experimental.gen_ai  # noqa: F401
 
-    print("Using efficient FP8 operators in FBGEMM.")
+    log.info("Using efficient FP8 operators in FBGEMM.")
 except ImportError:
-    print("No efficient FP8 operators. Please install FBGEMM in fp8_requirements.txt.")
+    log.error(
+        "No efficient FP8 operators. Please install FBGEMM in fp8_requirements.txt."
+    )
     raise
 
 import torch

--- a/llama_stack/providers/inline/inference/meta_reference/quantization/loader.py
+++ b/llama_stack/providers/inline/inference/meta_reference/quantization/loader.py
@@ -7,6 +7,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # This software may be used and distributed in accordance with the terms of the Llama 3 Community License Agreement.
 
+import logging
 import os
 from typing import Any, Dict, List, Optional
 
@@ -21,7 +22,6 @@ from llama_models.llama3.api.args import ModelArgs
 from llama_models.llama3.reference_impl.model import Transformer, TransformerBlock
 from llama_models.sku_list import resolve_model
 
-from termcolor import cprint
 from torch import nn, Tensor
 
 from torchao.quantization.GPTQ import Int8DynActInt4WeightLinear
@@ -29,6 +29,8 @@ from torchao.quantization.GPTQ import Int8DynActInt4WeightLinear
 from llama_stack.apis.inference import QuantizationType
 
 from ..config import MetaReferenceQuantizedInferenceConfig
+
+log = logging.getLogger(__name__)
 
 
 def swiglu_wrapper(
@@ -60,7 +62,7 @@ def convert_to_fp8_quantized_model(
 
     # Move weights to GPU with quantization
     if llama_model.quantization_format == CheckpointQuantizationFormat.fp8_mixed.value:
-        cprint("Loading fp8 scales...", "yellow")
+        log.info("Loading fp8 scales...")
         fp8_scales_path = os.path.join(
             checkpoint_dir, f"fp8_scales_{get_model_parallel_rank()}.pt"
         )
@@ -85,7 +87,7 @@ def convert_to_fp8_quantized_model(
                         fp8_activation_scale_ub,
                     )
     else:
-        cprint("Quantizing fp8 weights from bf16...", "yellow")
+        log.info("Quantizing fp8 weights from bf16...")
         for block in model.layers:
             if isinstance(block, TransformerBlock):
                 if block.layer_id == 0 or block.layer_id == (model.n_layers - 1):

--- a/llama_stack/providers/inline/inference/meta_reference/quantization/scripts/quantize_checkpoint.py
+++ b/llama_stack/providers/inline/inference/meta_reference/quantization/scripts/quantize_checkpoint.py
@@ -8,6 +8,7 @@
 # This software may be used and distributed in accordance with the terms of the Llama 3 Community License Agreement.
 
 import json
+import logging
 import os
 import shutil
 import sys
@@ -31,6 +32,8 @@ from torch.nn.parameter import Parameter
 from llama_stack.providers.inline.inference.meta_reference.quantization.fp8_impls import (
     quantize_fp8,
 )
+
+log = logging.getLogger(__name__)
 
 
 def main(
@@ -102,7 +105,7 @@ def main(
         else:
             torch.set_default_tensor_type(torch.cuda.HalfTensor)
 
-        print(ckpt_path)
+        log.info(ckpt_path)
         assert (
             quantized_ckpt_dir is not None
         ), "QUantized checkpoint directory should not be None"

--- a/llama_stack/providers/inline/meta_reference/telemetry/config.py
+++ b/llama_stack/providers/inline/meta_reference/telemetry/config.py
@@ -4,10 +4,18 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+from enum import Enum
+
 from llama_models.schema_utils import json_schema_type
 
 from pydantic import BaseModel
 
 
+class LogFormat(Enum):
+    TEXT = "text"
+    JSON = "json"
+
+
 @json_schema_type
-class ConsoleConfig(BaseModel): ...
+class ConsoleConfig(BaseModel):
+    log_format: LogFormat = LogFormat.JSON

--- a/llama_stack/providers/inline/safety/code_scanner/code_scanner.py
+++ b/llama_stack/providers/inline/safety/code_scanner/code_scanner.py
@@ -4,16 +4,16 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import logging
 from typing import Any, Dict, List
 
 from llama_models.llama3.api.datatypes import interleaved_text_media_as_str, Message
-from termcolor import cprint
 
 from .config import CodeScannerConfig
 
 from llama_stack.apis.safety import *  # noqa: F403
 
-
+log = logging.getLogger(__name__)
 ALLOWED_CODE_SCANNER_MODEL_IDS = [
     "CodeScanner",
     "CodeShield",
@@ -49,7 +49,7 @@ class MetaReferenceCodeScannerSafetyImpl(Safety):
         from codeshield.cs import CodeShield
 
         text = "\n".join([interleaved_text_media_as_str(m.content) for m in messages])
-        cprint(f"Running CodeScannerShield on {text[50:]}", color="magenta")
+        log.info(f"Running CodeScannerShield on {text[50:]}")
         result = await CodeShield.scan_code(text)
 
         violation = None

--- a/llama_stack/providers/inline/safety/prompt_guard/prompt_guard.py
+++ b/llama_stack/providers/inline/safety/prompt_guard/prompt_guard.py
@@ -4,10 +4,10 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import logging
 from typing import Any, Dict, List
 
 import torch
-from termcolor import cprint
 
 from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
@@ -20,6 +20,7 @@ from llama_stack.providers.datatypes import ShieldsProtocolPrivate
 
 from .config import PromptGuardConfig, PromptGuardType
 
+log = logging.getLogger(__name__)
 
 PROMPT_GUARD_MODEL = "Prompt-Guard-86M"
 
@@ -93,9 +94,8 @@ class PromptGuardShield:
         probabilities = torch.softmax(logits / self.temperature, dim=-1)
         score_embedded = probabilities[0, 1].item()
         score_malicious = probabilities[0, 2].item()
-        cprint(
+        log.info(
             f"Ran PromptGuardShield and got Scores: Embedded: {score_embedded}, Malicious: {score_malicious}",
-            color="magenta",
         )
 
         violation = None

--- a/llama_stack/providers/remote/inference/ollama/ollama.py
+++ b/llama_stack/providers/remote/inference/ollama/ollama.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import logging
 from typing import AsyncGenerator
 
 import httpx
@@ -39,6 +40,7 @@ from llama_stack.providers.utils.inference.prompt_adapter import (
     request_has_media,
 )
 
+log = logging.getLogger(__name__)
 
 model_aliases = [
     build_model_alias(
@@ -105,7 +107,7 @@ class OllamaInferenceAdapter(Inference, ModelsProtocolPrivate):
         return AsyncClient(host=self.url)
 
     async def initialize(self) -> None:
-        print(f"checking connectivity to Ollama at `{self.url}`...")
+        log.info(f"checking connectivity to Ollama at `{self.url}`...")
         try:
             await self.client.ps()
         except httpx.ConnectError as e:

--- a/llama_stack/providers/remote/inference/tgi/tgi.py
+++ b/llama_stack/providers/remote/inference/tgi/tgi.py
@@ -34,7 +34,7 @@ from llama_stack.providers.utils.inference.prompt_adapter import (
 
 from .config import InferenceAPIImplConfig, InferenceEndpointImplConfig, TGIImplConfig
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 class _HfAdapter(Inference, ModelsProtocolPrivate):
@@ -264,7 +264,7 @@ class _HfAdapter(Inference, ModelsProtocolPrivate):
 
 class TGIAdapter(_HfAdapter):
     async def initialize(self, config: TGIImplConfig) -> None:
-        print(f"Initializing TGI client with url={config.url}")
+        log.info(f"Initializing TGI client with url={config.url}")
         self.client = AsyncInferenceClient(model=config.url, token=config.api_token)
         endpoint_info = await self.client.get_endpoint_info()
         self.max_tokens = endpoint_info["max_total_tokens"]

--- a/llama_stack/providers/remote/inference/vllm/vllm.py
+++ b/llama_stack/providers/remote/inference/vllm/vllm.py
@@ -3,6 +3,8 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
+
+import logging
 from typing import AsyncGenerator
 
 from llama_models.llama3.api.chat_format import ChatFormat
@@ -34,6 +36,9 @@ from llama_stack.providers.utils.inference.prompt_adapter import (
 from .config import VLLMInferenceAdapterConfig
 
 
+log = logging.getLogger(__name__)
+
+
 def build_model_aliases():
     return [
         build_model_alias(
@@ -53,7 +58,7 @@ class VLLMInferenceAdapter(Inference, ModelsProtocolPrivate):
         self.client = None
 
     async def initialize(self) -> None:
-        print(f"Initializing VLLM client with base_url={self.config.url}")
+        log.info(f"Initializing VLLM client with base_url={self.config.url}")
         self.client = OpenAI(base_url=self.config.url, api_key=self.config.api_token)
 
     async def shutdown(self) -> None:

--- a/llama_stack/providers/remote/memory/chroma/chroma.py
+++ b/llama_stack/providers/remote/memory/chroma/chroma.py
@@ -5,6 +5,7 @@
 # the root directory of this source tree.
 
 import json
+import logging
 from typing import List
 from urllib.parse import urlparse
 
@@ -20,6 +21,8 @@ from llama_stack.providers.utils.memory.vector_store import (
     BankWithIndex,
     EmbeddingIndex,
 )
+
+log = logging.getLogger(__name__)
 
 
 class ChromaIndex(EmbeddingIndex):
@@ -56,10 +59,7 @@ class ChromaIndex(EmbeddingIndex):
                 doc = json.loads(doc)
                 chunk = Chunk(**doc)
             except Exception:
-                import traceback
-
-                traceback.print_exc()
-                print(f"Failed to parse document: {doc}")
+                log.error(f"Failed to parse document: {doc}", exc_info=True)
                 continue
 
             chunks.append(chunk)
@@ -73,7 +73,7 @@ class ChromaIndex(EmbeddingIndex):
 
 class ChromaMemoryAdapter(Memory, MemoryBanksProtocolPrivate):
     def __init__(self, url: str) -> None:
-        print(f"Initializing ChromaMemoryAdapter with url: {url}")
+        log.info(f"Initializing ChromaMemoryAdapter with url: {url}")
         url = url.rstrip("/")
         parsed = urlparse(url)
 
@@ -88,12 +88,10 @@ class ChromaMemoryAdapter(Memory, MemoryBanksProtocolPrivate):
 
     async def initialize(self) -> None:
         try:
-            print(f"Connecting to Chroma server at: {self.host}:{self.port}")
+            log.info(f"Connecting to Chroma server at: {self.host}:{self.port}")
             self.client = await chromadb.AsyncHttpClient(host=self.host, port=self.port)
         except Exception as e:
-            import traceback
-
-            traceback.print_exc()
+            log.error("Could not connect to Chroma server", exc_info=True)
             raise RuntimeError("Could not connect to Chroma server") from e
 
     async def shutdown(self) -> None:
@@ -123,10 +121,7 @@ class ChromaMemoryAdapter(Memory, MemoryBanksProtocolPrivate):
                 data = json.loads(collection.metadata["bank"])
                 bank = parse_obj_as(VectorMemoryBank, data)
             except Exception:
-                import traceback
-
-                traceback.print_exc()
-                print(f"Failed to parse bank: {collection.metadata}")
+                log.error(f"Failed to parse bank: {collection.metadata}", exc_info=True)
                 continue
 
             index = BankWithIndex(

--- a/llama_stack/providers/remote/memory/chroma/chroma.py
+++ b/llama_stack/providers/remote/memory/chroma/chroma.py
@@ -59,7 +59,7 @@ class ChromaIndex(EmbeddingIndex):
                 doc = json.loads(doc)
                 chunk = Chunk(**doc)
             except Exception:
-                log.error(f"Failed to parse document: {doc}", exc_info=True)
+                log.exception(f"Failed to parse document: {doc}")
                 continue
 
             chunks.append(chunk)
@@ -91,7 +91,7 @@ class ChromaMemoryAdapter(Memory, MemoryBanksProtocolPrivate):
             log.info(f"Connecting to Chroma server at: {self.host}:{self.port}")
             self.client = await chromadb.AsyncHttpClient(host=self.host, port=self.port)
         except Exception as e:
-            log.error("Could not connect to Chroma server", exc_info=True)
+            log.exception("Could not connect to Chroma server")
             raise RuntimeError("Could not connect to Chroma server") from e
 
     async def shutdown(self) -> None:
@@ -121,7 +121,7 @@ class ChromaMemoryAdapter(Memory, MemoryBanksProtocolPrivate):
                 data = json.loads(collection.metadata["bank"])
                 bank = parse_obj_as(VectorMemoryBank, data)
             except Exception:
-                log.error(f"Failed to parse bank: {collection.metadata}", exc_info=True)
+                log.exception(f"Failed to parse bank: {collection.metadata}")
                 continue
 
             index = BankWithIndex(

--- a/llama_stack/providers/remote/memory/pgvector/pgvector.py
+++ b/llama_stack/providers/remote/memory/pgvector/pgvector.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import logging
 from typing import List, Tuple
 
 import psycopg2
@@ -23,6 +24,8 @@ from llama_stack.providers.utils.memory.vector_store import (
 )
 
 from .config import PGVectorConfig
+
+log = logging.getLogger(__name__)
 
 
 def check_extension_version(cur):
@@ -124,7 +127,7 @@ class PGVectorMemoryAdapter(Memory, MemoryBanksProtocolPrivate):
         self.cache = {}
 
     async def initialize(self) -> None:
-        print(f"Initializing PGVector memory adapter with config: {self.config}")
+        log.info(f"Initializing PGVector memory adapter with config: {self.config}")
         try:
             self.conn = psycopg2.connect(
                 host=self.config.host,
@@ -138,7 +141,7 @@ class PGVectorMemoryAdapter(Memory, MemoryBanksProtocolPrivate):
 
             version = check_extension_version(self.cursor)
             if version:
-                print(f"Vector extension version: {version}")
+                log.info(f"Vector extension version: {version}")
             else:
                 raise RuntimeError("Vector extension is not installed.")
 
@@ -151,9 +154,7 @@ class PGVectorMemoryAdapter(Memory, MemoryBanksProtocolPrivate):
             """
             )
         except Exception as e:
-            import traceback
-
-            traceback.print_exc()
+            log.error("Could not connect to PGVector database server", exc_info=True)
             raise RuntimeError("Could not connect to PGVector database server") from e
 
     async def shutdown(self) -> None:

--- a/llama_stack/providers/remote/memory/pgvector/pgvector.py
+++ b/llama_stack/providers/remote/memory/pgvector/pgvector.py
@@ -154,7 +154,7 @@ class PGVectorMemoryAdapter(Memory, MemoryBanksProtocolPrivate):
             """
             )
         except Exception as e:
-            log.error("Could not connect to PGVector database server", exc_info=True)
+            log.exception("Could not connect to PGVector database server")
             raise RuntimeError("Could not connect to PGVector database server") from e
 
     async def shutdown(self) -> None:

--- a/llama_stack/providers/remote/memory/qdrant/qdrant.py
+++ b/llama_stack/providers/remote/memory/qdrant/qdrant.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-import traceback
+import logging
 import uuid
 from typing import Any, Dict, List
 
@@ -23,6 +23,7 @@ from llama_stack.providers.utils.memory.vector_store import (
     EmbeddingIndex,
 )
 
+log = logging.getLogger(__name__)
 CHUNK_ID_KEY = "_chunk_id"
 
 
@@ -90,7 +91,7 @@ class QdrantIndex(EmbeddingIndex):
             try:
                 chunk = Chunk(**point.payload["chunk_content"])
             except Exception:
-                traceback.print_exc()
+                log.error("Failed to parse chunk", exc_info=True)
                 continue
 
             chunks.append(chunk)

--- a/llama_stack/providers/remote/memory/qdrant/qdrant.py
+++ b/llama_stack/providers/remote/memory/qdrant/qdrant.py
@@ -91,7 +91,7 @@ class QdrantIndex(EmbeddingIndex):
             try:
                 chunk = Chunk(**point.payload["chunk_content"])
             except Exception:
-                log.error("Failed to parse chunk", exc_info=True)
+                log.exception("Failed to parse chunk")
                 continue
 
             chunks.append(chunk)

--- a/llama_stack/providers/remote/memory/weaviate/weaviate.py
+++ b/llama_stack/providers/remote/memory/weaviate/weaviate.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 import json
+import logging
 
 from typing import Any, Dict, List, Optional
 
@@ -21,6 +22,8 @@ from llama_stack.providers.utils.memory.vector_store import (
 )
 
 from .config import WeaviateConfig, WeaviateRequestProviderData
+
+log = logging.getLogger(__name__)
 
 
 class WeaviateIndex(EmbeddingIndex):
@@ -69,10 +72,8 @@ class WeaviateIndex(EmbeddingIndex):
                 chunk_dict = json.loads(chunk_json)
                 chunk = Chunk(**chunk_dict)
             except Exception:
-                import traceback
 
-                traceback.print_exc()
-                print(f"Failed to parse document: {chunk_json}")
+                log.error(f"Failed to parse document: {chunk_json}", exc_info=True)
                 continue
 
             chunks.append(chunk)

--- a/llama_stack/providers/remote/memory/weaviate/weaviate.py
+++ b/llama_stack/providers/remote/memory/weaviate/weaviate.py
@@ -72,8 +72,7 @@ class WeaviateIndex(EmbeddingIndex):
                 chunk_dict = json.loads(chunk_json)
                 chunk = Chunk(**chunk_dict)
             except Exception:
-
-                log.error(f"Failed to parse document: {chunk_json}", exc_info=True)
+                log.exception(f"Failed to parse document: {chunk_json}")
                 continue
 
             chunks.append(chunk)

--- a/llama_stack/providers/utils/inference/prompt_adapter.py
+++ b/llama_stack/providers/utils/inference/prompt_adapter.py
@@ -7,14 +7,13 @@
 import base64
 import io
 import json
+import logging
 from typing import Tuple
 
 import httpx
 
 from llama_models.llama3.api.chat_format import ChatFormat
 from PIL import Image as PIL_Image
-from termcolor import cprint
-
 from llama_models.llama3.api.datatypes import *  # noqa: F403
 from llama_stack.apis.inference import *  # noqa: F403
 from llama_models.datatypes import ModelFamily
@@ -28,6 +27,8 @@ from llama_models.llama3.prompt_templates import (
 from llama_models.sku_list import resolve_model
 
 from llama_stack.providers.utils.inference import supported_inference_models
+
+log = logging.getLogger(__name__)
 
 
 def content_has_media(content: InterleavedTextMedia):
@@ -175,13 +176,13 @@ def chat_completion_request_to_messages(
     """
     model = resolve_model(llama_model)
     if model is None:
-        cprint(f"Could not resolve model {llama_model}", color="red")
+        log.error(f"Could not resolve model {llama_model}")
         return request.messages
 
     allowed_models = supported_inference_models()
     descriptors = [m.descriptor() for m in allowed_models]
     if model.descriptor() not in descriptors:
-        cprint(f"Unsupported inference model? {model.descriptor()}", color="red")
+        log.error(f"Unsupported inference model? {model.descriptor()}")
         return request.messages
 
     if model.model_family == ModelFamily.llama3_1 or (

--- a/llama_stack/providers/utils/kvstore/postgres/postgres.py
+++ b/llama_stack/providers/utils/kvstore/postgres/postgres.py
@@ -47,7 +47,7 @@ class PostgresKVStoreImpl(KVStore):
             )
         except Exception as e:
 
-            log.error("Could not connect to PostgreSQL database server", exc_info=True)
+            log.exception("Could not connect to PostgreSQL database server")
             raise RuntimeError("Could not connect to PostgreSQL database server") from e
 
     def _namespaced_key(self, key: str) -> str:

--- a/llama_stack/providers/utils/kvstore/postgres/postgres.py
+++ b/llama_stack/providers/utils/kvstore/postgres/postgres.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import logging
 from datetime import datetime
 from typing import List, Optional
 
@@ -12,6 +13,8 @@ from psycopg2.extras import DictCursor
 
 from ..api import KVStore
 from ..config import PostgresKVStoreConfig
+
+log = logging.getLogger(__name__)
 
 
 class PostgresKVStoreImpl(KVStore):
@@ -43,9 +46,8 @@ class PostgresKVStoreImpl(KVStore):
                 """
             )
         except Exception as e:
-            import traceback
 
-            traceback.print_exc()
+            log.error("Could not connect to PostgreSQL database server", exc_info=True)
             raise RuntimeError("Could not connect to PostgreSQL database server") from e
 
     def _namespaced_key(self, key: str) -> str:

--- a/llama_stack/providers/utils/memory/vector_store.py
+++ b/llama_stack/providers/utils/memory/vector_store.py
@@ -5,6 +5,7 @@
 # the root directory of this source tree.
 import base64
 import io
+import logging
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -16,12 +17,13 @@ import httpx
 import numpy as np
 from numpy.typing import NDArray
 from pypdf import PdfReader
-from termcolor import cprint
 
 from llama_models.llama3.api.datatypes import *  # noqa: F403
 from llama_models.llama3.api.tokenizer import Tokenizer
 
 from llama_stack.apis.memory import *  # noqa: F403
+
+log = logging.getLogger(__name__)
 
 ALL_MINILM_L6_V2_DIMENSION = 384
 
@@ -35,7 +37,7 @@ def get_embedding_model(model: str) -> "SentenceTransformer":
     if loaded_model is not None:
         return loaded_model
 
-    print(f"Loading sentence transformer for {model}...")
+    log.info(f"Loading sentence transformer for {model}...")
     from sentence_transformers import SentenceTransformer
 
     loaded_model = SentenceTransformer(model)
@@ -92,7 +94,7 @@ def content_from_data(data_url: str) -> str:
         return "\n".join([page.extract_text() for page in pdf_reader.pages])
 
     else:
-        cprint("Could not extract content from data_url properly.", color="red")
+        log.error("Could not extract content from data_url properly.")
         return ""
 
 

--- a/llama_stack/providers/utils/telemetry/tracing.py
+++ b/llama_stack/providers/utils/telemetry/tracing.py
@@ -17,6 +17,8 @@ from typing import Any, Callable, Dict, List
 
 from llama_stack.apis.telemetry import *  # noqa: F403
 
+log = logging.getLogger(__name__)
+
 
 def generate_short_uuid(len: int = 12):
     full_uuid = uuid.uuid4()
@@ -40,7 +42,7 @@ class BackgroundLogger:
         try:
             self.log_queue.put_nowait(event)
         except queue.Full:
-            print("Log queue is full, dropping event")
+            log.error("Log queue is full, dropping event")
 
     def _process_logs(self):
         while True:
@@ -49,10 +51,7 @@ class BackgroundLogger:
                 # figure out how to use a thread's native loop
                 asyncio.run(self.api.log_event(event))
             except Exception:
-                import traceback
-
-                traceback.print_exc()
-                print("Error processing log event")
+                log.error("Error processing log event", exc_info=True)
             finally:
                 self.log_queue.task_done()
 
@@ -125,7 +124,7 @@ async def start_trace(name: str, attributes: Dict[str, Any] = None):
     global CURRENT_TRACE_CONTEXT, BACKGROUND_LOGGER
 
     if BACKGROUND_LOGGER is None:
-        print("No Telemetry implementation set. Skipping trace initialization...")
+        log.info("No Telemetry implementation set. Skipping trace initialization...")
         return
 
     trace_id = generate_short_uuid()

--- a/llama_stack/providers/utils/telemetry/tracing.py
+++ b/llama_stack/providers/utils/telemetry/tracing.py
@@ -51,7 +51,10 @@ class BackgroundLogger:
                 # figure out how to use a thread's native loop
                 asyncio.run(self.api.log_event(event))
             except Exception:
-                log.error("Error processing log event", exc_info=True)
+                import traceback
+
+                traceback.print_exc()
+                print("Error processing log event")
             finally:
                 self.log_queue.task_done()
 


### PR DESCRIPTION
# What does this PR do?

This PR moves all print statements to use logging. Things changed:
- Had to add `await start_trace("sse_generator")` to server.py to actually get tracing working. else was not seeing any logs
- If no telemetry provider is provided in the run.yaml, we will write to stdout
- by default, the logs are going to be in JSON, but we expose an option to configure to output in a human readable way.


## Test Plan
json output:
```
INFO:     ::1:50078 - "POST /alpha/agents/turn/create HTTP/1.1" 200 OK
{"timestamp": "2024-11-21T10:46:28.549597", "trace_id": "_m5MRCvkT7W9", "span_id": "i7nFQUerS4ea", "span_name": "sse_generator.retrieve_rag_context", "type": "log", "severity": "INFO", "message": "Loading sentence transformer for all-MiniLM-L6-v2..."}
{"timestamp": "2024-11-21T10:46:32.083074", "trace_id": "_m5MRCvkT7W9", "span_id": "i7nFQUerS4ea", "span_name": "sse_generator.retrieve_rag_context", "type": "log", "severity": "INFO", "message": "Use pytorch device_name: mps"}
{"timestamp": "2024-11-21T10:46:32.083133", "trace_id": "_m5MRCvkT7W9", "span_id": "i7nFQUerS4ea", "span_name": "sse_generator.retrieve_rag_context", "type": "log", "severity": "INFO", "message": "Load pretrained SentenceTransformer: all-MiniLM-L6-v2"}
Batches: 100% 1/1 [00:00<00:00,  4.34it/s]
{"timestamp": "2024-11-21T10:46:34.512107", "trace_id": "_m5MRCvkT7W9", "span_id": "i7nFQUerS4ea", "span_name": "sse_generator.retrieve_rag_context", "type": "log", "severity": "INFO", "message": "HTTP Request: POST http://localhost:8000/api/v2/tenants/default_tenant/databases/default_database/collections/ae039506-7bdf-412c-8bce-b25ff4237d79/query \"HTTP/1.1 200 OK\""}
{"timestamp": "2024-11-21T10:46:34.524691", "trace_id": "_m5MRCvkT7W9", "span_id": "5clgIM-hQuaI", "span_name": "sse_generator", "type": "log", "severity": "INFO", "message": "role='user' content='What are the top 5 topics that were explained in the documentation? Only list succinct bullet points.' context='Here are the retrieved documents for relevant context:\\n=== START-RETRIEVED-CONTEXT ===\\n\\nid:num-1; content:_\\nthe template from Llama2 to better support multiturn conversations. The same text\\nin the Llama3 Instruct format would look like this:\\n\\n.. code-block:: text\\n\\n    <|begin_of_text|><|start_header_id|>system<|end_header_id|>\\n\\n    You are a helpful, res...<more>...the default setting for our recipes.\\n\\n.. note::\\n\\n  Another common paradigm is \"mixed-precision\" training: where model weights are in ``bfloat16`` (or ``fp16``), and optimizer\\n  states are in ``fp32``. Currently, we don\\'t support mixed-precision training in torchtune.\\n\\n*Sounds great! How do I use it?*\\n\\nSimply use the ``dtype`` flag or config entry in all our recipes! For example, to use half-precision training in ``bf16``,\\nset ``dtype=bf16``.\\n\\n.. _\\n\\n=== END-RETRIEVED-CONTEXT ===\\n'"}
```

human readable output:
```
INFO:     Uvicorn running on http://['::', '0.0.0.0']:5000 (Press CTRL+C to quit)
INFO:     ::1:49964 - "GET /alpha/providers/list HTTP/1.1" 200 OK
INFO:     ::1:49964 - "GET /alpha/shields/list HTTP/1.1" 200 OK
/Users/dineshyv/code/llama-stack/llama_stack/distribution/routers/routing_tables.py:299: PydanticDeprecatedSince20: `parse_obj_as` is deprecated. Use `pydantic.TypeAdapter.validate_python` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.9/migration/
  memory_bank = parse_obj_as(
/Users/dineshyv/miniconda3/envs/llamastack-together/lib/python3.10/site-packages/pydantic/main.py:1138: PydanticDeprecatedSince20: The `json` method is deprecated; use `model_dump_json` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.9/migration/
  warnings.warn(
21:37:14.710 [INFO] [register_memory_bank] HTTP Request: POST http://localhost:8000/api/v2/tenants/default_tenant/databases/default_database/collections "HTTP/1.1 200 OK"
INFO:     ::1:49964 - "POST /alpha/memory-banks/register HTTP/1.1" 200 OK
INFO:     ::1:49964 - "GET /alpha/models/list HTTP/1.1" 200 OK
INFO:     ::1:49964 - "POST /alpha/agents/create HTTP/1.1" 200 OK
INFO:     ::1:49964 - "POST /alpha/agents/session/create HTTP/1.1" 200 OK
INFO:     ::1:49964 - "POST /alpha/agents/turn/create HTTP/1.1" 200 OK
21:37:14.762 [INFO] [sse_generator.retrieve_rag_context] Loading sentence transformer for all-MiniLM-L6-v2...
21:37:18.553 [INFO] [sse_generator.retrieve_rag_context] Use pytorch device_name: mps
21:37:18.553 [INFO] [sse_generator.retrieve_rag_context] Load pretrained SentenceTransformer: all-MiniLM-L6-v2
Batches: 100% 1/1 [00:00<00:00,  3.61it/s]
21:37:21.141 [INFO] [sse_generator.retrieve_rag_context] HTTP Request: POST http://localhost:8000/api/v2/tenants/default_tenant/databases/default_database/collections/ae039506-7bdf-412c-8bce-b25ff4237d79/query "HTTP/1.1 200 OK"
```
