### PR TITLE
Replaced zrangebylex method in the range method

### DIFF
--- a/llama_stack/apis/agents/client.py
+++ b/llama_stack/apis/agents/client.py
@@ -45,7 +45,7 @@ class AgentsClient(Agents):
     async def create_agent(self, agent_config: AgentConfig) -> AgentCreateResponse:
         async with httpx.AsyncClient() as client:
             response = await client.post(
-                f"{self.base_url}/agents/create",
+                f"{self.base_url}/alpha/agents/create",
                 json={
                     "agent_config": encodable_dict(agent_config),
                 },
@@ -61,7 +61,7 @@ class AgentsClient(Agents):
     ) -> AgentSessionCreateResponse:
         async with httpx.AsyncClient() as client:
             response = await client.post(
-                f"{self.base_url}/agents/session/create",
+                f"{self.base_url}/alpha/agents/session/create",
                 json={
                     "agent_id": agent_id,
                     "session_name": session_name,
@@ -86,7 +86,7 @@ class AgentsClient(Agents):
         async with httpx.AsyncClient() as client:
             async with client.stream(
                 "POST",
-                f"{self.base_url}/agents/turn/create",
+                f"{self.base_url}/alpha/agents/turn/create",
                 json=encodable_dict(request),
                 headers={"Content-Type": "application/json"},
                 timeout=20,

--- a/llama_stack/apis/agents/client.py
+++ b/llama_stack/apis/agents/client.py
@@ -45,7 +45,7 @@ class AgentsClient(Agents):
     async def create_agent(self, agent_config: AgentConfig) -> AgentCreateResponse:
         async with httpx.AsyncClient() as client:
             response = await client.post(
-                f"{self.base_url}/alpha/agents/create",
+                f"{self.base_url}/agents/create",
                 json={
                     "agent_config": encodable_dict(agent_config),
                 },
@@ -61,7 +61,7 @@ class AgentsClient(Agents):
     ) -> AgentSessionCreateResponse:
         async with httpx.AsyncClient() as client:
             response = await client.post(
-                f"{self.base_url}/alpha/agents/session/create",
+                f"{self.base_url}/agents/session/create",
                 json={
                     "agent_id": agent_id,
                     "session_name": session_name,
@@ -86,7 +86,7 @@ class AgentsClient(Agents):
         async with httpx.AsyncClient() as client:
             async with client.stream(
                 "POST",
-                f"{self.base_url}/alpha/agents/turn/create",
+                f"{self.base_url}/agents/turn/create",
                 json=encodable_dict(request),
                 headers={"Content-Type": "application/json"},
                 timeout=20,

--- a/llama_stack/providers/utils/kvstore/redis/redis.py
+++ b/llama_stack/providers/utils/kvstore/redis/redis.py
@@ -48,24 +48,27 @@ class RedisKVStoreImpl(KVStore):
     async def range(self, start_key: str, end_key: str) -> List[str]:
         start_key = self._namespaced_key(start_key)
         end_key = self._namespaced_key(end_key)
-
-        result = []
         cursor = 0
         pattern = start_key + "*"  # Match all keys starting with start_key prefix
-
+        matching_keys = []
         while True:
-            cursor, keys = await self.redis.scan(cursor, match=pattern)
+            cursor, keys = await self.redis.scan(cursor, match=pattern, count=1000)
+
             for key in keys:
                 key_str = key.decode("utf-8") if isinstance(key, bytes) else key
                 if start_key <= key_str <= end_key:
-                    value = await self.redis.get(key)
-                    if value is not None:
-                        value_str = (
-                            value.decode("utf-8") if isinstance(value, bytes) else value
-                        )
-                        result.append(value_str)
+                    matching_keys.append(key)
 
             if cursor == 0:
                 break
 
-        return result
+            # Then fetch all values in a single MGET call
+            if matching_keys:
+                values = await self.redis.mget(matching_keys)
+                return [
+                    value.decode("utf-8") if isinstance(value, bytes) else value
+                    for value in values
+                    if value is not None
+                ]
+
+            return []

--- a/llama_stack/providers/utils/kvstore/redis/redis.py
+++ b/llama_stack/providers/utils/kvstore/redis/redis.py
@@ -62,13 +62,13 @@ class RedisKVStoreImpl(KVStore):
             if cursor == 0:
                 break
 
-            # Then fetch all values in a single MGET call
-            if matching_keys:
-                values = await self.redis.mget(matching_keys)
-                return [
-                    value.decode("utf-8") if isinstance(value, bytes) else value
-                    for value in values
-                    if value is not None
-                ]
+        # Then fetch all values in a single MGET call
+        if matching_keys:
+            values = await self.redis.mget(matching_keys)
+            return [
+                value.decode("utf-8") if isinstance(value, bytes) else value
+                for value in values
+                if value is not None
+            ]
 
-            return []
+        return []


### PR DESCRIPTION
# What does this PR do?

In short, provide a summary of what this PR does and why. Usually, the relevant context should be present in a linked issue.

- [Currently redis as a kvstore is bugged, as the range method uses zrangebylex method. zrangebylex method is used when it is a sorted set but we are storing the value using .set method in the redis. This causes an error. Another issue is that zrangebylex method takes 3 args but only 2 are mentioned in the range method. This causes a runtime error. That method has been replaced with the current implementation in the PR ] Addresses issue (#520 )


## Test Plan

Please describe:
 - tests you ran to verify your changes with result summaries.
 - provide instructions so it can be reproduced.
`python llama_stack/apis/agents/client.py localhost 8001 tools_llama_3_1 meta-llama/Llama-3.1-70B-Instruct`
<img width="1711" alt="Screenshot 2024-11-25 at 2 59 55 PM" src="https://github.com/user-attachments/assets/c2551555-bc73-4427-b09b-c86d6deb2956">
<img width="634" alt="Screenshot 2024-11-25 at 3 00 33 PM" src="https://github.com/user-attachments/assets/a087718f-fc2a-424b-b096-4ecad08a07bf">

Have used redis in the run.yaml file as well for the persistence_store. Also enable_session_persistence turned to True for this test.
Have also tested this in a jupyter notebook to make sure the current flow does not work through multiple turns in the same session.

## Sources

Please link relevant resources if necessary.


## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Ran pre-commit to handle lint / formatting issues.
- [x] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Updated relevant documentation.
- [ ] Wrote necessary unit or integration tests.
