### PR TITLE
allow env NVIDIA_BASE_URL to set NVIDIAConfig.url

### DIFF
--- a/llama_stack/providers/remote/inference/nvidia/config.py
+++ b/llama_stack/providers/remote/inference/nvidia/config.py
@@ -35,7 +35,9 @@ class NVIDIAConfig(BaseModel):
     """
 
     url: str = Field(
-        default="https://integrate.api.nvidia.com",
+        default_factory=lambda: os.getenv(
+            "NVIDIA_BASE_URL", "https://integrate.api.nvidia.com"
+        ),
         description="A base url for accessing the NVIDIA NIM",
     )
     api_key: Optional[str] = Field(


### PR DESCRIPTION
# What does this PR do?

this allows setting an NVIDIA_BASE_URL variable to control the NVIDIAConfig.url option


## Test Plan

`pytest -s -v --providers inference=nvidia llama_stack/providers/tests/inference/ --env NVIDIA_BASE_URL=http://localhost:8000`


## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Ran pre-commit to handle lint / formatting issues.
- [x] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Updated relevant documentation.
- [ ] Wrote necessary unit or integration tests.
