### PR TITLE
Fix Conda Environment Name in Zero to Hero Documentation

### DIFF
--- a/docs/zero_to_hero_guide/README.md
+++ b/docs/zero_to_hero_guide/README.md
@@ -88,7 +88,7 @@ If you're looking for more specific topics like tool calling or agent setup, we 
 4. **Install Llama Stack**:
    - Open a new terminal and install `llama-stack`:
      ```bash
-     conda activate ollama 
+     conda activate ollama
      pip install llama-stack==0.0.53
      ```
 

--- a/docs/zero_to_hero_guide/README.md
+++ b/docs/zero_to_hero_guide/README.md
@@ -88,7 +88,7 @@ If you're looking for more specific topics like tool calling or agent setup, we 
 4. **Install Llama Stack**:
    - Open a new terminal and install `llama-stack`:
      ```bash
-     conda activate hack
+     conda activate ollama 
      pip install llama-stack==0.0.53
      ```
 


### PR DESCRIPTION
# What does this PR do?
This PR fixes issue #544, briefly described below:

In the Zero to Hero README.md, there was a commit (9928405e2cf4689f9e377d8cf3146aed15849e04) that changed the conda environment name from hack to ollama. However, there was one spot where this was not changed.