### PR TITLE
disable assertion of  dict type checking as an ad-hoc

### DIFF
--- a/llama_stack/providers/remote/inference/ollama/ollama.py
+++ b/llama_stack/providers/remote/inference/ollama/ollama.py
@@ -269,7 +269,8 @@ class OllamaInferenceAdapter(Inference, ModelsProtocolPrivate):
         if "messages" in params:
             r = await self.client.chat(**params)
         else:
-            r = await self.client.generate(**params)
+            r = await self.client.generate(**params)        
+        r = dict(r) #ad-hoc 
         assert isinstance(r, dict)
 
         if "message" in r:


### PR DESCRIPTION
# What does this PR do?

I found a bug while trying to use llama-stack as library. 
[Using Llama Stack as a Library — llama-stack documentation](https://llama-stack.readthedocs.io/en/latest/distributions/importing_as_library.html)

## Test Plan

- Bug:

```python
  response = await client.inference.chat_completion(
        messages=[UserMessage(content="What is the capital of France?", role="user")],        
        model_id=model_id,
        stream=False,
    )
    print("\nChat completion response:")
    print(response)

```
When I tried this code, it makes following error. 
```bash
  File "/llama-stack/llama_stack/providers/remote/inference/ollama/ollama.py", line 273, in _nonstream_chat_completion
    assert isinstance(r, dict)
```
So, I changed its type using `r = dict(r)`.  I think it could be an ad-hoc. 

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Ran pre-commit to handle lint / formatting issues.
- [ ] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Updated relevant documentation.
- [ ] Wrote necessary unit or integration tests.
