### PR TITLE
Renames otel config from jaeger to otel

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ You have two ways to install this repository:
    ```
 
 2. **Install from source**:
-   If you prefer to install from the source code, follow these steps:
+   If you prefer to install from the source code, make sure you have [conda installed](https://docs.conda.io/projects/conda/en/stable).
+   Then, follow these steps:
    ```bash
     mkdir -p ~/local
     cd ~/local

--- a/llama_stack/providers/inline/telemetry/meta_reference/config.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/config.py
@@ -13,7 +13,7 @@ from llama_stack.distribution.utils.config_dirs import RUNTIME_BASE_DIR
 
 
 class TelemetrySink(str, Enum):
-    JAEGER = "jaeger"
+    OTEL = "otel"
     SQLITE = "sqlite"
     CONSOLE = "console"
 

--- a/llama_stack/providers/inline/telemetry/meta_reference/config.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/config.py
@@ -29,7 +29,7 @@ class TelemetryConfig(BaseModel):
     )
     sinks: List[TelemetrySink] = Field(
         default=[TelemetrySink.CONSOLE, TelemetrySink.SQLITE],
-        description="List of telemetry sinks to enable (possible values: jaeger, sqlite, console)",
+        description="List of telemetry sinks to enable (possible values: otel, sqlite, console)",
     )
     sqlite_db_path: str = Field(
         default=(RUNTIME_BASE_DIR / "trace_store.db").as_posix(),

--- a/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
@@ -66,7 +66,7 @@ class TelemetryAdapter(Telemetry):
 
         provider = TracerProvider(resource=resource)
         trace.set_tracer_provider(provider)
-        if TelemetrySink.JAEGER in self.config.sinks:
+        if TelemetrySink.OTEL in self.config.sinks:
             otlp_exporter = OTLPSpanExporter(
                 endpoint=self.config.otel_endpoint,
             )


### PR DESCRIPTION
# What does this PR do?

#525 introduced a telemetry configuration named jaeger, but what it really is pointing to is an OTLP HTTP endpoint which is supported by most servers in the ecosystem, including raw opentelemetry collectors, several APMs, and even https://github.com/ymtdzzz/otel-tui

I chose to rename this to "otel" as it will bring in more people to the ecosystem vs feeling it only works with jaeger.  Later, we can use the [standard ENV](https://opentelemetry.io/docs/specs/otel/protocol/exporter/) to configure this if we like so that you can override things with variables people might expect.

Note: I also added to the README that you have to install conda. Depending on experience level of the user, and especially with miniforge vs other ways, I felt this helps.

## Test Plan

I would like to test this, but actually got a little lost. The previous PRs referenced yaml which doesn't seem published anywhere. It would be nice to have a pre-canned setup that uses ollama and turns on otel, but would also appreciate a hand on instructions meanwhile.

## Sources

https://github.com/meta-llama/llama-stack/pull/525

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Ran pre-commit to handle lint / formatting issues.
- [x] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Updated relevant documentation.
- [ ] Wrote necessary unit or integration tests.
