### PR TITLE
doc: llama-stack build --config help text references old directory

### DIFF
--- a/llama_stack/cli/stack/build.py
+++ b/llama_stack/cli/stack/build.py
@@ -51,7 +51,7 @@ class StackBuild(Subcommand):
             "--config",
             type=str,
             default=None,
-            help="Path to a config file to use for the build. You can find example configs in llama_stack/distribution/example_configs. If this argument is not provided, you will be prompted to enter information interactively",
+            help="Path to a config file to use for the build. You can find example configs in llama_stack/distribution/**/build.yaml. If this argument is not provided, you will be prompted to enter information interactively",
         )
 
         self.parser.add_argument(


### PR DESCRIPTION
# What does this PR do?

- llama-stack build --config help text references example_configs which no longer exists
- Update to refer new directory format to avoid confusion

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).