### PR TITLE
Add automatic PyPI release GitHub workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: PyPI Release
+
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distributions for PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+
+      - name: Install build dependencies
+        run: python -m pip install build
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: llama-stack-dists
+          path: dist/
+
+  pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    environment: release
+
+    needs:
+      - build
+
+    permissions:
+      # Used to authenticate to PyPI via OIDC: https://docs.pypi.org/trusted-publishers/
+      id-token: write
+
+    steps:
+      - name: fetch dists
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: llama-stack-dists
+          path: dist/
+
+      - name: publish
+        if: github.event_name == 'push'
+        uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 # v1.12.3
+        with:
+          attestations: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,9 @@ jobs:
   pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    environment: release
+    environment:
+      name: pypi
+      url: https://pypi.org/p/llama-stack
 
     needs:
       - build
@@ -51,7 +53,6 @@ jobs:
           path: dist/
 
       - name: publish
-        if: github.event_name == 'push'
         uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 # v1.12.3
         with:
           attestations: true


### PR DESCRIPTION
This PR adds a workflow to automatically publish the package (including attestations) to Python upon tag/release creation.

Note that this relies on trusted publishing: https://docs.pypi.org/trusted-publishers/

