### PR TITLE
Add missing environments field for vLLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Additionally, we have designed every element of the Stack such that APIs as well
 |                                           Chroma                                           |      Single Node       |                    |                    | :heavy_check_mark: |                    |                    |
 |                                         PG Vector                                          |      Single Node       |                    |                    | :heavy_check_mark: |                    |                    |
 |                                     PyTorch ExecuTorch                                     |     On-device iOS      | :heavy_check_mark: | :heavy_check_mark: |                    |                    |                    |
-|                        [vLLM](https://github.com/vllm-project/vllm)                        |                        |                    | :heavy_check_mark: |                    |                    |                    |
+|                        [vLLM](https://github.com/vllm-project/vllm)                        | Hosted and Single Node |                    | :heavy_check_mark: |                    |                    |                    |
 
 ### Distributions
 


### PR DESCRIPTION
@ashwinb sorry I missed this earlier in https://github.com/meta-llama/llama-stack/pull/604. 