### PR TITLE
Update the "InterleavedTextMedia" type 

### DIFF
--- a/docs/openapi_generator/generate.py
+++ b/docs/openapi_generator/generate.py
@@ -23,9 +23,10 @@ from llama_models import schema_utils
 # generation though, we need the full definitions and implementations from the
 #  (json-strong-typing) package.
 
-from .strong_typing.schema import json_schema_type
+from .strong_typing.schema import json_schema_type, register_schema
 
 schema_utils.json_schema_type = json_schema_type
+schema_utils.register_schema = register_schema
 
 from llama_stack.apis.version import LLAMA_STACK_API_VERSION  # noqa: E402
 from llama_stack.distribution.stack import LlamaStack  # noqa: E402

--- a/docs/resources/llama-stack-spec.html
+++ b/docs/resources/llama-stack-spec.html
@@ -2554,27 +2554,22 @@
             "ImageContentItem": {
                 "type": "object",
                 "properties": {
+                    "url": {
+                        "$ref": "#/components/schemas/URL"
+                    },
+                    "data": {
+                        "type": "string",
+                        "contentEncoding": "base64"
+                    },
                     "type": {
                         "type": "string",
                         "const": "image",
                         "default": "image"
-                    },
-                    "data": {
-                        "oneOf": [
-                            {
-                                "type": "string",
-                                "contentEncoding": "base64"
-                            },
-                            {
-                                "$ref": "#/components/schemas/URL"
-                            }
-                        ]
                     }
                 },
                 "additionalProperties": false,
                 "required": [
-                    "type",
-                    "data"
+                    "type"
                 ]
             },
             "InterleavedContent": {

--- a/docs/resources/llama-stack-spec.html
+++ b/docs/resources/llama-stack-spec.html
@@ -2531,27 +2531,7 @@
                         "default": "assistant"
                     },
                     "content": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "$ref": "#/components/schemas/ImageMedia"
-                            },
-                            {
-                                "type": "array",
-                                "items": {
-                                    "oneOf": [
-                                        {
-                                            "type": "string"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/ImageMedia"
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
+                        "$ref": "#/components/schemas/InterleavedContent"
                     },
                     "stop_reason": {
                         "$ref": "#/components/schemas/StopReason"
@@ -2571,23 +2551,19 @@
                     "tool_calls"
                 ]
             },
-            "ImageMedia": {
+            "ImageContentItem": {
                 "type": "object",
                 "properties": {
-                    "image": {
+                    "type": {
+                        "type": "string",
+                        "const": "image",
+                        "default": "image"
+                    },
+                    "data": {
                         "oneOf": [
                             {
-                                "type": "object",
-                                "properties": {
-                                    "format": {
-                                        "type": "string"
-                                    },
-                                    "format_description": {
-                                        "type": "string"
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "title": "This class represents an image object.  To create"
+                                "type": "string",
+                                "contentEncoding": "base64"
                             },
                             {
                                 "$ref": "#/components/schemas/URL"
@@ -2597,7 +2573,34 @@
                 },
                 "additionalProperties": false,
                 "required": [
-                    "image"
+                    "type",
+                    "data"
+                ]
+            },
+            "InterleavedContent": {
+                "oneOf": [
+                    {
+                        "type": "string"
+                    },
+                    {
+                        "$ref": "#/components/schemas/InterleavedContentItem"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/InterleavedContentItem"
+                        }
+                    }
+                ]
+            },
+            "InterleavedContentItem": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/ImageContentItem"
+                    },
+                    {
+                        "$ref": "#/components/schemas/TextContentItem"
+                    }
                 ]
             },
             "SamplingParams": {
@@ -2658,33 +2661,31 @@
                         "default": "system"
                     },
                     "content": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "$ref": "#/components/schemas/ImageMedia"
-                            },
-                            {
-                                "type": "array",
-                                "items": {
-                                    "oneOf": [
-                                        {
-                                            "type": "string"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/ImageMedia"
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
+                        "$ref": "#/components/schemas/InterleavedContent"
                     }
                 },
                 "additionalProperties": false,
                 "required": [
                     "role",
                     "content"
+                ]
+            },
+            "TextContentItem": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "const": "text",
+                        "default": "text"
+                    },
+                    "text": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "type",
+                    "text"
                 ]
             },
             "ToolCall": {
@@ -2885,27 +2886,7 @@
                         ]
                     },
                     "content": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "$ref": "#/components/schemas/ImageMedia"
-                            },
-                            {
-                                "type": "array",
-                                "items": {
-                                    "oneOf": [
-                                        {
-                                            "type": "string"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/ImageMedia"
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
+                        "$ref": "#/components/schemas/InterleavedContent"
                     }
                 },
                 "additionalProperties": false,
@@ -2930,50 +2911,10 @@
                         "default": "user"
                     },
                     "content": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "$ref": "#/components/schemas/ImageMedia"
-                            },
-                            {
-                                "type": "array",
-                                "items": {
-                                    "oneOf": [
-                                        {
-                                            "type": "string"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/ImageMedia"
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
+                        "$ref": "#/components/schemas/InterleavedContent"
                     },
                     "context": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "$ref": "#/components/schemas/ImageMedia"
-                            },
-                            {
-                                "type": "array",
-                                "items": {
-                                    "oneOf": [
-                                        {
-                                            "type": "string"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/ImageMedia"
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
+                        "$ref": "#/components/schemas/InterleavedContent"
                     }
                 },
                 "additionalProperties": false,
@@ -3066,27 +3007,7 @@
                     "content_batch": {
                         "type": "array",
                         "items": {
-                            "oneOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/ImageMedia"
-                                },
-                                {
-                                    "type": "array",
-                                    "items": {
-                                        "oneOf": [
-                                            {
-                                                "type": "string"
-                                            },
-                                            {
-                                                "$ref": "#/components/schemas/ImageMedia"
-                                            }
-                                        ]
-                                    }
-                                }
-                            ]
+                            "$ref": "#/components/schemas/InterleavedContent"
                         }
                     },
                     "sampling_params": {
@@ -3407,27 +3328,7 @@
                         "type": "string"
                     },
                     "content": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "$ref": "#/components/schemas/ImageMedia"
-                            },
-                            {
-                                "type": "array",
-                                "items": {
-                                    "oneOf": [
-                                        {
-                                            "type": "string"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/ImageMedia"
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
+                        "$ref": "#/components/schemas/InterleavedContent"
                     },
                     "sampling_params": {
                         "$ref": "#/components/schemas/SamplingParams"
@@ -4188,19 +4089,12 @@
                                 "type": "string"
                             },
                             {
-                                "$ref": "#/components/schemas/ImageMedia"
+                                "$ref": "#/components/schemas/InterleavedContentItem"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "oneOf": [
-                                        {
-                                            "type": "string"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/ImageMedia"
-                                        }
-                                    ]
+                                    "$ref": "#/components/schemas/InterleavedContentItem"
                                 }
                             },
                             {
@@ -4526,27 +4420,7 @@
                         }
                     },
                     "inserted_context": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "$ref": "#/components/schemas/ImageMedia"
-                            },
-                            {
-                                "type": "array",
-                                "items": {
-                                    "oneOf": [
-                                        {
-                                            "type": "string"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/ImageMedia"
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
+                        "$ref": "#/components/schemas/InterleavedContent"
                     }
                 },
                 "additionalProperties": false,
@@ -4693,27 +4567,7 @@
                         ]
                     },
                     "content": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "$ref": "#/components/schemas/ImageMedia"
-                            },
-                            {
-                                "type": "array",
-                                "items": {
-                                    "oneOf": [
-                                        {
-                                            "type": "string"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/ImageMedia"
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
+                        "$ref": "#/components/schemas/InterleavedContent"
                     }
                 },
                 "additionalProperties": false,
@@ -4839,27 +4693,7 @@
                     "contents": {
                         "type": "array",
                         "items": {
-                            "oneOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/ImageMedia"
-                                },
-                                {
-                                    "type": "array",
-                                    "items": {
-                                        "oneOf": [
-                                            {
-                                                "type": "string"
-                                            },
-                                            {
-                                                "$ref": "#/components/schemas/ImageMedia"
-                                            }
-                                        ]
-                                    }
-                                }
-                            ]
+                            "$ref": "#/components/schemas/InterleavedContent"
                         }
                     }
                 },
@@ -5502,148 +5336,7 @@
                     "dataset_schema": {
                         "type": "object",
                         "additionalProperties": {
-                            "oneOf": [
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string",
-                                            "const": "string",
-                                            "default": "string"
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                        "type"
-                                    ]
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string",
-                                            "const": "number",
-                                            "default": "number"
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                        "type"
-                                    ]
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string",
-                                            "const": "boolean",
-                                            "default": "boolean"
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                        "type"
-                                    ]
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string",
-                                            "const": "array",
-                                            "default": "array"
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                        "type"
-                                    ]
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string",
-                                            "const": "object",
-                                            "default": "object"
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                        "type"
-                                    ]
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string",
-                                            "const": "json",
-                                            "default": "json"
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                        "type"
-                                    ]
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string",
-                                            "const": "union",
-                                            "default": "union"
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                        "type"
-                                    ]
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string",
-                                            "const": "chat_completion_input",
-                                            "default": "chat_completion_input"
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                        "type"
-                                    ]
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string",
-                                            "const": "completion_input",
-                                            "default": "completion_input"
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                        "type"
-                                    ]
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string",
-                                            "const": "agent_turn_input",
-                                            "default": "agent_turn_input"
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                        "type"
-                                    ]
-                                }
-                            ]
+                            "$ref": "#/components/schemas/ParamType"
                         }
                     },
                     "url": {
@@ -5684,6 +5377,150 @@
                     "dataset_schema",
                     "url",
                     "metadata"
+                ]
+            },
+            "ParamType": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "const": "string",
+                                "default": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "const": "number",
+                                "default": "number"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "const": "boolean",
+                                "default": "boolean"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "const": "array",
+                                "default": "array"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "const": "object",
+                                "default": "object"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "const": "json",
+                                "default": "json"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "const": "union",
+                                "default": "union"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "const": "chat_completion_input",
+                                "default": "chat_completion_input"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "const": "completion_input",
+                                "default": "completion_input"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "const": "agent_turn_input",
+                                "default": "agent_turn_input"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "type"
+                        ]
+                    }
                 ]
             },
             "EvalTask": {
@@ -5903,148 +5740,7 @@
                         }
                     },
                     "return_type": {
-                        "oneOf": [
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "const": "string",
-                                        "default": "string"
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "type"
-                                ]
-                            },
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "const": "number",
-                                        "default": "number"
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "type"
-                                ]
-                            },
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "const": "boolean",
-                                        "default": "boolean"
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "type"
-                                ]
-                            },
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "const": "array",
-                                        "default": "array"
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "type"
-                                ]
-                            },
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "const": "object",
-                                        "default": "object"
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "type"
-                                ]
-                            },
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "const": "json",
-                                        "default": "json"
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "type"
-                                ]
-                            },
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "const": "union",
-                                        "default": "union"
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "type"
-                                ]
-                            },
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "const": "chat_completion_input",
-                                        "default": "chat_completion_input"
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "type"
-                                ]
-                            },
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "const": "completion_input",
-                                        "default": "completion_input"
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "type"
-                                ]
-                            },
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "const": "agent_turn_input",
-                                        "default": "agent_turn_input"
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "type"
-                                ]
-                            }
-                        ]
+                        "$ref": "#/components/schemas/ParamType"
                     },
                     "params": {
                         "oneOf": [
@@ -6330,19 +6026,12 @@
                                 "type": "string"
                             },
                             {
-                                "$ref": "#/components/schemas/ImageMedia"
+                                "$ref": "#/components/schemas/InterleavedContentItem"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "oneOf": [
-                                        {
-                                            "type": "string"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/ImageMedia"
-                                        }
-                                    ]
+                                    "$ref": "#/components/schemas/InterleavedContentItem"
                                 }
                             },
                             {
@@ -6960,27 +6649,7 @@
                         "type": "string"
                     },
                     "query": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "$ref": "#/components/schemas/ImageMedia"
-                            },
-                            {
-                                "type": "array",
-                                "items": {
-                                    "oneOf": [
-                                        {
-                                            "type": "string"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/ImageMedia"
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
+                        "$ref": "#/components/schemas/InterleavedContent"
                     },
                     "params": {
                         "type": "object",
@@ -7023,27 +6692,7 @@
                             "type": "object",
                             "properties": {
                                 "content": {
-                                    "oneOf": [
-                                        {
-                                            "type": "string"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/ImageMedia"
-                                        },
-                                        {
-                                            "type": "array",
-                                            "items": {
-                                                "oneOf": [
-                                                    {
-                                                        "type": "string"
-                                                    },
-                                                    {
-                                                        "$ref": "#/components/schemas/ImageMedia"
-                                                    }
-                                                ]
-                                            }
-                                        }
-                                    ]
+                                    "$ref": "#/components/schemas/InterleavedContent"
                                 },
                                 "token_count": {
                                     "type": "integer"
@@ -7261,148 +6910,7 @@
                     "dataset_schema": {
                         "type": "object",
                         "additionalProperties": {
-                            "oneOf": [
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string",
-                                            "const": "string",
-                                            "default": "string"
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                        "type"
-                                    ]
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string",
-                                            "const": "number",
-                                            "default": "number"
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                        "type"
-                                    ]
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string",
-                                            "const": "boolean",
-                                            "default": "boolean"
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                        "type"
-                                    ]
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string",
-                                            "const": "array",
-                                            "default": "array"
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                        "type"
-                                    ]
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string",
-                                            "const": "object",
-                                            "default": "object"
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                        "type"
-                                    ]
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string",
-                                            "const": "json",
-                                            "default": "json"
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                        "type"
-                                    ]
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string",
-                                            "const": "union",
-                                            "default": "union"
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                        "type"
-                                    ]
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string",
-                                            "const": "chat_completion_input",
-                                            "default": "chat_completion_input"
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                        "type"
-                                    ]
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string",
-                                            "const": "completion_input",
-                                            "default": "completion_input"
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                        "type"
-                                    ]
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string",
-                                            "const": "agent_turn_input",
-                                            "default": "agent_turn_input"
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                        "type"
-                                    ]
-                                }
-                            ]
+                            "$ref": "#/components/schemas/ParamType"
                         }
                     },
                     "url": {
@@ -7659,148 +7167,7 @@
                         "type": "string"
                     },
                     "return_type": {
-                        "oneOf": [
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "const": "string",
-                                        "default": "string"
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "type"
-                                ]
-                            },
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "const": "number",
-                                        "default": "number"
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "type"
-                                ]
-                            },
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "const": "boolean",
-                                        "default": "boolean"
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "type"
-                                ]
-                            },
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "const": "array",
-                                        "default": "array"
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "type"
-                                ]
-                            },
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "const": "object",
-                                        "default": "object"
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "type"
-                                ]
-                            },
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "const": "json",
-                                        "default": "json"
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "type"
-                                ]
-                            },
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "const": "union",
-                                        "default": "union"
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "type"
-                                ]
-                            },
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "const": "chat_completion_input",
-                                        "default": "chat_completion_input"
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "type"
-                                ]
-                            },
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "const": "completion_input",
-                                        "default": "completion_input"
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "type"
-                                ]
-                            },
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "const": "agent_turn_input",
-                                        "default": "agent_turn_input"
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "type"
-                                ]
-                            }
-                        ]
+                        "$ref": "#/components/schemas/ParamType"
                     },
                     "provider_scoring_fn_id": {
                         "type": "string"
@@ -8680,8 +8047,8 @@
             "description": "<SchemaDefinition schemaRef=\"#/components/schemas/HealthInfo\" />"
         },
         {
-            "name": "ImageMedia",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ImageMedia\" />"
+            "name": "ImageContentItem",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ImageContentItem\" />"
         },
         {
             "name": "Inference"
@@ -8696,6 +8063,14 @@
         },
         {
             "name": "Inspect"
+        },
+        {
+            "name": "InterleavedContent",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/InterleavedContent\" />"
+        },
+        {
+            "name": "InterleavedContentItem",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/InterleavedContentItem\" />"
         },
         {
             "name": "Job",
@@ -8789,6 +8164,10 @@
         {
             "name": "PaginatedRowsResult",
             "description": "<SchemaDefinition schemaRef=\"#/components/schemas/PaginatedRowsResult\" />"
+        },
+        {
+            "name": "ParamType",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ParamType\" />"
         },
         {
             "name": "PhotogenToolDefinition",
@@ -9016,6 +8395,10 @@
             "name": "Telemetry"
         },
         {
+            "name": "TextContentItem",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/TextContentItem\" />"
+        },
+        {
             "name": "TokenLogProbs",
             "description": "<SchemaDefinition schemaRef=\"#/components/schemas/TokenLogProbs\" />"
         },
@@ -9194,9 +8577,11 @@
                 "GraphMemoryBank",
                 "GraphMemoryBankParams",
                 "HealthInfo",
-                "ImageMedia",
+                "ImageContentItem",
                 "InferenceStep",
                 "InsertDocumentsRequest",
+                "InterleavedContent",
+                "InterleavedContentItem",
                 "Job",
                 "JobCancelRequest",
                 "JobStatus",
@@ -9218,6 +8603,7 @@
                 "OptimizerConfig",
                 "OptimizerType",
                 "PaginatedRowsResult",
+                "ParamType",
                 "PhotogenToolDefinition",
                 "PostTrainingJob",
                 "PostTrainingJobArtifactsResponse",
@@ -9269,6 +8655,7 @@
                 "SyntheticDataGenerateRequest",
                 "SyntheticDataGenerationResponse",
                 "SystemMessage",
+                "TextContentItem",
                 "TokenLogProbs",
                 "ToolCall",
                 "ToolCallDelta",

--- a/docs/resources/llama-stack-spec.yaml
+++ b/docs/resources/llama-stack-spec.yaml
@@ -1043,17 +1043,16 @@ components:
       additionalProperties: false
       properties:
         data:
-          oneOf:
-          - contentEncoding: base64
-            type: string
-          - $ref: '#/components/schemas/URL'
+          contentEncoding: base64
+          type: string
         type:
           const: image
           default: image
           type: string
+        url:
+          $ref: '#/components/schemas/URL'
       required:
       - type
-      - data
       type: object
     InferenceStep:
       additionalProperties: false

--- a/docs/resources/llama-stack-spec.yaml
+++ b/docs/resources/llama-stack-spec.yaml
@@ -275,11 +275,9 @@ components:
         content:
           oneOf:
           - type: string
-          - $ref: '#/components/schemas/ImageMedia'
+          - $ref: '#/components/schemas/InterleavedContentItem'
           - items:
-              oneOf:
-              - type: string
-              - $ref: '#/components/schemas/ImageMedia'
+              $ref: '#/components/schemas/InterleavedContentItem'
             type: array
           - $ref: '#/components/schemas/URL'
         mime_type:
@@ -353,14 +351,7 @@ components:
       properties:
         content_batch:
           items:
-            oneOf:
-            - type: string
-            - $ref: '#/components/schemas/ImageMedia'
-            - items:
-                oneOf:
-                - type: string
-                - $ref: '#/components/schemas/ImageMedia'
-              type: array
+            $ref: '#/components/schemas/InterleavedContent'
           type: array
         logprobs:
           additionalProperties: false
@@ -575,14 +566,7 @@ components:
       additionalProperties: false
       properties:
         content:
-          oneOf:
-          - type: string
-          - $ref: '#/components/schemas/ImageMedia'
-          - items:
-              oneOf:
-              - type: string
-              - $ref: '#/components/schemas/ImageMedia'
-            type: array
+          $ref: '#/components/schemas/InterleavedContent'
         role:
           const: assistant
           default: assistant
@@ -603,14 +587,7 @@ components:
       additionalProperties: false
       properties:
         content:
-          oneOf:
-          - type: string
-          - $ref: '#/components/schemas/ImageMedia'
-          - items:
-              oneOf:
-              - type: string
-              - $ref: '#/components/schemas/ImageMedia'
-            type: array
+          $ref: '#/components/schemas/InterleavedContent'
         logprobs:
           additionalProperties: false
           properties:
@@ -788,97 +765,7 @@ components:
       properties:
         dataset_schema:
           additionalProperties:
-            oneOf:
-            - additionalProperties: false
-              properties:
-                type:
-                  const: string
-                  default: string
-                  type: string
-              required:
-              - type
-              type: object
-            - additionalProperties: false
-              properties:
-                type:
-                  const: number
-                  default: number
-                  type: string
-              required:
-              - type
-              type: object
-            - additionalProperties: false
-              properties:
-                type:
-                  const: boolean
-                  default: boolean
-                  type: string
-              required:
-              - type
-              type: object
-            - additionalProperties: false
-              properties:
-                type:
-                  const: array
-                  default: array
-                  type: string
-              required:
-              - type
-              type: object
-            - additionalProperties: false
-              properties:
-                type:
-                  const: object
-                  default: object
-                  type: string
-              required:
-              - type
-              type: object
-            - additionalProperties: false
-              properties:
-                type:
-                  const: json
-                  default: json
-                  type: string
-              required:
-              - type
-              type: object
-            - additionalProperties: false
-              properties:
-                type:
-                  const: union
-                  default: union
-                  type: string
-              required:
-              - type
-              type: object
-            - additionalProperties: false
-              properties:
-                type:
-                  const: chat_completion_input
-                  default: chat_completion_input
-                  type: string
-              required:
-              - type
-              type: object
-            - additionalProperties: false
-              properties:
-                type:
-                  const: completion_input
-                  default: completion_input
-                  type: string
-              required:
-              - type
-              type: object
-            - additionalProperties: false
-              properties:
-                type:
-                  const: agent_turn_input
-                  default: agent_turn_input
-                  type: string
-              required:
-              - type
-              type: object
+            $ref: '#/components/schemas/ParamType'
           type: object
         identifier:
           type: string
@@ -951,14 +838,7 @@ components:
       properties:
         contents:
           items:
-            oneOf:
-            - type: string
-            - $ref: '#/components/schemas/ImageMedia'
-            - items:
-                oneOf:
-                - type: string
-                - $ref: '#/components/schemas/ImageMedia'
-              type: array
+            $ref: '#/components/schemas/InterleavedContent'
           type: array
         model_id:
           type: string
@@ -1159,22 +1039,21 @@ components:
       required:
       - status
       type: object
-    ImageMedia:
+    ImageContentItem:
       additionalProperties: false
       properties:
-        image:
+        data:
           oneOf:
-          - additionalProperties: false
-            properties:
-              format:
-                type: string
-              format_description:
-                type: string
-            title: This class represents an image object.  To create
-            type: object
+          - contentEncoding: base64
+            type: string
           - $ref: '#/components/schemas/URL'
+        type:
+          const: image
+          default: image
+          type: string
       required:
-      - image
+      - type
+      - data
       type: object
     InferenceStep:
       additionalProperties: false
@@ -1216,6 +1095,17 @@ components:
       - bank_id
       - documents
       type: object
+    InterleavedContent:
+      oneOf:
+      - type: string
+      - $ref: '#/components/schemas/InterleavedContentItem'
+      - items:
+          $ref: '#/components/schemas/InterleavedContentItem'
+        type: array
+    InterleavedContentItem:
+      oneOf:
+      - $ref: '#/components/schemas/ImageContentItem'
+      - $ref: '#/components/schemas/TextContentItem'
     Job:
       additionalProperties: false
       properties:
@@ -1395,11 +1285,9 @@ components:
         content:
           oneOf:
           - type: string
-          - $ref: '#/components/schemas/ImageMedia'
+          - $ref: '#/components/schemas/InterleavedContentItem'
           - items:
-              oneOf:
-              - type: string
-              - $ref: '#/components/schemas/ImageMedia'
+              $ref: '#/components/schemas/InterleavedContentItem'
             type: array
           - $ref: '#/components/schemas/URL'
         document_id:
@@ -1428,14 +1316,7 @@ components:
           format: date-time
           type: string
         inserted_context:
-          oneOf:
-          - type: string
-          - $ref: '#/components/schemas/ImageMedia'
-          - items:
-              oneOf:
-              - type: string
-              - $ref: '#/components/schemas/ImageMedia'
-            type: array
+          $ref: '#/components/schemas/InterleavedContent'
         memory_bank_ids:
           items:
             type: string
@@ -1731,6 +1612,98 @@ components:
       - rows
       - total_count
       type: object
+    ParamType:
+      oneOf:
+      - additionalProperties: false
+        properties:
+          type:
+            const: string
+            default: string
+            type: string
+        required:
+        - type
+        type: object
+      - additionalProperties: false
+        properties:
+          type:
+            const: number
+            default: number
+            type: string
+        required:
+        - type
+        type: object
+      - additionalProperties: false
+        properties:
+          type:
+            const: boolean
+            default: boolean
+            type: string
+        required:
+        - type
+        type: object
+      - additionalProperties: false
+        properties:
+          type:
+            const: array
+            default: array
+            type: string
+        required:
+        - type
+        type: object
+      - additionalProperties: false
+        properties:
+          type:
+            const: object
+            default: object
+            type: string
+        required:
+        - type
+        type: object
+      - additionalProperties: false
+        properties:
+          type:
+            const: json
+            default: json
+            type: string
+        required:
+        - type
+        type: object
+      - additionalProperties: false
+        properties:
+          type:
+            const: union
+            default: union
+            type: string
+        required:
+        - type
+        type: object
+      - additionalProperties: false
+        properties:
+          type:
+            const: chat_completion_input
+            default: chat_completion_input
+            type: string
+        required:
+        - type
+        type: object
+      - additionalProperties: false
+        properties:
+          type:
+            const: completion_input
+            default: completion_input
+            type: string
+        required:
+        - type
+        type: object
+      - additionalProperties: false
+        properties:
+          type:
+            const: agent_turn_input
+            default: agent_turn_input
+            type: string
+        required:
+        - type
+        type: object
     PhotogenToolDefinition:
       additionalProperties: false
       properties:
@@ -1918,14 +1891,7 @@ components:
             - type: object
           type: object
         query:
-          oneOf:
-          - type: string
-          - $ref: '#/components/schemas/ImageMedia'
-          - items:
-              oneOf:
-              - type: string
-              - $ref: '#/components/schemas/ImageMedia'
-            type: array
+          $ref: '#/components/schemas/InterleavedContent'
       required:
       - bank_id
       - query
@@ -1938,14 +1904,7 @@ components:
             additionalProperties: false
             properties:
               content:
-                oneOf:
-                - type: string
-                - $ref: '#/components/schemas/ImageMedia'
-                - items:
-                    oneOf:
-                    - type: string
-                    - $ref: '#/components/schemas/ImageMedia'
-                  type: array
+                $ref: '#/components/schemas/InterleavedContent'
               document_id:
                 type: string
               token_count:
@@ -2022,97 +1981,7 @@ components:
           type: string
         dataset_schema:
           additionalProperties:
-            oneOf:
-            - additionalProperties: false
-              properties:
-                type:
-                  const: string
-                  default: string
-                  type: string
-              required:
-              - type
-              type: object
-            - additionalProperties: false
-              properties:
-                type:
-                  const: number
-                  default: number
-                  type: string
-              required:
-              - type
-              type: object
-            - additionalProperties: false
-              properties:
-                type:
-                  const: boolean
-                  default: boolean
-                  type: string
-              required:
-              - type
-              type: object
-            - additionalProperties: false
-              properties:
-                type:
-                  const: array
-                  default: array
-                  type: string
-              required:
-              - type
-              type: object
-            - additionalProperties: false
-              properties:
-                type:
-                  const: object
-                  default: object
-                  type: string
-              required:
-              - type
-              type: object
-            - additionalProperties: false
-              properties:
-                type:
-                  const: json
-                  default: json
-                  type: string
-              required:
-              - type
-              type: object
-            - additionalProperties: false
-              properties:
-                type:
-                  const: union
-                  default: union
-                  type: string
-              required:
-              - type
-              type: object
-            - additionalProperties: false
-              properties:
-                type:
-                  const: chat_completion_input
-                  default: chat_completion_input
-                  type: string
-              required:
-              - type
-              type: object
-            - additionalProperties: false
-              properties:
-                type:
-                  const: completion_input
-                  default: completion_input
-                  type: string
-              required:
-              - type
-              type: object
-            - additionalProperties: false
-              properties:
-                type:
-                  const: agent_turn_input
-                  default: agent_turn_input
-                  type: string
-              required:
-              - type
-              type: object
+            $ref: '#/components/schemas/ParamType'
           type: object
         metadata:
           additionalProperties:
@@ -2223,97 +2092,7 @@ components:
         provider_scoring_fn_id:
           type: string
         return_type:
-          oneOf:
-          - additionalProperties: false
-            properties:
-              type:
-                const: string
-                default: string
-                type: string
-            required:
-            - type
-            type: object
-          - additionalProperties: false
-            properties:
-              type:
-                const: number
-                default: number
-                type: string
-            required:
-            - type
-            type: object
-          - additionalProperties: false
-            properties:
-              type:
-                const: boolean
-                default: boolean
-                type: string
-            required:
-            - type
-            type: object
-          - additionalProperties: false
-            properties:
-              type:
-                const: array
-                default: array
-                type: string
-            required:
-            - type
-            type: object
-          - additionalProperties: false
-            properties:
-              type:
-                const: object
-                default: object
-                type: string
-            required:
-            - type
-            type: object
-          - additionalProperties: false
-            properties:
-              type:
-                const: json
-                default: json
-                type: string
-            required:
-            - type
-            type: object
-          - additionalProperties: false
-            properties:
-              type:
-                const: union
-                default: union
-                type: string
-            required:
-            - type
-            type: object
-          - additionalProperties: false
-            properties:
-              type:
-                const: chat_completion_input
-                default: chat_completion_input
-                type: string
-            required:
-            - type
-            type: object
-          - additionalProperties: false
-            properties:
-              type:
-                const: completion_input
-                default: completion_input
-                type: string
-            required:
-            - type
-            type: object
-          - additionalProperties: false
-            properties:
-              type:
-                const: agent_turn_input
-                default: agent_turn_input
-                type: string
-            required:
-            - type
-            type: object
+          $ref: '#/components/schemas/ParamType'
         scoring_fn_id:
           type: string
       required:
@@ -2623,97 +2402,7 @@ components:
         provider_resource_id:
           type: string
         return_type:
-          oneOf:
-          - additionalProperties: false
-            properties:
-              type:
-                const: string
-                default: string
-                type: string
-            required:
-            - type
-            type: object
-          - additionalProperties: false
-            properties:
-              type:
-                const: number
-                default: number
-                type: string
-            required:
-            - type
-            type: object
-          - additionalProperties: false
-            properties:
-              type:
-                const: boolean
-                default: boolean
-                type: string
-            required:
-            - type
-            type: object
-          - additionalProperties: false
-            properties:
-              type:
-                const: array
-                default: array
-                type: string
-            required:
-            - type
-            type: object
-          - additionalProperties: false
-            properties:
-              type:
-                const: object
-                default: object
-                type: string
-            required:
-            - type
-            type: object
-          - additionalProperties: false
-            properties:
-              type:
-                const: json
-                default: json
-                type: string
-            required:
-            - type
-            type: object
-          - additionalProperties: false
-            properties:
-              type:
-                const: union
-                default: union
-                type: string
-            required:
-            - type
-            type: object
-          - additionalProperties: false
-            properties:
-              type:
-                const: chat_completion_input
-                default: chat_completion_input
-                type: string
-            required:
-            - type
-            type: object
-          - additionalProperties: false
-            properties:
-              type:
-                const: completion_input
-                default: completion_input
-                type: string
-            required:
-            - type
-            type: object
-          - additionalProperties: false
-            properties:
-              type:
-                const: agent_turn_input
-                default: agent_turn_input
-                type: string
-            required:
-            - type
-            type: object
+          $ref: '#/components/schemas/ParamType'
         type:
           const: scoring_function
           default: scoring_function
@@ -3112,14 +2801,7 @@ components:
       additionalProperties: false
       properties:
         content:
-          oneOf:
-          - type: string
-          - $ref: '#/components/schemas/ImageMedia'
-          - items:
-              oneOf:
-              - type: string
-              - $ref: '#/components/schemas/ImageMedia'
-            type: array
+          $ref: '#/components/schemas/InterleavedContent'
         role:
           const: system
           default: system
@@ -3127,6 +2809,19 @@ components:
       required:
       - role
       - content
+      type: object
+    TextContentItem:
+      additionalProperties: false
+      properties:
+        text:
+          type: string
+        type:
+          const: text
+          default: text
+          type: string
+      required:
+      - type
+      - text
       type: object
     TokenLogProbs:
       additionalProperties: false
@@ -3293,14 +2988,7 @@ components:
         call_id:
           type: string
         content:
-          oneOf:
-          - type: string
-          - $ref: '#/components/schemas/ImageMedia'
-          - items:
-              oneOf:
-              - type: string
-              - $ref: '#/components/schemas/ImageMedia'
-            type: array
+          $ref: '#/components/schemas/InterleavedContent'
         tool_name:
           oneOf:
           - $ref: '#/components/schemas/BuiltinTool'
@@ -3316,14 +3004,7 @@ components:
         call_id:
           type: string
         content:
-          oneOf:
-          - type: string
-          - $ref: '#/components/schemas/ImageMedia'
-          - items:
-              oneOf:
-              - type: string
-              - $ref: '#/components/schemas/ImageMedia'
-            type: array
+          $ref: '#/components/schemas/InterleavedContent'
         role:
           const: ipython
           default: ipython
@@ -3492,23 +3173,9 @@ components:
       additionalProperties: false
       properties:
         content:
-          oneOf:
-          - type: string
-          - $ref: '#/components/schemas/ImageMedia'
-          - items:
-              oneOf:
-              - type: string
-              - $ref: '#/components/schemas/ImageMedia'
-            type: array
+          $ref: '#/components/schemas/InterleavedContent'
         context:
-          oneOf:
-          - type: string
-          - $ref: '#/components/schemas/ImageMedia'
-          - items:
-              oneOf:
-              - type: string
-              - $ref: '#/components/schemas/ImageMedia'
-            type: array
+          $ref: '#/components/schemas/InterleavedContent'
         role:
           const: user
           default: user
@@ -5297,8 +4964,9 @@ tags:
   name: GraphMemoryBankParams
 - description: <SchemaDefinition schemaRef="#/components/schemas/HealthInfo" />
   name: HealthInfo
-- description: <SchemaDefinition schemaRef="#/components/schemas/ImageMedia" />
-  name: ImageMedia
+- description: <SchemaDefinition schemaRef="#/components/schemas/ImageContentItem"
+    />
+  name: ImageContentItem
 - name: Inference
 - description: <SchemaDefinition schemaRef="#/components/schemas/InferenceStep" />
   name: InferenceStep
@@ -5306,6 +4974,12 @@ tags:
     />
   name: InsertDocumentsRequest
 - name: Inspect
+- description: <SchemaDefinition schemaRef="#/components/schemas/InterleavedContent"
+    />
+  name: InterleavedContent
+- description: <SchemaDefinition schemaRef="#/components/schemas/InterleavedContentItem"
+    />
+  name: InterleavedContentItem
 - description: <SchemaDefinition schemaRef="#/components/schemas/Job" />
   name: Job
 - description: <SchemaDefinition schemaRef="#/components/schemas/JobCancelRequest"
@@ -5364,6 +5038,8 @@ tags:
 - description: <SchemaDefinition schemaRef="#/components/schemas/PaginatedRowsResult"
     />
   name: PaginatedRowsResult
+- description: <SchemaDefinition schemaRef="#/components/schemas/ParamType" />
+  name: ParamType
 - description: <SchemaDefinition schemaRef="#/components/schemas/PhotogenToolDefinition"
     />
   name: PhotogenToolDefinition
@@ -5521,6 +5197,9 @@ tags:
 - description: <SchemaDefinition schemaRef="#/components/schemas/SystemMessage" />
   name: SystemMessage
 - name: Telemetry
+- description: <SchemaDefinition schemaRef="#/components/schemas/TextContentItem"
+    />
+  name: TextContentItem
 - description: <SchemaDefinition schemaRef="#/components/schemas/TokenLogProbs" />
   name: TokenLogProbs
 - description: <SchemaDefinition schemaRef="#/components/schemas/ToolCall" />
@@ -5670,9 +5349,11 @@ x-tagGroups:
   - GraphMemoryBank
   - GraphMemoryBankParams
   - HealthInfo
-  - ImageMedia
+  - ImageContentItem
   - InferenceStep
   - InsertDocumentsRequest
+  - InterleavedContent
+  - InterleavedContentItem
   - Job
   - JobCancelRequest
   - JobStatus
@@ -5694,6 +5375,7 @@ x-tagGroups:
   - OptimizerConfig
   - OptimizerType
   - PaginatedRowsResult
+  - ParamType
   - PhotogenToolDefinition
   - PostTrainingJob
   - PostTrainingJobArtifactsResponse
@@ -5745,6 +5427,7 @@ x-tagGroups:
   - SyntheticDataGenerateRequest
   - SyntheticDataGenerationResponse
   - SystemMessage
+  - TextContentItem
   - TokenLogProbs
   - ToolCall
   - ToolCallDelta

--- a/llama_stack/apis/agents/agents.py
+++ b/llama_stack/apis/agents/agents.py
@@ -29,8 +29,7 @@ from llama_stack.apis.common.deployment_types import *  # noqa: F403
 from llama_stack.apis.inference import *  # noqa: F403
 from llama_stack.apis.safety import *  # noqa: F403
 from llama_stack.apis.memory import *  # noqa: F403
-from llama_stack.apis.common.deployment_types import URL
-from llama_stack.apis.inference import InterleavedContent
+from llama_stack.apis.common.content_types import InterleavedContent, URL
 
 
 @json_schema_type

--- a/llama_stack/apis/agents/agents.py
+++ b/llama_stack/apis/agents/agents.py
@@ -29,11 +29,13 @@ from llama_stack.apis.common.deployment_types import *  # noqa: F403
 from llama_stack.apis.inference import *  # noqa: F403
 from llama_stack.apis.safety import *  # noqa: F403
 from llama_stack.apis.memory import *  # noqa: F403
+from llama_stack.apis.common.deployment_types import URL
+from llama_stack.apis.inference import InterleavedContent
 
 
 @json_schema_type
 class Attachment(BaseModel):
-    content: InterleavedTextMedia | URL
+    content: InterleavedContent | URL
     mime_type: str
 
 
@@ -102,20 +104,20 @@ class _MemoryBankConfigCommon(BaseModel):
 
 
 class AgentVectorMemoryBankConfig(_MemoryBankConfigCommon):
-    type: Literal[MemoryBankType.vector.value] = MemoryBankType.vector.value
+    type: Literal["vector"] = "vector"
 
 
 class AgentKeyValueMemoryBankConfig(_MemoryBankConfigCommon):
-    type: Literal[MemoryBankType.keyvalue.value] = MemoryBankType.keyvalue.value
+    type: Literal["keyvalue"] = "keyvalue"
     keys: List[str]  # what keys to focus on
 
 
 class AgentKeywordMemoryBankConfig(_MemoryBankConfigCommon):
-    type: Literal[MemoryBankType.keyword.value] = MemoryBankType.keyword.value
+    type: Literal["keyword"] = "keyword"
 
 
 class AgentGraphMemoryBankConfig(_MemoryBankConfigCommon):
-    type: Literal[MemoryBankType.graph.value] = MemoryBankType.graph.value
+    type: Literal["graph"] = "graph"
     entities: List[str]  # what entities to focus on
 
 
@@ -230,7 +232,7 @@ class MemoryRetrievalStep(StepCommon):
         StepType.memory_retrieval.value
     )
     memory_bank_ids: List[str]
-    inserted_context: InterleavedTextMedia
+    inserted_context: InterleavedContent
 
 
 Step = Annotated[

--- a/llama_stack/apis/batch_inference/batch_inference.py
+++ b/llama_stack/apis/batch_inference/batch_inference.py
@@ -17,7 +17,7 @@ from llama_stack.apis.inference import *  # noqa: F403
 @json_schema_type
 class BatchCompletionRequest(BaseModel):
     model: str
-    content_batch: List[InterleavedTextMedia]
+    content_batch: List[InterleavedContent]
     sampling_params: Optional[SamplingParams] = SamplingParams()
     logprobs: Optional[LogProbConfig] = None
 
@@ -53,7 +53,7 @@ class BatchInference(Protocol):
     async def batch_completion(
         self,
         model: str,
-        content_batch: List[InterleavedTextMedia],
+        content_batch: List[InterleavedContent],
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         logprobs: Optional[LogProbConfig] = None,
     ) -> BatchCompletionResponse: ...

--- a/llama_stack/apis/common/content_types.py
+++ b/llama_stack/apis/common/content_types.py
@@ -1,0 +1,49 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from typing import Annotated, List, Literal, Union
+
+from llama_models.schema_utils import json_schema_type, register_schema
+
+from pydantic import BaseModel, Field
+
+
+@json_schema_type(
+    schema={"type": "string", "format": "uri", "pattern": "^(https?://|file://|data:)"}
+)
+class URL(BaseModel):
+    uri: str
+
+    def __str__(self) -> str:
+        return self.uri
+
+
+@json_schema_type
+class ImageContentItem(BaseModel):
+    type: Literal["image"] = "image"
+    data: Union[bytes, URL]
+
+
+@json_schema_type
+class TextContentItem(BaseModel):
+    type: Literal["text"] = "text"
+    text: str
+
+
+# other modalities can be added here
+InterleavedContentItem = register_schema(
+    Annotated[
+        Union[ImageContentItem, TextContentItem],
+        Field(discriminator="type"),
+    ],
+    name="InterleavedContentItem",
+)
+
+# accept a single "str" as a special case since it is common
+InterleavedContent = register_schema(
+    Union[str, InterleavedContentItem, List[InterleavedContentItem]],
+    name="InterleavedContent",
+)

--- a/llama_stack/apis/common/content_types.py
+++ b/llama_stack/apis/common/content_types.py
@@ -4,11 +4,11 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from typing import Annotated, List, Literal, Union
+from typing import Annotated, List, Literal, Optional, Union
 
 from llama_models.schema_utils import json_schema_type, register_schema
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 @json_schema_type(
@@ -21,10 +21,21 @@ class URL(BaseModel):
         return self.uri
 
 
+class _URLOrData(BaseModel):
+    url: Optional[URL] = None
+    data: Optional[bytes] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def validator(cls, values):
+        if isinstance(values, dict):
+            return values
+        return {"url": values}
+
+
 @json_schema_type
-class ImageContentItem(BaseModel):
+class ImageContentItem(_URLOrData):
     type: Literal["image"] = "image"
-    data: Union[bytes, URL]
 
 
 @json_schema_type

--- a/llama_stack/apis/common/deployment_types.py
+++ b/llama_stack/apis/common/deployment_types.py
@@ -12,16 +12,6 @@ from llama_models.schema_utils import json_schema_type
 from pydantic import BaseModel
 
 
-@json_schema_type(
-    schema={"type": "string", "format": "uri", "pattern": "^(https?://|file://|data:)"}
-)
-class URL(BaseModel):
-    uri: str
-
-    def __str__(self) -> str:
-        return self.uri
-
-
 @json_schema_type
 class RestAPIMethod(Enum):
     GET = "GET"

--- a/llama_stack/apis/common/deployment_types.py
+++ b/llama_stack/apis/common/deployment_types.py
@@ -7,11 +7,19 @@
 from enum import Enum
 from typing import Any, Dict, Optional
 
-from llama_models.llama3.api.datatypes import URL
-
 from llama_models.schema_utils import json_schema_type
 
 from pydantic import BaseModel
+
+
+@json_schema_type(
+    schema={"type": "string", "format": "uri", "pattern": "^(https?://|file://|data:)"}
+)
+class URL(BaseModel):
+    uri: str
+
+    def __str__(self) -> str:
+        return self.uri
 
 
 @json_schema_type

--- a/llama_stack/apis/common/deployment_types.py
+++ b/llama_stack/apis/common/deployment_types.py
@@ -11,6 +11,8 @@ from llama_models.schema_utils import json_schema_type
 
 from pydantic import BaseModel
 
+from llama_stack.apis.common.content_types import URL
+
 
 @json_schema_type
 class RestAPIMethod(Enum):

--- a/llama_stack/apis/common/training_types.py
+++ b/llama_stack/apis/common/training_types.py
@@ -10,8 +10,6 @@ from typing import Optional
 from llama_models.schema_utils import json_schema_type
 from pydantic import BaseModel
 
-from llama_stack.apis.common.deployment_types import URL
-
 
 @json_schema_type
 class PostTrainingMetric(BaseModel):

--- a/llama_stack/apis/common/training_types.py
+++ b/llama_stack/apis/common/training_types.py
@@ -10,6 +10,8 @@ from typing import Optional
 from llama_models.schema_utils import json_schema_type
 from pydantic import BaseModel
 
+from llama_stack.apis.common.deployment_types import URL
+
 
 @json_schema_type
 class PostTrainingMetric(BaseModel):

--- a/llama_stack/apis/common/type_system.py
+++ b/llama_stack/apis/common/type_system.py
@@ -6,6 +6,7 @@
 
 from typing import Literal, Union
 
+from llama_models.schema_utils import register_schema
 from pydantic import BaseModel, Field
 from typing_extensions import Annotated
 
@@ -53,21 +54,24 @@ class AgentTurnInputType(BaseModel):
     type: Literal["agent_turn_input"] = "agent_turn_input"
 
 
-ParamType = Annotated[
-    Union[
-        StringType,
-        NumberType,
-        BooleanType,
-        ArrayType,
-        ObjectType,
-        JsonType,
-        UnionType,
-        ChatCompletionInputType,
-        CompletionInputType,
-        AgentTurnInputType,
+ParamType = register_schema(
+    Annotated[
+        Union[
+            StringType,
+            NumberType,
+            BooleanType,
+            ArrayType,
+            ObjectType,
+            JsonType,
+            UnionType,
+            ChatCompletionInputType,
+            CompletionInputType,
+            AgentTurnInputType,
+        ],
+        Field(discriminator="type"),
     ],
-    Field(discriminator="type"),
-]
+    name="ParamType",
+)
 
 # TODO: recursive definition of ParamType in these containers
 # will cause infinite recursion in OpenAPI generation script

--- a/llama_stack/apis/datasets/datasets.py
+++ b/llama_stack/apis/datasets/datasets.py
@@ -6,11 +6,11 @@
 
 from typing import Any, Dict, List, Literal, Optional, Protocol
 
-from llama_models.llama3.api.datatypes import URL
-
 from llama_models.schema_utils import json_schema_type, webmethod
 
 from pydantic import BaseModel, Field
+
+from llama_stack.apis.common.deployment_types import URL
 
 from llama_stack.apis.common.type_system import ParamType
 from llama_stack.apis.resource import Resource, ResourceType

--- a/llama_stack/apis/datasets/datasets.py
+++ b/llama_stack/apis/datasets/datasets.py
@@ -10,7 +10,7 @@ from llama_models.schema_utils import json_schema_type, webmethod
 
 from pydantic import BaseModel, Field
 
-from llama_stack.apis.common.deployment_types import URL
+from llama_stack.apis.common.content_types import URL
 
 from llama_stack.apis.common.type_system import ParamType
 from llama_stack.apis.resource import Resource, ResourceType

--- a/llama_stack/apis/eval/eval.py
+++ b/llama_stack/apis/eval/eval.py
@@ -15,6 +15,7 @@ from llama_stack.apis.agents import AgentConfig
 from llama_stack.apis.common.job_types import Job, JobStatus
 from llama_stack.apis.scoring import *  # noqa: F403
 from llama_stack.apis.eval_tasks import *  # noqa: F403
+from llama_stack.apis.inference import SamplingParams, SystemMessage
 
 
 @json_schema_type

--- a/llama_stack/apis/inference/inference.py
+++ b/llama_stack/apis/inference/inference.py
@@ -25,12 +25,12 @@ from llama_models.llama3.api.datatypes import (
     ToolPromptFormat,
 )
 
-from llama_models.schema_utils import json_schema_type, register_schema, webmethod
+from llama_models.schema_utils import json_schema_type, webmethod
 
 from pydantic import BaseModel, Field, field_validator
 from typing_extensions import Annotated
 
-from llama_stack.apis.common.deployment_types import URL
+from llama_stack.apis.common.content_types import InterleavedContent
 
 from llama_stack.providers.utils.telemetry.trace_protocol import trace_protocol
 from llama_stack.apis.models import *  # noqa: F403
@@ -67,34 +67,6 @@ QuantizationConfig = Annotated[
     Union[Bf16QuantizationConfig, Fp8QuantizationConfig, Int4QuantizationConfig],
     Field(discriminator="type"),
 ]
-
-
-@json_schema_type
-class ImageContentItem(BaseModel):
-    type: Literal["image"] = "image"
-    data: Union[bytes, URL]
-
-
-@json_schema_type
-class TextContentItem(BaseModel):
-    type: Literal["text"] = "text"
-    text: str
-
-
-# other modalities can be added here
-InterleavedContentItem = register_schema(
-    Annotated[
-        Union[ImageContentItem, TextContentItem],
-        Field(discriminator="type"),
-    ],
-    name="InterleavedContentItem",
-)
-
-# accept a single "str" as a special case since it is common
-InterleavedContent = register_schema(
-    Union[str, InterleavedContentItem, List[InterleavedContentItem]],
-    name="InterleavedContent",
-)
 
 
 @json_schema_type

--- a/llama_stack/apis/inference/inference.py
+++ b/llama_stack/apis/inference/inference.py
@@ -25,7 +25,7 @@ from llama_models.llama3.api.datatypes import (
     ToolPromptFormat,
 )
 
-from llama_models.schema_utils import json_schema_type, webmethod
+from llama_models.schema_utils import json_schema_type, register_schema, webmethod
 
 from pydantic import BaseModel, Field, field_validator
 from typing_extensions import Annotated
@@ -82,13 +82,19 @@ class TextContentItem(BaseModel):
 
 
 # other modalities can be added here
-InterleavedContentItem = Annotated[
-    Union[ImageContentItem, TextContentItem],
-    Field(discriminator="type"),
-]
+InterleavedContentItem = register_schema(
+    Annotated[
+        Union[ImageContentItem, TextContentItem],
+        Field(discriminator="type"),
+    ],
+    name="InterleavedContentItem",
+)
 
 # accept a single "str" as a special case since it is common
-InterleavedContent = str | InterleavedContentItem | List[InterleavedContentItem]
+InterleavedContent = register_schema(
+    Union[str, InterleavedContentItem, List[InterleavedContentItem]],
+    name="InterleavedContent",
+)
 
 
 @json_schema_type

--- a/llama_stack/apis/inference/inference.py
+++ b/llama_stack/apis/inference/inference.py
@@ -16,14 +16,23 @@ from typing import (
     Union,
 )
 
+from llama_models.llama3.api.datatypes import (
+    BuiltinTool,
+    SamplingParams,
+    StopReason,
+    ToolCall,
+    ToolDefinition,
+    ToolPromptFormat,
+)
+
 from llama_models.schema_utils import json_schema_type, webmethod
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from typing_extensions import Annotated
 
-from llama_stack.providers.utils.telemetry.trace_protocol import trace_protocol
+from llama_stack.apis.common.deployment_types import URL
 
-from llama_models.llama3.api.datatypes import *  # noqa: F403
+from llama_stack.providers.utils.telemetry.trace_protocol import trace_protocol
 from llama_stack.apis.models import *  # noqa: F403
 
 
@@ -40,17 +49,17 @@ class QuantizationType(Enum):
 
 @json_schema_type
 class Fp8QuantizationConfig(BaseModel):
-    type: Literal[QuantizationType.fp8.value] = QuantizationType.fp8.value
+    type: Literal["fp8"] = "fp8"
 
 
 @json_schema_type
 class Bf16QuantizationConfig(BaseModel):
-    type: Literal[QuantizationType.bf16.value] = QuantizationType.bf16.value
+    type: Literal["bf16"] = "bf16"
 
 
 @json_schema_type
 class Int4QuantizationConfig(BaseModel):
-    type: Literal[QuantizationType.int4.value] = QuantizationType.int4.value
+    type: Literal["int4"] = "int4"
     scheme: Optional[str] = "int4_weight_int8_dynamic_activation"
 
 
@@ -58,6 +67,98 @@ QuantizationConfig = Annotated[
     Union[Bf16QuantizationConfig, Fp8QuantizationConfig, Int4QuantizationConfig],
     Field(discriminator="type"),
 ]
+
+
+@json_schema_type
+class ImageContentItem(BaseModel):
+    type: Literal["image"] = "image"
+    data: Union[bytes, URL]
+
+
+@json_schema_type
+class TextContentItem(BaseModel):
+    type: Literal["text"] = "text"
+    text: str
+
+
+# other modalities can be added here
+InterleavedContentItem = Annotated[
+    Union[ImageContentItem, TextContentItem],
+    Field(discriminator="type"),
+]
+
+# accept a single "str" as a special case since it is common
+InterleavedContent = str | InterleavedContentItem | List[InterleavedContentItem]
+
+
+@json_schema_type
+class UserMessage(BaseModel):
+    role: Literal["user"] = "user"
+    content: InterleavedContent
+    context: Optional[InterleavedContent] = None
+
+
+@json_schema_type
+class SystemMessage(BaseModel):
+    role: Literal["system"] = "system"
+    content: InterleavedContent
+
+
+@json_schema_type
+class ToolResponseMessage(BaseModel):
+    role: Literal["ipython"] = "ipython"
+    # it was nice to re-use the ToolResponse type, but having all messages
+    # have a `content` type makes things nicer too
+    call_id: str
+    tool_name: Union[BuiltinTool, str]
+    content: InterleavedContent
+
+
+@json_schema_type
+class CompletionMessage(BaseModel):
+    role: Literal["assistant"] = "assistant"
+    content: InterleavedContent
+    stop_reason: StopReason
+    tool_calls: List[ToolCall] = Field(default_factory=list)
+
+
+Message = Annotated[
+    Union[
+        UserMessage,
+        SystemMessage,
+        ToolResponseMessage,
+        CompletionMessage,
+    ],
+    Field(discriminator="role"),
+]
+
+
+@json_schema_type
+class ToolResponse(BaseModel):
+    call_id: str
+    tool_name: Union[BuiltinTool, str]
+    content: InterleavedContent
+
+    @field_validator("tool_name", mode="before")
+    @classmethod
+    def validate_field(cls, v):
+        if isinstance(v, str):
+            try:
+                return BuiltinTool(v)
+            except ValueError:
+                return v
+        return v
+
+
+@json_schema_type
+class ToolChoice(Enum):
+    auto = "auto"
+    required = "required"
+
+
+@json_schema_type
+class TokenLogProbs(BaseModel):
+    logprobs_by_token: Dict[str, float]
 
 
 @json_schema_type
@@ -117,7 +218,7 @@ ResponseFormat = Annotated[
 @json_schema_type
 class CompletionRequest(BaseModel):
     model: str
-    content: InterleavedTextMedia
+    content: InterleavedContent
     sampling_params: Optional[SamplingParams] = SamplingParams()
     response_format: Optional[ResponseFormat] = None
 
@@ -230,7 +331,7 @@ class Inference(Protocol):
     async def completion(
         self,
         model_id: str,
-        content: InterleavedTextMedia,
+        content: InterleavedContent,
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
         stream: Optional[bool] = False,
@@ -258,5 +359,5 @@ class Inference(Protocol):
     async def embeddings(
         self,
         model_id: str,
-        contents: List[InterleavedTextMedia],
+        contents: List[InterleavedContent],
     ) -> EmbeddingsResponse: ...

--- a/llama_stack/apis/inference/inference.py
+++ b/llama_stack/apis/inference/inference.py
@@ -247,7 +247,7 @@ class CompletionResponseStreamChunk(BaseModel):
 @json_schema_type
 class BatchCompletionRequest(BaseModel):
     model: str
-    content_batch: List[InterleavedTextMedia]
+    content_batch: List[InterleavedContent]
     sampling_params: Optional[SamplingParams] = SamplingParams()
     response_format: Optional[ResponseFormat] = None
     logprobs: Optional[LogProbConfig] = None

--- a/llama_stack/apis/memory/memory.py
+++ b/llama_stack/apis/memory/memory.py
@@ -8,27 +8,27 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
-from typing import List, Optional, Protocol, runtime_checkable
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
 
 from llama_models.schema_utils import json_schema_type, webmethod
-
 from pydantic import BaseModel, Field
 
-from llama_models.llama3.api.datatypes import *  # noqa: F403
-from llama_stack.apis.memory_banks import *  # noqa: F403
+from llama_stack.apis.common.deployment_types import URL
+from llama_stack.apis.inference import InterleavedContent
+from llama_stack.apis.memory_banks import MemoryBank
 from llama_stack.providers.utils.telemetry.trace_protocol import trace_protocol
 
 
 @json_schema_type
 class MemoryBankDocument(BaseModel):
     document_id: str
-    content: InterleavedTextMedia | URL
+    content: InterleavedContent | URL
     mime_type: str | None = None
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
 
 class Chunk(BaseModel):
-    content: InterleavedTextMedia
+    content: InterleavedContent
     token_count: int
     document_id: str
 
@@ -62,6 +62,6 @@ class Memory(Protocol):
     async def query_documents(
         self,
         bank_id: str,
-        query: InterleavedTextMedia,
+        query: InterleavedContent,
         params: Optional[Dict[str, Any]] = None,
     ) -> QueryDocumentsResponse: ...

--- a/llama_stack/apis/memory/memory.py
+++ b/llama_stack/apis/memory/memory.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
 from llama_models.schema_utils import json_schema_type, webmethod
 from pydantic import BaseModel, Field
 
-from llama_stack.apis.common.deployment_types import URL
+from llama_stack.apis.common.content_types import URL
 from llama_stack.apis.inference import InterleavedContent
 from llama_stack.apis.memory_banks import MemoryBank
 from llama_stack.providers.utils.telemetry.trace_protocol import trace_protocol

--- a/llama_stack/apis/safety/safety.py
+++ b/llama_stack/apis/safety/safety.py
@@ -5,15 +5,15 @@
 # the root directory of this source tree.
 
 from enum import Enum
-from typing import Any, Dict, List, Protocol, runtime_checkable
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
 
 from llama_models.schema_utils import json_schema_type, webmethod
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+from llama_stack.apis.inference import Message
+from llama_stack.apis.shields import Shield
 
 from llama_stack.providers.utils.telemetry.trace_protocol import trace_protocol
-
-from llama_models.llama3.api.datatypes import *  # noqa: F403
-from llama_stack.apis.shields import *  # noqa: F403
 
 
 @json_schema_type

--- a/llama_stack/apis/synthetic_data_generation/synthetic_data_generation.py
+++ b/llama_stack/apis/synthetic_data_generation/synthetic_data_generation.py
@@ -13,6 +13,7 @@ from llama_models.schema_utils import json_schema_type, webmethod
 from pydantic import BaseModel
 
 from llama_models.llama3.api.datatypes import *  # noqa: F403
+from llama_stack.apis.inference import Message
 
 
 class FilteringFunction(Enum):

--- a/llama_stack/distribution/library_client.py
+++ b/llama_stack/distribution/library_client.py
@@ -25,7 +25,6 @@ from llama_stack_client import (
     AsyncStream,
     LlamaStackClient,
     NOT_GIVEN,
-    Stream,
 )
 from pydantic import BaseModel, TypeAdapter
 from rich.console import Console
@@ -370,8 +369,10 @@ class AsyncLlamaStackAsLibraryClient(AsyncLlamaStackClient):
                     json=options.json_data,
                 ),
             )
-            origin = get_origin(stream_cls)
-            assert origin is Stream
+
+            # we use asynchronous impl always internally and channel all requests to AsyncLlamaStackClient
+            # however, the top-level caller may be a SyncAPIClient -- so its stream_cls might be a Stream (SyncStream)
+            # so we need to convert it to AsyncStream
             args = get_args(stream_cls)
             stream_cls = AsyncStream[args[0]]
             response = AsyncAPIResponse(

--- a/llama_stack/distribution/library_client.py
+++ b/llama_stack/distribution/library_client.py
@@ -13,10 +13,20 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from pathlib import Path
-from typing import Any, Generator, get_args, get_origin, Optional, Type, TypeVar, Union
+from typing import Any, Generator, get_args, get_origin, Optional, TypeVar
+
+import httpx
 
 import yaml
-from llama_stack_client import AsyncLlamaStackClient, LlamaStackClient, NOT_GIVEN
+from llama_stack_client import (
+    APIResponse,
+    AsyncAPIResponse,
+    AsyncLlamaStackClient,
+    AsyncStream,
+    LlamaStackClient,
+    NOT_GIVEN,
+    Stream,
+)
 from pydantic import BaseModel, TypeAdapter
 from rich.console import Console
 
@@ -66,7 +76,7 @@ def stream_across_asyncio_run_boundary(
         # make sure we make the generator in the event loop context
         gen = await async_gen_maker()
         try:
-            async for item in gen:
+            async for item in await gen:
                 result_queue.put(item)
         except Exception as e:
             print(f"Error in generator {e}")
@@ -112,31 +122,17 @@ def stream_across_asyncio_run_boundary(
         future.result()
 
 
-def convert_pydantic_to_json_value(value: Any, cast_to: Type) -> dict:
+def convert_pydantic_to_json_value(value: Any) -> Any:
     if isinstance(value, Enum):
         return value.value
     elif isinstance(value, list):
-        return [convert_pydantic_to_json_value(item, cast_to) for item in value]
+        return [convert_pydantic_to_json_value(item) for item in value]
     elif isinstance(value, dict):
-        return {k: convert_pydantic_to_json_value(v, cast_to) for k, v in value.items()}
+        return {k: convert_pydantic_to_json_value(v) for k, v in value.items()}
     elif isinstance(value, BaseModel):
-        # This is quite hacky and we should figure out how to use stuff from
-        # generated client-sdk code (using ApiResponse.parse() essentially)
-        value_dict = json.loads(value.model_dump_json())
-
-        origin = get_origin(cast_to)
-        if origin is Union:
-            args = get_args(cast_to)
-            for arg in args:
-                arg_name = arg.__name__.split(".")[-1]
-                value_name = value.__class__.__name__.split(".")[-1]
-                if arg_name == value_name:
-                    return arg(**value_dict)
-
-        # assume we have the correct association between the server-side type and the client-side type
-        return cast_to(**value_dict)
-
-    return value
+        return json.loads(value.model_dump_json())
+    else:
+        return value
 
 
 def convert_to_pydantic(annotation: Any, value: Any) -> Any:
@@ -278,16 +274,28 @@ class AsyncLlamaStackAsLibraryClient(AsyncLlamaStackClient):
         if not self.endpoint_impls:
             raise ValueError("Client not initialized")
 
-        params = options.params or {}
-        params |= options.json_data or {}
         if stream:
-            return self._call_streaming(options.url, params, cast_to)
+            return self._call_streaming(
+                cast_to=cast_to,
+                options=options,
+                stream_cls=stream_cls,
+            )
         else:
-            return await self._call_non_streaming(options.url, params, cast_to)
+            return await self._call_non_streaming(
+                cast_to=cast_to,
+                options=options,
+            )
 
     async def _call_non_streaming(
-        self, path: str, body: dict = None, cast_to: Any = None
+        self,
+        *,
+        cast_to: Any,
+        options: Any,
     ):
+        path = options.url
+
+        body = options.params or {}
+        body |= options.json_data or {}
         await start_trace(path, {"__location__": "library_client"})
         try:
             func = self.endpoint_impls.get(path)
@@ -295,11 +303,45 @@ class AsyncLlamaStackAsLibraryClient(AsyncLlamaStackClient):
                 raise ValueError(f"No endpoint found for {path}")
 
             body = self._convert_body(path, body)
-            return convert_pydantic_to_json_value(await func(**body), cast_to)
+            result = await func(**body)
+
+            json_content = json.dumps(convert_pydantic_to_json_value(result))
+            mock_response = httpx.Response(
+                status_code=httpx.codes.OK,
+                content=json_content.encode("utf-8"),
+                headers={
+                    "Content-Type": "application/json",
+                },
+                request=httpx.Request(
+                    method=options.method,
+                    url=options.url,
+                    params=options.params,
+                    headers=options.headers,
+                    json=options.json_data,
+                ),
+            )
+            response = APIResponse(
+                raw=mock_response,
+                client=self,
+                cast_to=cast_to,
+                options=options,
+                stream=False,
+                stream_cls=None,
+            )
+            return response.parse()
         finally:
             await end_trace()
 
-    async def _call_streaming(self, path: str, body: dict = None, cast_to: Any = None):
+    async def _call_streaming(
+        self,
+        *,
+        cast_to: Any,
+        options: Any,
+        stream_cls: Any,
+    ):
+        path = options.url
+        body = options.params or {}
+        body |= options.json_data or {}
         await start_trace(path, {"__location__": "library_client"})
         try:
             func = self.endpoint_impls.get(path)
@@ -307,8 +349,40 @@ class AsyncLlamaStackAsLibraryClient(AsyncLlamaStackClient):
                 raise ValueError(f"No endpoint found for {path}")
 
             body = self._convert_body(path, body)
-            async for chunk in await func(**body):
-                yield convert_pydantic_to_json_value(chunk, cast_to)
+
+            async def gen():
+                async for chunk in await func(**body):
+                    data = json.dumps(convert_pydantic_to_json_value(chunk))
+                    sse_event = f"data: {data}\n\n"
+                    yield sse_event.encode("utf-8")
+
+            mock_response = httpx.Response(
+                status_code=httpx.codes.OK,
+                content=gen(),
+                headers={
+                    "Content-Type": "application/json",
+                },
+                request=httpx.Request(
+                    method=options.method,
+                    url=options.url,
+                    params=options.params,
+                    headers=options.headers,
+                    json=options.json_data,
+                ),
+            )
+            origin = get_origin(stream_cls)
+            assert origin is Stream
+            args = get_args(stream_cls)
+            stream_cls = AsyncStream[args[0]]
+            response = AsyncAPIResponse(
+                raw=mock_response,
+                client=self,
+                cast_to=cast_to,
+                options=options,
+                stream=True,
+                stream_cls=stream_cls,
+            )
+            return await response.parse()
         finally:
             await end_trace()
 

--- a/llama_stack/distribution/routers/routers.py
+++ b/llama_stack/distribution/routers/routers.py
@@ -59,7 +59,7 @@ class MemoryRouter(Memory):
     async def query_documents(
         self,
         bank_id: str,
-        query: InterleavedTextMedia,
+        query: InterleavedContent,
         params: Optional[Dict[str, Any]] = None,
     ) -> QueryDocumentsResponse:
         return await self.routing_table.get_provider_impl(bank_id).query_documents(
@@ -133,7 +133,7 @@ class InferenceRouter(Inference):
     async def completion(
         self,
         model_id: str,
-        content: InterleavedTextMedia,
+        content: InterleavedContent,
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
         stream: Optional[bool] = False,
@@ -163,7 +163,7 @@ class InferenceRouter(Inference):
     async def embeddings(
         self,
         model_id: str,
-        contents: List[InterleavedTextMedia],
+        contents: List[InterleavedContent],
     ) -> EmbeddingsResponse:
         model = await self.routing_table.get_model(model_id)
         if model is None:

--- a/llama_stack/distribution/routers/routing_tables.py
+++ b/llama_stack/distribution/routers/routing_tables.py
@@ -16,7 +16,7 @@ from llama_stack.apis.memory_banks import *  # noqa: F403
 from llama_stack.apis.datasets import *  # noqa: F403
 from llama_stack.apis.eval_tasks import *  # noqa: F403
 
-from llama_stack.apis.common.deployment_types import URL
+from llama_stack.apis.common.content_types import URL
 
 from llama_stack.apis.common.type_system import ParamType
 from llama_stack.distribution.store import DistributionRegistry

--- a/llama_stack/distribution/routers/routing_tables.py
+++ b/llama_stack/distribution/routers/routing_tables.py
@@ -16,8 +16,7 @@ from llama_stack.apis.memory_banks import *  # noqa: F403
 from llama_stack.apis.datasets import *  # noqa: F403
 from llama_stack.apis.eval_tasks import *  # noqa: F403
 
-
-from llama_models.llama3.api.datatypes import URL
+from llama_stack.apis.common.deployment_types import URL
 
 from llama_stack.apis.common.type_system import ParamType
 from llama_stack.distribution.store import DistributionRegistry
@@ -30,7 +29,6 @@ def get_impl_api(p: Any) -> Api:
 
 # TODO: this should return the registered object for all APIs
 async def register_object_with_provider(obj: RoutableObject, p: Any) -> RoutableObject:
-
     api = get_impl_api(p)
 
     assert obj.provider_id != "remote", "Remote provider should not be registered"
@@ -76,7 +74,6 @@ class CommonRoutingTableImpl(RoutingTable):
         self.dist_registry = dist_registry
 
     async def initialize(self) -> None:
-
         async def add_objects(
             objs: List[RoutableObjectWithProvider], provider_id: str, cls
         ) -> None:

--- a/llama_stack/distribution/stack.py
+++ b/llama_stack/distribution/stack.py
@@ -6,6 +6,7 @@
 
 import logging
 import os
+import re
 from pathlib import Path
 from typing import Any, Dict
 
@@ -143,7 +144,7 @@ def replace_env_vars(config: Any, path: str = "") -> Any:
                 if default_val is None:
                     raise EnvVarError(env_var, path)
                 else:
-                    value = default_val
+                    value = default_val if default_val != "null" else None
 
             # expand "~" from the values
             return os.path.expanduser(value)

--- a/llama_stack/distribution/store/registry.py
+++ b/llama_stack/distribution/store/registry.py
@@ -5,7 +5,6 @@
 # the root directory of this source tree.
 
 import asyncio
-import json
 from contextlib import asynccontextmanager
 from typing import Dict, List, Optional, Protocol, Tuple
 
@@ -54,10 +53,7 @@ def _parse_registry_values(values: List[str]) -> List[RoutableObjectWithProvider
     """Utility function to parse registry values into RoutableObjectWithProvider objects."""
     all_objects = []
     for value in values:
-        obj = pydantic.parse_obj_as(
-            RoutableObjectWithProvider,
-            json.loads(value),
-        )
+        obj = pydantic.TypeAdapter(RoutableObjectWithProvider).validate_json(value)
         all_objects.append(obj)
     return all_objects
 
@@ -89,14 +85,7 @@ class DiskDistributionRegistry(DistributionRegistry):
         if not json_str:
             return None
 
-        objects_data = json.loads(json_str)
-        # Return only the first object if any exist
-        if objects_data:
-            return pydantic.parse_obj_as(
-                RoutableObjectWithProvider,
-                json.loads(objects_data),
-            )
-        return None
+        return pydantic.TypeAdapter(RoutableObjectWithProvider).validate_json(json_str)
 
     async def update(self, obj: RoutableObjectWithProvider) -> None:
         await self.kvstore.set(

--- a/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
@@ -26,6 +26,7 @@ from llama_stack.apis.memory_banks import *  # noqa: F403
 from llama_stack.apis.safety import *  # noqa: F403
 
 from llama_stack.providers.utils.kvstore import KVStore
+from llama_stack.providers.utils.memory.vector_store import concat_interleaved_content
 from llama_stack.providers.utils.telemetry import tracing
 
 from .persistence import AgentPersistence
@@ -387,7 +388,7 @@ class ChatAgent(ShieldRunnerMixin):
 
             if rag_context:
                 last_message = input_messages[-1]
-                last_message.context = "\n".join(rag_context)
+                last_message.context = rag_context
 
         elif attachments and AgentTool.code_interpreter.value in enabled_tools:
             urls = [a.content for a in attachments if isinstance(a.content, URL)]
@@ -687,7 +688,7 @@ class ChatAgent(ShieldRunnerMixin):
 
     async def _retrieve_context(
         self, session_id: str, messages: List[Message], attachments: List[Attachment]
-    ) -> Tuple[Optional[List[str]], Optional[List[int]]]:  # (rag_context, bank_ids)
+    ) -> Tuple[Optional[InterleavedContent], List[int]]:  # (rag_context, bank_ids)
         bank_ids = []
 
         memory = self._memory_tool_definition()
@@ -755,11 +756,16 @@ class ChatAgent(ShieldRunnerMixin):
                 break
             picked.append(f"id:{c.document_id}; content:{c.content}")
 
-        return [
-            "Here are the retrieved documents for relevant context:\n=== START-RETRIEVED-CONTEXT ===\n",
-            *picked,
-            "\n=== END-RETRIEVED-CONTEXT ===\n",
-        ], bank_ids
+        return (
+            concat_interleaved_content(
+                [
+                    "Here are the retrieved documents for relevant context:\n=== START-RETRIEVED-CONTEXT ===\n",
+                    *picked,
+                    "\n=== END-RETRIEVED-CONTEXT ===\n",
+                ]
+            ),
+            bank_ids,
+        )
 
     def _get_tools(self) -> List[ToolDefinition]:
         ret = []

--- a/llama_stack/providers/inline/agents/meta_reference/rag/context_retriever.py
+++ b/llama_stack/providers/inline/agents/meta_reference/rag/context_retriever.py
@@ -17,6 +17,9 @@ from llama_stack.apis.agents import (
     MemoryQueryGeneratorConfig,
 )
 from llama_stack.apis.inference import *  # noqa: F403
+from llama_stack.providers.utils.inference.prompt_adapter import (
+    interleaved_content_as_str,
+)
 
 
 async def generate_rag_query(
@@ -42,7 +45,7 @@ async def default_rag_query_generator(
     messages: List[Message],
     **kwargs,
 ):
-    return config.sep.join(interleaved_text_media_as_str(m.content) for m in messages)
+    return config.sep.join(interleaved_content_as_str(m.content) for m in messages)
 
 
 async def llm_rag_query_generator(

--- a/llama_stack/providers/inline/agents/meta_reference/safety.py
+++ b/llama_stack/providers/inline/agents/meta_reference/safety.py
@@ -9,8 +9,6 @@ import logging
 
 from typing import List
 
-from llama_models.llama3.api.datatypes import Message
-
 from llama_stack.apis.safety import *  # noqa: F403
 
 log = logging.getLogger(__name__)

--- a/llama_stack/providers/inline/agents/meta_reference/tools/builtin.py
+++ b/llama_stack/providers/inline/agents/meta_reference/tools/builtin.py
@@ -36,7 +36,7 @@ def interpret_content_as_attachment(content: str) -> Optional[Attachment]:
         snippet = match.group(1)
         data = json.loads(snippet)
         return Attachment(
-            content=URL(uri="file://" + data["filepath"]), mime_type=data["mimetype"]
+            url=URL(uri="file://" + data["filepath"]), mime_type=data["mimetype"]
         )
 
     return None

--- a/llama_stack/providers/inline/inference/meta_reference/inference.py
+++ b/llama_stack/providers/inline/inference/meta_reference/inference.py
@@ -7,25 +7,59 @@
 import asyncio
 import logging
 
-from typing import AsyncGenerator, List
+from typing import AsyncGenerator, List, Optional, Union
 
+from llama_models.datatypes import Model
+
+from llama_models.llama3.api.datatypes import (
+    RawMessage,
+    SamplingParams,
+    StopReason,
+    ToolDefinition,
+    ToolPromptFormat,
+)
 from llama_models.sku_list import resolve_model
 
-from llama_models.llama3.api.datatypes import *  # noqa: F403
+from llama_stack.apis.inference import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionResponseEvent,
+    ChatCompletionResponseEventType,
+    ChatCompletionResponseStreamChunk,
+    CompletionRequest,
+    CompletionResponse,
+    CompletionResponseStreamChunk,
+    Inference,
+    InterleavedContent,
+    LogProbConfig,
+    Message,
+    ResponseFormat,
+    TokenLogProbs,
+    ToolCallDelta,
+    ToolCallParseStatus,
+    ToolChoice,
+)
 
-from llama_stack.providers.utils.inference.model_registry import build_model_alias
-from llama_stack.apis.inference import *  # noqa: F403
+from llama_stack.apis.models import ModelType
 from llama_stack.providers.datatypes import ModelsProtocolPrivate
 from llama_stack.providers.utils.inference.embedding_mixin import (
     SentenceTransformerEmbeddingMixin,
 )
-from llama_stack.providers.utils.inference.model_registry import ModelRegistryHelper
+from llama_stack.providers.utils.inference.model_registry import (
+    build_model_alias,
+    ModelRegistryHelper,
+)
 from llama_stack.providers.utils.inference.prompt_adapter import (
-    convert_image_media_to_url,
-    request_has_media,
+    augment_content_with_response_format_prompt,
+    chat_completion_request_to_messages,
+    interleaved_content_convert_to_raw,
 )
 from .config import MetaReferenceInferenceConfig
-from .generation import Llama
+from .generation import (
+    ChatCompletionRequestWithRawContent,
+    CompletionRequestWithRawContent,
+    Llama,
+)
 from .model_parallel import LlamaModelParallelGenerator
 
 log = logging.getLogger(__name__)
@@ -90,7 +124,7 @@ class MetaReferenceInferenceImpl(
     async def completion(
         self,
         model_id: str,
-        content: InterleavedTextMedia,
+        content: InterleavedContent,
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
         stream: Optional[bool] = False,
@@ -99,6 +133,7 @@ class MetaReferenceInferenceImpl(
         if logprobs:
             assert logprobs.top_k == 1, f"Unexpected top_k={logprobs.top_k}"
 
+        content = augment_content_with_response_format_prompt(response_format, content)
         request = CompletionRequest(
             model=model_id,
             content=content,
@@ -108,7 +143,7 @@ class MetaReferenceInferenceImpl(
             logprobs=logprobs,
         )
         self.check_model(request)
-        request = await request_with_localized_media(request)
+        request = await convert_request_to_raw(request)
 
         if request.stream:
             return self._stream_completion(request)
@@ -233,7 +268,13 @@ class MetaReferenceInferenceImpl(
             logprobs=logprobs,
         )
         self.check_model(request)
-        request = await request_with_localized_media(request)
+
+        # augment and rewrite messages depending on the model
+        request.messages = chat_completion_request_to_messages(
+            request, self.model.core_model_id.value
+        )
+        # download media and convert to raw content so we can send it to the model
+        request = await convert_request_to_raw(request)
 
         if self.config.create_distributed_process_group:
             if SEMAPHORE.locked():
@@ -406,29 +447,16 @@ class MetaReferenceInferenceImpl(
                 yield x
 
 
-async def request_with_localized_media(
+async def convert_request_to_raw(
     request: Union[ChatCompletionRequest, CompletionRequest],
-) -> Union[ChatCompletionRequest, CompletionRequest]:
-    if not request_has_media(request):
-        return request
-
-    async def _convert_single_content(content):
-        if isinstance(content, ImageMedia):
-            url = await convert_image_media_to_url(content, download=True)
-            return ImageMedia(image=URL(uri=url))
-        else:
-            return content
-
-    async def _convert_content(content):
-        if isinstance(content, list):
-            return [await _convert_single_content(c) for c in content]
-        else:
-            return await _convert_single_content(content)
-
+) -> Union[ChatCompletionRequestWithRawContent, CompletionRequestWithRawContent]:
     if isinstance(request, ChatCompletionRequest):
+        messages = []
         for m in request.messages:
-            m.content = await _convert_content(m.content)
+            content = await interleaved_content_convert_to_raw(m.content)
+            messages.append(RawMessage(**m.model_dump(), content=content))
+        request.messages = messages
     else:
-        request.content = await _convert_content(request.content)
+        request.content = await interleaved_content_convert_to_raw(request.content)
 
     return request

--- a/llama_stack/providers/inline/inference/vllm/vllm.py
+++ b/llama_stack/providers/inline/inference/vllm/vllm.py
@@ -114,7 +114,7 @@ class VLLMInferenceImpl(Inference, ModelsProtocolPrivate):
     async def completion(
         self,
         model_id: str,
-        content: InterleavedTextMedia,
+        content: InterleavedContent,
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
         stream: Optional[bool] = False,
@@ -218,8 +218,6 @@ class VLLMInferenceImpl(Inference, ModelsProtocolPrivate):
             yield chunk
 
     async def embeddings(
-        self, model_id: str, contents: list[InterleavedTextMedia]
+        self, model_id: str, contents: List[InterleavedContent]
     ) -> EmbeddingsResponse:
-        log.info("vLLM embeddings")
-        # TODO
         raise NotImplementedError()

--- a/llama_stack/providers/inline/memory/chroma/__init__.py
+++ b/llama_stack/providers/inline/memory/chroma/__init__.py
@@ -4,12 +4,18 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+from typing import Dict
+
+from llama_stack.providers.datatypes import Api, ProviderSpec
+
 from .config import ChromaInlineImplConfig
 
 
-async def get_provider_impl(config: ChromaInlineImplConfig, _deps):
+async def get_provider_impl(
+    config: ChromaInlineImplConfig, deps: Dict[Api, ProviderSpec]
+):
     from llama_stack.providers.remote.memory.chroma.chroma import ChromaMemoryAdapter
 
-    impl = ChromaMemoryAdapter(config)
+    impl = ChromaMemoryAdapter(config, deps[Api.inference])
     await impl.initialize()
     return impl

--- a/llama_stack/providers/inline/memory/faiss/faiss.py
+++ b/llama_stack/providers/inline/memory/faiss/faiss.py
@@ -19,9 +19,10 @@ from numpy.typing import NDArray
 from llama_models.llama3.api.datatypes import *  # noqa: F403
 
 from llama_stack.apis.memory import *  # noqa: F403
+from llama_stack.apis.inference import InterleavedContent
+from llama_stack.apis.memory_banks import MemoryBankType, VectorMemoryBank
 from llama_stack.providers.datatypes import Api, MemoryBanksProtocolPrivate
 from llama_stack.providers.utils.kvstore import kvstore_impl
-
 from llama_stack.providers.utils.memory.vector_store import (
     BankWithIndex,
     EmbeddingIndex,
@@ -208,7 +209,7 @@ class FaissMemoryImpl(Memory, MemoryBanksProtocolPrivate):
     async def query_documents(
         self,
         bank_id: str,
-        query: InterleavedTextMedia,
+        query: InterleavedContent,
         params: Optional[Dict[str, Any]] = None,
     ) -> QueryDocumentsResponse:
         index = self.cache.get(bank_id)

--- a/llama_stack/providers/inline/safety/code_scanner/code_scanner.py
+++ b/llama_stack/providers/inline/safety/code_scanner/code_scanner.py
@@ -7,13 +7,17 @@
 import logging
 from typing import Any, Dict, List
 
-from llama_models.llama3.api.datatypes import interleaved_text_media_as_str, Message
+from llama_stack.apis.safety import *  # noqa: F403
+from llama_stack.apis.inference import Message
+from llama_stack.providers.utils.inference.prompt_adapter import (
+    interleaved_content_as_str,
+)
 
 from .config import CodeScannerConfig
 
-from llama_stack.apis.safety import *  # noqa: F403
 
 log = logging.getLogger(__name__)
+
 ALLOWED_CODE_SCANNER_MODEL_IDS = [
     "CodeScanner",
     "CodeShield",
@@ -48,7 +52,7 @@ class MetaReferenceCodeScannerSafetyImpl(Safety):
 
         from codeshield.cs import CodeShield
 
-        text = "\n".join([interleaved_text_media_as_str(m.content) for m in messages])
+        text = "\n".join([interleaved_content_as_str(m.content) for m in messages])
         log.info(f"Running CodeScannerShield on {text[50:]}")
         result = await CodeShield.scan_code(text)
 

--- a/llama_stack/providers/inline/safety/llama_guard/llama_guard.py
+++ b/llama_stack/providers/inline/safety/llama_guard/llama_guard.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional
 from llama_models.llama3.api.datatypes import *  # noqa: F403
 from llama_stack.apis.inference import *  # noqa: F403
 from llama_stack.apis.safety import *  # noqa: F403
+from llama_stack.apis.common.content_types import ImageContentItem, TextContentItem
 from llama_stack.distribution.datatypes import Api
 
 from llama_stack.providers.datatypes import ShieldsProtocolPrivate

--- a/llama_stack/providers/inline/safety/llama_guard/llama_guard.py
+++ b/llama_stack/providers/inline/safety/llama_guard/llama_guard.py
@@ -15,6 +15,9 @@ from llama_stack.apis.safety import *  # noqa: F403
 from llama_stack.distribution.datatypes import Api
 
 from llama_stack.providers.datatypes import ShieldsProtocolPrivate
+from llama_stack.providers.utils.inference.prompt_adapter import (
+    interleaved_content_as_str,
+)
 
 from .config import LlamaGuardConfig
 
@@ -258,18 +261,18 @@ class LlamaGuardShield:
         most_recent_img = None
 
         for m in messages[::-1]:
-            if isinstance(m.content, str):
+            if isinstance(m.content, str) or isinstance(m.content, TextContentItem):
                 conversation.append(m)
-            elif isinstance(m.content, ImageMedia):
+            elif isinstance(m.content, ImageContentItem):
                 if most_recent_img is None and m.role == Role.user.value:
                     most_recent_img = m.content
                     conversation.append(m)
             elif isinstance(m.content, list):
                 content = []
                 for c in m.content:
-                    if isinstance(c, str):
+                    if isinstance(c, str) or isinstance(c, TextContentItem):
                         content.append(c)
-                    elif isinstance(c, ImageMedia):
+                    elif isinstance(c, ImageContentItem):
                         if most_recent_img is None and m.role == Role.user.value:
                             most_recent_img = c
                             content.append(c)
@@ -292,7 +295,7 @@ class LlamaGuardShield:
         categories_str = "\n".join(categories)
         conversations_str = "\n\n".join(
             [
-                f"{m.role.capitalize()}: {interleaved_text_media_as_str(m.content)}"
+                f"{m.role.capitalize()}: {interleaved_content_as_str(m.content)}"
                 for m in messages
             ]
         )

--- a/llama_stack/providers/inline/safety/prompt_guard/prompt_guard.py
+++ b/llama_stack/providers/inline/safety/prompt_guard/prompt_guard.py
@@ -17,6 +17,9 @@ from llama_stack.apis.safety import *  # noqa: F403
 from llama_models.llama3.api.datatypes import *  # noqa: F403
 
 from llama_stack.providers.datatypes import ShieldsProtocolPrivate
+from llama_stack.providers.utils.inference.prompt_adapter import (
+    interleaved_content_as_str,
+)
 
 from .config import PromptGuardConfig, PromptGuardType
 
@@ -83,7 +86,7 @@ class PromptGuardShield:
 
     async def run(self, messages: List[Message]) -> RunShieldResponse:
         message = messages[-1]
-        text = interleaved_text_media_as_str(message.content)
+        text = interleaved_content_as_str(message.content)
 
         # run model on messages and return response
         inputs = self.tokenizer(text, return_tensors="pt")

--- a/llama_stack/providers/registry/memory.py
+++ b/llama_stack/providers/registry/memory.py
@@ -65,6 +65,7 @@ def available_providers() -> List[ProviderSpec]:
             pip_packages=EMBEDDING_DEPS + ["chromadb"],
             module="llama_stack.providers.inline.memory.chroma",
             config_class="llama_stack.providers.inline.memory.chroma.ChromaInlineImplConfig",
+            api_dependencies=[Api.inference],
         ),
         remote_provider_spec(
             Api.memory,

--- a/llama_stack/providers/remote/inference/bedrock/bedrock.py
+++ b/llama_stack/providers/remote/inference/bedrock/bedrock.py
@@ -7,6 +7,7 @@
 from typing import *  # noqa: F403
 import json
 import uuid
+
 from botocore.client import BaseClient
 from llama_models.datatypes import CoreModelId
 from llama_models.llama3.api.chat_format import ChatFormat

--- a/llama_stack/providers/remote/inference/cerebras/cerebras.py
+++ b/llama_stack/providers/remote/inference/cerebras/cerebras.py
@@ -10,7 +10,6 @@ from cerebras.cloud.sdk import AsyncCerebras
 
 from llama_models.llama3.api.chat_format import ChatFormat
 
-from llama_models.llama3.api.datatypes import Message
 from llama_models.llama3.api.tokenizer import Tokenizer
 
 from llama_stack.apis.inference import *  # noqa: F403

--- a/llama_stack/providers/remote/inference/cerebras/cerebras.py
+++ b/llama_stack/providers/remote/inference/cerebras/cerebras.py
@@ -69,7 +69,7 @@ class CerebrasInferenceAdapter(ModelRegistryHelper, Inference):
     async def completion(
         self,
         model_id: str,
-        content: InterleavedTextMedia,
+        content: InterleavedContent,
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
         stream: Optional[bool] = False,
@@ -166,11 +166,11 @@ class CerebrasInferenceAdapter(ModelRegistryHelper, Inference):
             raise ValueError("`top_k` not supported by Cerebras")
 
         prompt = ""
-        if type(request) == ChatCompletionRequest:
+        if isinstance(request, ChatCompletionRequest):
             prompt = chat_completion_request_to_prompt(
                 request, self.get_llama_model(request.model), self.formatter
             )
-        elif type(request) == CompletionRequest:
+        elif isinstance(request, CompletionRequest):
             prompt = completion_request_to_prompt(request, self.formatter)
         else:
             raise ValueError(f"Unknown request type {type(request)}")
@@ -185,6 +185,6 @@ class CerebrasInferenceAdapter(ModelRegistryHelper, Inference):
     async def embeddings(
         self,
         model_id: str,
-        contents: List[InterleavedTextMedia],
+        contents: List[InterleavedContent],
     ) -> EmbeddingsResponse:
         raise NotImplementedError()

--- a/llama_stack/providers/remote/inference/databricks/databricks.py
+++ b/llama_stack/providers/remote/inference/databricks/databricks.py
@@ -10,7 +10,6 @@ from llama_models.datatypes import CoreModelId
 
 from llama_models.llama3.api.chat_format import ChatFormat
 
-from llama_models.llama3.api.datatypes import Message
 from llama_models.llama3.api.tokenizer import Tokenizer
 
 from openai import OpenAI

--- a/llama_stack/providers/remote/inference/databricks/databricks.py
+++ b/llama_stack/providers/remote/inference/databricks/databricks.py
@@ -62,7 +62,7 @@ class DatabricksInferenceAdapter(ModelRegistryHelper, Inference):
     async def completion(
         self,
         model: str,
-        content: InterleavedTextMedia,
+        content: InterleavedContent,
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
         stream: Optional[bool] = False,
@@ -135,6 +135,6 @@ class DatabricksInferenceAdapter(ModelRegistryHelper, Inference):
     async def embeddings(
         self,
         model: str,
-        contents: List[InterleavedTextMedia],
+        contents: List[InterleavedContent],
     ) -> EmbeddingsResponse:
         raise NotImplementedError()

--- a/llama_stack/providers/remote/inference/fireworks/fireworks.py
+++ b/llama_stack/providers/remote/inference/fireworks/fireworks.py
@@ -19,6 +19,7 @@ from llama_stack.providers.utils.inference.model_registry import (
     ModelRegistryHelper,
 )
 from llama_stack.providers.utils.inference.openai_compat import (
+    convert_message_to_openai_dict,
     get_sampling_options,
     process_chat_completion_response,
     process_chat_completion_stream_response,
@@ -29,7 +30,7 @@ from llama_stack.providers.utils.inference.prompt_adapter import (
     chat_completion_request_to_prompt,
     completion_request_to_prompt,
     content_has_media,
-    convert_message_to_dict,
+    interleaved_content_as_str,
     request_has_media,
 )
 
@@ -108,7 +109,7 @@ class FireworksInferenceAdapter(
     async def completion(
         self,
         model_id: str,
-        content: InterleavedTextMedia,
+        content: InterleavedContent,
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
         stream: Optional[bool] = False,
@@ -238,7 +239,7 @@ class FireworksInferenceAdapter(
         if isinstance(request, ChatCompletionRequest):
             if media_present:
                 input_dict["messages"] = [
-                    await convert_message_to_dict(m) for m in request.messages
+                    await convert_message_to_openai_dict(m) for m in request.messages
                 ]
             else:
                 input_dict["prompt"] = chat_completion_request_to_prompt(
@@ -265,7 +266,7 @@ class FireworksInferenceAdapter(
     async def embeddings(
         self,
         model_id: str,
-        contents: List[InterleavedTextMedia],
+        contents: List[InterleavedContent],
     ) -> EmbeddingsResponse:
         model = await self.model_store.get_model(model_id)
 
@@ -277,7 +278,7 @@ class FireworksInferenceAdapter(
         ), "Fireworks does not support media for embeddings"
         response = self._get_client().embeddings.create(
             model=model.provider_resource_id,
-            input=[interleaved_text_media_as_str(content) for content in contents],
+            input=[interleaved_content_as_str(content) for content in contents],
             **kwargs,
         )
 

--- a/llama_stack/providers/remote/inference/fireworks/fireworks.py
+++ b/llama_stack/providers/remote/inference/fireworks/fireworks.py
@@ -10,7 +10,6 @@ from fireworks.client import Fireworks
 from llama_models.datatypes import CoreModelId
 
 from llama_models.llama3.api.chat_format import ChatFormat
-from llama_models.llama3.api.datatypes import Message
 from llama_models.llama3.api.tokenizer import Tokenizer
 from llama_stack.apis.inference import *  # noqa: F403
 from llama_stack.distribution.request_headers import NeedsRequestProviderData

--- a/llama_stack/providers/remote/inference/ollama/ollama.py
+++ b/llama_stack/providers/remote/inference/ollama/ollama.py
@@ -11,7 +11,6 @@ import httpx
 from llama_models.datatypes import CoreModelId
 
 from llama_models.llama3.api.chat_format import ChatFormat
-from llama_models.llama3.api.datatypes import Message
 from llama_models.llama3.api.tokenizer import Tokenizer
 from ollama import AsyncClient
 
@@ -90,7 +89,7 @@ model_aliases = [
         CoreModelId.llama3_2_11b_vision_instruct.value,
     ),
     build_model_alias_with_just_provider_model_id(
-        "llama3.2-vision",
+        "llama3.2-vision:latest",
         CoreModelId.llama3_2_11b_vision_instruct.value,
     ),
     build_model_alias(

--- a/llama_stack/providers/remote/inference/ollama/ollama.py
+++ b/llama_stack/providers/remote/inference/ollama/ollama.py
@@ -21,8 +21,8 @@ from llama_stack.providers.utils.inference.model_registry import (
 )
 
 from llama_stack.apis.inference import *  # noqa: F403
+from llama_stack.apis.common.content_types import ImageContentItem, TextContentItem
 from llama_stack.providers.datatypes import ModelsProtocolPrivate
-
 from llama_stack.providers.utils.inference.openai_compat import (
     get_sampling_options,
     OpenAICompatCompletionChoice,

--- a/llama_stack/providers/remote/inference/tgi/tgi.py
+++ b/llama_stack/providers/remote/inference/tgi/tgi.py
@@ -83,7 +83,7 @@ class _HfAdapter(Inference, ModelsProtocolPrivate):
     async def completion(
         self,
         model_id: str,
-        content: InterleavedTextMedia,
+        content: InterleavedContent,
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
         stream: Optional[bool] = False,
@@ -267,7 +267,7 @@ class _HfAdapter(Inference, ModelsProtocolPrivate):
     async def embeddings(
         self,
         model_id: str,
-        contents: List[InterleavedTextMedia],
+        contents: List[InterleavedContent],
     ) -> EmbeddingsResponse:
         raise NotImplementedError()
 

--- a/llama_stack/providers/remote/inference/together/together.py
+++ b/llama_stack/providers/remote/inference/together/together.py
@@ -22,6 +22,7 @@ from llama_stack.providers.utils.inference.model_registry import (
     ModelRegistryHelper,
 )
 from llama_stack.providers.utils.inference.openai_compat import (
+    convert_message_to_openai_dict,
     get_sampling_options,
     process_chat_completion_response,
     process_chat_completion_stream_response,
@@ -32,7 +33,7 @@ from llama_stack.providers.utils.inference.prompt_adapter import (
     chat_completion_request_to_prompt,
     completion_request_to_prompt,
     content_has_media,
-    convert_message_to_dict,
+    interleaved_content_as_str,
     request_has_media,
 )
 
@@ -92,7 +93,7 @@ class TogetherInferenceAdapter(
     async def completion(
         self,
         model_id: str,
-        content: InterleavedTextMedia,
+        content: InterleavedContent,
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
         stream: Optional[bool] = False,
@@ -230,7 +231,7 @@ class TogetherInferenceAdapter(
         if isinstance(request, ChatCompletionRequest):
             if media_present:
                 input_dict["messages"] = [
-                    await convert_message_to_dict(m) for m in request.messages
+                    await convert_message_to_openai_dict(m) for m in request.messages
                 ]
             else:
                 input_dict["prompt"] = chat_completion_request_to_prompt(
@@ -252,7 +253,7 @@ class TogetherInferenceAdapter(
     async def embeddings(
         self,
         model_id: str,
-        contents: List[InterleavedTextMedia],
+        contents: List[InterleavedContent],
     ) -> EmbeddingsResponse:
         model = await self.model_store.get_model(model_id)
         assert all(
@@ -260,7 +261,7 @@ class TogetherInferenceAdapter(
         ), "Together does not support media for embeddings"
         r = self._get_client().embeddings.create(
             model=model.provider_resource_id,
-            input=[interleaved_text_media_as_str(content) for content in contents],
+            input=[interleaved_content_as_str(content) for content in contents],
         )
         embeddings = [item.embedding for item in r.data]
         return EmbeddingsResponse(embeddings=embeddings)

--- a/llama_stack/providers/remote/inference/together/together.py
+++ b/llama_stack/providers/remote/inference/together/together.py
@@ -10,7 +10,6 @@ from llama_models.datatypes import CoreModelId
 
 from llama_models.llama3.api.chat_format import ChatFormat
 
-from llama_models.llama3.api.datatypes import Message
 from llama_models.llama3.api.tokenizer import Tokenizer
 
 from together import Together

--- a/llama_stack/providers/remote/inference/vllm/vllm.py
+++ b/llama_stack/providers/remote/inference/vllm/vllm.py
@@ -8,7 +8,6 @@ import logging
 from typing import AsyncGenerator
 
 from llama_models.llama3.api.chat_format import ChatFormat
-from llama_models.llama3.api.datatypes import Message
 from llama_models.llama3.api.tokenizer import Tokenizer
 from llama_models.sku_list import all_registered_models
 

--- a/llama_stack/providers/remote/inference/vllm/vllm.py
+++ b/llama_stack/providers/remote/inference/vllm/vllm.py
@@ -22,6 +22,7 @@ from llama_stack.providers.utils.inference.model_registry import (
     ModelRegistryHelper,
 )
 from llama_stack.providers.utils.inference.openai_compat import (
+    convert_message_to_openai_dict,
     get_sampling_options,
     process_chat_completion_response,
     process_chat_completion_stream_response,
@@ -30,7 +31,7 @@ from llama_stack.providers.utils.inference.prompt_adapter import (
     chat_completion_request_to_prompt,
     completion_request_to_prompt,
     content_has_media,
-    convert_message_to_dict,
+    interleaved_content_as_str,
     request_has_media,
 )
 
@@ -71,7 +72,7 @@ class VLLMInferenceAdapter(Inference, ModelsProtocolPrivate):
     async def completion(
         self,
         model_id: str,
-        content: InterleavedTextMedia,
+        content: InterleavedContent,
         sampling_params: Optional[SamplingParams] = SamplingParams(),
         response_format: Optional[ResponseFormat] = None,
         stream: Optional[bool] = False,
@@ -163,7 +164,7 @@ class VLLMInferenceAdapter(Inference, ModelsProtocolPrivate):
             if media_present:
                 # vllm does not seem to work well with image urls, so we download the images
                 input_dict["messages"] = [
-                    await convert_message_to_dict(m, download=True)
+                    await convert_message_to_openai_dict(m, download=True)
                     for m in request.messages
                 ]
             else:
@@ -202,7 +203,7 @@ class VLLMInferenceAdapter(Inference, ModelsProtocolPrivate):
     async def embeddings(
         self,
         model_id: str,
-        contents: List[InterleavedTextMedia],
+        contents: List[InterleavedContent],
     ) -> EmbeddingsResponse:
         model = await self.model_store.get_model(model_id)
 
@@ -215,7 +216,7 @@ class VLLMInferenceAdapter(Inference, ModelsProtocolPrivate):
         ), "VLLM does not support media for embeddings"
         response = self.client.embeddings.create(
             model=model.provider_resource_id,
-            input=[interleaved_text_media_as_str(content) for content in contents],
+            input=[interleaved_content_as_str(content) for content in contents],
             **kwargs,
         )
 

--- a/llama_stack/providers/remote/memory/chroma/chroma.py
+++ b/llama_stack/providers/remote/memory/chroma/chroma.py
@@ -6,13 +6,14 @@
 import asyncio
 import json
 import logging
-from typing import List
+from typing import List, Optional, Union
 from urllib.parse import urlparse
 
 import chromadb
 from numpy.typing import NDArray
 
 from llama_stack.apis.memory import *  # noqa: F403
+from llama_stack.apis.memory_banks import MemoryBankType
 from llama_stack.providers.datatypes import Api, MemoryBanksProtocolPrivate
 from llama_stack.providers.inline.memory.chroma import ChromaInlineImplConfig
 from llama_stack.providers.utils.memory.vector_store import (
@@ -151,7 +152,7 @@ class ChromaMemoryAdapter(Memory, MemoryBanksProtocolPrivate):
     async def query_documents(
         self,
         bank_id: str,
-        query: InterleavedTextMedia,
+        query: InterleavedContent,
         params: Optional[Dict[str, Any]] = None,
     ) -> QueryDocumentsResponse:
         index = await self._get_and_cache_bank_index(bank_id)

--- a/llama_stack/providers/remote/memory/pgvector/pgvector.py
+++ b/llama_stack/providers/remote/memory/pgvector/pgvector.py
@@ -15,7 +15,7 @@ from psycopg2.extras import execute_values, Json
 from pydantic import BaseModel, parse_obj_as
 
 from llama_stack.apis.memory import *  # noqa: F403
-
+from llama_stack.apis.memory_banks import MemoryBankType, VectorMemoryBank
 from llama_stack.providers.datatypes import Api, MemoryBanksProtocolPrivate
 
 from llama_stack.providers.utils.memory.vector_store import (
@@ -188,7 +188,7 @@ class PGVectorMemoryAdapter(Memory, MemoryBanksProtocolPrivate):
     async def query_documents(
         self,
         bank_id: str,
-        query: InterleavedTextMedia,
+        query: InterleavedContent,
         params: Optional[Dict[str, Any]] = None,
     ) -> QueryDocumentsResponse:
         index = await self._get_and_cache_bank_index(bank_id)

--- a/llama_stack/providers/remote/memory/qdrant/qdrant.py
+++ b/llama_stack/providers/remote/memory/qdrant/qdrant.py
@@ -13,8 +13,7 @@ from qdrant_client import AsyncQdrantClient, models
 from qdrant_client.models import PointStruct
 
 from llama_stack.apis.memory_banks import *  # noqa: F403
-from llama_stack.providers.datatypes import MemoryBanksProtocolPrivate
-
+from llama_stack.providers.datatypes import Api, MemoryBanksProtocolPrivate
 from llama_stack.apis.memory import *  # noqa: F403
 
 from llama_stack.providers.remote.memory.qdrant.config import QdrantConfig
@@ -160,7 +159,7 @@ class QdrantVectorMemoryAdapter(Memory, MemoryBanksProtocolPrivate):
     async def query_documents(
         self,
         bank_id: str,
-        query: InterleavedTextMedia,
+        query: InterleavedContent,
         params: Optional[Dict[str, Any]] = None,
     ) -> QueryDocumentsResponse:
         index = await self._get_and_cache_bank_index(bank_id)

--- a/llama_stack/providers/remote/memory/weaviate/weaviate.py
+++ b/llama_stack/providers/remote/memory/weaviate/weaviate.py
@@ -15,6 +15,7 @@ from weaviate.classes.init import Auth
 from weaviate.classes.query import Filter
 
 from llama_stack.apis.memory import *  # noqa: F403
+from llama_stack.apis.memory_banks import MemoryBankType
 from llama_stack.distribution.request_headers import NeedsRequestProviderData
 from llama_stack.providers.datatypes import Api, MemoryBanksProtocolPrivate
 from llama_stack.providers.utils.memory.vector_store import (
@@ -186,7 +187,7 @@ class WeaviateMemoryAdapter(
     async def query_documents(
         self,
         bank_id: str,
-        query: InterleavedTextMedia,
+        query: InterleavedContent,
         params: Optional[Dict[str, Any]] = None,
     ) -> QueryDocumentsResponse:
         index = await self._get_and_cache_bank_index(bank_id)

--- a/llama_stack/providers/tests/agents/conftest.py
+++ b/llama_stack/providers/tests/agents/conftest.py
@@ -81,13 +81,13 @@ def pytest_addoption(parser):
     parser.addoption(
         "--inference-model",
         action="store",
-        default="meta-llama/Llama-3.1-8B-Instruct",
+        default="meta-llama/Llama-3.2-3B-Instruct",
         help="Specify the inference model to use for testing",
     )
     parser.addoption(
         "--safety-shield",
         action="store",
-        default="meta-llama/Llama-Guard-3-8B",
+        default="meta-llama/Llama-Guard-3-1B",
         help="Specify the safety shield to use for testing",
     )
 

--- a/llama_stack/providers/tests/inference/fixtures.py
+++ b/llama_stack/providers/tests/inference/fixtures.py
@@ -113,6 +113,7 @@ def inference_vllm_remote() -> ProviderFixture:
                 provider_type="remote::vllm",
                 config=VLLMInferenceAdapterConfig(
                     url=get_env_or_fail("VLLM_URL"),
+                    max_tokens=int(os.getenv("VLLM_MAX_TOKENS", 2048)),
                 ).model_dump(),
             )
         ],

--- a/llama_stack/providers/tests/inference/fixtures.py
+++ b/llama_stack/providers/tests/inference/fixtures.py
@@ -192,6 +192,19 @@ def inference_tgi() -> ProviderFixture:
     )
 
 
+@pytest.fixture(scope="session")
+def inference_sentence_transformers() -> ProviderFixture:
+    return ProviderFixture(
+        providers=[
+            Provider(
+                provider_id="sentence_transformers",
+                provider_type="inline::sentence-transformers",
+                config={},
+            )
+        ]
+    )
+
+
 def get_model_short_name(model_name: str) -> str:
     """Convert model name to a short test identifier.
 

--- a/llama_stack/providers/tests/inference/test_vision_inference.py
+++ b/llama_stack/providers/tests/inference/test_vision_inference.py
@@ -11,7 +11,7 @@ import pytest
 
 from llama_models.llama3.api.datatypes import *  # noqa: F403
 from llama_stack.apis.inference import *  # noqa: F403
-from llama_stack.apis.common.content_types import ImageContentItem, TextContentItem
+from llama_stack.apis.common.content_types import ImageContentItem, TextContentItem, URL
 
 from .utils import group_chunks
 
@@ -32,7 +32,7 @@ class TestVisionModelInference:
             ),
             (
                 ImageContentItem(
-                    data=URL(
+                    url=URL(
                         uri="https://www.healthypawspetinsurance.com/Images/V3/DogAndPuppyInsurance/Dog_CTA_Desktop_HeroImage.jpg"
                     )
                 ),
@@ -98,7 +98,7 @@ class TestVisionModelInference:
 
         images = [
             ImageContentItem(
-                data=URL(
+                url=URL(
                     uri="https://www.healthypawspetinsurance.com/Images/V3/DogAndPuppyInsurance/Dog_CTA_Desktop_HeroImage.jpg"
                 )
             ),

--- a/llama_stack/providers/tests/inference/test_vision_inference.py
+++ b/llama_stack/providers/tests/inference/test_vision_inference.py
@@ -7,7 +7,6 @@
 from pathlib import Path
 
 import pytest
-from PIL import Image as PIL_Image
 
 
 from llama_models.llama3.api.datatypes import *  # noqa: F403
@@ -17,6 +16,9 @@ from .utils import group_chunks
 
 THIS_DIR = Path(__file__).parent
 
+with open(THIS_DIR / "pasta.jpeg", "rb") as f:
+    PASTA_IMAGE = f.read()
+
 
 class TestVisionModelInference:
     @pytest.mark.asyncio
@@ -24,12 +26,12 @@ class TestVisionModelInference:
         "image, expected_strings",
         [
             (
-                ImageMedia(image=PIL_Image.open(THIS_DIR / "pasta.jpeg")),
+                ImageContentItem(data=PASTA_IMAGE),
                 ["spaghetti"],
             ),
             (
-                ImageMedia(
-                    image=URL(
+                ImageContentItem(
+                    data=URL(
                         uri="https://www.healthypawspetinsurance.com/Images/V3/DogAndPuppyInsurance/Dog_CTA_Desktop_HeroImage.jpg"
                     )
                 ),
@@ -58,7 +60,12 @@ class TestVisionModelInference:
             model_id=inference_model,
             messages=[
                 UserMessage(content="You are a helpful assistant."),
-                UserMessage(content=[image, "Describe this image in two sentences."]),
+                UserMessage(
+                    content=[
+                        image,
+                        TextContentItem(text="Describe this image in two sentences."),
+                    ]
+                ),
             ],
             stream=False,
             sampling_params=SamplingParams(max_tokens=100),
@@ -89,8 +96,8 @@ class TestVisionModelInference:
             )
 
         images = [
-            ImageMedia(
-                image=URL(
+            ImageContentItem(
+                data=URL(
                     uri="https://www.healthypawspetinsurance.com/Images/V3/DogAndPuppyInsurance/Dog_CTA_Desktop_HeroImage.jpg"
                 )
             ),
@@ -106,7 +113,12 @@ class TestVisionModelInference:
                     messages=[
                         UserMessage(content="You are a helpful assistant."),
                         UserMessage(
-                            content=[image, "Describe this image in two sentences."]
+                            content=[
+                                image,
+                                TextContentItem(
+                                    text="Describe this image in two sentences."
+                                ),
+                            ]
                         ),
                     ],
                     stream=True,

--- a/llama_stack/providers/tests/inference/test_vision_inference.py
+++ b/llama_stack/providers/tests/inference/test_vision_inference.py
@@ -11,6 +11,7 @@ import pytest
 
 from llama_models.llama3.api.datatypes import *  # noqa: F403
 from llama_stack.apis.inference import *  # noqa: F403
+from llama_stack.apis.common.content_types import ImageContentItem, TextContentItem
 
 from .utils import group_chunks
 

--- a/llama_stack/providers/tests/memory/conftest.py
+++ b/llama_stack/providers/tests/memory/conftest.py
@@ -15,23 +15,23 @@ from .fixtures import MEMORY_FIXTURES
 DEFAULT_PROVIDER_COMBINATIONS = [
     pytest.param(
         {
-            "inference": "meta_reference",
+            "inference": "sentence_transformers",
             "memory": "faiss",
         },
-        id="meta_reference",
-        marks=pytest.mark.meta_reference,
+        id="sentence_transformers",
+        marks=pytest.mark.sentence_transformers,
     ),
     pytest.param(
         {
             "inference": "ollama",
-            "memory": "pgvector",
+            "memory": "faiss",
         },
         id="ollama",
         marks=pytest.mark.ollama,
     ),
     pytest.param(
         {
-            "inference": "together",
+            "inference": "sentence_transformers",
             "memory": "chroma",
         },
         id="chroma",
@@ -58,10 +58,10 @@ DEFAULT_PROVIDER_COMBINATIONS = [
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--inference-model",
+        "--embedding-model",
         action="store",
         default=None,
-        help="Specify the inference model to use for testing",
+        help="Specify the embedding model to use for testing",
     )
 
 
@@ -74,15 +74,15 @@ def pytest_configure(config):
 
 
 def pytest_generate_tests(metafunc):
-    if "inference_model" in metafunc.fixturenames:
-        model = metafunc.config.getoption("--inference-model")
-        if not model:
-            raise ValueError(
-                "No inference model specified. Please provide a valid inference model."
-            )
-        params = [pytest.param(model, id="")]
+    if "embedding_model" in metafunc.fixturenames:
+        model = metafunc.config.getoption("--embedding-model")
+        if model:
+            params = [pytest.param(model, id="")]
+        else:
+            params = [pytest.param("all-MiniLM-L6-v2", id="")]
 
-        metafunc.parametrize("inference_model", params, indirect=True)
+        metafunc.parametrize("embedding_model", params, indirect=True)
+
     if "memory_stack" in metafunc.fixturenames:
         available_fixtures = {
             "inference": INFERENCE_FIXTURES,

--- a/llama_stack/providers/tests/memory/fixtures.py
+++ b/llama_stack/providers/tests/memory/fixtures.py
@@ -25,6 +25,13 @@ from ..env import get_env_or_fail
 
 
 @pytest.fixture(scope="session")
+def embedding_model(request):
+    if hasattr(request, "param"):
+        return request.param
+    return request.config.getoption("--embedding-model", None)
+
+
+@pytest.fixture(scope="session")
 def memory_remote() -> ProviderFixture:
     return remote_stack_fixture()
 
@@ -107,7 +114,7 @@ MEMORY_FIXTURES = ["faiss", "pgvector", "weaviate", "remote", "chroma"]
 
 
 @pytest_asyncio.fixture(scope="session")
-async def memory_stack(inference_model, request):
+async def memory_stack(embedding_model, request):
     fixture_dict = request.param
 
     providers = {}
@@ -124,7 +131,7 @@ async def memory_stack(inference_model, request):
         provider_data,
         models=[
             ModelInput(
-                model_id=inference_model,
+                model_id=embedding_model,
                 model_type=ModelType.embedding,
                 metadata={
                     "embedding_dimension": get_env_or_fail("EMBEDDING_DIMENSION"),

--- a/llama_stack/providers/tests/memory/test_memory.py
+++ b/llama_stack/providers/tests/memory/test_memory.py
@@ -46,13 +46,13 @@ def sample_documents():
 
 
 async def register_memory_bank(
-    banks_impl: MemoryBanks, inference_model: str
+    banks_impl: MemoryBanks, embedding_model: str
 ) -> MemoryBank:
     bank_id = f"test_bank_{uuid.uuid4().hex}"
     return await banks_impl.register_memory_bank(
         memory_bank_id=bank_id,
         params=VectorMemoryBankParams(
-            embedding_model=inference_model,
+            embedding_model=embedding_model,
             chunk_size_in_tokens=512,
             overlap_size_in_tokens=64,
         ),
@@ -61,11 +61,11 @@ async def register_memory_bank(
 
 class TestMemory:
     @pytest.mark.asyncio
-    async def test_banks_list(self, memory_stack, inference_model):
+    async def test_banks_list(self, memory_stack, embedding_model):
         _, banks_impl = memory_stack
 
         # Register a test bank
-        registered_bank = await register_memory_bank(banks_impl, inference_model)
+        registered_bank = await register_memory_bank(banks_impl, embedding_model)
 
         try:
             # Verify our bank shows up in list
@@ -86,7 +86,7 @@ class TestMemory:
         )
 
     @pytest.mark.asyncio
-    async def test_banks_register(self, memory_stack, inference_model):
+    async def test_banks_register(self, memory_stack, embedding_model):
         _, banks_impl = memory_stack
 
         bank_id = f"test_bank_{uuid.uuid4().hex}"
@@ -96,7 +96,7 @@ class TestMemory:
             await banks_impl.register_memory_bank(
                 memory_bank_id=bank_id,
                 params=VectorMemoryBankParams(
-                    embedding_model=inference_model,
+                    embedding_model=embedding_model,
                     chunk_size_in_tokens=512,
                     overlap_size_in_tokens=64,
                 ),
@@ -111,7 +111,7 @@ class TestMemory:
             await banks_impl.register_memory_bank(
                 memory_bank_id=bank_id,
                 params=VectorMemoryBankParams(
-                    embedding_model=inference_model,
+                    embedding_model=embedding_model,
                     chunk_size_in_tokens=512,
                     overlap_size_in_tokens=64,
                 ),
@@ -129,14 +129,14 @@ class TestMemory:
 
     @pytest.mark.asyncio
     async def test_query_documents(
-        self, memory_stack, inference_model, sample_documents
+        self, memory_stack, embedding_model, sample_documents
     ):
         memory_impl, banks_impl = memory_stack
 
         with pytest.raises(ValueError):
             await memory_impl.insert_documents("test_bank", sample_documents)
 
-        registered_bank = await register_memory_bank(banks_impl, inference_model)
+        registered_bank = await register_memory_bank(banks_impl, embedding_model)
         await memory_impl.insert_documents(
             registered_bank.memory_bank_id, sample_documents
         )

--- a/llama_stack/providers/tests/post_training/fixtures.py
+++ b/llama_stack/providers/tests/post_training/fixtures.py
@@ -7,8 +7,8 @@
 import pytest
 import pytest_asyncio
 
-from llama_models.llama3.api.datatypes import URL
 from llama_stack.apis.common.type_system import *  # noqa: F403
+from llama_stack.apis.common.deployment_types import URL
 from llama_stack.apis.datasets import DatasetInput
 from llama_stack.apis.models import ModelInput
 

--- a/llama_stack/providers/tests/post_training/fixtures.py
+++ b/llama_stack/providers/tests/post_training/fixtures.py
@@ -8,7 +8,7 @@ import pytest
 import pytest_asyncio
 
 from llama_stack.apis.common.type_system import *  # noqa: F403
-from llama_stack.apis.common.deployment_types import URL
+from llama_stack.apis.common.content_types import URL
 from llama_stack.apis.datasets import DatasetInput
 from llama_stack.apis.models import ModelInput
 

--- a/llama_stack/providers/tests/safety/conftest.py
+++ b/llama_stack/providers/tests/safety/conftest.py
@@ -74,7 +74,9 @@ def pytest_addoption(parser):
 
 
 SAFETY_SHIELD_PARAMS = [
-    pytest.param("Llama-Guard-3-1B", marks=pytest.mark.guard_1b, id="guard_1b"),
+    pytest.param(
+        "meta-llama/Llama-Guard-3-1B", marks=pytest.mark.guard_1b, id="guard_1b"
+    ),
 ]
 
 
@@ -86,6 +88,7 @@ def pytest_generate_tests(metafunc):
     if "safety_shield" in metafunc.fixturenames:
         shield_id = metafunc.config.getoption("--safety-shield")
         if shield_id:
+            assert shield_id.startswith("meta-llama/")
             params = [pytest.param(shield_id, id="")]
         else:
             params = SAFETY_SHIELD_PARAMS

--- a/llama_stack/providers/tests/safety/test_safety.py
+++ b/llama_stack/providers/tests/safety/test_safety.py
@@ -10,6 +10,7 @@ from llama_models.llama3.api.datatypes import *  # noqa: F403
 from llama_stack.apis.safety import *  # noqa: F403
 
 from llama_stack.distribution.datatypes import *  # noqa: F403
+from llama_stack.apis.inference import UserMessage
 
 # How to run this test:
 #

--- a/llama_stack/providers/utils/datasetio/url_utils.py
+++ b/llama_stack/providers/utils/datasetio/url_utils.py
@@ -10,7 +10,7 @@ from urllib.parse import unquote
 
 import pandas
 
-from llama_stack.apis.common.deployment_types import URL
+from llama_stack.apis.common.content_types import URL
 
 from llama_stack.providers.utils.memory.vector_store import parse_data_url
 

--- a/llama_stack/providers/utils/datasetio/url_utils.py
+++ b/llama_stack/providers/utils/datasetio/url_utils.py
@@ -10,7 +10,7 @@ from urllib.parse import unquote
 
 import pandas
 
-from llama_models.llama3.api.datatypes import URL
+from llama_stack.apis.common.deployment_types import URL
 
 from llama_stack.providers.utils.memory.vector_store import parse_data_url
 

--- a/llama_stack/providers/utils/inference/embedding_mixin.py
+++ b/llama_stack/providers/utils/inference/embedding_mixin.py
@@ -7,9 +7,11 @@
 import logging
 from typing import List
 
-from llama_models.llama3.api.datatypes import InterleavedTextMedia
-
-from llama_stack.apis.inference.inference import EmbeddingsResponse, ModelStore
+from llama_stack.apis.inference import (
+    EmbeddingsResponse,
+    InterleavedContent,
+    ModelStore,
+)
 
 EMBEDDING_MODELS = {}
 
@@ -23,7 +25,7 @@ class SentenceTransformerEmbeddingMixin:
     async def embeddings(
         self,
         model_id: str,
-        contents: List[InterleavedTextMedia],
+        contents: List[InterleavedContent],
     ) -> EmbeddingsResponse:
         model = await self.model_store.get_model(model_id)
         embedding_model = self._load_sentence_transformer_model(

--- a/llama_stack/providers/utils/inference/openai_compat.py
+++ b/llama_stack/providers/utils/inference/openai_compat.py
@@ -13,6 +13,8 @@ from llama_models.llama3.api.datatypes import StopReason
 from llama_stack.apis.inference import *  # noqa: F403
 from pydantic import BaseModel
 
+from llama_stack.apis.common.content_types import ImageContentItem, TextContentItem
+
 from llama_stack.providers.utils.inference.prompt_adapter import (
     convert_image_content_to_url,
 )

--- a/llama_stack/providers/utils/inference/openai_compat.py
+++ b/llama_stack/providers/utils/inference/openai_compat.py
@@ -93,11 +93,15 @@ def process_chat_completion_response(
 ) -> ChatCompletionResponse:
     choice = response.choices[0]
 
-    completion_message = formatter.decode_assistant_message_from_content(
+    raw_message = formatter.decode_assistant_message_from_content(
         text_from_choice(choice), get_stop_reason(choice.finish_reason)
     )
     return ChatCompletionResponse(
-        completion_message=completion_message,
+        completion_message=CompletionMessage(
+            content=raw_message.content,
+            stop_reason=raw_message.stop_reason,
+            tool_calls=raw_message.tool_calls,
+        ),
         logprobs=None,
     )
 

--- a/llama_stack/providers/utils/inference/prompt_adapter.py
+++ b/llama_stack/providers/utils/inference/prompt_adapter.py
@@ -34,19 +34,21 @@ from llama_models.llama3.prompt_templates import (
 from llama_models.sku_list import resolve_model
 from PIL import Image as PIL_Image
 
-from llama_stack.apis.common.deployment_types import URL
+from llama_stack.apis.common.content_types import (
+    ImageContentItem,
+    InterleavedContent,
+    InterleavedContentItem,
+    TextContentItem,
+    URL,
+)
 
 from llama_stack.apis.inference import (
     ChatCompletionRequest,
     CompletionRequest,
-    ImageContentItem,
-    InterleavedContent,
-    InterleavedContentItem,
     Message,
     ResponseFormat,
     ResponseFormatType,
     SystemMessage,
-    TextContentItem,
     ToolChoice,
     UserMessage,
 )

--- a/llama_stack/providers/utils/inference/prompt_adapter.py
+++ b/llama_stack/providers/utils/inference/prompt_adapter.py
@@ -103,6 +103,8 @@ async def interleaved_content_convert_to_raw(
                         data = response.content
                 else:
                     raise ValueError("Unsupported URL type")
+            else:
+                data = c.data
             return RawMediaItem(data=data)
         else:
             raise ValueError(f"Unsupported content type: {type(c)}")

--- a/llama_stack/providers/utils/inference/prompt_adapter.py
+++ b/llama_stack/providers/utils/inference/prompt_adapter.py
@@ -139,9 +139,9 @@ def request_has_media(request: Union[ChatCompletionRequest, CompletionRequest]):
 
 
 async def localize_image_content(media: ImageContentItem) -> Tuple[bytes, str]:
-    if isinstance(media.data, URL) and media.data.uri.startswith("http"):
+    if media.url and media.url.uri.startswith("http"):
         async with httpx.AsyncClient() as client:
-            r = await client.get(media.data.uri)
+            r = await client.get(media.url.uri)
             content = r.content
             content_type = r.headers.get("content-type")
             if content_type:
@@ -157,8 +157,8 @@ async def localize_image_content(media: ImageContentItem) -> Tuple[bytes, str]:
 async def convert_image_content_to_url(
     media: ImageContentItem, download: bool = False, include_format: bool = True
 ) -> str:
-    if isinstance(media.data, URL) and not download:
-        return media.data.uri
+    if media.url and not download:
+        return media.url.uri
 
     content, format = await localize_image_content(media)
     if include_format:

--- a/llama_stack/providers/utils/inference/prompt_adapter.py
+++ b/llama_stack/providers/utils/inference/prompt_adapter.py
@@ -4,19 +4,26 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import asyncio
 import base64
-import io
 import json
 import logging
-from typing import Tuple
+import re
+from typing import List, Optional, Tuple, Union
 
 import httpx
+from llama_models.datatypes import is_multimodal, ModelFamily
 
 from llama_models.llama3.api.chat_format import ChatFormat
-from PIL import Image as PIL_Image
-from llama_models.llama3.api.datatypes import *  # noqa: F403
-from llama_stack.apis.inference import *  # noqa: F403
-from llama_models.datatypes import ModelFamily
+from llama_models.llama3.api.datatypes import (
+    RawContent,
+    RawContentItem,
+    RawMediaItem,
+    RawTextItem,
+    Role,
+    ToolChoice,
+    ToolPromptFormat,
+)
 from llama_models.llama3.prompt_templates import (
     BuiltinToolGenerator,
     FunctionTagCustomToolGenerator,
@@ -25,15 +32,89 @@ from llama_models.llama3.prompt_templates import (
     SystemDefaultGenerator,
 )
 from llama_models.sku_list import resolve_model
+from PIL import Image as PIL_Image
+
+from llama_stack.apis.common.deployment_types import URL
+
+from llama_stack.apis.inference import (
+    ChatCompletionRequest,
+    CompletionRequest,
+    ImageContentItem,
+    InterleavedContent,
+    InterleavedContentItem,
+    Message,
+    ResponseFormat,
+    ResponseFormatType,
+    SystemMessage,
+    TextContentItem,
+    UserMessage,
+)
 
 from llama_stack.providers.utils.inference import supported_inference_models
 
 log = logging.getLogger(__name__)
 
 
-def content_has_media(content: InterleavedTextMedia):
+def interleaved_content_as_str(content: InterleavedContent, sep: str = " ") -> str:
+    def _process(c) -> str:
+        if isinstance(c, str):
+            return c
+        elif isinstance(c, ImageContentItem):
+            return "<image>"
+        elif isinstance(c, TextContentItem):
+            return c.text
+        else:
+            raise ValueError(f"Unsupported content type: {type(c)}")
+
+    if isinstance(content, list):
+        return sep.join(_process(c) for c in content)
+    else:
+        return _process(content)
+
+
+async def interleaved_content_convert_to_raw(
+    content: InterleavedContent,
+) -> RawContent:
+    """Download content from URLs / files etc. so plain bytes can be sent to the model"""
+
+    async def _localize_single(c: str | InterleavedContentItem) -> str | RawContentItem:
+        if isinstance(c, str):
+            return RawTextItem(text=c)
+        elif isinstance(c, TextContentItem):
+            return RawTextItem(text=c.text)
+        elif isinstance(c, ImageContentItem):
+            # load image and return PIL version
+            img = c.data
+            if isinstance(img, URL):
+                if img.uri.startswith("data"):
+                    match = re.match(r"data:image/(\w+);base64,(.+)", img.uri)
+                    if not match:
+                        raise ValueError("Invalid data URL format")
+                    _, image_data = match.groups()
+                    data = base64.b64decode(image_data)
+                elif img.uri.startswith("file://"):
+                    path = img.uri[len("file://") :]
+                    with open(path, "rb") as f:
+                        data = f.read()  # type: ignore
+                elif img.uri.startswith("http"):
+                    async with httpx.AsyncClient() as client:
+                        response = await client.get(img.uri)
+                        data = response.content
+                else:
+                    raise ValueError("Unsupported URL type")
+            return RawMediaItem(data=data)
+        else:
+            raise ValueError(f"Unsupported content type: {type(c)}")
+
+    if isinstance(content, list):
+        return await asyncio.gather(*(_localize_single(c) for c in content))
+    else:
+        return await _localize_single(content)
+
+
+def content_has_media(content: InterleavedContent):
     def _has_media_content(c):
-        return isinstance(c, ImageMedia)
+        return isinstance(c, ImageContentItem)
 
     if isinstance(content, list):
         return any(_has_media_content(c) for c in content)
@@ -52,69 +133,35 @@ def request_has_media(request: Union[ChatCompletionRequest, CompletionRequest]):
         return content_has_media(request.content)
 
 
-async def convert_image_media_to_url(
-    media: ImageMedia, download: bool = False, include_format: bool = True
-) -> str:
-    if isinstance(media.image, PIL_Image.Image):
-        if media.image.format == "PNG":
-            format = "png"
-        elif media.image.format == "GIF":
-            format = "gif"
-        elif media.image.format == "JPEG":
-            format = "jpeg"
-        else:
-            raise ValueError(f"Unsupported image format {media.image.format}")
-
-        bytestream = io.BytesIO()
-        media.image.save(bytestream, format=media.image.format)
-        bytestream.seek(0)
-        content = bytestream.getvalue()
+async def localize_image_content(media: ImageContentItem) -> Tuple[bytes, str]:
+    if isinstance(media.data, URL) and media.data.uri.startswith("http"):
+        async with httpx.AsyncClient() as client:
+            r = await client.get(media.image.uri)
+            content = r.content
+            content_type = r.headers.get("content-type")
+            if content_type:
+                format = content_type.split("/")[-1]
+            else:
+                format = "png"
+        return content, format
     else:
-        if not download:
-            return media.image.uri
-        else:
-            assert isinstance(media.image, URL)
-            async with httpx.AsyncClient() as client:
-                r = await client.get(media.image.uri)
-                content = r.content
-                content_type = r.headers.get("content-type")
-                if content_type:
-                    format = content_type.split("/")[-1]
-                else:
-                    format = "png"
+        image = PIL_Image.open(media.data)
+        return media.data, image.format
 
+
+async def convert_image_content_to_url(
+    media: ImageContentItem, download: bool = False, include_format: bool = True
+) -> str:
+    if isinstance(media.data, URL) and not download:
+        return media.image.uri
+
+    content, format = await localize_image_content(media)
     if include_format:
         return f"data:image/{format};base64," + base64.b64encode(content).decode(
             "utf-8"
         )
     else:
         return base64.b64encode(content).decode("utf-8")
-
-
-# TODO: name this function better! this is about OpenAI compatibile image
-# media conversion of the message. this should probably go in openai_compat.py
-async def convert_message_to_dict(message: Message, download: bool = False) -> dict:
-    async def _convert_content(content) -> dict:
-        if isinstance(content, ImageMedia):
-            return {
-                "type": "image_url",
-                "image_url": {
-                    "url": await convert_image_media_to_url(content, download=download),
-                },
-            }
-        else:
-            assert isinstance(content, str)
-            return {"type": "text", "text": content}
-
-    if isinstance(message.content, list):
-        content = [await _convert_content(c) for c in message.content]
-    else:
-        content = [await _convert_content(message.content)]
-
-    return {
-        "role": message.role,
-        "content": content,
-    }
 
 
 def completion_request_to_prompt(
@@ -330,7 +377,7 @@ def augment_messages_for_tools_llama_3_2(
         sys_content += "\n"
 
     if existing_system_message:
-        sys_content += interleaved_text_media_as_str(
+        sys_content += interleaved_content_as_str(
             existing_system_message.content, sep="\n"
         )
 

--- a/llama_stack/providers/utils/memory/file_utils.py
+++ b/llama_stack/providers/utils/memory/file_utils.py
@@ -8,7 +8,7 @@ import base64
 import mimetypes
 import os
 
-from llama_stack.apis.common.deployment_types import URL
+from llama_stack.apis.common.content_types import URL
 
 
 def data_url_from_file(file_path: str) -> URL:

--- a/llama_stack/providers/utils/memory/file_utils.py
+++ b/llama_stack/providers/utils/memory/file_utils.py
@@ -8,7 +8,7 @@ import base64
 import mimetypes
 import os
 
-from llama_models.llama3.api.datatypes import URL
+from llama_stack.apis.common.deployment_types import URL
 
 
 def data_url_from_file(file_path: str) -> URL:

--- a/llama_stack/providers/utils/memory/vector_store.py
+++ b/llama_stack/providers/utils/memory/vector_store.py
@@ -21,7 +21,7 @@ from pypdf import PdfReader
 from llama_models.llama3.api.datatypes import *  # noqa: F403
 from llama_models.llama3.api.tokenizer import Tokenizer
 
-from llama_stack.apis.inference import InterleavedContent, TextContentItem
+from llama_stack.apis.common.content_types import InterleavedContent, TextContentItem
 from llama_stack.apis.memory import *  # noqa: F403
 from llama_stack.apis.memory_banks import VectorMemoryBank
 from llama_stack.providers.datatypes import Api

--- a/llama_stack/providers/utils/memory/vector_store.py
+++ b/llama_stack/providers/utils/memory/vector_store.py
@@ -22,7 +22,11 @@ from llama_models.llama3.api.datatypes import *  # noqa: F403
 from llama_models.llama3.api.tokenizer import Tokenizer
 
 from llama_stack.apis.memory import *  # noqa: F403
+from llama_stack.apis.memory_banks import VectorMemoryBank
 from llama_stack.providers.datatypes import Api
+from llama_stack.providers.utils.inference.prompt_adapter import (
+    interleaved_content_as_str,
+)
 
 log = logging.getLogger(__name__)
 
@@ -108,7 +112,7 @@ async def content_from_doc(doc: MemoryBankDocument) -> str:
             else:
                 return r.text
 
-    return interleaved_text_media_as_str(doc.content)
+    return interleaved_content_as_str(doc.content)
 
 
 def make_overlapped_chunks(
@@ -174,7 +178,7 @@ class BankWithIndex:
 
     async def query_documents(
         self,
-        query: InterleavedTextMedia,
+        query: InterleavedContent,
         params: Optional[Dict[str, Any]] = None,
     ) -> QueryDocumentsResponse:
         if params is None:

--- a/llama_stack/templates/bedrock/bedrock.py
+++ b/llama_stack/templates/bedrock/bedrock.py
@@ -7,12 +7,14 @@
 from pathlib import Path
 
 from llama_models.sku_list import all_registered_models
+
+from llama_stack.apis.models import ModelInput
 from llama_stack.distribution.datatypes import Provider
 
 from llama_stack.providers.inline.memory.faiss.config import FaissImplConfig
-from llama_stack.templates.template import DistributionTemplate, RunConfigSettings
 from llama_stack.providers.remote.inference.bedrock.bedrock import MODEL_ALIASES
-from llama_stack.apis.models import ModelInput
+from llama_stack.templates.template import DistributionTemplate, RunConfigSettings
+
 
 def get_distribution_template() -> DistributionTemplate:
     providers = {

--- a/tests/client-sdk/conftest.py
+++ b/tests/client-sdk/conftest.py
@@ -3,13 +3,22 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
+import os
+
 import pytest
+from llama_stack import LlamaStackAsLibraryClient
 
 from llama_stack.providers.tests.env import get_env_or_fail
 from llama_stack_client import LlamaStackClient
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def llama_stack_client():
-    """Fixture to create a fresh LlamaStackClient instance for each test"""
-    return LlamaStackClient(base_url=get_env_or_fail("LLAMA_STACK_BASE_URL"))
+    if os.environ.get("LLAMA_STACK_CONFIG"):
+        client = LlamaStackAsLibraryClient(get_env_or_fail("LLAMA_STACK_CONFIG"))
+        client.initialize()
+    elif os.environ.get("LLAMA_STACK_BASE_URL"):
+        client = LlamaStackClient(base_url=get_env_or_fail("LLAMA_STACK_BASE_URL"))
+    else:
+        raise ValueError("LLAMA_STACK_CONFIG or LLAMA_STACK_BASE_URL must be set")
+    return client

--- a/tests/client-sdk/inference/test_inference.py
+++ b/tests/client-sdk/inference/test_inference.py
@@ -4,21 +4,8 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-import sys
-import traceback
-import warnings
-
 import pytest
 from llama_stack_client.lib.inference.event_logger import EventLogger
-
-
-def warn_with_traceback(message, category, filename, lineno, file=None, line=None):
-    log = file if hasattr(file, "write") else sys.stderr
-    traceback.print_stack(file=log)
-    log.write(warnings.formatwarning(message, category, filename, lineno, line))
-
-
-warnings.showwarning = warn_with_traceback
 
 
 def test_text_chat_completion(llama_stack_client):

--- a/tests/client-sdk/inference/test_inference.py
+++ b/tests/client-sdk/inference/test_inference.py
@@ -4,8 +4,21 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import sys
+import traceback
+import warnings
+
 import pytest
 from llama_stack_client.lib.inference.event_logger import EventLogger
+
+
+def warn_with_traceback(message, category, filename, lineno, file=None, line=None):
+    log = file if hasattr(file, "write") else sys.stderr
+    traceback.print_stack(file=log)
+    log.write(warnings.formatwarning(message, category, filename, lineno, line))
+
+
+warnings.showwarning = warn_with_traceback
 
 
 def test_text_chat_completion(llama_stack_client):
@@ -55,11 +68,15 @@ def test_image_chat_completion(llama_stack_client):
         "role": "user",
         "content": [
             {
-                "image": {
+                "type": "image",
+                "data": {
                     "uri": "https://www.healthypawspetinsurance.com/Images/V3/DogAndPuppyInsurance/Dog_CTA_Desktop_HeroImage.jpg"
-                }
+                },
             },
-            "Describe what is in this image.",
+            {
+                "type": "text",
+                "text": "Describe what is in this image.",
+            },
         ],
     }
     response = llama_stack_client.inference.chat_completion(

--- a/tests/client-sdk/memory/test_memory.py
+++ b/tests/client-sdk/memory/test_memory.py
@@ -22,6 +22,7 @@ def test_memory_bank(llama_stack_client):
     llama_stack_client.memory_banks.register(
         memory_bank_id=memory_bank_id,
         params={
+            "memory_bank_type": "vector",
             "embedding_model": "all-MiniLM-L6-v2",
             "chunk_size_in_tokens": 512,
             "overlap_size_in_tokens": 64,


### PR DESCRIPTION
## What does this PR do?

This is a long-pending change and particularly important to get done now. 

Specifically:
- we cannot "localize" (aka download) any URLs from media attachments anywhere near our modeling code. it must be done within llama-stack.
- `PIL.Image` is infesting all our APIs via `ImageMedia -> InterleavedTextMedia` and that cannot be right at all. Anything in the API surface must be "naturally serializable". We need a standard `{ type: "image", image_url: "<...>" }` which is more extensible
- `UserMessage`, `SystemMessage`, etc. are moved completely to llama-stack from the llama-models repository. 

See https://github.com/meta-llama/llama-models/pull/244 for the corresponding PR in llama-models. 

## Test Plan

```bash
cd llama_stack/providers/tests

pytest -s -v -k "fireworks or ollama or together" inference/test_vision_inference.py
pytest -s -v -k "(fireworks or ollama or together) and llama_3b" inference/test_text_inference.py
pytest -s -v -k chroma memory/test_memory.py \
  --env EMBEDDING_DIMENSION=384 --env CHROMA_DB_PATH=/tmp/foobar

pytest -s -v -k fireworks agents/test_agents.py  \
   --safety-shield=meta-llama/Llama-Guard-3-8B \
   --inference-model=meta-llama/Llama-3.1-8B-Instruct
```

Updated the client sdk (see PR ...), installed the SDK in the same environment and then ran the SDK tests:

```bash
cd tests/client-sdk
LLAMA_STACK_CONFIG=together pytest -s -v agents/test_agents.py
LLAMA_STACK_CONFIG=ollama pytest -s -v memory/test_memory.py

# this one needed a bit of hacking in the run.yaml to ensure I could register the vision model correctly
INFERENCE_MODEL=llama3.2-vision:latest LLAMA_STACK_CONFIG=ollama pytest -s -v inference/test_inference.py
```