### PR TITLE
docs: Update getting_started.ipynb link to correct jupyter notebook path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Please checkout our [Documentation](https://llama-stack.readthedocs.io/en/latest
     * Guide using `llama` CLI to work with Llama models (download, study prompts), and building/starting a Llama Stack distribution.
 * [Getting Started](https://llama-stack.readthedocs.io/en/latest/getting_started/index.html)
     * Quick guide to start a Llama Stack server.
-    * [Jupyter notebook](./docs/getting_started.ipynb) to walk-through how to use simple text and vision inference llama_stack_client APIs
+    * [Jupyter notebook](./docs/notebooks/Llama_Stack_Building_AI_Applications.ipynb) to walk-through how to use simple text and vision inference llama_stack_client APIs
     * The complete Llama Stack lesson [Colab notebook](https://colab.research.google.com/drive/1dtVmxotBsI4cGZQNsJRYPrLiDeT0Wnwt) of the new [Llama 3.2 course on Deeplearning.ai](https://learn.deeplearning.ai/courses/introducing-multimodal-llama-3-2/lesson/8/llama-stack).
     * A [Zero-to-Hero Guide](https://github.com/meta-llama/llama-stack/tree/main/docs/zero_to_hero_guide) that guide you through all the key components of llama stack with code samples.
 * [Contributing](CONTRIBUTING.md)


### PR DESCRIPTION
# What does this PR do?

This PR fixes a broken link in the README.md that was causing a 404 error. The link to `getting_started.ipynb` was pointing to a non-existent file. Updated it to point to the correct notebook `Llama_Stack_Building_AI_Applications.ipynb` which contains the walk-through for text and vision inference llama_stack_client APIs.

- [x] Addresses issue (#633 )

## Test Plan

1. Verified that the new notebook path exists:
   ```bash
   ls docs/notebooks/Llama_Stack_Building_AI_Applications.ipynb
   ```

2. Verified the notebook content contains text and vision inference examples by:
   - Checking the notebook contents
   - Confirming the presence of vision models like Llama-3.2-11B-Vision-Instruct
   - Verifying llama_stack_client API usage examples


## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Ran pre-commit to handle lint / formatting issues.
- [x] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md), Pull Request section.
- [x] Updated relevant documentation.
- [ ] Wrote necessary unit or integration tests (N/A - documentation change only).