### PR TITLE
Update Cerebras from Llama 3.1 to 3.3

### DIFF
--- a/docs/source/distributions/self_hosted_distro/cerebras.md
+++ b/docs/source/distributions/self_hosted_distro/cerebras.md
@@ -23,7 +23,7 @@ The following environment variables can be configured:
 The following models are available by default:
 
 - `meta-llama/Llama-3.1-8B-Instruct (llama3.1-8b)`
-- `meta-llama/Llama-3.1-70B-Instruct (llama3.1-70b)`
+- `meta-llama/Llama-3.3-70B-Instruct (llama-3.3-70b)`
 
 
 ### Prerequisite: API Keys

--- a/llama_stack/providers/remote/inference/cerebras/cerebras.py
+++ b/llama_stack/providers/remote/inference/cerebras/cerebras.py
@@ -41,8 +41,8 @@ model_aliases = [
         CoreModelId.llama3_1_8b_instruct.value,
     ),
     build_model_alias(
-        "llama3.1-70b",
-        CoreModelId.llama3_1_70b_instruct.value,
+        "llama-3.3-70b",
+        CoreModelId.llama3_3_70b_instruct.value,
     ),
 ]
 

--- a/llama_stack/templates/cerebras/run.yaml
+++ b/llama_stack/templates/cerebras/run.yaml
@@ -56,9 +56,9 @@ models:
   provider_model_id: llama3.1-8b
   model_type: llm
 - metadata: {}
-  model_id: meta-llama/Llama-3.1-70B-Instruct
+  model_id: meta-llama/Llama-3.3-70B-Instruct
   provider_id: cerebras
-  provider_model_id: llama3.1-70b
+  provider_model_id: llama-3.3-70b
   model_type: llm
 - metadata:
     embedding_dimension: 384


### PR DESCRIPTION
# What does this PR do?

Cerebras is rolling out support for llama 3.3 70b and deprecating llama 3.1 70b. This PR updates the documentation, config, and internal mapping to reflect this change.

cc: @ashwinb @raghotham 