### PR TITLE
store attributes values in builtin types to avoid otel warnings

### DIFF
--- a/llama_stack/providers/utils/telemetry/trace_protocol.py
+++ b/llama_stack/providers/utils/telemetry/trace_protocol.py
@@ -6,10 +6,8 @@
 
 import asyncio
 import inspect
-from datetime import datetime
 from functools import wraps
 from typing import Any, AsyncGenerator, Callable, Type, TypeVar
-from uuid import UUID
 
 from pydantic import BaseModel
 
@@ -19,17 +17,17 @@ T = TypeVar("T")
 def serialize_value(value: Any) -> Any:
     """Serialize a single value into JSON-compatible format."""
     if value is None:
-        return None
+        return ""
     elif isinstance(value, (str, int, float, bool)):
         return value
+    elif hasattr(value, "_name_"):
+        return value._name_
     elif isinstance(value, BaseModel):
-        return value.model_dump()
+        return value.model_dump_json()
     elif isinstance(value, (list, tuple, set)):
         return [serialize_value(item) for item in value]
     elif isinstance(value, dict):
         return {str(k): serialize_value(v) for k, v in value.items()}
-    elif isinstance(value, (datetime, UUID)):
-        return str(value)
     else:
         return str(value)
 

--- a/llama_stack/providers/utils/telemetry/tracing.py
+++ b/llama_stack/providers/utils/telemetry/tracing.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, Dict, List
 
 
 from llama_stack.apis.telemetry import *  # noqa: F403
+from llama_stack.providers.utils.telemetry.trace_protocol import serialize_value
 
 log = logging.getLogger(__name__)
 
@@ -223,7 +224,7 @@ class SpanContextManager:
         if self.span:
             if self.span.attributes is None:
                 self.span.attributes = {}
-            self.span.attributes[key] = value
+            self.span.attributes[key] = serialize_value(value)
 
     async def __aenter__(self):
         global CURRENT_TRACE_CONTEXT


### PR DESCRIPTION
# What does this PR do?

Serialize objects to built in types to avoid otel warnings


## Test Plan

╰─❯ llama stack run ~/.llama/distributions/llamastack-together/together-run.yaml


