### PR TITLE
Removed unnecessary CONDA_PREFIX env var in installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ You have two ways to install this repository:
     conda activate stack
 
     cd llama-stack
-    $CONDA_PREFIX/bin/pip install -e .
+    pip install -e .
    ```
 
 ## Documentation


### PR DESCRIPTION
This is not needed since `conda activate stack` has already been executed.