### PR TITLE
[Post Training] Fix missing import

### DIFF
--- a/llama_stack/providers/inline/post_training/torchtune/common/utils.py
+++ b/llama_stack/providers/inline/post_training/torchtune/common/utils.py
@@ -15,6 +15,8 @@ from typing import Any, Callable, Dict, List
 
 import torch
 from llama_models.datatypes import Model
+
+from llama_models.llama3.api.datatypes import BaseModel
 from llama_models.sku_list import resolve_model
 from llama_stack.apis.common.type_system import ParamType, StringType
 from llama_stack.apis.datasets import Datasets

--- a/llama_stack/providers/inline/post_training/torchtune/recipes/lora_finetuning_single_device.py
+++ b/llama_stack/providers/inline/post_training/torchtune/recipes/lora_finetuning_single_device.py
@@ -7,6 +7,7 @@
 import logging
 import os
 import time
+from datetime import datetime
 from functools import partial
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple


### PR DESCRIPTION
## context
Post training apis are broken after the import * refactor https://github.com/meta-llama/llama-stack/pull/689. This PR is adding the missing import back

## Test
Issue a post training request from client and the training finishes successfully

<img width="1101" alt="Screenshot 2025-01-02 at 12 18 45 PM" src="https://github.com/user-attachments/assets/8c781459-f340-4021-85e1-fc68b1dcb8c8" />

<img width="782" alt="Screenshot 2025-01-02 at 12 18 52 PM" src="https://github.com/user-attachments/assets/14b04b7d-e5c7-4662-8fa6-748446ad3511" />

