### PR TITLE
Add X-LlamaStack-Client-Version, rename ProviderData -> Provider-Data

### DIFF
--- a/docs/openapi_generator/pyopenapi/generator.py
+++ b/docs/openapi_generator/pyopenapi/generator.py
@@ -486,9 +486,18 @@ class Generator:
         parameters = path_parameters + query_parameters
         parameters += [
             Parameter(
-                name="X-LlamaStack-ProviderData",
+                name="X-LlamaStack-Provider-Data",
                 in_=ParameterLocation.Header,
                 description="JSON-encoded provider data which will be made available to the adapter servicing the API",
+                required=False,
+                schema=self.schema_builder.classdef_to_ref(str),
+            )
+        ]
+        parameters += [
+            Parameter(
+                name="X-LlamaStack-Client-Version",
+                in_=ParameterLocation.Header,
+                description="Version of the client making the request. This is used to ensure that the client and server are compatible.",
                 required=False,
                 schema=self.schema_builder.classdef_to_ref(str),
             )

--- a/docs/resources/llama-stack-spec.html
+++ b/docs/resources/llama-stack-spec.html
@@ -41,9 +41,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -81,9 +90,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -121,9 +139,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -154,9 +181,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -201,9 +237,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -248,9 +293,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -288,9 +342,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -328,9 +391,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -375,9 +447,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -408,9 +489,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -441,9 +531,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -481,9 +580,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -521,9 +629,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -577,9 +694,18 @@
                         }
                     },
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -649,9 +775,18 @@
                         }
                     },
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -703,9 +838,18 @@
                         }
                     },
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -748,9 +892,18 @@
                         }
                     },
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -793,9 +946,18 @@
                         }
                     },
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -851,9 +1013,18 @@
                         }
                     },
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -896,9 +1067,18 @@
                         }
                     },
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -958,9 +1138,18 @@
                         }
                     },
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1003,9 +1192,18 @@
                         }
                     },
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1048,9 +1246,18 @@
                         }
                     },
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1097,9 +1304,18 @@
                         }
                     },
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1145,9 +1361,18 @@
                         }
                     },
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1183,9 +1408,18 @@
                         }
                     },
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1228,9 +1462,18 @@
                         }
                     },
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1273,9 +1516,18 @@
                         }
                     },
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1303,9 +1555,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1333,9 +1594,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1356,9 +1626,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1397,9 +1676,18 @@
                 "summary": "Run a tool with the given arguments",
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1430,9 +1718,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1486,9 +1783,18 @@
                         }
                     },
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1539,9 +1845,18 @@
                         }
                     },
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1569,9 +1884,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1599,9 +1923,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1642,9 +1975,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1672,9 +2014,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1705,9 +2056,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1741,9 +2101,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1779,9 +2148,18 @@
                         }
                     },
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1819,9 +2197,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1849,9 +2236,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1880,9 +2276,18 @@
                 "summary": "List tool groups with optional provider",
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1919,9 +2324,18 @@
                         }
                     },
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1942,9 +2356,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1982,9 +2405,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -2022,9 +2454,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -2062,9 +2503,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -2102,9 +2552,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -2135,9 +2594,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -2168,9 +2636,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -2197,9 +2674,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -2237,9 +2723,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -2270,9 +2765,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -2310,9 +2814,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -2344,9 +2857,18 @@
                 "summary": "Register a tool group",
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -2384,9 +2906,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -2424,9 +2955,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -2457,9 +2997,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -2497,9 +3046,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -2537,9 +3095,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -2577,9 +3144,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -2617,9 +3193,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -2650,9 +3235,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -2683,9 +3277,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -2716,9 +3319,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -2750,9 +3362,18 @@
                 "summary": "Unregister a tool group",
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -2790,9 +3411,18 @@
                 ],
                 "parameters": [
                     {
-                        "name": "X-LlamaStack-ProviderData",
+                        "name": "X-LlamaStack-Provider-Data",
                         "in": "header",
                         "description": "JSON-encoded provider data which will be made available to the adapter servicing the API",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-LlamaStack-Client-Version",
+                        "in": "header",
+                        "description": "Version of the client making the request. This is used to ensure that the client and server are compatible.",
                         "required": false,
                         "schema": {
                             "type": "string"

--- a/docs/resources/llama-stack-spec.yaml
+++ b/docs/resources/llama-stack-spec.yaml
@@ -3184,7 +3184,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3209,7 +3216,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3230,7 +3244,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3255,7 +3276,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3286,7 +3314,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3331,7 +3366,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3350,7 +3392,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3393,7 +3442,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3412,7 +3468,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3437,7 +3500,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3462,7 +3532,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3503,7 +3580,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3527,7 +3611,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3548,7 +3639,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3567,7 +3665,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3588,7 +3693,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3614,7 +3726,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3635,7 +3754,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3654,7 +3780,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3675,7 +3808,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3700,7 +3840,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3731,7 +3878,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3760,7 +3914,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3781,7 +3942,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3806,7 +3974,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3825,7 +4000,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3852,7 +4034,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3879,7 +4068,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3909,7 +4105,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3934,7 +4137,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3957,7 +4167,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3976,7 +4193,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -3997,7 +4221,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4018,7 +4249,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4048,7 +4286,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4069,7 +4314,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4088,7 +4340,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4113,7 +4372,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4139,7 +4405,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4160,7 +4433,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4186,7 +4466,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4207,7 +4494,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4226,7 +4520,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4251,7 +4552,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4276,7 +4584,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4297,7 +4612,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4320,7 +4642,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4350,7 +4679,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4371,7 +4707,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4390,7 +4733,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4411,7 +4761,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4436,7 +4793,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4466,7 +4830,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4487,7 +4858,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4506,7 +4884,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4531,7 +4916,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4566,7 +4958,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4593,7 +4992,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4614,7 +5020,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4639,7 +5052,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4664,7 +5084,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4685,7 +5112,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4716,7 +5150,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4746,7 +5187,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4765,7 +5213,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4785,7 +5240,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4807,7 +5269,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4834,7 +5303,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4858,7 +5334,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
@@ -4878,7 +5361,14 @@ paths:
       - description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
         in: header
-        name: X-LlamaStack-ProviderData
+        name: X-LlamaStack-Provider-Data
+        required: false
+        schema:
+          type: string
+      - description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        in: header
+        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string

--- a/llama_stack/distribution/request_headers.py
+++ b/llama_stack/distribution/request_headers.py
@@ -40,8 +40,8 @@ class NeedsRequestProviderData:
 
 def set_request_provider_data(headers: Dict[str, str]):
     keys = [
-        "X-LlamaStack-ProviderData",
-        "x-llamastack-providerdata",
+        "X-LlamaStack-Provider-Data",
+        "x-llamastack-provider-data",
     ]
     for key in keys:
         val = headers.get(key, None)

--- a/llama_stack/providers/inline/scoring/braintrust/braintrust.py
+++ b/llama_stack/providers/inline/scoring/braintrust/braintrust.py
@@ -156,7 +156,7 @@ class BraintrustScoringImpl(
             provider_data = self.get_request_provider_data()
             if provider_data is None or not provider_data.openai_api_key:
                 raise ValueError(
-                    'Pass OpenAI API Key in the header X-LlamaStack-ProviderData as { "openai_api_key": <your api key>}'
+                    'Pass OpenAI API Key in the header X-LlamaStack-Provider-Data as { "openai_api_key": <your api key>}'
                 )
             self.config.openai_api_key = provider_data.openai_api_key
 

--- a/llama_stack/providers/remote/inference/fireworks/fireworks.py
+++ b/llama_stack/providers/remote/inference/fireworks/fireworks.py
@@ -118,7 +118,7 @@ class FireworksInferenceAdapter(
             provider_data = self.get_request_provider_data()
             if provider_data is None or not provider_data.fireworks_api_key:
                 raise ValueError(
-                    'Pass Fireworks API Key in the header X-LlamaStack-ProviderData as { "fireworks_api_key": <your api key>}'
+                    'Pass Fireworks API Key in the header X-LlamaStack-Provider-Data as { "fireworks_api_key": <your api key>}'
                 )
             return provider_data.fireworks_api_key
 

--- a/llama_stack/providers/remote/inference/groq/groq.py
+++ b/llama_stack/providers/remote/inference/groq/groq.py
@@ -145,6 +145,6 @@ class GroqInferenceAdapter(Inference, ModelRegistryHelper, NeedsRequestProviderD
             provider_data = self.get_request_provider_data()
             if provider_data is None or not provider_data.groq_api_key:
                 raise ValueError(
-                    'Pass Groq API Key in the header X-LlamaStack-ProviderData as { "groq_api_key": "<your api key>" }'
+                    'Pass Groq API Key in the header X-LlamaStack-Provider-Data as { "groq_api_key": "<your api key>" }'
                 )
             return Groq(api_key=provider_data.groq_api_key)

--- a/llama_stack/providers/remote/inference/together/together.py
+++ b/llama_stack/providers/remote/inference/together/together.py
@@ -135,7 +135,7 @@ class TogetherInferenceAdapter(
             provider_data = self.get_request_provider_data()
             if provider_data is None or not provider_data.together_api_key:
                 raise ValueError(
-                    'Pass Together API Key in the header X-LlamaStack-ProviderData as { "together_api_key": <your api key>}'
+                    'Pass Together API Key in the header X-LlamaStack-Provider-Data as { "together_api_key": <your api key>}'
                 )
             together_api_key = provider_data.together_api_key
         return Together(api_key=together_api_key)

--- a/llama_stack/providers/remote/tool_runtime/bing_search/bing_search.py
+++ b/llama_stack/providers/remote/tool_runtime/bing_search/bing_search.py
@@ -46,7 +46,7 @@ class BingSearchToolRuntimeImpl(
         provider_data = self.get_request_provider_data()
         if provider_data is None or not provider_data.api_key:
             raise ValueError(
-                'Pass Bing Search API Key in the header X-LlamaStack-ProviderData as { "api_key": <your api key>}'
+                'Pass Bing Search API Key in the header X-LlamaStack-Provider-Data as { "api_key": <your api key>}'
             )
         return provider_data.api_key
 

--- a/llama_stack/providers/remote/tool_runtime/brave_search/brave_search.py
+++ b/llama_stack/providers/remote/tool_runtime/brave_search/brave_search.py
@@ -45,7 +45,7 @@ class BraveSearchToolRuntimeImpl(
         provider_data = self.get_request_provider_data()
         if provider_data is None or not provider_data.api_key:
             raise ValueError(
-                'Pass Search provider\'s API Key in the header X-LlamaStack-ProviderData as { "api_key": <your api key>}'
+                'Pass Search provider\'s API Key in the header X-LlamaStack-Provider-Data as { "api_key": <your api key>}'
             )
         return provider_data.api_key
 

--- a/llama_stack/providers/remote/tool_runtime/tavily_search/tavily_search.py
+++ b/llama_stack/providers/remote/tool_runtime/tavily_search/tavily_search.py
@@ -45,7 +45,7 @@ class TavilySearchToolRuntimeImpl(
         provider_data = self.get_request_provider_data()
         if provider_data is None or not provider_data.api_key:
             raise ValueError(
-                'Pass Search provider\'s API Key in the header X-LlamaStack-ProviderData as { "api_key": <your api key>}'
+                'Pass Search provider\'s API Key in the header X-LlamaStack-Provider-Data as { "api_key": <your api key>}'
             )
         return provider_data.api_key
 

--- a/llama_stack/providers/remote/tool_runtime/wolfram_alpha/wolfram_alpha.py
+++ b/llama_stack/providers/remote/tool_runtime/wolfram_alpha/wolfram_alpha.py
@@ -46,7 +46,7 @@ class WolframAlphaToolRuntimeImpl(
         provider_data = self.get_request_provider_data()
         if provider_data is None or not provider_data.api_key:
             raise ValueError(
-                'Pass WolframAlpha API Key in the header X-LlamaStack-ProviderData as { "api_key": <your api key>}'
+                'Pass WolframAlpha API Key in the header X-LlamaStack-Provider-Data as { "api_key": <your api key>}'
             )
         return provider_data.api_key
 

--- a/llama_stack/providers/tests/resolver.py
+++ b/llama_stack/providers/tests/resolver.py
@@ -79,7 +79,7 @@ async def construct_stack_for_test(
 
     if provider_data:
         set_request_provider_data(
-            {"X-LlamaStack-ProviderData": json.dumps(provider_data)}
+            {"X-LlamaStack-Provider-Data": json.dumps(provider_data)}
         )
 
     return test_stack


### PR DESCRIPTION
Add another header so client SDKs can identify their versions which can be used for immediate detection of possible compatibility issues. A semver mismatch against the wrong server should be immediately flagged and requests should be denied.

Also change `X-LlamaStack-ProviderData` to `X-LlamaStack-Provider-Data` since that hyphenation is better.