### PR TITLE
add inline mcp provider

### DIFF
--- a/docs/resources/llama-stack-spec.html
+++ b/docs/resources/llama-stack-spec.html
@@ -6548,6 +6548,83 @@
                     "model_context_protocol"
                 ]
             },
+            "MCPConfig": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/MCPInlineConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/MCPRemoteConfig"
+                    }
+                ]
+            },
+            "MCPInlineConfig": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "const": "inline",
+                        "default": "inline"
+                    },
+                    "command": {
+                        "type": "string"
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "env": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "type": "boolean"
+                                },
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "type",
+                    "command"
+                ]
+            },
+            "MCPRemoteConfig": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "const": "remote",
+                        "default": "remote"
+                    },
+                    "mcp_endpoint": {
+                        "$ref": "#/components/schemas/URL"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "type",
+                    "mcp_endpoint"
+                ]
+            },
             "ToolGroup": {
                 "type": "object",
                 "properties": {
@@ -6565,8 +6642,8 @@
                         "const": "tool_group",
                         "default": "tool_group"
                     },
-                    "mcp_endpoint": {
-                        "$ref": "#/components/schemas/URL"
+                    "mcp_config": {
+                        "$ref": "#/components/schemas/MCPConfig"
                     },
                     "args": {
                         "type": "object",
@@ -6916,8 +6993,8 @@
             "ListRuntimeToolsRequest": {
                 "type": "object",
                 "properties": {
-                    "mcp_endpoint": {
-                        "$ref": "#/components/schemas/URL"
+                    "mcp_config": {
+                        "$ref": "#/components/schemas/MCPConfig"
                     }
                 },
                 "additionalProperties": false
@@ -8022,8 +8099,8 @@
                     "provider_id": {
                         "type": "string"
                     },
-                    "mcp_endpoint": {
-                        "$ref": "#/components/schemas/URL"
+                    "mcp_config": {
+                        "$ref": "#/components/schemas/MCPConfig"
                     },
                     "args": {
                         "type": "object",
@@ -8933,6 +9010,18 @@
             "description": "<SchemaDefinition schemaRef=\"#/components/schemas/LoraFinetuningConfig\" />"
         },
         {
+            "name": "MCPConfig",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/MCPConfig\" />"
+        },
+        {
+            "name": "MCPInlineConfig",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/MCPInlineConfig\" />"
+        },
+        {
+            "name": "MCPRemoteConfig",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/MCPRemoteConfig\" />"
+        },
+        {
             "name": "Memory"
         },
         {
@@ -9437,6 +9526,9 @@
                 "LogEventRequest",
                 "LogSeverity",
                 "LoraFinetuningConfig",
+                "MCPConfig",
+                "MCPInlineConfig",
+                "MCPRemoteConfig",
                 "MemoryBankDocument",
                 "MemoryRetrievalStep",
                 "Message",

--- a/docs/resources/llama-stack-spec.yaml
+++ b/docs/resources/llama-stack-spec.yaml
@@ -1125,8 +1125,8 @@ components:
     ListRuntimeToolsRequest:
       additionalProperties: false
       properties:
-        mcp_endpoint:
-          $ref: '#/components/schemas/URL'
+        mcp_config:
+          $ref: '#/components/schemas/MCPConfig'
       type: object
     LogEventRequest:
       additionalProperties: false
@@ -1183,6 +1183,50 @@ components:
       - apply_lora_to_output
       - rank
       - alpha
+      type: object
+    MCPConfig:
+      oneOf:
+      - $ref: '#/components/schemas/MCPInlineConfig'
+      - $ref: '#/components/schemas/MCPRemoteConfig'
+    MCPInlineConfig:
+      additionalProperties: false
+      properties:
+        args:
+          items:
+            type: string
+          type: array
+        command:
+          type: string
+        env:
+          additionalProperties:
+            oneOf:
+            - type: 'null'
+            - type: boolean
+            - type: number
+            - type: string
+            - type: array
+            - type: object
+          type: object
+        type:
+          const: inline
+          default: inline
+          type: string
+      required:
+      - type
+      - command
+      type: object
+    MCPRemoteConfig:
+      additionalProperties: false
+      properties:
+        mcp_endpoint:
+          $ref: '#/components/schemas/URL'
+        type:
+          const: remote
+          default: remote
+          type: string
+      required:
+      - type
+      - mcp_endpoint
       type: object
     MemoryBankDocument:
       additionalProperties: false
@@ -1897,8 +1941,8 @@ components:
             - type: array
             - type: object
           type: object
-        mcp_endpoint:
-          $ref: '#/components/schemas/URL'
+        mcp_config:
+          $ref: '#/components/schemas/MCPConfig'
         provider_id:
           type: string
         toolgroup_id:
@@ -2773,8 +2817,8 @@ components:
           type: object
         identifier:
           type: string
-        mcp_endpoint:
-          $ref: '#/components/schemas/URL'
+        mcp_config:
+          $ref: '#/components/schemas/MCPConfig'
         provider_id:
           type: string
         provider_resource_id:
@@ -5615,6 +5659,14 @@ tags:
 - description: <SchemaDefinition schemaRef="#/components/schemas/LoraFinetuningConfig"
     />
   name: LoraFinetuningConfig
+- description: <SchemaDefinition schemaRef="#/components/schemas/MCPConfig" />
+  name: MCPConfig
+- description: <SchemaDefinition schemaRef="#/components/schemas/MCPInlineConfig"
+    />
+  name: MCPInlineConfig
+- description: <SchemaDefinition schemaRef="#/components/schemas/MCPRemoteConfig"
+    />
+  name: MCPRemoteConfig
 - name: Memory
 - description: <SchemaDefinition schemaRef="#/components/schemas/MemoryBankDocument"
     />
@@ -5982,6 +6034,9 @@ x-tagGroups:
   - LogEventRequest
   - LogSeverity
   - LoraFinetuningConfig
+  - MCPConfig
+  - MCPInlineConfig
+  - MCPRemoteConfig
   - MemoryBankDocument
   - MemoryRetrievalStep
   - Message

--- a/llama_stack/distribution/routers/routers.py
+++ b/llama_stack/distribution/routers/routers.py
@@ -6,7 +6,7 @@
 
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
-from llama_stack.apis.common.content_types import InterleavedContent, URL
+from llama_stack.apis.common.content_types import InterleavedContent
 from llama_stack.apis.datasetio import DatasetIO, PaginatedRowsResult
 from llama_stack.apis.eval import (
     AppEvalTaskConfig,
@@ -38,7 +38,7 @@ from llama_stack.apis.scoring import (
     ScoringFnParams,
 )
 from llama_stack.apis.shields import Shield
-from llama_stack.apis.tools import ToolDef, ToolRuntime
+from llama_stack.apis.tools import MCPConfig, ToolDef, ToolRuntime
 from llama_stack.providers.datatypes import RoutingTable
 
 
@@ -418,8 +418,10 @@ class ToolRuntimeRouter(ToolRuntime):
         )
 
     async def list_runtime_tools(
-        self, tool_group_id: Optional[str] = None, mcp_endpoint: Optional[URL] = None
+        self,
+        tool_group_id: Optional[str] = None,
+        mcp_config: Optional[MCPConfig] = None,
     ) -> List[ToolDef]:
         return await self.routing_table.get_provider_impl(tool_group_id).list_tools(
-            tool_group_id, mcp_endpoint
+            tool_group_id, mcp_config
         )

--- a/llama_stack/distribution/routers/routing_tables.py
+++ b/llama_stack/distribution/routers/routing_tables.py
@@ -26,7 +26,7 @@ from llama_stack.apis.scoring_functions import (
     ScoringFunctions,
 )
 from llama_stack.apis.shields import Shield, Shields
-from llama_stack.apis.tools import Tool, ToolGroup, ToolGroups, ToolHost
+from llama_stack.apis.tools import MCPConfig, Tool, ToolGroup, ToolGroups, ToolHost
 from llama_stack.distribution.datatypes import (
     RoutableObject,
     RoutableObjectWithProvider,
@@ -504,15 +504,15 @@ class ToolGroupsRoutingTable(CommonRoutingTableImpl, ToolGroups):
         self,
         toolgroup_id: str,
         provider_id: str,
-        mcp_endpoint: Optional[URL] = None,
+        mcp_config: Optional[MCPConfig] = None,
         args: Optional[Dict[str, Any]] = None,
     ) -> None:
         tools = []
         tool_defs = await self.impls_by_provider_id[provider_id].list_runtime_tools(
-            toolgroup_id, mcp_endpoint
+            toolgroup_id, mcp_config
         )
         tool_host = (
-            ToolHost.model_context_protocol if mcp_endpoint else ToolHost.distribution
+            ToolHost.model_context_protocol if mcp_config else ToolHost.distribution
         )
 
         for tool_def in tool_defs:
@@ -547,7 +547,7 @@ class ToolGroupsRoutingTable(CommonRoutingTableImpl, ToolGroups):
                 identifier=toolgroup_id,
                 provider_id=provider_id,
                 provider_resource_id=toolgroup_id,
-                mcp_endpoint=mcp_endpoint,
+                mcp_config=mcp_config,
                 args=args,
             )
         )

--- a/llama_stack/providers/inline/tool_runtime/code_interpreter/code_interpreter.py
+++ b/llama_stack/providers/inline/tool_runtime/code_interpreter/code_interpreter.py
@@ -9,8 +9,8 @@ import logging
 import tempfile
 from typing import Any, Dict, List, Optional
 
-from llama_stack.apis.common.content_types import URL
 from llama_stack.apis.tools import (
+    MCPConfig,
     Tool,
     ToolDef,
     ToolInvocationResult,
@@ -43,7 +43,9 @@ class CodeInterpreterToolRuntimeImpl(ToolsProtocolPrivate, ToolRuntime):
         return
 
     async def list_runtime_tools(
-        self, tool_group_id: Optional[str] = None, mcp_endpoint: Optional[URL] = None
+        self,
+        tool_group_id: Optional[str] = None,
+        mcp_config: Optional[MCPConfig] = None,
     ) -> List[ToolDef]:
         return [
             ToolDef(

--- a/llama_stack/providers/inline/tool_runtime/memory/memory.py
+++ b/llama_stack/providers/inline/tool_runtime/memory/memory.py
@@ -10,11 +10,11 @@ import secrets
 import string
 from typing import Any, Dict, List, Optional
 
-from llama_stack.apis.common.content_types import URL
 from llama_stack.apis.inference import Inference, InterleavedContent
 from llama_stack.apis.memory import Memory, QueryDocumentsResponse
 from llama_stack.apis.memory_banks import MemoryBanks
 from llama_stack.apis.tools import (
+    MCPConfig,
     ToolDef,
     ToolInvocationResult,
     ToolParameter,
@@ -52,7 +52,9 @@ class MemoryToolRuntimeImpl(ToolsProtocolPrivate, ToolRuntime):
         pass
 
     async def list_runtime_tools(
-        self, tool_group_id: Optional[str] = None, mcp_endpoint: Optional[URL] = None
+        self,
+        tool_group_id: Optional[str] = None,
+        mcp_config: Optional[MCPConfig] = None,
     ) -> List[ToolDef]:
         return [
             ToolDef(

--- a/llama_stack/providers/inline/tool_runtime/model_context_protocol/__init__.py
+++ b/llama_stack/providers/inline/tool_runtime/model_context_protocol/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from pydantic import BaseModel
+
+from .config import ModelContextProtocolConfig
+from .model_context_protocol import ModelContextProtocolToolRuntimeImpl
+
+
+class ModelContextProtocolToolProviderDataValidator(BaseModel):
+    api_key: str
+
+
+async def get_provider_impl(config: ModelContextProtocolConfig, _deps):
+    impl = ModelContextProtocolToolRuntimeImpl(config)
+    await impl.initialize()
+    return impl

--- a/llama_stack/providers/inline/tool_runtime/model_context_protocol/config.py
+++ b/llama_stack/providers/inline/tool_runtime/model_context_protocol/config.py
@@ -1,0 +1,11 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from pydantic import BaseModel
+
+
+class ModelContextProtocolConfig(BaseModel):
+    pass

--- a/llama_stack/providers/registry/tool_runtime.py
+++ b/llama_stack/providers/registry/tool_runtime.py
@@ -32,6 +32,13 @@ def available_providers() -> List[ProviderSpec]:
             module="llama_stack.providers.inline.tool_runtime.code_interpreter",
             config_class="llama_stack.providers.inline.tool_runtime.code_interpreter.config.CodeInterpreterToolConfig",
         ),
+        InlineProviderSpec(
+            api=Api.tool_runtime,
+            provider_type="inline::model-context-protocol",
+            pip_packages=["mcp"],
+            module="llama_stack.providers.inline.tool_runtime.model_context_protocol",
+            config_class="llama_stack.providers.inline.tool_runtime.model_context_protocol.config.ModelContextProtocolConfig",
+        ),
         remote_provider_spec(
             api=Api.tool_runtime,
             adapter=AdapterSpec(

--- a/llama_stack/providers/remote/tool_runtime/brave_search/brave_search.py
+++ b/llama_stack/providers/remote/tool_runtime/brave_search/brave_search.py
@@ -9,8 +9,8 @@ from typing import Any, Dict, List, Optional
 import requests
 from llama_models.llama3.api.datatypes import BuiltinTool
 
-from llama_stack.apis.common.content_types import URL
 from llama_stack.apis.tools import (
+    MCPConfig,
     Tool,
     ToolDef,
     ToolInvocationResult,
@@ -50,7 +50,9 @@ class BraveSearchToolRuntimeImpl(
         return provider_data.api_key
 
     async def list_runtime_tools(
-        self, tool_group_id: Optional[str] = None, mcp_endpoint: Optional[URL] = None
+        self,
+        tool_group_id: Optional[str] = None,
+        mcp_config: Optional[MCPConfig] = None,
     ) -> List[ToolDef]:
         return [
             ToolDef(

--- a/llama_stack/providers/remote/tool_runtime/tavily_search/tavily_search.py
+++ b/llama_stack/providers/remote/tool_runtime/tavily_search/tavily_search.py
@@ -9,8 +9,8 @@ from typing import Any, Dict, List, Optional
 
 import requests
 
-from llama_stack.apis.common.content_types import URL
 from llama_stack.apis.tools import (
+    MCPConfig,
     Tool,
     ToolDef,
     ToolInvocationResult,
@@ -50,7 +50,9 @@ class TavilySearchToolRuntimeImpl(
         return provider_data.api_key
 
     async def list_runtime_tools(
-        self, tool_group_id: Optional[str] = None, mcp_endpoint: Optional[URL] = None
+        self,
+        tool_group_id: Optional[str] = None,
+        mcp_config: Optional[MCPConfig] = None,
     ) -> List[ToolDef]:
         return [
             ToolDef(

--- a/llama_stack/providers/remote/tool_runtime/wolfram_alpha/wolfram_alpha.py
+++ b/llama_stack/providers/remote/tool_runtime/wolfram_alpha/wolfram_alpha.py
@@ -9,8 +9,8 @@ from typing import Any, Dict, List, Optional
 
 import requests
 
-from llama_stack.apis.common.content_types import URL
 from llama_stack.apis.tools import (
+    MCPConfig,
     Tool,
     ToolDef,
     ToolInvocationResult,
@@ -51,7 +51,9 @@ class WolframAlphaToolRuntimeImpl(
         return provider_data.api_key
 
     async def list_runtime_tools(
-        self, tool_group_id: Optional[str] = None, mcp_endpoint: Optional[URL] = None
+        self,
+        tool_group_id: Optional[str] = None,
+        mcp_config: Optional[MCPConfig] = None,
     ) -> List[ToolDef]:
         return [
             ToolDef(


### PR DESCRIPTION
# What does this PR do?

This PR adds an inline MCP provider which starts an MCP server inside a processes and communicates to it via STD IO.



## Test Plan

LLAMA_STACK_CONFIG="/Users/dineshyv/.llama/distributions/llamastack-fireworks/fireworks-run.yaml" pytest -v tests/client-sdk/agents/test_agents.py -k "test_mcp_agent"

run.yaml: https://gist.github.com/dineshyv/3c97c73f4655bf44daa272789de5e0eb
