### PR TITLE
Fix incorrect Python binary path for UBI9 image

### DIFF
--- a/llama_stack/distribution/build_container.sh
+++ b/llama_stack/distribution/build_container.sh
@@ -59,7 +59,7 @@ WORKDIR /app
 
 RUN microdnf -y update && microdnf install -y iputils net-tools wget \
     vim-minimal python3.11 python3.11-pip python3.11-wheel \
-    python3.11-setuptools && ln -s /bin/pip3.11 /bin/pip && microdnf clean all
+    python3.11-setuptools && ln -s /bin/pip3.11 /bin/pip && ln -s /bin/python3.11 /bin/python && microdnf clean all
 
 EOF
 else


### PR DESCRIPTION
This was missed during a rebase in https://github.com/meta-llama/llama-stack/pull/676. 

Fixed the following error:
```
Error: crun: executable file `python` not found in $PATH: No such file or directory: OCI runtime attempted to invoke a command that was not found
++ error_handler 88
++ echo 'Error occurred in script at line: 88'
Error occurred in script at line: 88
```

cc @hardikjshah 