### PR TITLE
introduce and use a generic ContentDelta

### DIFF
--- a/docs/resources/llama-stack-spec.html
+++ b/docs/resources/llama-stack-spec.html
@@ -3843,8 +3843,8 @@
                 "properties": {
                     "role": {
                         "type": "string",
-                        "const": "ipython",
-                        "default": "ipython"
+                        "const": "tool",
+                        "default": "tool"
                     },
                     "call_id": {
                         "type": "string"
@@ -4185,14 +4185,7 @@
                         "$ref": "#/components/schemas/ChatCompletionResponseEventType"
                     },
                     "delta": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "$ref": "#/components/schemas/ToolCallDelta"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/ContentDelta"
                     },
                     "logprobs": {
                         "type": "array",
@@ -4232,6 +4225,50 @@
                 ],
                 "title": "SSE-stream of these events."
             },
+            "ContentDelta": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "const": "text",
+                                "default": "text"
+                            },
+                            "text": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "type",
+                            "text"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "const": "image",
+                                "default": "image"
+                            },
+                            "data": {
+                                "type": "string",
+                                "contentEncoding": "base64"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "type",
+                            "data"
+                        ]
+                    },
+                    {
+                        "$ref": "#/components/schemas/ToolCallDelta"
+                    }
+                ]
+            },
             "TokenLogProbs": {
                 "type": "object",
                 "properties": {
@@ -4250,6 +4287,11 @@
             "ToolCallDelta": {
                 "type": "object",
                 "properties": {
+                    "type": {
+                        "type": "string",
+                        "const": "tool_call",
+                        "default": "tool_call"
+                    },
                     "content": {
                         "oneOf": [
                             {
@@ -4266,6 +4308,7 @@
                 },
                 "additionalProperties": false,
                 "required": [
+                    "type",
                     "content",
                     "parse_status"
                 ]
@@ -4275,8 +4318,8 @@
                 "enum": [
                     "started",
                     "in_progress",
-                    "failure",
-                    "success"
+                    "failed",
+                    "succeeded"
                 ]
             },
             "CompletionRequest": {
@@ -4777,18 +4820,16 @@
                     "step_id": {
                         "type": "string"
                     },
-                    "text_delta": {
-                        "type": "string"
-                    },
-                    "tool_call_delta": {
-                        "$ref": "#/components/schemas/ToolCallDelta"
+                    "delta": {
+                        "$ref": "#/components/schemas/ContentDelta"
                     }
                 },
                 "additionalProperties": false,
                 "required": [
                     "event_type",
                     "step_type",
-                    "step_id"
+                    "step_id",
+                    "delta"
                 ]
             },
             "AgentTurnResponseStepStartPayload": {
@@ -8759,6 +8800,10 @@
             "description": "streamed completion response.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/CompletionResponseStreamChunk\" />"
         },
         {
+            "name": "ContentDelta",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ContentDelta\" />"
+        },
+        {
             "name": "CreateAgentRequest",
             "description": "<SchemaDefinition schemaRef=\"#/components/schemas/CreateAgentRequest\" />"
         },
@@ -9392,6 +9437,7 @@
                 "CompletionRequest",
                 "CompletionResponse",
                 "CompletionResponseStreamChunk",
+                "ContentDelta",
                 "CreateAgentRequest",
                 "CreateAgentSessionRequest",
                 "CreateAgentTurnRequest",

--- a/docs/resources/llama-stack-spec.yaml
+++ b/docs/resources/llama-stack-spec.yaml
@@ -150,6 +150,8 @@ components:
     AgentTurnResponseStepProgressPayload:
       additionalProperties: false
       properties:
+        delta:
+          $ref: '#/components/schemas/ContentDelta'
         event_type:
           const: step_progress
           default: step_progress
@@ -163,14 +165,11 @@ components:
           - shield_call
           - memory_retrieval
           type: string
-        text_delta:
-          type: string
-        tool_call_delta:
-          $ref: '#/components/schemas/ToolCallDelta'
       required:
       - event_type
       - step_type
       - step_id
+      - delta
       type: object
     AgentTurnResponseStepStartPayload:
       additionalProperties: false
@@ -462,9 +461,7 @@ components:
       additionalProperties: false
       properties:
         delta:
-          oneOf:
-          - type: string
-          - $ref: '#/components/schemas/ToolCallDelta'
+          $ref: '#/components/schemas/ContentDelta'
         event_type:
           $ref: '#/components/schemas/ChatCompletionResponseEventType'
         logprobs:
@@ -571,6 +568,34 @@ components:
       - delta
       title: streamed completion response.
       type: object
+    ContentDelta:
+      oneOf:
+      - additionalProperties: false
+        properties:
+          text:
+            type: string
+          type:
+            const: text
+            default: text
+            type: string
+        required:
+        - type
+        - text
+        type: object
+      - additionalProperties: false
+        properties:
+          data:
+            contentEncoding: base64
+            type: string
+          type:
+            const: image
+            default: image
+            type: string
+        required:
+        - type
+        - data
+        type: object
+      - $ref: '#/components/schemas/ToolCallDelta'
     CreateAgentRequest:
       additionalProperties: false
       properties:
@@ -2664,7 +2689,12 @@ components:
           - $ref: '#/components/schemas/ToolCall'
         parse_status:
           $ref: '#/components/schemas/ToolCallParseStatus'
+        type:
+          const: tool_call
+          default: tool_call
+          type: string
       required:
+      - type
       - content
       - parse_status
       type: object
@@ -2672,8 +2702,8 @@ components:
       enum:
       - started
       - in_progress
-      - failure
-      - success
+      - failed
+      - succeeded
       type: string
     ToolChoice:
       enum:
@@ -2888,8 +2918,8 @@ components:
         content:
           $ref: '#/components/schemas/InterleavedContent'
         role:
-          const: ipython
-          default: ipython
+          const: tool
+          default: tool
           type: string
         tool_name:
           oneOf:
@@ -5500,6 +5530,8 @@ tags:
     <SchemaDefinition schemaRef="#/components/schemas/CompletionResponseStreamChunk"
     />'
   name: CompletionResponseStreamChunk
+- description: <SchemaDefinition schemaRef="#/components/schemas/ContentDelta" />
+  name: ContentDelta
 - description: <SchemaDefinition schemaRef="#/components/schemas/CreateAgentRequest"
     />
   name: CreateAgentRequest
@@ -5939,6 +5971,7 @@ x-tagGroups:
   - CompletionRequest
   - CompletionResponse
   - CompletionResponseStreamChunk
+  - ContentDelta
   - CreateAgentRequest
   - CreateAgentSessionRequest
   - CreateAgentTurnRequest

--- a/llama_stack/apis/agents/agents.py
+++ b/llama_stack/apis/agents/agents.py
@@ -22,12 +22,11 @@ from llama_models.schema_utils import json_schema_type, register_schema, webmeth
 from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import Annotated
 
-from llama_stack.apis.common.content_types import InterleavedContent, URL
+from llama_stack.apis.common.content_types import ContentDelta, InterleavedContent, URL
 from llama_stack.apis.inference import (
     CompletionMessage,
     SamplingParams,
     ToolCall,
-    ToolCallDelta,
     ToolChoice,
     ToolPromptFormat,
     ToolResponse,
@@ -216,8 +215,7 @@ class AgentTurnResponseStepProgressPayload(BaseModel):
     step_type: StepType
     step_id: str
 
-    text_delta: Optional[str] = None
-    tool_call_delta: Optional[ToolCallDelta] = None
+    delta: ContentDelta
 
 
 @json_schema_type

--- a/llama_stack/apis/agents/event_logger.py
+++ b/llama_stack/apis/agents/event_logger.py
@@ -11,8 +11,12 @@ from llama_models.llama3.api.tool_utils import ToolUtils
 from termcolor import cprint
 
 from llama_stack.apis.agents import AgentTurnResponseEventType, StepType
-
+from llama_stack.apis.common.content_types import ToolCallParseStatus
 from llama_stack.apis.inference import ToolResponseMessage
+
+from llama_stack.providers.utils.inference.prompt_adapter import (
+    interleaved_content_as_str,
+)
 
 
 class LogEvent:
@@ -57,8 +61,11 @@ class EventLogger:
                 # since it does not produce event but instead
                 # a Message
                 if isinstance(chunk, ToolResponseMessage):
-                    yield chunk, LogEvent(
-                        role="CustomTool", content=chunk.content, color="grey"
+                    yield (
+                        chunk,
+                        LogEvent(
+                            role="CustomTool", content=chunk.content, color="grey"
+                        ),
                     )
                 continue
 
@@ -80,14 +87,20 @@ class EventLogger:
             ):
                 violation = event.payload.step_details.violation
                 if not violation:
-                    yield event, LogEvent(
-                        role=step_type, content="No Violation", color="magenta"
+                    yield (
+                        event,
+                        LogEvent(
+                            role=step_type, content="No Violation", color="magenta"
+                        ),
                     )
                 else:
-                    yield event, LogEvent(
-                        role=step_type,
-                        content=f"{violation.metadata} {violation.user_message}",
-                        color="red",
+                    yield (
+                        event,
+                        LogEvent(
+                            role=step_type,
+                            content=f"{violation.metadata} {violation.user_message}",
+                            color="red",
+                        ),
                     )
 
             # handle inference
@@ -95,8 +108,11 @@ class EventLogger:
                 if stream:
                     if event_type == EventType.step_start.value:
                         # TODO: Currently this event is never received
-                        yield event, LogEvent(
-                            role=step_type, content="", end="", color="yellow"
+                        yield (
+                            event,
+                            LogEvent(
+                                role=step_type, content="", end="", color="yellow"
+                            ),
                         )
                     elif event_type == EventType.step_progress.value:
                         # HACK: if previous was not step/event was not inference's step_progress
@@ -107,24 +123,34 @@ class EventLogger:
                             previous_event_type != EventType.step_progress.value
                             and previous_step_type != StepType.inference
                         ):
-                            yield event, LogEvent(
-                                role=step_type, content="", end="", color="yellow"
+                            yield (
+                                event,
+                                LogEvent(
+                                    role=step_type, content="", end="", color="yellow"
+                                ),
                             )
 
-                        if event.payload.tool_call_delta:
-                            if isinstance(event.payload.tool_call_delta.content, str):
-                                yield event, LogEvent(
-                                    role=None,
-                                    content=event.payload.tool_call_delta.content,
-                                    end="",
-                                    color="cyan",
+                        delta = event.payload.delta
+                        if delta.type == "tool_call":
+                            if delta.parse_status == ToolCallParseStatus.success:
+                                yield (
+                                    event,
+                                    LogEvent(
+                                        role=None,
+                                        content=delta.content,
+                                        end="",
+                                        color="cyan",
+                                    ),
                                 )
                         else:
-                            yield event, LogEvent(
-                                role=None,
-                                content=event.payload.text_delta,
-                                end="",
-                                color="yellow",
+                            yield (
+                                event,
+                                LogEvent(
+                                    role=None,
+                                    content=delta.text,
+                                    end="",
+                                    color="yellow",
+                                ),
                             )
                     else:
                         # step_complete
@@ -140,10 +166,13 @@ class EventLogger:
                             )
                         else:
                             content = response.content
-                        yield event, LogEvent(
-                            role=step_type,
-                            content=content,
-                            color="yellow",
+                        yield (
+                            event,
+                            LogEvent(
+                                role=step_type,
+                                content=content,
+                                color="yellow",
+                            ),
                         )
 
             # handle tool_execution
@@ -155,16 +184,22 @@ class EventLogger:
             ):
                 details = event.payload.step_details
                 for t in details.tool_calls:
-                    yield event, LogEvent(
-                        role=step_type,
-                        content=f"Tool:{t.tool_name} Args:{t.arguments}",
-                        color="green",
+                    yield (
+                        event,
+                        LogEvent(
+                            role=step_type,
+                            content=f"Tool:{t.tool_name} Args:{t.arguments}",
+                            color="green",
+                        ),
                     )
                 for r in details.tool_responses:
-                    yield event, LogEvent(
-                        role=step_type,
-                        content=f"Tool:{r.tool_name} Response:{r.content}",
-                        color="green",
+                    yield (
+                        event,
+                        LogEvent(
+                            role=step_type,
+                            content=f"Tool:{r.tool_name} Response:{r.content}",
+                            color="green",
+                        ),
                     )
 
             if (
@@ -172,15 +207,16 @@ class EventLogger:
                 and event_type == EventType.step_complete.value
             ):
                 details = event.payload.step_details
-                inserted_context = interleaved_text_media_as_str(
-                    details.inserted_context
-                )
+                inserted_context = interleaved_content_as_str(details.inserted_context)
                 content = f"fetched {len(inserted_context)} bytes from {details.memory_bank_ids}"
 
-                yield event, LogEvent(
-                    role=step_type,
-                    content=content,
-                    color="cyan",
+                yield (
+                    event,
+                    LogEvent(
+                        role=step_type,
+                        content=content,
+                        color="cyan",
+                    ),
                 )
 
             previous_event_type = event_type

--- a/llama_stack/apis/agents/event_logger.py
+++ b/llama_stack/apis/agents/event_logger.py
@@ -132,7 +132,7 @@ class EventLogger:
 
                         delta = event.payload.delta
                         if delta.type == "tool_call":
-                            if delta.parse_status == ToolCallParseStatus.success:
+                            if delta.parse_status == ToolCallParseStatus.succeeded:
                                 yield (
                                     event,
                                     LogEvent(

--- a/llama_stack/apis/common/content_types.py
+++ b/llama_stack/apis/common/content_types.py
@@ -5,10 +5,12 @@
 # the root directory of this source tree.
 
 import base64
+from enum import Enum
 from typing import Annotated, List, Literal, Optional, Union
 
-from llama_models.schema_utils import json_schema_type, register_schema
+from llama_models.llama3.api.datatypes import ToolCall
 
+from llama_models.schema_utils import json_schema_type, register_schema
 from pydantic import BaseModel, Field, field_serializer, model_validator
 
 
@@ -59,4 +61,43 @@ InterleavedContentItem = register_schema(
 InterleavedContent = register_schema(
     Union[str, InterleavedContentItem, List[InterleavedContentItem]],
     name="InterleavedContent",
+)
+
+
+class TextDelta(BaseModel):
+    type: Literal["text"] = "text"
+    text: str
+
+
+class ImageDelta(BaseModel):
+    type: Literal["image"] = "image"
+    data: bytes
+
+
+@json_schema_type
+class ToolCallParseStatus(Enum):
+    started = "started"
+    in_progress = "in_progress"
+    failed = "failed"
+    succeeded = "succeeded"
+
+
+@json_schema_type
+class ToolCallDelta(BaseModel):
+    type: Literal["tool_call"] = "tool_call"
+
+    # you either send an in-progress tool call so the client can stream a long
+    # code generation or you send the final parsed tool call at the end of the
+    # stream
+    content: Union[str, ToolCall]
+    parse_status: ToolCallParseStatus
+
+
+# streaming completions send a stream of ContentDeltas
+ContentDelta = register_schema(
+    Annotated[
+        Union[TextDelta, ImageDelta, ToolCallDelta],
+        Field(discriminator="type"),
+    ],
+    name="ContentDelta",
 )

--- a/llama_stack/apis/inference/inference.py
+++ b/llama_stack/apis/inference/inference.py
@@ -29,7 +29,7 @@ from llama_models.schema_utils import json_schema_type, register_schema, webmeth
 from pydantic import BaseModel, Field, field_validator
 from typing_extensions import Annotated
 
-from llama_stack.apis.common.content_types import InterleavedContent
+from llama_stack.apis.common.content_types import ContentDelta, InterleavedContent
 from llama_stack.apis.models import Model
 from llama_stack.providers.utils.telemetry.trace_protocol import trace_protocol
 
@@ -148,25 +148,11 @@ class ChatCompletionResponseEventType(Enum):
 
 
 @json_schema_type
-class ToolCallParseStatus(Enum):
-    started = "started"
-    in_progress = "in_progress"
-    failure = "failure"
-    success = "success"
-
-
-@json_schema_type
-class ToolCallDelta(BaseModel):
-    content: Union[str, ToolCall]
-    parse_status: ToolCallParseStatus
-
-
-@json_schema_type
 class ChatCompletionResponseEvent(BaseModel):
     """Chat completion response event."""
 
     event_type: ChatCompletionResponseEventType
-    delta: Union[str, ToolCallDelta]
+    delta: ContentDelta
     logprobs: Optional[List[TokenLogProbs]] = None
     stop_reason: Optional[StopReason] = None
 

--- a/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
@@ -415,7 +415,7 @@ class ChatAgent(ShieldRunnerMixin):
                             step_type=StepType.tool_execution.value,
                             step_id=step_id,
                             delta=ToolCallDelta(
-                                parse_status=ToolCallParseStatus.success,
+                                parse_status=ToolCallParseStatus.succeeded,
                                 content=ToolCall(
                                     call_id="",
                                     tool_name=MEMORY_QUERY_TOOL,
@@ -511,7 +511,7 @@ class ChatAgent(ShieldRunnerMixin):
 
                     delta = event.delta
                     if delta.type == "tool_call":
-                        if delta.parse_status == ToolCallParseStatus.success:
+                        if delta.parse_status == ToolCallParseStatus.succeeded:
                             tool_calls.append(delta.content)
                         if stream:
                             yield AgentTurnResponseStreamChunk(

--- a/llama_stack/providers/inline/inference/meta_reference/inference.py
+++ b/llama_stack/providers/inline/inference/meta_reference/inference.py
@@ -16,6 +16,11 @@ from llama_models.llama3.api.datatypes import (
 )
 from llama_models.sku_list import resolve_model
 
+from llama_stack.apis.common.content_types import (
+    TextDelta,
+    ToolCallDelta,
+    ToolCallParseStatus,
+)
 from llama_stack.apis.inference import (
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -32,8 +37,6 @@ from llama_stack.apis.inference import (
     Message,
     ResponseFormat,
     TokenLogProbs,
-    ToolCallDelta,
-    ToolCallParseStatus,
     ToolChoice,
 )
 from llama_stack.apis.models import Model, ModelType
@@ -190,14 +193,14 @@ class MetaReferenceInferenceImpl(
                         ]
 
                 yield CompletionResponseStreamChunk(
-                    delta=text,
+                    delta=TextDelta(text=text),
                     stop_reason=stop_reason,
                     logprobs=logprobs if request.logprobs else None,
                 )
 
             if stop_reason is None:
                 yield CompletionResponseStreamChunk(
-                    delta="",
+                    delta=TextDelta(text=""),
                     stop_reason=StopReason.out_of_tokens,
                 )
 
@@ -352,7 +355,7 @@ class MetaReferenceInferenceImpl(
             yield ChatCompletionResponseStreamChunk(
                 event=ChatCompletionResponseEvent(
                     event_type=ChatCompletionResponseEventType.start,
-                    delta="",
+                    delta=TextDelta(text=""),
                 )
             )
 
@@ -392,7 +395,7 @@ class MetaReferenceInferenceImpl(
                         parse_status=ToolCallParseStatus.in_progress,
                     )
                 else:
-                    delta = text
+                    delta = TextDelta(text=text)
 
                 if stop_reason is None:
                     if request.logprobs:
@@ -449,7 +452,7 @@ class MetaReferenceInferenceImpl(
             yield ChatCompletionResponseStreamChunk(
                 event=ChatCompletionResponseEvent(
                     event_type=ChatCompletionResponseEventType.complete,
-                    delta="",
+                    delta=TextDelta(text=""),
                     stop_reason=stop_reason,
                 )
             )

--- a/llama_stack/providers/inline/inference/meta_reference/inference.py
+++ b/llama_stack/providers/inline/inference/meta_reference/inference.py
@@ -431,7 +431,7 @@ class MetaReferenceInferenceImpl(
                         event_type=ChatCompletionResponseEventType.progress,
                         delta=ToolCallDelta(
                             content="",
-                            parse_status=ToolCallParseStatus.failure,
+                            parse_status=ToolCallParseStatus.failed,
                         ),
                         stop_reason=stop_reason,
                     )
@@ -443,7 +443,7 @@ class MetaReferenceInferenceImpl(
                         event_type=ChatCompletionResponseEventType.progress,
                         delta=ToolCallDelta(
                             content=tool_call,
-                            parse_status=ToolCallParseStatus.success,
+                            parse_status=ToolCallParseStatus.succeeded,
                         ),
                         stop_reason=stop_reason,
                     )

--- a/llama_stack/providers/remote/inference/groq/groq_utils.py
+++ b/llama_stack/providers/remote/inference/groq/groq_utils.py
@@ -30,6 +30,11 @@ from groq.types.shared.function_definition import FunctionDefinition
 
 from llama_models.llama3.api.datatypes import ToolParamDefinition
 
+from llama_stack.apis.common.content_types import (
+    TextDelta,
+    ToolCallDelta,
+    ToolCallParseStatus,
+)
 from llama_stack.apis.inference import (
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -40,8 +45,6 @@ from llama_stack.apis.inference import (
     Message,
     StopReason,
     ToolCall,
-    ToolCallDelta,
-    ToolCallParseStatus,
     ToolDefinition,
     ToolPromptFormat,
 )
@@ -162,7 +165,7 @@ def convert_chat_completion_response(
 
 
 def _map_finish_reason_to_stop_reason(
-    finish_reason: Literal["stop", "length", "tool_calls"]
+    finish_reason: Literal["stop", "length", "tool_calls"],
 ) -> StopReason:
     """
     Convert a Groq chat completion finish_reason to a StopReason.
@@ -185,7 +188,6 @@ def _map_finish_reason_to_stop_reason(
 async def convert_chat_completion_response_stream(
     stream: Stream[ChatCompletionChunk],
 ) -> AsyncGenerator[ChatCompletionResponseStreamChunk, None]:
-
     event_type = ChatCompletionResponseEventType.start
     for chunk in stream:
         choice = chunk.choices[0]
@@ -194,7 +196,7 @@ async def convert_chat_completion_response_stream(
             yield ChatCompletionResponseStreamChunk(
                 event=ChatCompletionResponseEvent(
                     event_type=ChatCompletionResponseEventType.complete,
-                    delta=choice.delta.content or "",
+                    delta=TextDelta(text=choice.delta.content or ""),
                     logprobs=None,
                     stop_reason=_map_finish_reason_to_stop_reason(choice.finish_reason),
                 )
@@ -221,7 +223,7 @@ async def convert_chat_completion_response_stream(
             yield ChatCompletionResponseStreamChunk(
                 event=ChatCompletionResponseEvent(
                     event_type=event_type,
-                    delta=choice.delta.content or "",
+                    delta=TextDelta(text=choice.delta.content or ""),
                     logprobs=None,
                 )
             )

--- a/llama_stack/providers/remote/inference/groq/groq_utils.py
+++ b/llama_stack/providers/remote/inference/groq/groq_utils.py
@@ -215,7 +215,7 @@ async def convert_chat_completion_response_stream(
                     event_type=event_type,
                     delta=ToolCallDelta(
                         content=tool_call,
-                        parse_status=ToolCallParseStatus.success,
+                        parse_status=ToolCallParseStatus.succeeded,
                     ),
                 )
             )

--- a/llama_stack/providers/remote/inference/nvidia/openai_utils.py
+++ b/llama_stack/providers/remote/inference/nvidia/openai_utils.py
@@ -34,6 +34,11 @@ from openai.types.chat.chat_completion_message_tool_call_param import (
 from openai.types.completion import Completion as OpenAICompletion
 from openai.types.completion_choice import Logprobs as OpenAICompletionLogprobs
 
+from llama_stack.apis.common.content_types import (
+    TextDelta,
+    ToolCallDelta,
+    ToolCallParseStatus,
+)
 from llama_stack.apis.inference import (
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -48,8 +53,6 @@ from llama_stack.apis.inference import (
     Message,
     SystemMessage,
     TokenLogProbs,
-    ToolCallDelta,
-    ToolCallParseStatus,
     ToolResponseMessage,
     UserMessage,
 )
@@ -432,69 +435,6 @@ async def convert_openai_chat_completion_stream(
     """
     Convert a stream of OpenAI chat completion chunks into a stream
     of ChatCompletionResponseStreamChunk.
-
-    OpenAI ChatCompletionChunk:
-        choices: List[Choice]
-
-    OpenAI Choice:  # different from the non-streamed Choice
-        delta: ChoiceDelta
-        finish_reason: Optional[Literal["stop", "length", "tool_calls", "content_filter", "function_call"]]
-        logprobs: Optional[ChoiceLogprobs]
-
-    OpenAI ChoiceDelta:
-        content: Optional[str]
-        role: Optional[Literal["system", "user", "assistant", "tool"]]
-        tool_calls: Optional[List[ChoiceDeltaToolCall]]
-
-    OpenAI ChoiceDeltaToolCall:
-        index: int
-        id: Optional[str]
-        function: Optional[ChoiceDeltaToolCallFunction]
-        type: Optional[Literal["function"]]
-
-    OpenAI ChoiceDeltaToolCallFunction:
-        name: Optional[str]
-        arguments: Optional[str]
-
-    ->
-
-    ChatCompletionResponseStreamChunk:
-        event: ChatCompletionResponseEvent
-
-    ChatCompletionResponseEvent:
-        event_type: ChatCompletionResponseEventType
-        delta: Union[str, ToolCallDelta]
-        logprobs: Optional[List[TokenLogProbs]]
-        stop_reason: Optional[StopReason]
-
-    ChatCompletionResponseEventType:
-        start = "start"
-        progress = "progress"
-        complete = "complete"
-
-    ToolCallDelta:
-        content: Union[str, ToolCall]
-        parse_status: ToolCallParseStatus
-
-    ToolCall:
-        call_id: str
-        tool_name: str
-        arguments: str
-
-    ToolCallParseStatus:
-        started = "started"
-        in_progress = "in_progress"
-        failure = "failure"
-        success = "success"
-
-    TokenLogProbs:
-        logprobs_by_token: Dict[str, float]
-         - token, logprob
-
-    StopReason:
-        end_of_turn = "end_of_turn"
-        end_of_message = "end_of_message"
-        out_of_tokens = "out_of_tokens"
     """
 
     # generate a stream of ChatCompletionResponseEventType: start -> progress -> progress -> ...
@@ -543,7 +483,7 @@ async def convert_openai_chat_completion_stream(
                 yield ChatCompletionResponseStreamChunk(
                     event=ChatCompletionResponseEvent(
                         event_type=next(event_type),
-                        delta=choice.delta.content,
+                        delta=TextDelta(text=choice.delta.content),
                         logprobs=_convert_openai_logprobs(choice.logprobs),
                     )
                 )
@@ -570,7 +510,7 @@ async def convert_openai_chat_completion_stream(
             yield ChatCompletionResponseStreamChunk(
                 event=ChatCompletionResponseEvent(
                     event_type=next(event_type),
-                    delta=choice.delta.content or "",  # content is not optional
+                    delta=TextDelta(text=choice.delta.content or ""),
                     logprobs=_convert_openai_logprobs(choice.logprobs),
                 )
             )
@@ -578,7 +518,7 @@ async def convert_openai_chat_completion_stream(
     yield ChatCompletionResponseStreamChunk(
         event=ChatCompletionResponseEvent(
             event_type=ChatCompletionResponseEventType.complete,
-            delta="",
+            delta=TextDelta(text=""),
             stop_reason=stop_reason,
         )
     )
@@ -653,18 +593,6 @@ def _convert_openai_completion_logprobs(
 ) -> Optional[List[TokenLogProbs]]:
     """
     Convert an OpenAI CompletionLogprobs into a list of TokenLogProbs.
-
-    OpenAI CompletionLogprobs:
-        text_offset: Optional[List[int]]
-        token_logprobs: Optional[List[float]]
-        tokens: Optional[List[str]]
-        top_logprobs: Optional[List[Dict[str, float]]]
-
-    ->
-
-    TokenLogProbs:
-        logprobs_by_token: Dict[str, float]
-            - token, logprob
     """
     if not logprobs:
         return None
@@ -679,28 +607,6 @@ def convert_openai_completion_choice(
 ) -> CompletionResponse:
     """
     Convert an OpenAI Completion Choice into a CompletionResponse.
-
-    OpenAI Completion Choice:
-        text: str
-        finish_reason: str
-        logprobs: Optional[ChoiceLogprobs]
-
-    ->
-
-    CompletionResponse:
-        completion_message: CompletionMessage
-        logprobs: Optional[List[TokenLogProbs]]
-
-    CompletionMessage:
-        role: Literal["assistant"]
-        content: str | ImageMedia | List[str | ImageMedia]
-        stop_reason: StopReason
-        tool_calls: List[ToolCall]
-
-    class StopReason(Enum):
-        end_of_turn = "end_of_turn"
-        end_of_message = "end_of_message"
-        out_of_tokens = "out_of_tokens"
     """
     return CompletionResponse(
         content=choice.text,
@@ -715,32 +621,11 @@ async def convert_openai_completion_stream(
     """
     Convert a stream of OpenAI Completions into a stream
     of ChatCompletionResponseStreamChunks.
-
-    OpenAI Completion:
-        id: str
-        choices: List[OpenAICompletionChoice]
-        created: int
-        model: str
-        system_fingerprint: Optional[str]
-        usage: Optional[OpenAICompletionUsage]
-
-    OpenAI CompletionChoice:
-        finish_reason: str
-        index: int
-        logprobs: Optional[OpenAILogprobs]
-        text: str
-
-    ->
-
-    CompletionResponseStreamChunk:
-        delta: str
-        stop_reason: Optional[StopReason]
-        logprobs: Optional[List[TokenLogProbs]]
     """
     async for chunk in stream:
         choice = chunk.choices[0]
         yield CompletionResponseStreamChunk(
-            delta=choice.text,
+            delta=TextDelta(text=choice.text),
             stop_reason=_convert_openai_finish_reason(choice.finish_reason),
             logprobs=_convert_openai_completion_logprobs(choice.logprobs),
         )

--- a/llama_stack/providers/remote/inference/nvidia/openai_utils.py
+++ b/llama_stack/providers/remote/inference/nvidia/openai_utils.py
@@ -501,7 +501,7 @@ async def convert_openai_chat_completion_stream(
                     event_type=next(event_type),
                     delta=ToolCallDelta(
                         content=_convert_openai_tool_calls(choice.delta.tool_calls)[0],
-                        parse_status=ToolCallParseStatus.success,
+                        parse_status=ToolCallParseStatus.succeeded,
                     ),
                     logprobs=_convert_openai_logprobs(choice.logprobs),
                 )

--- a/llama_stack/providers/tests/inference/test_text_inference.py
+++ b/llama_stack/providers/tests/inference/test_text_inference.py
@@ -475,7 +475,7 @@ class TestInference:
 
         last = grouped[ChatCompletionResponseEventType.progress][-1]
         # assert last.event.stop_reason == expected_stop_reason
-        assert last.event.delta.parse_status == ToolCallParseStatus.success
+        assert last.event.delta.parse_status == ToolCallParseStatus.succeeded
         assert last.event.delta.content.type == "tool_call"
 
         call = last.event.delta.content

--- a/llama_stack/providers/utils/inference/openai_compat.py
+++ b/llama_stack/providers/utils/inference/openai_compat.py
@@ -11,7 +11,13 @@ from llama_models.llama3.api.chat_format import ChatFormat
 from llama_models.llama3.api.datatypes import SamplingParams, StopReason
 from pydantic import BaseModel
 
-from llama_stack.apis.common.content_types import ImageContentItem, TextContentItem
+from llama_stack.apis.common.content_types import (
+    ImageContentItem,
+    TextContentItem,
+    TextDelta,
+    ToolCallDelta,
+    ToolCallParseStatus,
+)
 
 from llama_stack.apis.inference import (
     ChatCompletionResponse,
@@ -22,8 +28,6 @@ from llama_stack.apis.inference import (
     CompletionResponse,
     CompletionResponseStreamChunk,
     Message,
-    ToolCallDelta,
-    ToolCallParseStatus,
 )
 
 from llama_stack.providers.utils.inference.prompt_adapter import (
@@ -138,7 +142,7 @@ async def process_completion_stream_response(
             text = ""
             continue
         yield CompletionResponseStreamChunk(
-            delta=text,
+            delta=TextDelta(text=text),
             stop_reason=stop_reason,
         )
         if finish_reason:
@@ -149,7 +153,7 @@ async def process_completion_stream_response(
             break
 
     yield CompletionResponseStreamChunk(
-        delta="",
+        delta=TextDelta(text=""),
         stop_reason=stop_reason,
     )
 
@@ -160,7 +164,7 @@ async def process_chat_completion_stream_response(
     yield ChatCompletionResponseStreamChunk(
         event=ChatCompletionResponseEvent(
             event_type=ChatCompletionResponseEventType.start,
-            delta="",
+            delta=TextDelta(text=""),
         )
     )
 
@@ -227,7 +231,7 @@ async def process_chat_completion_stream_response(
             yield ChatCompletionResponseStreamChunk(
                 event=ChatCompletionResponseEvent(
                     event_type=ChatCompletionResponseEventType.progress,
-                    delta=text,
+                    delta=TextDelta(text=text),
                     stop_reason=stop_reason,
                 )
             )
@@ -262,7 +266,7 @@ async def process_chat_completion_stream_response(
     yield ChatCompletionResponseStreamChunk(
         event=ChatCompletionResponseEvent(
             event_type=ChatCompletionResponseEventType.complete,
-            delta="",
+            delta=TextDelta(text=""),
             stop_reason=stop_reason,
         )
     )

--- a/llama_stack/providers/utils/inference/openai_compat.py
+++ b/llama_stack/providers/utils/inference/openai_compat.py
@@ -245,7 +245,7 @@ async def process_chat_completion_stream_response(
                 event_type=ChatCompletionResponseEventType.progress,
                 delta=ToolCallDelta(
                     content="",
-                    parse_status=ToolCallParseStatus.failure,
+                    parse_status=ToolCallParseStatus.failed,
                 ),
                 stop_reason=stop_reason,
             )
@@ -257,7 +257,7 @@ async def process_chat_completion_stream_response(
                 event_type=ChatCompletionResponseEventType.progress,
                 delta=ToolCallDelta(
                     content=tool_call,
-                    parse_status=ToolCallParseStatus.success,
+                    parse_status=ToolCallParseStatus.succeeded,
                 ),
                 stop_reason=stop_reason,
             )


### PR DESCRIPTION
## What does this PR do?

This PR introduces a `ContentDelta` type so that a chat completion can send in a stream of deltas of various types uniformly. These updates are necessary to ensure future updates or capabilities of future models can be absorbed incrementally without creating backwards incompatibility later.

**Note**: this change is backwards incompatible.
