### PR TITLE
[bugfix] fix streaming GeneratorExit exception with LlamaStackAsLibraryClient

### DIFF
--- a/llama_stack/distribution/library_client.py
+++ b/llama_stack/distribution/library_client.py
@@ -144,15 +144,12 @@ class LlamaStackAsLibraryClient(LlamaStackClient):
             print(f"Removed handler {handler.__class__.__name__} from root logger")
 
     def request(self, *args, **kwargs):
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        async_response = loop.run_until_complete(
-            self.async_client.request(*args, **kwargs)
-        )
+        async_response = asyncio.run(self.async_client.request(*args, **kwargs))
+
         if kwargs.get("stream"):
-            # NOTE: We are using AsyncLlamaStackClient under the hood
-            # We need to convert the AsyncStream from async client into
-            # SyncStream return type for streaming
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
             def sync_generator():
                 try:
                     while True:
@@ -165,7 +162,6 @@ class LlamaStackAsLibraryClient(LlamaStackClient):
 
             return sync_generator()
         else:
-            loop.close()
             return async_response
 
 

--- a/llama_stack/distribution/library_client.py
+++ b/llama_stack/distribution/library_client.py
@@ -168,11 +168,7 @@ class LlamaStackAsLibraryClient(LlamaStackClient):
 
             return sync_generator()
         else:
-
-            async def _request():
-                return await self.async_client.request(*args, **kwargs)
-
-            return asyncio.run(_request())
+            return asyncio.run(self.async_client.request(*args, **kwargs))
 
 
 class AsyncLlamaStackAsLibraryClient(AsyncLlamaStackClient):

--- a/llama_stack/distribution/library_client.py
+++ b/llama_stack/distribution/library_client.py
@@ -147,6 +147,9 @@ class LlamaStackAsLibraryClient(LlamaStackClient):
         async_response = asyncio.run(self.async_client.request(*args, **kwargs))
 
         if kwargs.get("stream"):
+            # NOTE: We are using AsyncLlamaStackClient under the hood
+            # A new event loop is needed to convert the AsyncStream
+            # from async client into SyncStream return type for streaming
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
 


### PR DESCRIPTION
# What does this PR do?

#### Issue
- Using Jupyter notebook with LlamaStackAsLibraryClient + streaming gives exception
```
Exception ignored in: <async_generator object HTTP11ConnectionByteStream.__aiter__ at 0x32a95a740>
Traceback (most recent call last):
  File "/opt/anaconda3/envs/fresh/lib/python3.11/site-packages/httpcore/_async/connection_pool.py", line 404, in _aiter_
    yield part
RuntimeError: async generator ignored GeneratorExit
```

- Reproduce w/ https://github.com/meta-llama/llama-stack/blob/notebook-streaming-debug/inline.ipynb

#### Fix
- Issue likely comes from stream_across_asyncio_run_boundary closing connection too soon when interacting in jupyter environment
- This uses an alternative way to convert AsyncStream to SyncStream return type by sync version of LlamaStackAsLibraryClient, which calls AsyncLlamaStackAsLibraryClient calling async impls under the hood

#### Additional changes
- Moved tracing logic into AsyncLlamaStackAsLibraryClient.request s.t. streaming / non-streaming request for LlamaStackAsLibraryClient shares same code

## Test Plan

- Test w/ together & fireworks & ollama with streaming and non-streaming using notebook in: https://github.com/meta-llama/llama-stack/blob/notebook-streaming-debug/inline.ipynb
- Note: need to restart kernel and run pip install -e . in jupyter interpreter for local code change to take effect

<img width="826" alt="image" src="https://github.com/user-attachments/assets/5f90985d-1aee-452c-a599-2157f5654fea" />


## Sources

Please link relevant resources if necessary.


## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Ran pre-commit to handle lint / formatting issues.
- [ ] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Updated relevant documentation.
- [ ] Wrote necessary unit or integration tests.
