### PR TITLE
[openapi] add schema type register for TextDelta & ImageDelta

### DIFF
--- a/docs/resources/llama-stack-spec.html
+++ b/docs/resources/llama-stack-spec.html
@@ -4228,45 +4228,51 @@
             "ContentDelta": {
                 "oneOf": [
                     {
-                        "type": "object",
-                        "properties": {
-                            "type": {
-                                "type": "string",
-                                "const": "text",
-                                "default": "text"
-                            },
-                            "text": {
-                                "type": "string"
-                            }
-                        },
-                        "additionalProperties": false,
-                        "required": [
-                            "type",
-                            "text"
-                        ]
+                        "$ref": "#/components/schemas/TextDelta"
                     },
                     {
-                        "type": "object",
-                        "properties": {
-                            "type": {
-                                "type": "string",
-                                "const": "image",
-                                "default": "image"
-                            },
-                            "data": {
-                                "type": "string",
-                                "contentEncoding": "base64"
-                            }
-                        },
-                        "additionalProperties": false,
-                        "required": [
-                            "type",
-                            "data"
-                        ]
+                        "$ref": "#/components/schemas/ImageDelta"
                     },
                     {
                         "$ref": "#/components/schemas/ToolCallDelta"
                     }
+                ]
+            },
+            "ImageDelta": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "const": "image",
+                        "default": "image"
+                    },
+                    "data": {
+                        "type": "string",
+                        "contentEncoding": "base64"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "type",
+                    "data"
+                ]
+            },
+            "TextDelta": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "const": "text",
+                        "default": "text"
+                    },
+                    "text": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "type",
+                    "text"
                 ]
             },
             "TokenLogProbs": {
@@ -7261,6 +7267,9 @@
                     "shuffle": {
                         "type": "boolean"
                     },
+                    "data_format": {
+                        "$ref": "#/components/schemas/DatasetFormat"
+                    },
                     "validation_dataset_id": {
                         "type": "string"
                     },
@@ -7277,7 +7286,15 @@
                 "required": [
                     "dataset_id",
                     "batch_size",
-                    "shuffle"
+                    "shuffle",
+                    "data_format"
+                ]
+            },
+            "DatasetFormat": {
+                "type": "string",
+                "enum": [
+                    "instruct",
+                    "dialog"
                 ]
             },
             "EfficiencyConfig": {
@@ -8828,6 +8845,10 @@
             "description": "<SchemaDefinition schemaRef=\"#/components/schemas/Dataset\" />"
         },
         {
+            "name": "DatasetFormat",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/DatasetFormat\" />"
+        },
+        {
             "name": "DatasetIO"
         },
         {
@@ -8894,6 +8915,10 @@
         {
             "name": "ImageContentItem",
             "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ImageContentItem\" />"
+        },
+        {
+            "name": "ImageDelta",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ImageDelta\" />"
         },
         {
             "name": "Inference"
@@ -9244,6 +9269,10 @@
             "description": "<SchemaDefinition schemaRef=\"#/components/schemas/TextContentItem\" />"
         },
         {
+            "name": "TextDelta",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/TextDelta\" />"
+        },
+        {
             "name": "TokenLogProbs",
             "description": "<SchemaDefinition schemaRef=\"#/components/schemas/TokenLogProbs\" />"
         },
@@ -9444,6 +9473,7 @@
                 "DPOAlignmentConfig",
                 "DataConfig",
                 "Dataset",
+                "DatasetFormat",
                 "DeleteAgentsRequest",
                 "DeleteAgentsSessionRequest",
                 "EfficiencyConfig",
@@ -9458,6 +9488,7 @@
                 "GraphMemoryBankParams",
                 "HealthInfo",
                 "ImageContentItem",
+                "ImageDelta",
                 "InferenceStep",
                 "InsertDocumentsRequest",
                 "InterleavedContent",
@@ -9536,6 +9567,7 @@
                 "SyntheticDataGenerationResponse",
                 "SystemMessage",
                 "TextContentItem",
+                "TextDelta",
                 "TokenLogProbs",
                 "Tool",
                 "ToolCall",

--- a/docs/resources/llama-stack-spec.yaml
+++ b/docs/resources/llama-stack-spec.yaml
@@ -570,31 +570,8 @@ components:
       type: object
     ContentDelta:
       oneOf:
-      - additionalProperties: false
-        properties:
-          text:
-            type: string
-          type:
-            const: text
-            default: text
-            type: string
-        required:
-        - type
-        - text
-        type: object
-      - additionalProperties: false
-        properties:
-          data:
-            contentEncoding: base64
-            type: string
-          type:
-            const: image
-            default: image
-            type: string
-        required:
-        - type
-        - data
-        type: object
+      - $ref: '#/components/schemas/TextDelta'
+      - $ref: '#/components/schemas/ImageDelta'
       - $ref: '#/components/schemas/ToolCallDelta'
     CreateAgentRequest:
       additionalProperties: false
@@ -680,6 +657,8 @@ components:
       properties:
         batch_size:
           type: integer
+        data_format:
+          $ref: '#/components/schemas/DatasetFormat'
         dataset_id:
           type: string
         packed:
@@ -696,6 +675,7 @@ components:
       - dataset_id
       - batch_size
       - shuffle
+      - data_format
       type: object
     Dataset:
       additionalProperties: false
@@ -735,6 +715,11 @@ components:
       - url
       - metadata
       type: object
+    DatasetFormat:
+      enum:
+      - instruct
+      - dialog
+      type: string
     DeleteAgentsRequest:
       additionalProperties: false
       properties:
@@ -959,6 +944,20 @@ components:
           $ref: '#/components/schemas/URL'
       required:
       - type
+      type: object
+    ImageDelta:
+      additionalProperties: false
+      properties:
+        data:
+          contentEncoding: base64
+          type: string
+        type:
+          const: image
+          default: image
+          type: string
+      required:
+      - type
+      - data
       type: object
     InferenceStep:
       additionalProperties: false
@@ -2576,6 +2575,19 @@ components:
       - content
       type: object
     TextContentItem:
+      additionalProperties: false
+      properties:
+        text:
+          type: string
+        type:
+          const: text
+          default: text
+          type: string
+      required:
+      - type
+      - text
+      type: object
+    TextDelta:
       additionalProperties: false
       properties:
         text:
@@ -5548,6 +5560,8 @@ tags:
   name: DataConfig
 - description: <SchemaDefinition schemaRef="#/components/schemas/Dataset" />
   name: Dataset
+- description: <SchemaDefinition schemaRef="#/components/schemas/DatasetFormat" />
+  name: DatasetFormat
 - name: DatasetIO
 - name: Datasets
 - description: <SchemaDefinition schemaRef="#/components/schemas/DeleteAgentsRequest"
@@ -5592,6 +5606,8 @@ tags:
 - description: <SchemaDefinition schemaRef="#/components/schemas/ImageContentItem"
     />
   name: ImageContentItem
+- description: <SchemaDefinition schemaRef="#/components/schemas/ImageDelta" />
+  name: ImageDelta
 - name: Inference
 - description: <SchemaDefinition schemaRef="#/components/schemas/InferenceStep" />
   name: InferenceStep
@@ -5824,6 +5840,8 @@ tags:
 - description: <SchemaDefinition schemaRef="#/components/schemas/TextContentItem"
     />
   name: TextContentItem
+- description: <SchemaDefinition schemaRef="#/components/schemas/TextDelta" />
+  name: TextDelta
 - description: <SchemaDefinition schemaRef="#/components/schemas/TokenLogProbs" />
   name: TokenLogProbs
 - description: <SchemaDefinition schemaRef="#/components/schemas/Tool" />
@@ -5978,6 +5996,7 @@ x-tagGroups:
   - DPOAlignmentConfig
   - DataConfig
   - Dataset
+  - DatasetFormat
   - DeleteAgentsRequest
   - DeleteAgentsSessionRequest
   - EfficiencyConfig
@@ -5992,6 +6011,7 @@ x-tagGroups:
   - GraphMemoryBankParams
   - HealthInfo
   - ImageContentItem
+  - ImageDelta
   - InferenceStep
   - InsertDocumentsRequest
   - InterleavedContent
@@ -6070,6 +6090,7 @@ x-tagGroups:
   - SyntheticDataGenerationResponse
   - SystemMessage
   - TextContentItem
+  - TextDelta
   - TokenLogProbs
   - Tool
   - ToolCall

--- a/llama_stack/apis/common/content_types.py
+++ b/llama_stack/apis/common/content_types.py
@@ -64,11 +64,13 @@ InterleavedContent = register_schema(
 )
 
 
+@json_schema_type
 class TextDelta(BaseModel):
     type: Literal["text"] = "text"
     text: str
 
 
+@json_schema_type
 class ImageDelta(BaseModel):
     type: Literal["image"] = "image"
     data: bytes


### PR DESCRIPTION
# What does this PR do?

<img width="1005" alt="image" src="https://github.com/user-attachments/assets/ea14b4fa-4c91-47ac-aaf7-f9e86baee7c3" />

- our client SDK outputs UnionMember0, which is confusing, we should add the TextDelta / ImageDelta to our OpenAPI spec
- https://github.com/meta-llama/llama-stack-client-python/blob/4112088de40917e0c4efcb15e3b257c081288759/src/llama_stack_client/types/shared/content_delta.py#L12-L31

```
ChatCompletionResponseStreamChunk(event=ChatCompletionResponseStreamChunkEvent(delta=UnionMember0(text='', type='text'), event_type='start', logprobs=None, stop_reason=None))
```


## Test Plan
- as reference to avoid too much conflicts to update the OpenAPI spec
- cc @ashwinb  @dineshyv  @hardikjshah 

## Sources

Please link relevant resources if necessary.


## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Ran pre-commit to handle lint / formatting issues.
- [ ] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Updated relevant documentation.
- [ ] Wrote necessary unit or integration tests.
