### PR TITLE
Add notebook testing to nightly build job

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,14 +1,15 @@
 name: Publish Python 🐍 distribution 📦 to TestPyPI
 
 on:
-  workflow_dispatch:  # Keep manual trigger
-    inputs:
-      version:
-        description: 'Version number (e.g. 0.0.63.dev20250111)'
-        required: true
-        type: string
-  schedule:
-    - cron: "0 0 * * *"  # Run every day at midnight
+  push:
+  # workflow_dispatch:  # Keep manual trigger
+  #   inputs:
+  #     version:
+  #       description: 'Version number (e.g. 0.0.63.dev20250111)'
+  #       required: true
+  #       type: string
+  # schedule:
+  #   - cron: "0 0 * * *"  # Run every day at midnight
 
 jobs:
   trigger-client-and-models-build:

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -238,6 +238,7 @@ jobs:
     - name: Test Notebook
       run: |
         pip install pytest nbval
+        llama stack build --template fireworks --image-type venv
         pytest -v -s --nbval-lax ./docs/notebooks/Llama_Stack_Building_AI_Applications.ipynb
 
     # TODO: add trigger for integration test workflow & docker builds

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -238,7 +238,7 @@ jobs:
     - name: Test Notebook
       run: |
         pip install pytest nbval
-        llama stack build --template fireworks --image-type venv
+        llama stack build --template together --image-type venv
         pytest -v -s --nbval-lax ./docs/notebooks/Llama_Stack_Building_AI_Applications.ipynb
 
     # TODO: add trigger for integration test workflow & docker builds

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,15 +1,14 @@
 name: Publish Python 🐍 distribution 📦 to TestPyPI
 
 on:
-  push:
-  # workflow_dispatch:  # Keep manual trigger
-  #   inputs:
-  #     version:
-  #       description: 'Version number (e.g. 0.0.63.dev20250111)'
-  #       required: true
-  #       type: string
-  # schedule:
-  #   - cron: "0 0 * * *"  # Run every day at midnight
+  workflow_dispatch:  # Keep manual trigger
+    inputs:
+      version:
+        description: 'Version number (e.g. 0.0.63.dev20250111)'
+        required: true
+        type: string
+  schedule:
+    - cron: "0 0 * * *"  # Run every day at midnight
 
 jobs:
   trigger-client-and-models-build:

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -199,7 +199,13 @@ jobs:
       - publish-to-testpypi
       - trigger-client-and-models-build
     runs-on: ubuntu-latest
+    env:
+      TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
+      TAVILY_SEARCH_API_KEY: ${{ secrets.TAVILY_SEARCH_API_KEY }}
     steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Install the package
       run: |
         max_attempts=6
@@ -228,5 +234,9 @@ jobs:
         llama stack list-apis
         llama stack list-providers inference
         llama stack list-providers telemetry
+    - name: Test Notebook
+      run: |
+        pip install pytest nbval
+        pytest -v -s --nbval-lax ./docs/notebooks/Llama_Stack_Building_AI_Applications.ipynb
 
     # TODO: add trigger for integration test workflow & docker builds


### PR DESCRIPTION
# What does this PR do?

Adds testing of the notebook to the nightly build job 

## Test Plan

Here is a sample run -- 
https://github.com/meta-llama/llama-stack/actions/runs/12815889197?pr=785