### PR TITLE
Fix telemetry

### DIFF
--- a/llama_stack/providers/utils/telemetry/dataset_mixin.py
+++ b/llama_stack/providers/utils/telemetry/dataset_mixin.py
@@ -53,7 +53,7 @@ class TelemetryDatasetMixin:
         spans = []
 
         for trace in traces:
-            spans_by_id = await self.get_span_tree(
+            spans_by_id = await self.query_span_tree(
                 span_id=trace.root_span_id,
                 attributes_to_return=attributes_to_return,
                 max_depth=max_depth,


### PR DESCRIPTION
# What does this PR do?

PR fixes couple of issues with telemetry:
1) The REST refactor changed the method from get_span_tree to query_span_tree, which is causing the server side to return empty spans
2) Library client has introduced a new event loop, which required changing the location of where start and end trace are called


## Test Plan
 LLAMA_STACK_CONFIG="/Users/dineshyv/.llama/distributions/llamastack-fireworks/fireworks-run.yaml" pytest -v tests/client-sdk/agents/test_agents.py -k "test_builtin_tool_web_search"


And querying for spans from the agent run using the library client.