### PR TITLE
Pin torchtune pkg version

### DIFF
--- a/llama_stack/providers/registry/post_training.py
+++ b/llama_stack/providers/registry/post_training.py
@@ -14,7 +14,7 @@ def available_providers() -> List[ProviderSpec]:
         InlineProviderSpec(
             api=Api.post_training,
             provider_type="inline::torchtune",
-            pip_packages=["torch", "torchtune==0.4.0", "torchao==0.8.0", "numpy"],
+            pip_packages=["torch", "torchtune==0.5.0", "torchao==0.8.0", "numpy"],
             module="llama_stack.providers.inline.post_training.torchtune",
             config_class="llama_stack.providers.inline.post_training.torchtune.TorchtunePostTrainingConfig",
             api_dependencies=[

--- a/llama_stack/providers/registry/post_training.py
+++ b/llama_stack/providers/registry/post_training.py
@@ -14,7 +14,7 @@ def available_providers() -> List[ProviderSpec]:
         InlineProviderSpec(
             api=Api.post_training,
             provider_type="inline::torchtune",
-            pip_packages=["torch", "torchtune", "torchao", "numpy"],
+            pip_packages=["torch", "torchtune==0.4.0", "torchao==0.8.0", "numpy"],
             module="llama_stack.providers.inline.post_training.torchtune",
             config_class="llama_stack.providers.inline.post_training.torchtune.TorchtunePostTrainingConfig",
             api_dependencies=[


### PR DESCRIPTION
## context
This is the follow up of https://github.com/meta-llama/llama-stack/pull/674. Since torchtune is still in alpha stage and the apis are not guarantee backward compatible. Pin the torchtune and torchao pkg version to avoid the latest torchtune release breaks llama stack post training. 

We will bump the version number manually after with the new pkg release some testing 

## test 
ping an old torchtune pkg version (0.4.0) and the 0.4.0 was installed 
<img width="1016" alt="Screenshot 2025-01-16 at 3 06 47 PM" src="https://github.com/user-attachments/assets/630b05d0-8d0d-4e2f-8b48-22e578a62659" />

