### PR TITLE
correct parameter order of build_model_alias call in inference.py

### DIFF
--- a/llama_stack/providers/inline/inference/meta_reference/inference.py
+++ b/llama_stack/providers/inline/inference/meta_reference/inference.py
@@ -121,8 +121,8 @@ class MetaReferenceInferenceImpl(
         self.model_registry_helper = ModelRegistryHelper(
             [
                 build_model_alias(
-                    llama_model.descriptor(),
                     llama_model.core_model_id.value,
+                    llama_model.descriptor(),
                 )
             ],
         )


### PR DESCRIPTION
Corrects parameter order passed to build_model_alias allowing Llama-3.2-3B-Instruct-qlora-int4-eo8 to be used (https://github.com/meta-llama/llama-stack/issues/824)