### PR TITLE
Fix fireworks client sdk chat completion with images

### DIFF
--- a/llama_stack/providers/remote/inference/fireworks/fireworks.py
+++ b/llama_stack/providers/remote/inference/fireworks/fireworks.py
@@ -265,7 +265,8 @@ class FireworksInferenceAdapter(
         if isinstance(request, ChatCompletionRequest):
             if media_present:
                 input_dict["messages"] = [
-                    await convert_message_to_openai_dict(m) for m in request.messages
+                    await convert_message_to_openai_dict(m, download=True)
+                    for m in request.messages
                 ]
             else:
                 input_dict["prompt"] = await chat_completion_request_to_prompt(


### PR DESCRIPTION
Enable downloads before sending request to fireworks. 

Test using -- 
`LLAMA_STACK_CONFIG=./llama_stack/templates/fireworks/run.yaml pytest -s -v -k 'test_image_chat_completion_streaming' tests/client-sdk`