### PR TITLE
create a github action for triggering client-sdk tests on new pull-request

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: auto-tests
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
+      FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
+      TAVILY_SEARCH_API_KEY: ${{ secrets.TAVILY_SEARCH_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Echo branch name
+        run: echo "Running on branch ${{ github.ref }}"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest
+          pip install -e .
+      - name: Build providers
+        run: |
+          llama stack build --template fireworks --image-type venv
+          llama stack build --template together --image-type venv
+      - name: Run Together test
+        working-directory: "${{ github.workspace }}"
+        run:
+          LLAMA_STACK_CONFIG=./llama_stack/templates/together/run.yaml pytest ./tests/client-sdk/inference/test_inference.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.commit_sha }}
+      - name: Read CODEOWNERS file
+        run: |
+          cat .github/CODEOWNERS
 
       - name: Echo commit SHA
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  test-llama-stack-as-library:
     runs-on: ubuntu-latest
     env:
       TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
@@ -37,6 +37,24 @@ jobs:
 
       - name: Run client-sdk test
         working-directory: "${{ github.workspace }}"
+        env:
+          REPORT_OUTPUT: md_report.md
+        shell: bash
         run: |
+          pip install --upgrade pytest-md-report
+          echo "REPORT_FILE=${REPORT_OUTPUT}" >> "$GITHUB_ENV"
+
           export INFERENCE_MODEL=meta-llama/Llama-3.1-8B-Instruct
-          LLAMA_STACK_CONFIG=./llama_stack/templates/${{ matrix.provider }}/run.yaml pytest ./tests/client-sdk/inference/test_inference.py
+          LLAMA_STACK_CONFIG=./llama_stack/templates/${{ matrix.provider }}/run.yaml pytest --md-report --md-report-verbose=1 ./tests/client-sdk/inference/test_inference.py --md-report-output "$REPORT_OUTPUT"
+
+      - name: Output reports to the job summary
+        if: always()
+        shell: bash
+        run: |
+          if [ -f "$REPORT_FILE" ]; then
+            echo "<details><summary> Test Report for ${{ matrix.provider }} </summary>" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            cat "$REPORT_FILE" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "</details>" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,6 @@ name: auto-tests
 
 on:
   pull_request:
-  push:
   workflow_dispatch:
 
 jobs:
@@ -14,20 +13,30 @@ jobs:
       TAVILY_SEARCH_API_KEY: ${{ secrets.TAVILY_SEARCH_API_KEY }}
     strategy:
       matrix:
-        provider: [fireworks, ollama]
+        provider: [fireworks, together]
     steps:
       - uses: actions/checkout@v4
+
       - name: Echo branch name
         run: echo "Running on branch ${{ github.ref }}"
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt pytest
           pip install -e .
+
       - name: Build providers
         run: |
           llama stack build --template ${{ matrix.provider }} --image-type venv
+
+      - name: Install the latest llama-stack-client & llama-models packages
+        run: |
+          pip install -e git+https://github.com/meta-llama/llama-stack-client-python.git#egg=llama-stack-client
+          pip install -e git+https://github.com/meta-llama/llama-models.git#egg=llama-models
+
       - name: Run client-sdk test
         working-directory: "${{ github.workspace }}"
-        run:
+        run: |
+          export INFERENCE_MODEL=meta-llama/Llama-3.1-8B-Instruct
           LLAMA_STACK_CONFIG=./llama_stack/templates/${{ matrix.provider }}/run.yaml pytest ./tests/client-sdk/inference/test_inference.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,9 @@ jobs:
       TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
       FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
       TAVILY_SEARCH_API_KEY: ${{ secrets.TAVILY_SEARCH_API_KEY }}
+    strategy:
+      matrix:
+        provider: [fireworks, ollama]
     steps:
       - uses: actions/checkout@v4
       - name: Echo branch name
@@ -23,9 +26,8 @@ jobs:
           pip install -e .
       - name: Build providers
         run: |
-          llama stack build --template fireworks --image-type venv
-          llama stack build --template together --image-type venv
-      - name: Run Together test
+          llama stack build --template ${{ matrix.provider }} --image-type venv
+      - name: Run client-sdk test
         working-directory: "${{ github.workspace }}"
         run:
-          LLAMA_STACK_CONFIG=./llama_stack/templates/together/run.yaml pytest ./tests/client-sdk/inference/test_inference.py
+          LLAMA_STACK_CONFIG=./llama_stack/templates/${{ matrix.provider }}/run.yaml pytest ./tests/client-sdk/inference/test_inference.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,9 +23,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.commit_sha }}
-      - name: Read CODEOWNERS file
-        run: |
-          cat .github/CODEOWNERS
 
       - name: Echo commit SHA
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,13 @@
 name: auto-tests
 
 on:
-  pull_request:
+  # pull_request:
   workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: 'Specific Commit SHA to trigger on'
+        required: false
+        default: $GITHUB_SHA # default to the last commit of $GITHUB_REF branch
 
 jobs:
   test-llama-stack-as-library:
@@ -16,9 +21,13 @@ jobs:
         provider: [fireworks, together]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.commit_sha }}
 
-      - name: Echo branch name
-        run: echo "Running on branch ${{ github.ref }}"
+      - name: Echo commit SHA
+        run: |
+          echo "Triggered on commit SHA: ${{ github.event.inputs.commit_sha }}"
+          git rev-parse HEAD
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
# What does this PR do?

Create a new github action that runs integration tests on fireworks and together distro upon new PR 

**Key features:**
1) Run inference client-sdk tests on fireworks and together distro. Load distro as a library
2) Pull changes from latest github repo (llama-models) and (llama-stack-client-python) 
3) output a test summary 

**Next steps:**
- Expand the ci test action to (llama-models) and (llama-stack-client-python) repo to make sure the changes there does not break the imports in llama-stack

## Test Plan

See [the job run triggered by this PR](https://github.com/meta-llama/llama-stack/actions/runs/12926663190?pr=850)

