### PR TITLE
Update discriminator to have the correct `mapping`

### DIFF
--- a/docs/openapi_generator/strong_typing/classdef.py
+++ b/docs/openapi_generator/strong_typing/classdef.py
@@ -123,9 +123,15 @@ class JsonSchemaAnyOf(JsonSchemaNode):
 
 
 @dataclass
+class Discriminator:
+    propertyName: str
+    mapping: Dict[str, str]
+
+
+@dataclass
 class JsonSchemaOneOf(JsonSchemaNode):
     oneOf: List["JsonSchemaAny"]
-    discriminator: Optional[str]
+    discriminator: Optional[Discriminator]
 
 
 JsonSchemaAny = Union[

--- a/docs/openapi_generator/strong_typing/schema.py
+++ b/docs/openapi_generator/strong_typing/schema.py
@@ -456,8 +456,19 @@ class JsonSchemaGenerator:
                 ]
             }
             if discriminator:
+                # for each union type, we need to read the value of the discriminator
+                mapping = {}
+                for union_type in typing.get_args(typ):
+                    props = self.type_to_schema(union_type, force_expand=True)[
+                        "properties"
+                    ]
+                    mapping[props[discriminator]["default"]] = self.type_to_schema(
+                        union_type
+                    )["$ref"]
+
                 ret["discriminator"] = {
                     "propertyName": discriminator,
+                    "mapping": mapping,
                 }
             return ret
         elif origin_type is Literal:

--- a/docs/resources/llama-stack-spec.html
+++ b/docs/resources/llama-stack-spec.html
@@ -5047,40 +5047,42 @@
                 "type": "object",
                 "properties": {
                     "payload": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/AgentTurnResponseStepStartPayload"
-                            },
-                            {
-                                "$ref": "#/components/schemas/AgentTurnResponseStepProgressPayload"
-                            },
-                            {
-                                "$ref": "#/components/schemas/AgentTurnResponseStepCompletePayload"
-                            },
-                            {
-                                "$ref": "#/components/schemas/AgentTurnResponseTurnStartPayload"
-                            },
-                            {
-                                "$ref": "#/components/schemas/AgentTurnResponseTurnCompletePayload"
-                            }
-                        ],
-                        "discriminator": {
-                            "propertyName": "event_type",
-                            "mapping": {
-                                "step_start": "#/components/schemas/AgentTurnResponseStepStartPayload",
-                                "step_progress": "#/components/schemas/AgentTurnResponseStepProgressPayload",
-                                "step_complete": "#/components/schemas/AgentTurnResponseStepCompletePayload",
-                                "turn_start": "#/components/schemas/AgentTurnResponseTurnStartPayload",
-                                "turn_complete": "#/components/schemas/AgentTurnResponseTurnCompletePayload"
-                            }
-                        }
+                        "$ref": "#/components/schemas/AgentTurnResponseEventPayload"
                     }
                 },
                 "additionalProperties": false,
                 "required": [
                     "payload"
+                ]
+            },
+            "AgentTurnResponseEventPayload": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/AgentTurnResponseStepStartPayload"
+                    },
+                    {
+                        "$ref": "#/components/schemas/AgentTurnResponseStepProgressPayload"
+                    },
+                    {
+                        "$ref": "#/components/schemas/AgentTurnResponseStepCompletePayload"
+                    },
+                    {
+                        "$ref": "#/components/schemas/AgentTurnResponseTurnStartPayload"
+                    },
+                    {
+                        "$ref": "#/components/schemas/AgentTurnResponseTurnCompletePayload"
+                    }
                 ],
-                "title": "Streamed agent execution response."
+                "discriminator": {
+                    "propertyName": "event_type",
+                    "mapping": {
+                        "step_start": "#/components/schemas/AgentTurnResponseStepStartPayload",
+                        "step_progress": "#/components/schemas/AgentTurnResponseStepProgressPayload",
+                        "step_complete": "#/components/schemas/AgentTurnResponseStepCompletePayload",
+                        "turn_start": "#/components/schemas/AgentTurnResponseTurnStartPayload",
+                        "turn_complete": "#/components/schemas/AgentTurnResponseTurnCompletePayload"
+                    }
+                }
             },
             "AgentTurnResponseStepCompletePayload": {
                 "type": "object",
@@ -5677,44 +5679,12 @@
                         "default": "app"
                     },
                     "eval_candidate": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/ModelCandidate"
-                            },
-                            {
-                                "$ref": "#/components/schemas/AgentCandidate"
-                            }
-                        ],
-                        "discriminator": {
-                            "propertyName": "type",
-                            "mapping": {
-                                "model": "#/components/schemas/ModelCandidate",
-                                "agent": "#/components/schemas/AgentCandidate"
-                            }
-                        }
+                        "$ref": "#/components/schemas/EvalCandidate"
                     },
                     "scoring_params": {
                         "type": "object",
                         "additionalProperties": {
-                            "oneOf": [
-                                {
-                                    "$ref": "#/components/schemas/LLMAsJudgeScoringFnParams"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/RegexParserScoringFnParams"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/BasicScoringFnParams"
-                                }
-                            ],
-                            "discriminator": {
-                                "propertyName": "type",
-                                "mapping": {
-                                    "llm_as_judge": "#/components/schemas/LLMAsJudgeScoringFnParams",
-                                    "regex_parser": "#/components/schemas/RegexParserScoringFnParams",
-                                    "basic": "#/components/schemas/BasicScoringFnParams"
-                                }
-                            }
+                            "$ref": "#/components/schemas/ScoringFnParams"
                         }
                     },
                     "num_examples": {
@@ -5757,21 +5727,7 @@
                         "default": "benchmark"
                     },
                     "eval_candidate": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/ModelCandidate"
-                            },
-                            {
-                                "$ref": "#/components/schemas/AgentCandidate"
-                            }
-                        ],
-                        "discriminator": {
-                            "propertyName": "type",
-                            "mapping": {
-                                "model": "#/components/schemas/ModelCandidate",
-                                "agent": "#/components/schemas/AgentCandidate"
-                            }
-                        }
+                        "$ref": "#/components/schemas/EvalCandidate"
                     },
                     "num_examples": {
                         "type": "integer"
@@ -5782,6 +5738,40 @@
                     "type",
                     "eval_candidate"
                 ]
+            },
+            "EvalCandidate": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/ModelCandidate"
+                    },
+                    {
+                        "$ref": "#/components/schemas/AgentCandidate"
+                    }
+                ],
+                "discriminator": {
+                    "propertyName": "type",
+                    "mapping": {
+                        "model": "#/components/schemas/ModelCandidate",
+                        "agent": "#/components/schemas/AgentCandidate"
+                    }
+                }
+            },
+            "EvalTaskConfig": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/BenchmarkEvalTaskConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/AppEvalTaskConfig"
+                    }
+                ],
+                "discriminator": {
+                    "propertyName": "type",
+                    "mapping": {
+                        "benchmark": "#/components/schemas/BenchmarkEvalTaskConfig",
+                        "app": "#/components/schemas/AppEvalTaskConfig"
+                    }
+                }
             },
             "LLMAsJudgeScoringFnParams": {
                 "type": "object",
@@ -5867,6 +5857,27 @@
                     "type"
                 ]
             },
+            "ScoringFnParams": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/LLMAsJudgeScoringFnParams"
+                    },
+                    {
+                        "$ref": "#/components/schemas/RegexParserScoringFnParams"
+                    },
+                    {
+                        "$ref": "#/components/schemas/BasicScoringFnParams"
+                    }
+                ],
+                "discriminator": {
+                    "propertyName": "type",
+                    "mapping": {
+                        "llm_as_judge": "#/components/schemas/LLMAsJudgeScoringFnParams",
+                        "regex_parser": "#/components/schemas/RegexParserScoringFnParams",
+                        "basic": "#/components/schemas/BasicScoringFnParams"
+                    }
+                }
+            },
             "EvaluateRowsRequest": {
                 "type": "object",
                 "properties": {
@@ -5905,21 +5916,7 @@
                         }
                     },
                     "task_config": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/BenchmarkEvalTaskConfig"
-                            },
-                            {
-                                "$ref": "#/components/schemas/AppEvalTaskConfig"
-                            }
-                        ],
-                        "discriminator": {
-                            "propertyName": "type",
-                            "mapping": {
-                                "benchmark": "#/components/schemas/BenchmarkEvalTaskConfig",
-                                "app": "#/components/schemas/AppEvalTaskConfig"
-                            }
-                        }
+                        "$ref": "#/components/schemas/EvalTaskConfig"
                     }
                 },
                 "additionalProperties": false,
@@ -6571,25 +6568,7 @@
                         "$ref": "#/components/schemas/ParamType"
                     },
                     "params": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/LLMAsJudgeScoringFnParams"
-                            },
-                            {
-                                "$ref": "#/components/schemas/RegexParserScoringFnParams"
-                            },
-                            {
-                                "$ref": "#/components/schemas/BasicScoringFnParams"
-                            }
-                        ],
-                        "discriminator": {
-                            "propertyName": "type",
-                            "mapping": {
-                                "llm_as_judge": "#/components/schemas/LLMAsJudgeScoringFnParams",
-                                "regex_parser": "#/components/schemas/RegexParserScoringFnParams",
-                                "basic": "#/components/schemas/BasicScoringFnParams"
-                            }
-                        }
+                        "$ref": "#/components/schemas/ScoringFnParams"
                     }
                 },
                 "additionalProperties": false,
@@ -7503,6 +7482,27 @@
                     "data"
                 ]
             },
+            "Event": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/UnstructuredLogEvent"
+                    },
+                    {
+                        "$ref": "#/components/schemas/MetricEvent"
+                    },
+                    {
+                        "$ref": "#/components/schemas/StructuredLogEvent"
+                    }
+                ],
+                "discriminator": {
+                    "propertyName": "type",
+                    "mapping": {
+                        "unstructured_log": "#/components/schemas/UnstructuredLogEvent",
+                        "metric": "#/components/schemas/MetricEvent",
+                        "structured_log": "#/components/schemas/StructuredLogEvent"
+                    }
+                }
+            },
             "LogSeverity": {
                 "type": "string",
                 "enum": [
@@ -7668,21 +7668,7 @@
                         "default": "structured_log"
                     },
                     "payload": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/SpanStartPayload"
-                            },
-                            {
-                                "$ref": "#/components/schemas/SpanEndPayload"
-                            }
-                        ],
-                        "discriminator": {
-                            "propertyName": "type",
-                            "mapping": {
-                                "span_start": "#/components/schemas/SpanStartPayload",
-                                "span_end": "#/components/schemas/SpanEndPayload"
-                            }
-                        }
+                        "$ref": "#/components/schemas/StructuredLogPayload"
                     }
                 },
                 "additionalProperties": false,
@@ -7693,6 +7679,23 @@
                     "type",
                     "payload"
                 ]
+            },
+            "StructuredLogPayload": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/SpanStartPayload"
+                    },
+                    {
+                        "$ref": "#/components/schemas/SpanEndPayload"
+                    }
+                ],
+                "discriminator": {
+                    "propertyName": "type",
+                    "mapping": {
+                        "span_start": "#/components/schemas/SpanStartPayload",
+                        "span_end": "#/components/schemas/SpanEndPayload"
+                    }
+                }
             },
             "UnstructuredLogEvent": {
                 "type": "object",
@@ -7758,25 +7761,7 @@
                 "type": "object",
                 "properties": {
                     "event": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/UnstructuredLogEvent"
-                            },
-                            {
-                                "$ref": "#/components/schemas/MetricEvent"
-                            },
-                            {
-                                "$ref": "#/components/schemas/StructuredLogEvent"
-                            }
-                        ],
-                        "discriminator": {
-                            "propertyName": "type",
-                            "mapping": {
-                                "unstructured_log": "#/components/schemas/UnstructuredLogEvent",
-                                "metric": "#/components/schemas/MetricEvent",
-                                "structured_log": "#/components/schemas/StructuredLogEvent"
-                            }
-                        }
+                        "$ref": "#/components/schemas/Event"
                     },
                     "ttl_seconds": {
                         "type": "integer"
@@ -8495,25 +8480,7 @@
                         "type": "string"
                     },
                     "params": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/LLMAsJudgeScoringFnParams"
-                            },
-                            {
-                                "$ref": "#/components/schemas/RegexParserScoringFnParams"
-                            },
-                            {
-                                "$ref": "#/components/schemas/BasicScoringFnParams"
-                            }
-                        ],
-                        "discriminator": {
-                            "propertyName": "type",
-                            "mapping": {
-                                "llm_as_judge": "#/components/schemas/LLMAsJudgeScoringFnParams",
-                                "regex_parser": "#/components/schemas/RegexParserScoringFnParams",
-                                "basic": "#/components/schemas/BasicScoringFnParams"
-                            }
-                        }
+                        "$ref": "#/components/schemas/ScoringFnParams"
                     }
                 },
                 "additionalProperties": false,
@@ -8639,21 +8606,7 @@
                 "type": "object",
                 "properties": {
                     "task_config": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/BenchmarkEvalTaskConfig"
-                            },
-                            {
-                                "$ref": "#/components/schemas/AppEvalTaskConfig"
-                            }
-                        ],
-                        "discriminator": {
-                            "propertyName": "type",
-                            "mapping": {
-                                "benchmark": "#/components/schemas/BenchmarkEvalTaskConfig",
-                                "app": "#/components/schemas/AppEvalTaskConfig"
-                            }
-                        }
+                        "$ref": "#/components/schemas/EvalTaskConfig"
                     }
                 },
                 "additionalProperties": false,
@@ -8792,25 +8745,7 @@
                         "additionalProperties": {
                             "oneOf": [
                                 {
-                                    "oneOf": [
-                                        {
-                                            "$ref": "#/components/schemas/LLMAsJudgeScoringFnParams"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/RegexParserScoringFnParams"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/BasicScoringFnParams"
-                                        }
-                                    ],
-                                    "discriminator": {
-                                        "propertyName": "type",
-                                        "mapping": {
-                                            "llm_as_judge": "#/components/schemas/LLMAsJudgeScoringFnParams",
-                                            "regex_parser": "#/components/schemas/RegexParserScoringFnParams",
-                                            "basic": "#/components/schemas/BasicScoringFnParams"
-                                        }
-                                    }
+                                    "$ref": "#/components/schemas/ScoringFnParams"
                                 },
                                 {
                                     "type": "null"
@@ -8851,25 +8786,7 @@
                         "additionalProperties": {
                             "oneOf": [
                                 {
-                                    "oneOf": [
-                                        {
-                                            "$ref": "#/components/schemas/LLMAsJudgeScoringFnParams"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/RegexParserScoringFnParams"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/BasicScoringFnParams"
-                                        }
-                                    ],
-                                    "discriminator": {
-                                        "propertyName": "type",
-                                        "mapping": {
-                                            "llm_as_judge": "#/components/schemas/LLMAsJudgeScoringFnParams",
-                                            "regex_parser": "#/components/schemas/RegexParserScoringFnParams",
-                                            "basic": "#/components/schemas/BasicScoringFnParams"
-                                        }
-                                    }
+                                    "$ref": "#/components/schemas/ScoringFnParams"
                                 },
                                 {
                                     "type": "null"
@@ -8905,6 +8822,23 @@
                 "required": [
                     "results"
                 ]
+            },
+            "AlgorithmConfig": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/LoraFinetuningConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/QATFinetuningConfig"
+                    }
+                ],
+                "discriminator": {
+                    "propertyName": "type",
+                    "mapping": {
+                        "LoRA": "#/components/schemas/LoraFinetuningConfig",
+                        "QAT": "#/components/schemas/QATFinetuningConfig"
+                    }
+                }
             },
             "LoraFinetuningConfig": {
                 "type": "object",
@@ -9039,21 +8973,7 @@
                         "type": "string"
                     },
                     "algorithm_config": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/LoraFinetuningConfig"
-                            },
-                            {
-                                "$ref": "#/components/schemas/QATFinetuningConfig"
-                            }
-                        ],
-                        "discriminator": {
-                            "propertyName": "type",
-                            "mapping": {
-                                "LoRA": "#/components/schemas/LoraFinetuningConfig",
-                                "QAT": "#/components/schemas/QATFinetuningConfig"
-                            }
-                        }
+                        "$ref": "#/components/schemas/AlgorithmConfig"
                     }
                 },
                 "additionalProperties": false,
@@ -9210,7 +9130,11 @@
         },
         {
             "name": "AgentTurnResponseEvent",
-            "description": "Streamed agent execution response.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseEvent\" />"
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseEvent\" />"
+        },
+        {
+            "name": "AgentTurnResponseEventPayload",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseEventPayload\" />"
         },
         {
             "name": "AgentTurnResponseStepCompletePayload",
@@ -9242,6 +9166,10 @@
         {
             "name": "AggregationFunctionType",
             "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AggregationFunctionType\" />"
+        },
+        {
+            "name": "AlgorithmConfig",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AlgorithmConfig\" />"
         },
         {
             "name": "AppEvalTaskConfig",
@@ -9400,8 +9328,16 @@
             "name": "Eval"
         },
         {
+            "name": "EvalCandidate",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/EvalCandidate\" />"
+        },
+        {
             "name": "EvalTask",
             "description": "<SchemaDefinition schemaRef=\"#/components/schemas/EvalTask\" />"
+        },
+        {
+            "name": "EvalTaskConfig",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/EvalTaskConfig\" />"
         },
         {
             "name": "EvalTasks"
@@ -9413,6 +9349,10 @@
         {
             "name": "EvaluateRowsRequest",
             "description": "<SchemaDefinition schemaRef=\"#/components/schemas/EvaluateRowsRequest\" />"
+        },
+        {
+            "name": "Event",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/Event\" />"
         },
         {
             "name": "GrammarResponseFormat",
@@ -9761,6 +9701,10 @@
             "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ScoringFn\" />"
         },
         {
+            "name": "ScoringFnParams",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ScoringFnParams\" />"
+        },
+        {
             "name": "ScoringFunctions"
         },
         {
@@ -9813,6 +9757,10 @@
         {
             "name": "StructuredLogEvent",
             "description": "<SchemaDefinition schemaRef=\"#/components/schemas/StructuredLogEvent\" />"
+        },
+        {
+            "name": "StructuredLogPayload",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/StructuredLogPayload\" />"
         },
         {
             "name": "SupervisedFineTuneRequest",
@@ -10010,6 +9958,7 @@
                 "AgentTool",
                 "AgentTurnInputType",
                 "AgentTurnResponseEvent",
+                "AgentTurnResponseEventPayload",
                 "AgentTurnResponseStepCompletePayload",
                 "AgentTurnResponseStepProgressPayload",
                 "AgentTurnResponseStepStartPayload",
@@ -10017,6 +9966,7 @@
                 "AgentTurnResponseTurnCompletePayload",
                 "AgentTurnResponseTurnStartPayload",
                 "AggregationFunctionType",
+                "AlgorithmConfig",
                 "AppEvalTaskConfig",
                 "AppendRowsRequest",
                 "ArrayType",
@@ -10053,9 +10003,12 @@
                 "EfficiencyConfig",
                 "EmbeddingsRequest",
                 "EmbeddingsResponse",
+                "EvalCandidate",
                 "EvalTask",
+                "EvalTaskConfig",
                 "EvaluateResponse",
                 "EvaluateRowsRequest",
+                "Event",
                 "GrammarResponseFormat",
                 "GreedySamplingStrategy",
                 "HealthInfo",
@@ -10138,6 +10091,7 @@
                 "ScoreRequest",
                 "ScoreResponse",
                 "ScoringFn",
+                "ScoringFnParams",
                 "ScoringResult",
                 "Session",
                 "Shield",
@@ -10150,6 +10104,7 @@
                 "StopReason",
                 "StringType",
                 "StructuredLogEvent",
+                "StructuredLogPayload",
                 "SupervisedFineTuneRequest",
                 "SyntheticDataGenerateRequest",
                 "SyntheticDataGenerationResponse",

--- a/docs/resources/llama-stack-spec.html
+++ b/docs/resources/llama-stack-spec.html
@@ -3812,7 +3812,11 @@
                     }
                 ],
                 "discriminator": {
-                    "propertyName": "type"
+                    "propertyName": "type",
+                    "mapping": {
+                        "image": "#/components/schemas/ImageContentItem",
+                        "text": "#/components/schemas/TextContentItem"
+                    }
                 }
             },
             "Message": {
@@ -3831,7 +3835,13 @@
                     }
                 ],
                 "discriminator": {
-                    "propertyName": "role"
+                    "propertyName": "role",
+                    "mapping": {
+                        "user": "#/components/schemas/UserMessage",
+                        "system": "#/components/schemas/SystemMessage",
+                        "tool": "#/components/schemas/ToolResponseMessage",
+                        "assistant": "#/components/schemas/CompletionMessage"
+                    }
                 }
             },
             "SamplingParams": {
@@ -3850,7 +3860,12 @@
                             }
                         ],
                         "discriminator": {
-                            "propertyName": "type"
+                            "propertyName": "type",
+                            "mapping": {
+                                "greedy": "#/components/schemas/GreedySamplingStrategy",
+                                "top_p": "#/components/schemas/TopPSamplingStrategy",
+                                "top_k": "#/components/schemas/TopKSamplingStrategy"
+                            }
                         }
                     },
                     "max_tokens": {
@@ -4313,91 +4328,101 @@
                     "job_uuid"
                 ]
             },
+            "GrammarResponseFormat": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "const": "grammar",
+                        "default": "grammar"
+                    },
+                    "bnf": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "type": "boolean"
+                                },
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "type",
+                    "bnf"
+                ]
+            },
+            "JsonSchemaResponseFormat": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "const": "json_schema",
+                        "default": "json_schema"
+                    },
+                    "json_schema": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "type": "boolean"
+                                },
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "type",
+                    "json_schema"
+                ]
+            },
             "ResponseFormat": {
                 "oneOf": [
                     {
-                        "type": "object",
-                        "properties": {
-                            "type": {
-                                "type": "string",
-                                "const": "json_schema",
-                                "default": "json_schema"
-                            },
-                            "json_schema": {
-                                "type": "object",
-                                "additionalProperties": {
-                                    "oneOf": [
-                                        {
-                                            "type": "null"
-                                        },
-                                        {
-                                            "type": "boolean"
-                                        },
-                                        {
-                                            "type": "number"
-                                        },
-                                        {
-                                            "type": "string"
-                                        },
-                                        {
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": "object"
-                                        }
-                                    ]
-                                }
-                            }
-                        },
-                        "additionalProperties": false,
-                        "required": [
-                            "type",
-                            "json_schema"
-                        ]
+                        "$ref": "#/components/schemas/JsonSchemaResponseFormat"
                     },
                     {
-                        "type": "object",
-                        "properties": {
-                            "type": {
-                                "type": "string",
-                                "const": "grammar",
-                                "default": "grammar"
-                            },
-                            "bnf": {
-                                "type": "object",
-                                "additionalProperties": {
-                                    "oneOf": [
-                                        {
-                                            "type": "null"
-                                        },
-                                        {
-                                            "type": "boolean"
-                                        },
-                                        {
-                                            "type": "number"
-                                        },
-                                        {
-                                            "type": "string"
-                                        },
-                                        {
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": "object"
-                                        }
-                                    ]
-                                }
-                            }
-                        },
-                        "additionalProperties": false,
-                        "required": [
-                            "type",
-                            "bnf"
-                        ]
+                        "$ref": "#/components/schemas/GrammarResponseFormat"
                     }
                 ],
                 "discriminator": {
-                    "propertyName": "type"
+                    "propertyName": "type",
+                    "mapping": {
+                        "json_schema": "#/components/schemas/JsonSchemaResponseFormat",
+                        "grammar": "#/components/schemas/GrammarResponseFormat"
+                    }
                 }
             },
             "ChatCompletionRequest": {
@@ -4529,7 +4554,12 @@
                     }
                 ],
                 "discriminator": {
-                    "propertyName": "type"
+                    "propertyName": "type",
+                    "mapping": {
+                        "text": "#/components/schemas/TextDelta",
+                        "image": "#/components/schemas/ImageDelta",
+                        "tool_call": "#/components/schemas/ToolCallDelta"
+                    }
                 }
             },
             "ImageDelta": {
@@ -4737,8 +4767,7 @@
                         "default": "auto"
                     },
                     "tool_prompt_format": {
-                        "$ref": "#/components/schemas/ToolPromptFormat",
-                        "default": "json"
+                        "$ref": "#/components/schemas/ToolPromptFormat"
                     },
                     "max_infer_iters": {
                         "type": "integer",
@@ -5036,7 +5065,14 @@
                             }
                         ],
                         "discriminator": {
-                            "propertyName": "event_type"
+                            "propertyName": "event_type",
+                            "mapping": {
+                                "step_start": "#/components/schemas/AgentTurnResponseStepStartPayload",
+                                "step_progress": "#/components/schemas/AgentTurnResponseStepProgressPayload",
+                                "step_complete": "#/components/schemas/AgentTurnResponseStepCompletePayload",
+                                "turn_start": "#/components/schemas/AgentTurnResponseTurnStartPayload",
+                                "turn_complete": "#/components/schemas/AgentTurnResponseTurnCompletePayload"
+                            }
                         }
                     }
                 },
@@ -5082,7 +5118,13 @@
                             }
                         ],
                         "discriminator": {
-                            "propertyName": "step_type"
+                            "propertyName": "step_type",
+                            "mapping": {
+                                "inference": "#/components/schemas/InferenceStep",
+                                "tool_execution": "#/components/schemas/ToolExecutionStep",
+                                "shield_call": "#/components/schemas/ShieldCallStep",
+                                "memory_retrieval": "#/components/schemas/MemoryRetrievalStep"
+                            }
                         }
                     }
                 },
@@ -5485,7 +5527,13 @@
                                 }
                             ],
                             "discriminator": {
-                                "propertyName": "step_type"
+                                "propertyName": "step_type",
+                                "mapping": {
+                                    "inference": "#/components/schemas/InferenceStep",
+                                    "tool_execution": "#/components/schemas/ToolExecutionStep",
+                                    "shield_call": "#/components/schemas/ShieldCallStep",
+                                    "memory_retrieval": "#/components/schemas/MemoryRetrievalStep"
+                                }
                             }
                         }
                     },
@@ -5638,7 +5686,11 @@
                             }
                         ],
                         "discriminator": {
-                            "propertyName": "type"
+                            "propertyName": "type",
+                            "mapping": {
+                                "model": "#/components/schemas/ModelCandidate",
+                                "agent": "#/components/schemas/AgentCandidate"
+                            }
                         }
                     },
                     "scoring_params": {
@@ -5656,7 +5708,12 @@
                                 }
                             ],
                             "discriminator": {
-                                "propertyName": "type"
+                                "propertyName": "type",
+                                "mapping": {
+                                    "llm_as_judge": "#/components/schemas/LLMAsJudgeScoringFnParams",
+                                    "regex_parser": "#/components/schemas/RegexParserScoringFnParams",
+                                    "basic": "#/components/schemas/BasicScoringFnParams"
+                                }
                             }
                         }
                     },
@@ -5709,7 +5766,11 @@
                             }
                         ],
                         "discriminator": {
-                            "propertyName": "type"
+                            "propertyName": "type",
+                            "mapping": {
+                                "model": "#/components/schemas/ModelCandidate",
+                                "agent": "#/components/schemas/AgentCandidate"
+                            }
                         }
                     },
                     "num_examples": {
@@ -5853,7 +5914,11 @@
                             }
                         ],
                         "discriminator": {
-                            "propertyName": "type"
+                            "propertyName": "type",
+                            "mapping": {
+                                "benchmark": "#/components/schemas/BenchmarkEvalTaskConfig",
+                                "app": "#/components/schemas/AppEvalTaskConfig"
+                            }
                         }
                     }
                 },
@@ -6019,7 +6084,13 @@
                             }
                         ],
                         "discriminator": {
-                            "propertyName": "step_type"
+                            "propertyName": "step_type",
+                            "mapping": {
+                                "inference": "#/components/schemas/InferenceStep",
+                                "tool_execution": "#/components/schemas/ToolExecutionStep",
+                                "shield_call": "#/components/schemas/ShieldCallStep",
+                                "memory_retrieval": "#/components/schemas/MemoryRetrievalStep"
+                            }
                         }
                     }
                 },
@@ -6237,7 +6308,19 @@
                     }
                 ],
                 "discriminator": {
-                    "propertyName": "type"
+                    "propertyName": "type",
+                    "mapping": {
+                        "string": "#/components/schemas/StringType",
+                        "number": "#/components/schemas/NumberType",
+                        "boolean": "#/components/schemas/BooleanType",
+                        "array": "#/components/schemas/ArrayType",
+                        "object": "#/components/schemas/ObjectType",
+                        "json": "#/components/schemas/JsonType",
+                        "union": "#/components/schemas/UnionType",
+                        "chat_completion_input": "#/components/schemas/ChatCompletionInputType",
+                        "completion_input": "#/components/schemas/CompletionInputType",
+                        "agent_turn_input": "#/components/schemas/AgentTurnInputType"
+                    }
                 }
             },
             "StringType": {
@@ -6500,7 +6583,12 @@
                             }
                         ],
                         "discriminator": {
-                            "propertyName": "type"
+                            "propertyName": "type",
+                            "mapping": {
+                                "llm_as_judge": "#/components/schemas/LLMAsJudgeScoringFnParams",
+                                "regex_parser": "#/components/schemas/RegexParserScoringFnParams",
+                                "basic": "#/components/schemas/BasicScoringFnParams"
+                            }
                         }
                     }
                 },
@@ -7589,7 +7677,11 @@
                             }
                         ],
                         "discriminator": {
-                            "propertyName": "type"
+                            "propertyName": "type",
+                            "mapping": {
+                                "span_start": "#/components/schemas/SpanStartPayload",
+                                "span_end": "#/components/schemas/SpanEndPayload"
+                            }
                         }
                     }
                 },
@@ -7678,7 +7770,12 @@
                             }
                         ],
                         "discriminator": {
-                            "propertyName": "type"
+                            "propertyName": "type",
+                            "mapping": {
+                                "unstructured_log": "#/components/schemas/UnstructuredLogEvent",
+                                "metric": "#/components/schemas/MetricEvent",
+                                "structured_log": "#/components/schemas/StructuredLogEvent"
+                            }
                         }
                     },
                     "ttl_seconds": {
@@ -8011,7 +8108,11 @@
                     }
                 ],
                 "discriminator": {
-                    "propertyName": "type"
+                    "propertyName": "type",
+                    "mapping": {
+                        "default": "#/components/schemas/DefaultRAGQueryGeneratorConfig",
+                        "llm": "#/components/schemas/LLMRAGQueryGeneratorConfig"
+                    }
                 }
             },
             "QueryRequest": {
@@ -8406,7 +8507,12 @@
                             }
                         ],
                         "discriminator": {
-                            "propertyName": "type"
+                            "propertyName": "type",
+                            "mapping": {
+                                "llm_as_judge": "#/components/schemas/LLMAsJudgeScoringFnParams",
+                                "regex_parser": "#/components/schemas/RegexParserScoringFnParams",
+                                "basic": "#/components/schemas/BasicScoringFnParams"
+                            }
                         }
                     }
                 },
@@ -8542,7 +8648,11 @@
                             }
                         ],
                         "discriminator": {
-                            "propertyName": "type"
+                            "propertyName": "type",
+                            "mapping": {
+                                "benchmark": "#/components/schemas/BenchmarkEvalTaskConfig",
+                                "app": "#/components/schemas/AppEvalTaskConfig"
+                            }
                         }
                     }
                 },
@@ -8694,7 +8804,12 @@
                                         }
                                     ],
                                     "discriminator": {
-                                        "propertyName": "type"
+                                        "propertyName": "type",
+                                        "mapping": {
+                                            "llm_as_judge": "#/components/schemas/LLMAsJudgeScoringFnParams",
+                                            "regex_parser": "#/components/schemas/RegexParserScoringFnParams",
+                                            "basic": "#/components/schemas/BasicScoringFnParams"
+                                        }
                                     }
                                 },
                                 {
@@ -8748,7 +8863,12 @@
                                         }
                                     ],
                                     "discriminator": {
-                                        "propertyName": "type"
+                                        "propertyName": "type",
+                                        "mapping": {
+                                            "llm_as_judge": "#/components/schemas/LLMAsJudgeScoringFnParams",
+                                            "regex_parser": "#/components/schemas/RegexParserScoringFnParams",
+                                            "basic": "#/components/schemas/BasicScoringFnParams"
+                                        }
                                     }
                                 },
                                 {
@@ -8928,7 +9048,11 @@
                             }
                         ],
                         "discriminator": {
-                            "propertyName": "type"
+                            "propertyName": "type",
+                            "mapping": {
+                                "LoRA": "#/components/schemas/LoraFinetuningConfig",
+                                "QAT": "#/components/schemas/QATFinetuningConfig"
+                            }
                         }
                     }
                 },
@@ -9291,6 +9415,10 @@
             "description": "<SchemaDefinition schemaRef=\"#/components/schemas/EvaluateRowsRequest\" />"
         },
         {
+            "name": "GrammarResponseFormat",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/GrammarResponseFormat\" />"
+        },
+        {
             "name": "GreedySamplingStrategy",
             "description": "<SchemaDefinition schemaRef=\"#/components/schemas/GreedySamplingStrategy\" />"
         },
@@ -9343,6 +9471,10 @@
         {
             "name": "JobStatus",
             "description": "<SchemaDefinition schemaRef=\"#/components/schemas/JobStatus\" />"
+        },
+        {
+            "name": "JsonSchemaResponseFormat",
+            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/JsonSchemaResponseFormat\" />"
         },
         {
             "name": "JsonType",
@@ -9924,6 +10056,7 @@
                 "EvalTask",
                 "EvaluateResponse",
                 "EvaluateRowsRequest",
+                "GrammarResponseFormat",
                 "GreedySamplingStrategy",
                 "HealthInfo",
                 "ImageContentItem",
@@ -9936,6 +10069,7 @@
                 "InvokeToolRequest",
                 "Job",
                 "JobStatus",
+                "JsonSchemaResponseFormat",
                 "JsonType",
                 "LLMAsJudgeScoringFnParams",
                 "LLMRAGQueryGeneratorConfig",

--- a/docs/resources/llama-stack-spec.yaml
+++ b/docs/resources/llama-stack-spec.yaml
@@ -45,7 +45,6 @@ components:
           default: auto
         tool_prompt_format:
           $ref: '#/components/schemas/ToolPromptFormat'
-          default: json
         toolgroups:
           items:
             $ref: '#/components/schemas/AgentTool'
@@ -77,6 +76,11 @@ components:
       properties:
         step:
           discriminator:
+            mapping:
+              inference: '#/components/schemas/InferenceStep'
+              memory_retrieval: '#/components/schemas/MemoryRetrievalStep'
+              shield_call: '#/components/schemas/ShieldCallStep'
+              tool_execution: '#/components/schemas/ToolExecutionStep'
             propertyName: step_type
           oneOf:
           - $ref: '#/components/schemas/InferenceStep'
@@ -122,6 +126,12 @@ components:
       properties:
         payload:
           discriminator:
+            mapping:
+              step_complete: '#/components/schemas/AgentTurnResponseStepCompletePayload'
+              step_progress: '#/components/schemas/AgentTurnResponseStepProgressPayload'
+              step_start: '#/components/schemas/AgentTurnResponseStepStartPayload'
+              turn_complete: '#/components/schemas/AgentTurnResponseTurnCompletePayload'
+              turn_start: '#/components/schemas/AgentTurnResponseTurnStartPayload'
             propertyName: event_type
           oneOf:
           - $ref: '#/components/schemas/AgentTurnResponseStepStartPayload'
@@ -142,6 +152,11 @@ components:
           type: string
         step_details:
           discriminator:
+            mapping:
+              inference: '#/components/schemas/InferenceStep'
+              memory_retrieval: '#/components/schemas/MemoryRetrievalStep'
+              shield_call: '#/components/schemas/ShieldCallStep'
+              tool_execution: '#/components/schemas/ToolExecutionStep'
             propertyName: step_type
           oneOf:
           - $ref: '#/components/schemas/InferenceStep'
@@ -265,6 +280,9 @@ components:
       properties:
         eval_candidate:
           discriminator:
+            mapping:
+              agent: '#/components/schemas/AgentCandidate'
+              model: '#/components/schemas/ModelCandidate'
             propertyName: type
           oneOf:
           - $ref: '#/components/schemas/ModelCandidate'
@@ -274,6 +292,10 @@ components:
         scoring_params:
           additionalProperties:
             discriminator:
+              mapping:
+                basic: '#/components/schemas/BasicScoringFnParams'
+                llm_as_judge: '#/components/schemas/LLMAsJudgeScoringFnParams'
+                regex_parser: '#/components/schemas/RegexParserScoringFnParams'
               propertyName: type
             oneOf:
             - $ref: '#/components/schemas/LLMAsJudgeScoringFnParams'
@@ -413,6 +435,9 @@ components:
       properties:
         eval_candidate:
           discriminator:
+            mapping:
+              agent: '#/components/schemas/AgentCandidate'
+              model: '#/components/schemas/ModelCandidate'
             propertyName: type
           oneOf:
           - $ref: '#/components/schemas/ModelCandidate'
@@ -632,6 +657,10 @@ components:
       type: object
     ContentDelta:
       discriminator:
+        mapping:
+          image: '#/components/schemas/ImageDelta'
+          text: '#/components/schemas/TextDelta'
+          tool_call: '#/components/schemas/ToolCallDelta'
         propertyName: type
       oneOf:
       - $ref: '#/components/schemas/TextDelta'
@@ -912,6 +941,9 @@ components:
           type: array
         task_config:
           discriminator:
+            mapping:
+              app: '#/components/schemas/AppEvalTaskConfig'
+              benchmark: '#/components/schemas/BenchmarkEvalTaskConfig'
             propertyName: type
           oneOf:
           - $ref: '#/components/schemas/BenchmarkEvalTaskConfig'
@@ -920,6 +952,27 @@ components:
       - input_rows
       - scoring_functions
       - task_config
+      type: object
+    GrammarResponseFormat:
+      additionalProperties: false
+      properties:
+        bnf:
+          additionalProperties:
+            oneOf:
+            - type: 'null'
+            - type: boolean
+            - type: number
+            - type: string
+            - type: array
+            - type: object
+          type: object
+        type:
+          const: grammar
+          default: grammar
+          type: string
+      required:
+      - type
+      - bnf
       type: object
     GreedySamplingStrategy:
       additionalProperties: false
@@ -1055,6 +1108,9 @@ components:
         type: array
     InterleavedContentItem:
       discriminator:
+        mapping:
+          image: '#/components/schemas/ImageContentItem'
+          text: '#/components/schemas/TextContentItem'
         propertyName: type
       oneOf:
       - $ref: '#/components/schemas/ImageContentItem'
@@ -1093,6 +1149,27 @@ components:
       - failed
       - scheduled
       type: string
+    JsonSchemaResponseFormat:
+      additionalProperties: false
+      properties:
+        json_schema:
+          additionalProperties:
+            oneOf:
+            - type: 'null'
+            - type: boolean
+            - type: number
+            - type: string
+            - type: array
+            - type: object
+          type: object
+        type:
+          const: json_schema
+          default: json_schema
+          type: string
+      required:
+      - type
+      - json_schema
+      type: object
     JsonType:
       additionalProperties: false
       properties:
@@ -1263,6 +1340,10 @@ components:
       properties:
         event:
           discriminator:
+            mapping:
+              metric: '#/components/schemas/MetricEvent'
+              structured_log: '#/components/schemas/StructuredLogEvent'
+              unstructured_log: '#/components/schemas/UnstructuredLogEvent'
             propertyName: type
           oneOf:
           - $ref: '#/components/schemas/UnstructuredLogEvent'
@@ -1346,6 +1427,11 @@ components:
       type: object
     Message:
       discriminator:
+        mapping:
+          assistant: '#/components/schemas/CompletionMessage'
+          system: '#/components/schemas/SystemMessage'
+          tool: '#/components/schemas/ToolResponseMessage'
+          user: '#/components/schemas/UserMessage'
         propertyName: role
       oneOf:
       - $ref: '#/components/schemas/UserMessage'
@@ -1518,6 +1604,17 @@ components:
       type: object
     ParamType:
       discriminator:
+        mapping:
+          agent_turn_input: '#/components/schemas/AgentTurnInputType'
+          array: '#/components/schemas/ArrayType'
+          boolean: '#/components/schemas/BooleanType'
+          chat_completion_input: '#/components/schemas/ChatCompletionInputType'
+          completion_input: '#/components/schemas/CompletionInputType'
+          json: '#/components/schemas/JsonType'
+          number: '#/components/schemas/NumberType'
+          object: '#/components/schemas/ObjectType'
+          string: '#/components/schemas/StringType'
+          union: '#/components/schemas/UnionType'
         propertyName: type
       oneOf:
       - $ref: '#/components/schemas/StringType'
@@ -1830,6 +1927,9 @@ components:
       type: object
     RAGQueryGeneratorConfig:
       discriminator:
+        mapping:
+          default: '#/components/schemas/DefaultRAGQueryGeneratorConfig'
+          llm: '#/components/schemas/LLMRAGQueryGeneratorConfig'
         propertyName: type
       oneOf:
       - $ref: '#/components/schemas/DefaultRAGQueryGeneratorConfig'
@@ -1949,6 +2049,10 @@ components:
           type: string
         params:
           discriminator:
+            mapping:
+              basic: '#/components/schemas/BasicScoringFnParams'
+              llm_as_judge: '#/components/schemas/LLMAsJudgeScoringFnParams'
+              regex_parser: '#/components/schemas/RegexParserScoringFnParams'
             propertyName: type
           oneOf:
           - $ref: '#/components/schemas/LLMAsJudgeScoringFnParams'
@@ -2031,48 +2135,13 @@ components:
       type: object
     ResponseFormat:
       discriminator:
+        mapping:
+          grammar: '#/components/schemas/GrammarResponseFormat'
+          json_schema: '#/components/schemas/JsonSchemaResponseFormat'
         propertyName: type
       oneOf:
-      - additionalProperties: false
-        properties:
-          json_schema:
-            additionalProperties:
-              oneOf:
-              - type: 'null'
-              - type: boolean
-              - type: number
-              - type: string
-              - type: array
-              - type: object
-            type: object
-          type:
-            const: json_schema
-            default: json_schema
-            type: string
-        required:
-        - type
-        - json_schema
-        type: object
-      - additionalProperties: false
-        properties:
-          bnf:
-            additionalProperties:
-              oneOf:
-              - type: 'null'
-              - type: boolean
-              - type: number
-              - type: string
-              - type: array
-              - type: object
-            type: object
-          type:
-            const: grammar
-            default: grammar
-            type: string
-        required:
-        - type
-        - bnf
-        type: object
+      - $ref: '#/components/schemas/JsonSchemaResponseFormat'
+      - $ref: '#/components/schemas/GrammarResponseFormat'
     RouteInfo:
       additionalProperties: false
       properties:
@@ -2094,6 +2163,9 @@ components:
       properties:
         task_config:
           discriminator:
+            mapping:
+              app: '#/components/schemas/AppEvalTaskConfig'
+              benchmark: '#/components/schemas/BenchmarkEvalTaskConfig'
             propertyName: type
           oneOf:
           - $ref: '#/components/schemas/BenchmarkEvalTaskConfig'
@@ -2163,6 +2235,10 @@ components:
           type: number
         strategy:
           discriminator:
+            mapping:
+              greedy: '#/components/schemas/GreedySamplingStrategy'
+              top_k: '#/components/schemas/TopKSamplingStrategy'
+              top_p: '#/components/schemas/TopPSamplingStrategy'
             propertyName: type
           oneOf:
           - $ref: '#/components/schemas/GreedySamplingStrategy'
@@ -2202,6 +2278,10 @@ components:
           additionalProperties:
             oneOf:
             - discriminator:
+                mapping:
+                  basic: '#/components/schemas/BasicScoringFnParams'
+                  llm_as_judge: '#/components/schemas/LLMAsJudgeScoringFnParams'
+                  regex_parser: '#/components/schemas/RegexParserScoringFnParams'
                 propertyName: type
               oneOf:
               - $ref: '#/components/schemas/LLMAsJudgeScoringFnParams'
@@ -2245,6 +2325,10 @@ components:
           additionalProperties:
             oneOf:
             - discriminator:
+                mapping:
+                  basic: '#/components/schemas/BasicScoringFnParams'
+                  llm_as_judge: '#/components/schemas/LLMAsJudgeScoringFnParams'
+                  regex_parser: '#/components/schemas/RegexParserScoringFnParams'
                 propertyName: type
               oneOf:
               - $ref: '#/components/schemas/LLMAsJudgeScoringFnParams'
@@ -2285,6 +2369,10 @@ components:
           type: object
         params:
           discriminator:
+            mapping:
+              basic: '#/components/schemas/BasicScoringFnParams'
+              llm_as_judge: '#/components/schemas/LLMAsJudgeScoringFnParams'
+              regex_parser: '#/components/schemas/RegexParserScoringFnParams'
             propertyName: type
           oneOf:
           - $ref: '#/components/schemas/LLMAsJudgeScoringFnParams'
@@ -2544,6 +2632,9 @@ components:
           type: object
         payload:
           discriminator:
+            mapping:
+              span_end: '#/components/schemas/SpanEndPayload'
+              span_start: '#/components/schemas/SpanStartPayload'
             propertyName: type
           oneOf:
           - $ref: '#/components/schemas/SpanStartPayload'
@@ -2571,6 +2662,9 @@ components:
       properties:
         algorithm_config:
           discriminator:
+            mapping:
+              LoRA: '#/components/schemas/LoraFinetuningConfig'
+              QAT: '#/components/schemas/QATFinetuningConfig'
             propertyName: type
           oneOf:
           - $ref: '#/components/schemas/LoraFinetuningConfig'
@@ -3160,6 +3254,11 @@ components:
         steps:
           items:
             discriminator:
+              mapping:
+                inference: '#/components/schemas/InferenceStep'
+                memory_retrieval: '#/components/schemas/MemoryRetrievalStep'
+                shield_call: '#/components/schemas/ShieldCallStep'
+                tool_execution: '#/components/schemas/ToolExecutionStep'
               propertyName: step_type
             oneOf:
             - $ref: '#/components/schemas/InferenceStep'
@@ -5846,6 +5945,9 @@ tags:
 - description: <SchemaDefinition schemaRef="#/components/schemas/EvaluateRowsRequest"
     />
   name: EvaluateRowsRequest
+- description: <SchemaDefinition schemaRef="#/components/schemas/GrammarResponseFormat"
+    />
+  name: GrammarResponseFormat
 - description: <SchemaDefinition schemaRef="#/components/schemas/GreedySamplingStrategy"
     />
   name: GreedySamplingStrategy
@@ -5878,6 +5980,9 @@ tags:
   name: Job
 - description: <SchemaDefinition schemaRef="#/components/schemas/JobStatus" />
   name: JobStatus
+- description: <SchemaDefinition schemaRef="#/components/schemas/JsonSchemaResponseFormat"
+    />
+  name: JsonSchemaResponseFormat
 - description: <SchemaDefinition schemaRef="#/components/schemas/JsonType" />
   name: JsonType
 - description: <SchemaDefinition schemaRef="#/components/schemas/LLMAsJudgeScoringFnParams"
@@ -6285,6 +6390,7 @@ x-tagGroups:
   - EvalTask
   - EvaluateResponse
   - EvaluateRowsRequest
+  - GrammarResponseFormat
   - GreedySamplingStrategy
   - HealthInfo
   - ImageContentItem
@@ -6297,6 +6403,7 @@ x-tagGroups:
   - InvokeToolRequest
   - Job
   - JobStatus
+  - JsonSchemaResponseFormat
   - JsonType
   - LLMAsJudgeScoringFnParams
   - LLMRAGQueryGeneratorConfig

--- a/docs/resources/llama-stack-spec.yaml
+++ b/docs/resources/llama-stack-spec.yaml
@@ -125,24 +125,25 @@ components:
       additionalProperties: false
       properties:
         payload:
-          discriminator:
-            mapping:
-              step_complete: '#/components/schemas/AgentTurnResponseStepCompletePayload'
-              step_progress: '#/components/schemas/AgentTurnResponseStepProgressPayload'
-              step_start: '#/components/schemas/AgentTurnResponseStepStartPayload'
-              turn_complete: '#/components/schemas/AgentTurnResponseTurnCompletePayload'
-              turn_start: '#/components/schemas/AgentTurnResponseTurnStartPayload'
-            propertyName: event_type
-          oneOf:
-          - $ref: '#/components/schemas/AgentTurnResponseStepStartPayload'
-          - $ref: '#/components/schemas/AgentTurnResponseStepProgressPayload'
-          - $ref: '#/components/schemas/AgentTurnResponseStepCompletePayload'
-          - $ref: '#/components/schemas/AgentTurnResponseTurnStartPayload'
-          - $ref: '#/components/schemas/AgentTurnResponseTurnCompletePayload'
+          $ref: '#/components/schemas/AgentTurnResponseEventPayload'
       required:
       - payload
-      title: Streamed agent execution response.
       type: object
+    AgentTurnResponseEventPayload:
+      discriminator:
+        mapping:
+          step_complete: '#/components/schemas/AgentTurnResponseStepCompletePayload'
+          step_progress: '#/components/schemas/AgentTurnResponseStepProgressPayload'
+          step_start: '#/components/schemas/AgentTurnResponseStepStartPayload'
+          turn_complete: '#/components/schemas/AgentTurnResponseTurnCompletePayload'
+          turn_start: '#/components/schemas/AgentTurnResponseTurnStartPayload'
+        propertyName: event_type
+      oneOf:
+      - $ref: '#/components/schemas/AgentTurnResponseStepStartPayload'
+      - $ref: '#/components/schemas/AgentTurnResponseStepProgressPayload'
+      - $ref: '#/components/schemas/AgentTurnResponseStepCompletePayload'
+      - $ref: '#/components/schemas/AgentTurnResponseTurnStartPayload'
+      - $ref: '#/components/schemas/AgentTurnResponseTurnCompletePayload'
     AgentTurnResponseStepCompletePayload:
       additionalProperties: false
       properties:
@@ -275,32 +276,25 @@ components:
       - categorical_count
       - accuracy
       type: string
+    AlgorithmConfig:
+      discriminator:
+        mapping:
+          LoRA: '#/components/schemas/LoraFinetuningConfig'
+          QAT: '#/components/schemas/QATFinetuningConfig'
+        propertyName: type
+      oneOf:
+      - $ref: '#/components/schemas/LoraFinetuningConfig'
+      - $ref: '#/components/schemas/QATFinetuningConfig'
     AppEvalTaskConfig:
       additionalProperties: false
       properties:
         eval_candidate:
-          discriminator:
-            mapping:
-              agent: '#/components/schemas/AgentCandidate'
-              model: '#/components/schemas/ModelCandidate'
-            propertyName: type
-          oneOf:
-          - $ref: '#/components/schemas/ModelCandidate'
-          - $ref: '#/components/schemas/AgentCandidate'
+          $ref: '#/components/schemas/EvalCandidate'
         num_examples:
           type: integer
         scoring_params:
           additionalProperties:
-            discriminator:
-              mapping:
-                basic: '#/components/schemas/BasicScoringFnParams'
-                llm_as_judge: '#/components/schemas/LLMAsJudgeScoringFnParams'
-                regex_parser: '#/components/schemas/RegexParserScoringFnParams'
-              propertyName: type
-            oneOf:
-            - $ref: '#/components/schemas/LLMAsJudgeScoringFnParams'
-            - $ref: '#/components/schemas/RegexParserScoringFnParams'
-            - $ref: '#/components/schemas/BasicScoringFnParams'
+            $ref: '#/components/schemas/ScoringFnParams'
           type: object
         type:
           const: app
@@ -434,14 +428,7 @@ components:
       additionalProperties: false
       properties:
         eval_candidate:
-          discriminator:
-            mapping:
-              agent: '#/components/schemas/AgentCandidate'
-              model: '#/components/schemas/ModelCandidate'
-            propertyName: type
-          oneOf:
-          - $ref: '#/components/schemas/ModelCandidate'
-          - $ref: '#/components/schemas/AgentCandidate'
+          $ref: '#/components/schemas/EvalCandidate'
         num_examples:
           type: integer
         type:
@@ -859,6 +846,15 @@ components:
       required:
       - embeddings
       type: object
+    EvalCandidate:
+      discriminator:
+        mapping:
+          agent: '#/components/schemas/AgentCandidate'
+          model: '#/components/schemas/ModelCandidate'
+        propertyName: type
+      oneOf:
+      - $ref: '#/components/schemas/ModelCandidate'
+      - $ref: '#/components/schemas/AgentCandidate'
     EvalTask:
       additionalProperties: false
       properties:
@@ -897,6 +893,15 @@ components:
       - scoring_functions
       - metadata
       type: object
+    EvalTaskConfig:
+      discriminator:
+        mapping:
+          app: '#/components/schemas/AppEvalTaskConfig'
+          benchmark: '#/components/schemas/BenchmarkEvalTaskConfig'
+        propertyName: type
+      oneOf:
+      - $ref: '#/components/schemas/BenchmarkEvalTaskConfig'
+      - $ref: '#/components/schemas/AppEvalTaskConfig'
     EvaluateResponse:
       additionalProperties: false
       properties:
@@ -940,19 +945,23 @@ components:
             type: string
           type: array
         task_config:
-          discriminator:
-            mapping:
-              app: '#/components/schemas/AppEvalTaskConfig'
-              benchmark: '#/components/schemas/BenchmarkEvalTaskConfig'
-            propertyName: type
-          oneOf:
-          - $ref: '#/components/schemas/BenchmarkEvalTaskConfig'
-          - $ref: '#/components/schemas/AppEvalTaskConfig'
+          $ref: '#/components/schemas/EvalTaskConfig'
       required:
       - input_rows
       - scoring_functions
       - task_config
       type: object
+    Event:
+      discriminator:
+        mapping:
+          metric: '#/components/schemas/MetricEvent'
+          structured_log: '#/components/schemas/StructuredLogEvent'
+          unstructured_log: '#/components/schemas/UnstructuredLogEvent'
+        propertyName: type
+      oneOf:
+      - $ref: '#/components/schemas/UnstructuredLogEvent'
+      - $ref: '#/components/schemas/MetricEvent'
+      - $ref: '#/components/schemas/StructuredLogEvent'
     GrammarResponseFormat:
       additionalProperties: false
       properties:
@@ -1339,16 +1348,7 @@ components:
       additionalProperties: false
       properties:
         event:
-          discriminator:
-            mapping:
-              metric: '#/components/schemas/MetricEvent'
-              structured_log: '#/components/schemas/StructuredLogEvent'
-              unstructured_log: '#/components/schemas/UnstructuredLogEvent'
-            propertyName: type
-          oneOf:
-          - $ref: '#/components/schemas/UnstructuredLogEvent'
-          - $ref: '#/components/schemas/MetricEvent'
-          - $ref: '#/components/schemas/StructuredLogEvent'
+          $ref: '#/components/schemas/Event'
         ttl_seconds:
           type: integer
       required:
@@ -2048,16 +2048,7 @@ components:
         description:
           type: string
         params:
-          discriminator:
-            mapping:
-              basic: '#/components/schemas/BasicScoringFnParams'
-              llm_as_judge: '#/components/schemas/LLMAsJudgeScoringFnParams'
-              regex_parser: '#/components/schemas/RegexParserScoringFnParams'
-            propertyName: type
-          oneOf:
-          - $ref: '#/components/schemas/LLMAsJudgeScoringFnParams'
-          - $ref: '#/components/schemas/RegexParserScoringFnParams'
-          - $ref: '#/components/schemas/BasicScoringFnParams'
+          $ref: '#/components/schemas/ScoringFnParams'
         provider_id:
           type: string
         provider_scoring_fn_id:
@@ -2162,14 +2153,7 @@ components:
       additionalProperties: false
       properties:
         task_config:
-          discriminator:
-            mapping:
-              app: '#/components/schemas/AppEvalTaskConfig'
-              benchmark: '#/components/schemas/BenchmarkEvalTaskConfig'
-            propertyName: type
-          oneOf:
-          - $ref: '#/components/schemas/BenchmarkEvalTaskConfig'
-          - $ref: '#/components/schemas/AppEvalTaskConfig'
+          $ref: '#/components/schemas/EvalTaskConfig'
       required:
       - task_config
       type: object
@@ -2277,16 +2261,7 @@ components:
         scoring_functions:
           additionalProperties:
             oneOf:
-            - discriminator:
-                mapping:
-                  basic: '#/components/schemas/BasicScoringFnParams'
-                  llm_as_judge: '#/components/schemas/LLMAsJudgeScoringFnParams'
-                  regex_parser: '#/components/schemas/RegexParserScoringFnParams'
-                propertyName: type
-              oneOf:
-              - $ref: '#/components/schemas/LLMAsJudgeScoringFnParams'
-              - $ref: '#/components/schemas/RegexParserScoringFnParams'
-              - $ref: '#/components/schemas/BasicScoringFnParams'
+            - $ref: '#/components/schemas/ScoringFnParams'
             - type: 'null'
           type: object
       required:
@@ -2324,16 +2299,7 @@ components:
         scoring_functions:
           additionalProperties:
             oneOf:
-            - discriminator:
-                mapping:
-                  basic: '#/components/schemas/BasicScoringFnParams'
-                  llm_as_judge: '#/components/schemas/LLMAsJudgeScoringFnParams'
-                  regex_parser: '#/components/schemas/RegexParserScoringFnParams'
-                propertyName: type
-              oneOf:
-              - $ref: '#/components/schemas/LLMAsJudgeScoringFnParams'
-              - $ref: '#/components/schemas/RegexParserScoringFnParams'
-              - $ref: '#/components/schemas/BasicScoringFnParams'
+            - $ref: '#/components/schemas/ScoringFnParams'
             - type: 'null'
           type: object
       required:
@@ -2368,16 +2334,7 @@ components:
             - type: object
           type: object
         params:
-          discriminator:
-            mapping:
-              basic: '#/components/schemas/BasicScoringFnParams'
-              llm_as_judge: '#/components/schemas/LLMAsJudgeScoringFnParams'
-              regex_parser: '#/components/schemas/RegexParserScoringFnParams'
-            propertyName: type
-          oneOf:
-          - $ref: '#/components/schemas/LLMAsJudgeScoringFnParams'
-          - $ref: '#/components/schemas/RegexParserScoringFnParams'
-          - $ref: '#/components/schemas/BasicScoringFnParams'
+          $ref: '#/components/schemas/ScoringFnParams'
         provider_id:
           type: string
         provider_resource_id:
@@ -2396,6 +2353,17 @@ components:
       - metadata
       - return_type
       type: object
+    ScoringFnParams:
+      discriminator:
+        mapping:
+          basic: '#/components/schemas/BasicScoringFnParams'
+          llm_as_judge: '#/components/schemas/LLMAsJudgeScoringFnParams'
+          regex_parser: '#/components/schemas/RegexParserScoringFnParams'
+        propertyName: type
+      oneOf:
+      - $ref: '#/components/schemas/LLMAsJudgeScoringFnParams'
+      - $ref: '#/components/schemas/RegexParserScoringFnParams'
+      - $ref: '#/components/schemas/BasicScoringFnParams'
     ScoringResult:
       additionalProperties: false
       properties:
@@ -2631,14 +2599,7 @@ components:
             - type: object
           type: object
         payload:
-          discriminator:
-            mapping:
-              span_end: '#/components/schemas/SpanEndPayload'
-              span_start: '#/components/schemas/SpanStartPayload'
-            propertyName: type
-          oneOf:
-          - $ref: '#/components/schemas/SpanStartPayload'
-          - $ref: '#/components/schemas/SpanEndPayload'
+          $ref: '#/components/schemas/StructuredLogPayload'
         span_id:
           type: string
         timestamp:
@@ -2657,18 +2618,20 @@ components:
       - type
       - payload
       type: object
+    StructuredLogPayload:
+      discriminator:
+        mapping:
+          span_end: '#/components/schemas/SpanEndPayload'
+          span_start: '#/components/schemas/SpanStartPayload'
+        propertyName: type
+      oneOf:
+      - $ref: '#/components/schemas/SpanStartPayload'
+      - $ref: '#/components/schemas/SpanEndPayload'
     SupervisedFineTuneRequest:
       additionalProperties: false
       properties:
         algorithm_config:
-          discriminator:
-            mapping:
-              LoRA: '#/components/schemas/LoraFinetuningConfig'
-              QAT: '#/components/schemas/QATFinetuningConfig'
-            propertyName: type
-          oneOf:
-          - $ref: '#/components/schemas/LoraFinetuningConfig'
-          - $ref: '#/components/schemas/QATFinetuningConfig'
+          $ref: '#/components/schemas/AlgorithmConfig'
         checkpoint_dir:
           type: string
         hyperparam_search_config:
@@ -5786,11 +5749,12 @@ tags:
 - description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnInputType"
     />
   name: AgentTurnInputType
-- description: 'Streamed agent execution response.
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseEvent" />'
+- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseEvent"
+    />
   name: AgentTurnResponseEvent
+- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseEventPayload"
+    />
+  name: AgentTurnResponseEventPayload
 - description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepCompletePayload"
     />
   name: AgentTurnResponseStepCompletePayload
@@ -5816,6 +5780,9 @@ tags:
 - description: <SchemaDefinition schemaRef="#/components/schemas/AggregationFunctionType"
     />
   name: AggregationFunctionType
+- description: <SchemaDefinition schemaRef="#/components/schemas/AlgorithmConfig"
+    />
+  name: AlgorithmConfig
 - description: <SchemaDefinition schemaRef="#/components/schemas/AppEvalTaskConfig"
     />
   name: AppEvalTaskConfig
@@ -5936,8 +5903,12 @@ tags:
     />
   name: EmbeddingsResponse
 - name: Eval
+- description: <SchemaDefinition schemaRef="#/components/schemas/EvalCandidate" />
+  name: EvalCandidate
 - description: <SchemaDefinition schemaRef="#/components/schemas/EvalTask" />
   name: EvalTask
+- description: <SchemaDefinition schemaRef="#/components/schemas/EvalTaskConfig" />
+  name: EvalTaskConfig
 - name: EvalTasks
 - description: <SchemaDefinition schemaRef="#/components/schemas/EvaluateResponse"
     />
@@ -5945,6 +5916,8 @@ tags:
 - description: <SchemaDefinition schemaRef="#/components/schemas/EvaluateRowsRequest"
     />
   name: EvaluateRowsRequest
+- description: <SchemaDefinition schemaRef="#/components/schemas/Event" />
+  name: Event
 - description: <SchemaDefinition schemaRef="#/components/schemas/GrammarResponseFormat"
     />
   name: GrammarResponseFormat
@@ -6173,6 +6146,9 @@ tags:
 - name: Scoring
 - description: <SchemaDefinition schemaRef="#/components/schemas/ScoringFn" />
   name: ScoringFn
+- description: <SchemaDefinition schemaRef="#/components/schemas/ScoringFnParams"
+    />
+  name: ScoringFnParams
 - name: ScoringFunctions
 - description: <SchemaDefinition schemaRef="#/components/schemas/ScoringResult" />
   name: ScoringResult
@@ -6207,6 +6183,9 @@ tags:
 - description: <SchemaDefinition schemaRef="#/components/schemas/StructuredLogEvent"
     />
   name: StructuredLogEvent
+- description: <SchemaDefinition schemaRef="#/components/schemas/StructuredLogPayload"
+    />
+  name: StructuredLogPayload
 - description: <SchemaDefinition schemaRef="#/components/schemas/SupervisedFineTuneRequest"
     />
   name: SupervisedFineTuneRequest
@@ -6344,6 +6323,7 @@ x-tagGroups:
   - AgentTool
   - AgentTurnInputType
   - AgentTurnResponseEvent
+  - AgentTurnResponseEventPayload
   - AgentTurnResponseStepCompletePayload
   - AgentTurnResponseStepProgressPayload
   - AgentTurnResponseStepStartPayload
@@ -6351,6 +6331,7 @@ x-tagGroups:
   - AgentTurnResponseTurnCompletePayload
   - AgentTurnResponseTurnStartPayload
   - AggregationFunctionType
+  - AlgorithmConfig
   - AppEvalTaskConfig
   - AppendRowsRequest
   - ArrayType
@@ -6387,9 +6368,12 @@ x-tagGroups:
   - EfficiencyConfig
   - EmbeddingsRequest
   - EmbeddingsResponse
+  - EvalCandidate
   - EvalTask
+  - EvalTaskConfig
   - EvaluateResponse
   - EvaluateRowsRequest
+  - Event
   - GrammarResponseFormat
   - GreedySamplingStrategy
   - HealthInfo
@@ -6472,6 +6456,7 @@ x-tagGroups:
   - ScoreRequest
   - ScoreResponse
   - ScoringFn
+  - ScoringFnParams
   - ScoringResult
   - Session
   - Shield
@@ -6484,6 +6469,7 @@ x-tagGroups:
   - StopReason
   - StringType
   - StructuredLogEvent
+  - StructuredLogPayload
   - SupervisedFineTuneRequest
   - SyntheticDataGenerateRequest
   - SyntheticDataGenerationResponse

--- a/llama_stack/apis/agents/agents.py
+++ b/llama_stack/apis/agents/agents.py
@@ -229,11 +229,8 @@ class AgentTurnResponseTurnCompletePayload(BaseModel):
     turn: Turn
 
 
-@json_schema_type
-class AgentTurnResponseEvent(BaseModel):
-    """Streamed agent execution response."""
-
-    payload: Annotated[
+AgentTurnResponseEventPayload = register_schema(
+    Annotated[
         Union[
             AgentTurnResponseStepStartPayload,
             AgentTurnResponseStepProgressPayload,
@@ -242,7 +239,14 @@ class AgentTurnResponseEvent(BaseModel):
             AgentTurnResponseTurnCompletePayload,
         ],
         Field(discriminator="event_type"),
-    ]
+    ],
+    name="AgentTurnResponseEventPayload",
+)
+
+
+@json_schema_type
+class AgentTurnResponseEvent(BaseModel):
+    payload: AgentTurnResponseEventPayload
 
 
 @json_schema_type

--- a/llama_stack/apis/eval/eval.py
+++ b/llama_stack/apis/eval/eval.py
@@ -6,7 +6,7 @@
 
 from typing import Any, Dict, List, Literal, Optional, Protocol, Union
 
-from llama_models.schema_utils import json_schema_type, webmethod
+from llama_models.schema_utils import json_schema_type, register_schema, webmethod
 from pydantic import BaseModel, Field
 from typing_extensions import Annotated
 
@@ -31,9 +31,10 @@ class AgentCandidate(BaseModel):
     config: AgentConfig
 
 
-EvalCandidate = Annotated[
-    Union[ModelCandidate, AgentCandidate], Field(discriminator="type")
-]
+EvalCandidate = register_schema(
+    Annotated[Union[ModelCandidate, AgentCandidate], Field(discriminator="type")],
+    name="EvalCandidate",
+)
 
 
 @json_schema_type
@@ -61,9 +62,12 @@ class AppEvalTaskConfig(BaseModel):
     # we could optinally add any specific dataset config here
 
 
-EvalTaskConfig = Annotated[
-    Union[BenchmarkEvalTaskConfig, AppEvalTaskConfig], Field(discriminator="type")
-]
+EvalTaskConfig = register_schema(
+    Annotated[
+        Union[BenchmarkEvalTaskConfig, AppEvalTaskConfig], Field(discriminator="type")
+    ],
+    name="EvalTaskConfig",
+)
 
 
 @json_schema_type

--- a/llama_stack/apis/inference/inference.py
+++ b/llama_stack/apis/inference/inference.py
@@ -157,11 +157,13 @@ class ChatCompletionResponseEvent(BaseModel):
     stop_reason: Optional[StopReason] = None
 
 
+@json_schema_type
 class ResponseFormatType(Enum):
     json_schema = "json_schema"
     grammar = "grammar"
 
 
+@json_schema_type
 class JsonSchemaResponseFormat(BaseModel):
     type: Literal[ResponseFormatType.json_schema.value] = (
         ResponseFormatType.json_schema.value
@@ -169,6 +171,7 @@ class JsonSchemaResponseFormat(BaseModel):
     json_schema: Dict[str, Any]
 
 
+@json_schema_type
 class GrammarResponseFormat(BaseModel):
     type: Literal[ResponseFormatType.grammar.value] = ResponseFormatType.grammar.value
     bnf: Dict[str, Any]

--- a/llama_stack/apis/post_training/post_training.py
+++ b/llama_stack/apis/post_training/post_training.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Protocol, Union
 
-from llama_models.schema_utils import json_schema_type, webmethod
+from llama_models.schema_utils import json_schema_type, register_schema, webmethod
 from pydantic import BaseModel, Field
 from typing_extensions import Annotated
 
@@ -88,9 +88,12 @@ class QATFinetuningConfig(BaseModel):
     group_size: int
 
 
-AlgorithmConfig = Annotated[
-    Union[LoraFinetuningConfig, QATFinetuningConfig], Field(discriminator="type")
-]
+AlgorithmConfig = register_schema(
+    Annotated[
+        Union[LoraFinetuningConfig, QATFinetuningConfig], Field(discriminator="type")
+    ],
+    name="AlgorithmConfig",
+)
 
 
 @json_schema_type

--- a/llama_stack/apis/scoring_functions/scoring_functions.py
+++ b/llama_stack/apis/scoring_functions/scoring_functions.py
@@ -16,7 +16,7 @@ from typing import (
     Union,
 )
 
-from llama_models.schema_utils import json_schema_type, webmethod
+from llama_models.schema_utils import json_schema_type, register_schema, webmethod
 from pydantic import BaseModel, Field
 from typing_extensions import Annotated
 
@@ -82,14 +82,17 @@ class BasicScoringFnParams(BaseModel):
     )
 
 
-ScoringFnParams = Annotated[
-    Union[
-        LLMAsJudgeScoringFnParams,
-        RegexParserScoringFnParams,
-        BasicScoringFnParams,
+ScoringFnParams = register_schema(
+    Annotated[
+        Union[
+            LLMAsJudgeScoringFnParams,
+            RegexParserScoringFnParams,
+            BasicScoringFnParams,
+        ],
+        Field(discriminator="type"),
     ],
-    Field(discriminator="type"),
-]
+    name="ScoringFnParams",
+)
 
 
 class CommonScoringFnFields(BaseModel):

--- a/llama_stack/apis/telemetry/telemetry.py
+++ b/llama_stack/apis/telemetry/telemetry.py
@@ -17,7 +17,7 @@ from typing import (
     Union,
 )
 
-from llama_models.schema_utils import json_schema_type, webmethod
+from llama_models.schema_utils import json_schema_type, register_schema, webmethod
 from pydantic import BaseModel, Field
 from typing_extensions import Annotated
 
@@ -115,13 +115,16 @@ class SpanEndPayload(BaseModel):
     status: SpanStatus
 
 
-StructuredLogPayload = Annotated[
-    Union[
-        SpanStartPayload,
-        SpanEndPayload,
+StructuredLogPayload = register_schema(
+    Annotated[
+        Union[
+            SpanStartPayload,
+            SpanEndPayload,
+        ],
+        Field(discriminator="type"),
     ],
-    Field(discriminator="type"),
-]
+    name="StructuredLogPayload",
+)
 
 
 @json_schema_type
@@ -130,14 +133,17 @@ class StructuredLogEvent(EventCommon):
     payload: StructuredLogPayload
 
 
-Event = Annotated[
-    Union[
-        UnstructuredLogEvent,
-        MetricEvent,
-        StructuredLogEvent,
+Event = register_schema(
+    Annotated[
+        Union[
+            UnstructuredLogEvent,
+            MetricEvent,
+            StructuredLogEvent,
+        ],
+        Field(discriminator="type"),
     ],
-    Field(discriminator="type"),
-]
+    name="Event",
+)
 
 
 @json_schema_type


### PR DESCRIPTION
See https://swagger.io/docs/specification/v3_0/data-models/inheritance-and-polymorphism/#discriminator

When specifying discriminators, mapping must be specified unless the value of the discriminator is the subtype itself (which in our case is not.)

The changes in the YAML are self-explanatory.

