### PR TITLE
Fix telemetry init

### DIFF
--- a/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
@@ -81,7 +81,9 @@ class TelemetryAdapter(TelemetryDatasetMixin, Telemetry):
         )
 
         global _TRACER_PROVIDER
-        # Initialize the correct span processor based on the provider state
+        # Initialize the correct span processor based on the provider state.
+        # This is needed since once the span processor is set, it cannot be unset.
+        # Recreating the telemetry adapter multiple times will result in duplicate span processors.
         if _TRACER_PROVIDER is None:
             provider = TracerProvider(resource=resource)
             trace.set_tracer_provider(provider)

--- a/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
@@ -84,6 +84,8 @@ class TelemetryAdapter(TelemetryDatasetMixin, Telemetry):
         # Initialize the correct span processor based on the provider state.
         # This is needed since once the span processor is set, it cannot be unset.
         # Recreating the telemetry adapter multiple times will result in duplicate span processors.
+        # Since the library client can be recreated multiple times in a notebook,
+        # the kernel will hold on to the span processor and cause duplicate spans to be written.
         if _TRACER_PROVIDER is None:
             provider = TracerProvider(resource=resource)
             trace.set_tracer_provider(provider)


### PR DESCRIPTION
# What does this PR do?

When you re-initialize the library client in a notebook, we were seeing this error:
```
Getting traces for session_id=5c8d1969-0957-49d2-b852-32cbb8ef8caf
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
[<ipython-input-11-d74bb6cdd3ab>](https://localhost:8080/#) in <cell line: 0>()
      7 agent_logs = []
      8 
----> 9 for span in client.telemetry.query_spans(
     10     attribute_filters=[
     11         {"key": "session_id", "op": "eq", "value": session_id},

10 frames
[/usr/local/lib/python3.11/dist-packages/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py](https://localhost:8080/#) in query_traces(self, attribute_filters, limit, offset, order_by)
    246     ) -> QueryTracesResponse:
    247         return QueryTracesResponse(
--> 248             data=await self.trace_store.query_traces(
    249                 attribute_filters=attribute_filters,
    250                 limit=limit,

AttributeError: 'TelemetryAdapter' object has no attribute 'trace_store'
```

This is happening because the we were skipping some required steps for the object state as part of the global _TRACE_PROVIDER check. This PR moves the initialization of the object state out of the TRACE_PROVIDER init.
