### PR TITLE
Add windows support for build execution

### DIFF
--- a/llama_stack/distribution/build.py
+++ b/llama_stack/distribution/build.py
@@ -21,7 +21,7 @@ from llama_stack.distribution.distribution import get_provider_registry
 
 from llama_stack.distribution.utils.config_dirs import BUILDS_BASE_DIR
 
-from llama_stack.distribution.utils.exec import run_command, run_with_pty
+from llama_stack.distribution.utils.exec import run_command, run_with_pty, run_with_win
 from llama_stack.providers.datatypes import Api
 
 log = logging.getLogger(__name__)
@@ -157,7 +157,9 @@ def build_image(
 
     is_terminal = sys.stdin.isatty()
     if is_terminal:
-        return_code = run_with_pty(args)
+        return_code = (
+            run_with_win(args) if sys.platform.startswith("win") else run_with_pty(args)
+        )
     else:
         return_code = run_command(args)
 


### PR DESCRIPTION
# What does this PR do?

This PR implements windows platform support for build_container.sh execution from terminal. Additionally, it resolves "no support for Terminos and PTY for Window PC" issues.

- [x] Addresses issue (#issue)
Releates issues: https://github.com/meta-llama/llama-stack/issues/826, https://github.com/meta-llama/llama-stack/issues/726

## Test Plan

Please describe:
 - tests you ran to verify your changes with result summaries.
 - provide instructions so it can be reproduced.


## Sources

Please link relevant resources if necessary.


## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Ran pre-commit to handle lint / formatting issues.
- [x] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Updated relevant documentation.
- [ ] Wrote necessary unit or integration tests.
