### PR TITLE
Fix the error when starting the server

### DIFF
--- a/llama_stack/apis/agents/agents.py
+++ b/llama_stack/apis/agents/agents.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from llama_stack.apis.common.content_types import ContentDelta, InterleavedContent, URL
 from llama_stack.apis.inference import (
     CompletionMessage,
+    ResponseFormat,
     SamplingParams,
     ToolCall,
     ToolChoice,
@@ -32,7 +33,6 @@ from llama_stack.apis.inference import (
     ToolResponse,
     ToolResponseMessage,
     UserMessage,
-    ResponseFormat
 )
 from llama_stack.apis.safety import SafetyViolation
 from llama_stack.apis.tools import ToolDef

--- a/llama_stack/apis/agents/agents.py
+++ b/llama_stack/apis/agents/agents.py
@@ -32,6 +32,7 @@ from llama_stack.apis.inference import (
     ToolResponse,
     ToolResponseMessage,
     UserMessage,
+    ResponseFormat
 )
 from llama_stack.apis.safety import SafetyViolation
 from llama_stack.apis.tools import ToolDef

--- a/llama_stack/cli/stack/run.py
+++ b/llama_stack/cli/stack/run.py
@@ -199,4 +199,8 @@ class StackRun(Subcommand):
                 return
             run_args.extend(["--env", f"{key}={value}"])
 
-        run_with_win(run_args) if sys.platform.startswith("win") else run_with_pty(run_args)
+        (
+            run_with_win(run_args)
+            if sys.platform.startswith("win")
+            else run_with_pty(run_args)
+        )

--- a/llama_stack/cli/stack/run.py
+++ b/llama_stack/cli/stack/run.py
@@ -199,4 +199,4 @@ class StackRun(Subcommand):
                 return
             run_args.extend(["--env", f"{key}={value}"])
 
-        run_with_win(args) if sys.platform.startswith("win") else run_with_pty(args)
+        run_with_win(run_args) if sys.platform.startswith("win") else run_with_pty(run_args)


### PR DESCRIPTION
# What does this PR do?

Pull the latest source code from GitHub and noticed two errors when starting the server.

- Missed import `ResponseFormat` in `agent.py`. Here is the error log
```
File "./llama_stack/llama-stack_main/llama_stack/apis/agents/agents.py", line 169, in AgentConfig
    response_format: Optional[ResponseFormat] = None
NameError: name 'ResponseFormat' is not defined. Did you mean: 'response_format'?
```

- Used incorrect parameters for subprocess in `run,py`. Here is the error log
```
  File "llamastack-sn-provider/lib/python3.10/subprocess.py", line 1722, in _execute_child
    args = list(args)
TypeError: 'Namespace' object is not iterable
```

# Step to reproduce

1. Build the stack
`llama stack build --template sambanova --image-type conda --image-name llamastack-sn-provider`

2. Star the server
```
SAMBANOVA_API_KEY="ABC" \
    llama stack run sambanova \
        --port 8008 \
        --image-name llamastack-sn-provider

```

## Before submitting

- [N] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [Y] Ran pre-commit to handle lint / formatting issues.
- [Y] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [N] Updated relevant documentation.
- [N] Wrote necessary unit or integration tests.
