### PR TITLE
Use ruamel.yaml to format the OpenAPI spec

### DIFF
--- a/docs/openapi_generator/generate.py
+++ b/docs/openapi_generator/generate.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from pathlib import Path
 
 import fire
-import yaml
+import ruamel.yaml as yaml
 
 from llama_models import schema_utils
 
@@ -61,7 +61,13 @@ def main(output_dir: str):
     )
 
     with open(output_dir / "llama-stack-spec.yaml", "w", encoding="utf-8") as fp:
-        yaml.dump(spec.get_json(), fp, allow_unicode=True)
+        y = yaml.YAML()
+        y.default_flow_style = False
+        y.block_seq_indent = 2
+        y.dump(
+            spec.get_json(),
+            fp,
+        )
 
     with open(output_dir / "llama-stack-spec.html", "w") as fp:
         spec.write_html(fp, pretty_print=True)

--- a/docs/openapi_generator/generate.py
+++ b/docs/openapi_generator/generate.py
@@ -67,6 +67,9 @@ def main(output_dir: str):
         y.map_indent = 2
         y.sequence_indent = 4
         y.sequence_dash_offset = 2
+        y.width = 80
+        y.allow_unicode = True
+        y.explicit_start = True
         y.dump(
             spec.get_json(),
             fp,

--- a/docs/openapi_generator/generate.py
+++ b/docs/openapi_generator/generate.py
@@ -64,6 +64,9 @@ def main(output_dir: str):
         y = yaml.YAML()
         y.default_flow_style = False
         y.block_seq_indent = 2
+        y.map_indent = 2
+        y.sequence_indent = 4
+        y.sequence_dash_offset = 2
         y.dump(
             spec.get_json(),
             fp,

--- a/docs/openapi_generator/pyopenapi/generator.py
+++ b/docs/openapi_generator/pyopenapi/generator.py
@@ -403,14 +403,16 @@ class Generator:
         self.responses = {}
 
     def _build_type_tag(self, ref: str, schema: Schema) -> Tag:
-        definition = f'<SchemaDefinition schemaRef="#/components/schemas/{ref}" />'
+        # Don't include schema definition in the tag description because for one,
+        # it is not very valuable and for another, it causes string formatting
+        # discrepancies via the Stainless Studio.
+        #
+        # definition = f'<SchemaDefinition schemaRef="#/components/schemas/{ref}" />'
         title = typing.cast(str, schema.get("title"))
         description = typing.cast(str, schema.get("description"))
         return Tag(
             name=ref,
-            description="\n\n".join(
-                s for s in (title, description, definition) if s is not None
-            ),
+            description="\n\n".join(s for s in (title, description) if s is not None),
         )
 
     def _build_extra_tag_groups(

--- a/docs/resources/llama-stack-spec.html
+++ b/docs/resources/llama-stack-spec.html
@@ -4781,6 +4781,9 @@
                     },
                     "enable_session_persistence": {
                         "type": "boolean"
+                    },
+                    "response_format": {
+                        "$ref": "#/components/schemas/ResponseFormat"
                     }
                 },
                 "additionalProperties": false,

--- a/docs/resources/llama-stack-spec.html
+++ b/docs/resources/llama-stack-spec.html
@@ -9105,205 +9105,205 @@
     "tags": [
         {
             "name": "AgentCandidate",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentCandidate\" />"
+            "description": ""
         },
         {
             "name": "AgentConfig",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentConfig\" />"
+            "description": ""
         },
         {
             "name": "AgentCreateResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentCreateResponse\" />"
+            "description": ""
         },
         {
             "name": "AgentSessionCreateResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentSessionCreateResponse\" />"
+            "description": ""
         },
         {
             "name": "AgentStepResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentStepResponse\" />"
+            "description": ""
         },
         {
             "name": "AgentTool",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentTool\" />"
+            "description": ""
         },
         {
             "name": "AgentTurnInputType",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnInputType\" />"
+            "description": ""
         },
         {
             "name": "AgentTurnResponseEvent",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseEvent\" />"
+            "description": ""
         },
         {
             "name": "AgentTurnResponseEventPayload",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseEventPayload\" />"
+            "description": ""
         },
         {
             "name": "AgentTurnResponseStepCompletePayload",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseStepCompletePayload\" />"
+            "description": ""
         },
         {
             "name": "AgentTurnResponseStepProgressPayload",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseStepProgressPayload\" />"
+            "description": ""
         },
         {
             "name": "AgentTurnResponseStepStartPayload",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseStepStartPayload\" />"
+            "description": ""
         },
         {
             "name": "AgentTurnResponseStreamChunk",
-            "description": "streamed agent turn completion response.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseStreamChunk\" />"
+            "description": "streamed agent turn completion response."
         },
         {
             "name": "AgentTurnResponseTurnCompletePayload",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseTurnCompletePayload\" />"
+            "description": ""
         },
         {
             "name": "AgentTurnResponseTurnStartPayload",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AgentTurnResponseTurnStartPayload\" />"
+            "description": ""
         },
         {
             "name": "Agents"
         },
         {
             "name": "AggregationFunctionType",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AggregationFunctionType\" />"
+            "description": ""
         },
         {
             "name": "AlgorithmConfig",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AlgorithmConfig\" />"
+            "description": ""
         },
         {
             "name": "AppEvalTaskConfig",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AppEvalTaskConfig\" />"
+            "description": ""
         },
         {
             "name": "AppendRowsRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/AppendRowsRequest\" />"
+            "description": ""
         },
         {
             "name": "ArrayType",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ArrayType\" />"
+            "description": ""
         },
         {
             "name": "BasicScoringFnParams",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/BasicScoringFnParams\" />"
+            "description": ""
         },
         {
             "name": "BatchChatCompletionRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/BatchChatCompletionRequest\" />"
+            "description": ""
         },
         {
             "name": "BatchChatCompletionResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/BatchChatCompletionResponse\" />"
+            "description": ""
         },
         {
             "name": "BatchCompletionRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/BatchCompletionRequest\" />"
+            "description": ""
         },
         {
             "name": "BatchCompletionResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/BatchCompletionResponse\" />"
+            "description": ""
         },
         {
             "name": "BatchInference (Coming Soon)"
         },
         {
             "name": "BenchmarkEvalTaskConfig",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/BenchmarkEvalTaskConfig\" />"
+            "description": ""
         },
         {
             "name": "BooleanType",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/BooleanType\" />"
+            "description": ""
         },
         {
             "name": "BuiltinTool",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/BuiltinTool\" />"
+            "description": ""
         },
         {
             "name": "CancelTrainingJobRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/CancelTrainingJobRequest\" />"
+            "description": ""
         },
         {
             "name": "ChatCompletionInputType",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ChatCompletionInputType\" />"
+            "description": ""
         },
         {
             "name": "ChatCompletionRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ChatCompletionRequest\" />"
+            "description": ""
         },
         {
             "name": "ChatCompletionResponse",
-            "description": "Chat completion response.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/ChatCompletionResponse\" />"
+            "description": "Chat completion response."
         },
         {
             "name": "ChatCompletionResponseEvent",
-            "description": "Chat completion response event.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/ChatCompletionResponseEvent\" />"
+            "description": "Chat completion response event."
         },
         {
             "name": "ChatCompletionResponseEventType",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ChatCompletionResponseEventType\" />"
+            "description": ""
         },
         {
             "name": "ChatCompletionResponseStreamChunk",
-            "description": "SSE-stream of these events.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/ChatCompletionResponseStreamChunk\" />"
+            "description": "SSE-stream of these events."
         },
         {
             "name": "Checkpoint",
-            "description": "Checkpoint created during training runs\n\n<SchemaDefinition schemaRef=\"#/components/schemas/Checkpoint\" />"
+            "description": "Checkpoint created during training runs"
         },
         {
             "name": "CompletionInputType",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/CompletionInputType\" />"
+            "description": ""
         },
         {
             "name": "CompletionMessage",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/CompletionMessage\" />"
+            "description": ""
         },
         {
             "name": "CompletionRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/CompletionRequest\" />"
+            "description": ""
         },
         {
             "name": "CompletionResponse",
-            "description": "Completion response.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/CompletionResponse\" />"
+            "description": "Completion response."
         },
         {
             "name": "CompletionResponseStreamChunk",
-            "description": "streamed completion response.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/CompletionResponseStreamChunk\" />"
+            "description": "streamed completion response."
         },
         {
             "name": "ContentDelta",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ContentDelta\" />"
+            "description": ""
         },
         {
             "name": "CreateAgentRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/CreateAgentRequest\" />"
+            "description": ""
         },
         {
             "name": "CreateAgentSessionRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/CreateAgentSessionRequest\" />"
+            "description": ""
         },
         {
             "name": "CreateAgentTurnRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/CreateAgentTurnRequest\" />"
+            "description": ""
         },
         {
             "name": "DPOAlignmentConfig",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/DPOAlignmentConfig\" />"
+            "description": ""
         },
         {
             "name": "DataConfig",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/DataConfig\" />"
+            "description": ""
         },
         {
             "name": "Dataset",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/Dataset\" />"
+            "description": ""
         },
         {
             "name": "DatasetFormat",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/DatasetFormat\" />"
+            "description": ""
         },
         {
             "name": "DatasetIO"
@@ -9313,601 +9313,601 @@
         },
         {
             "name": "DefaultRAGQueryGeneratorConfig",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/DefaultRAGQueryGeneratorConfig\" />"
+            "description": ""
         },
         {
             "name": "EfficiencyConfig",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/EfficiencyConfig\" />"
+            "description": ""
         },
         {
             "name": "EmbeddingsRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/EmbeddingsRequest\" />"
+            "description": ""
         },
         {
             "name": "EmbeddingsResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/EmbeddingsResponse\" />"
+            "description": ""
         },
         {
             "name": "Eval"
         },
         {
             "name": "EvalCandidate",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/EvalCandidate\" />"
+            "description": ""
         },
         {
             "name": "EvalTask",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/EvalTask\" />"
+            "description": ""
         },
         {
             "name": "EvalTaskConfig",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/EvalTaskConfig\" />"
+            "description": ""
         },
         {
             "name": "EvalTasks"
         },
         {
             "name": "EvaluateResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/EvaluateResponse\" />"
+            "description": ""
         },
         {
             "name": "EvaluateRowsRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/EvaluateRowsRequest\" />"
+            "description": ""
         },
         {
             "name": "Event",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/Event\" />"
+            "description": ""
         },
         {
             "name": "GrammarResponseFormat",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/GrammarResponseFormat\" />"
+            "description": ""
         },
         {
             "name": "GreedySamplingStrategy",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/GreedySamplingStrategy\" />"
+            "description": ""
         },
         {
             "name": "HealthInfo",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/HealthInfo\" />"
+            "description": ""
         },
         {
             "name": "ImageContentItem",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ImageContentItem\" />"
+            "description": ""
         },
         {
             "name": "ImageDelta",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ImageDelta\" />"
+            "description": ""
         },
         {
             "name": "Inference"
         },
         {
             "name": "InferenceStep",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/InferenceStep\" />"
+            "description": ""
         },
         {
             "name": "InsertChunksRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/InsertChunksRequest\" />"
+            "description": ""
         },
         {
             "name": "InsertRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/InsertRequest\" />"
+            "description": ""
         },
         {
             "name": "Inspect"
         },
         {
             "name": "InterleavedContent",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/InterleavedContent\" />"
+            "description": ""
         },
         {
             "name": "InterleavedContentItem",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/InterleavedContentItem\" />"
+            "description": ""
         },
         {
             "name": "InvokeToolRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/InvokeToolRequest\" />"
+            "description": ""
         },
         {
             "name": "Job",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/Job\" />"
+            "description": ""
         },
         {
             "name": "JobStatus",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/JobStatus\" />"
+            "description": ""
         },
         {
             "name": "JsonSchemaResponseFormat",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/JsonSchemaResponseFormat\" />"
+            "description": ""
         },
         {
             "name": "JsonType",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/JsonType\" />"
+            "description": ""
         },
         {
             "name": "LLMAsJudgeScoringFnParams",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/LLMAsJudgeScoringFnParams\" />"
+            "description": ""
         },
         {
             "name": "LLMRAGQueryGeneratorConfig",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/LLMRAGQueryGeneratorConfig\" />"
+            "description": ""
         },
         {
             "name": "ListDatasetsResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ListDatasetsResponse\" />"
+            "description": ""
         },
         {
             "name": "ListEvalTasksResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ListEvalTasksResponse\" />"
+            "description": ""
         },
         {
             "name": "ListModelsResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ListModelsResponse\" />"
+            "description": ""
         },
         {
             "name": "ListPostTrainingJobsResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ListPostTrainingJobsResponse\" />"
+            "description": ""
         },
         {
             "name": "ListProvidersResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ListProvidersResponse\" />"
+            "description": ""
         },
         {
             "name": "ListRoutesResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ListRoutesResponse\" />"
+            "description": ""
         },
         {
             "name": "ListScoringFunctionsResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ListScoringFunctionsResponse\" />"
+            "description": ""
         },
         {
             "name": "ListShieldsResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ListShieldsResponse\" />"
+            "description": ""
         },
         {
             "name": "ListToolGroupsResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ListToolGroupsResponse\" />"
+            "description": ""
         },
         {
             "name": "ListToolsResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ListToolsResponse\" />"
+            "description": ""
         },
         {
             "name": "ListVectorDBsResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ListVectorDBsResponse\" />"
+            "description": ""
         },
         {
             "name": "LogEventRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/LogEventRequest\" />"
+            "description": ""
         },
         {
             "name": "LogSeverity",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/LogSeverity\" />"
+            "description": ""
         },
         {
             "name": "LoraFinetuningConfig",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/LoraFinetuningConfig\" />"
+            "description": ""
         },
         {
             "name": "MemoryRetrievalStep",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/MemoryRetrievalStep\" />"
+            "description": ""
         },
         {
             "name": "Message",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/Message\" />"
+            "description": ""
         },
         {
             "name": "MetricEvent",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/MetricEvent\" />"
+            "description": ""
         },
         {
             "name": "Model",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/Model\" />"
+            "description": ""
         },
         {
             "name": "ModelCandidate",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ModelCandidate\" />"
+            "description": ""
         },
         {
             "name": "ModelType",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ModelType\" />"
+            "description": ""
         },
         {
             "name": "Models"
         },
         {
             "name": "NumberType",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/NumberType\" />"
+            "description": ""
         },
         {
             "name": "ObjectType",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ObjectType\" />"
+            "description": ""
         },
         {
             "name": "OptimizerConfig",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/OptimizerConfig\" />"
+            "description": ""
         },
         {
             "name": "OptimizerType",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/OptimizerType\" />"
+            "description": ""
         },
         {
             "name": "PaginatedRowsResult",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/PaginatedRowsResult\" />"
+            "description": ""
         },
         {
             "name": "ParamType",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ParamType\" />"
+            "description": ""
         },
         {
             "name": "PostTraining (Coming Soon)"
         },
         {
             "name": "PostTrainingJob",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/PostTrainingJob\" />"
+            "description": ""
         },
         {
             "name": "PostTrainingJobArtifactsResponse",
-            "description": "Artifacts of a finetuning job.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/PostTrainingJobArtifactsResponse\" />"
+            "description": "Artifacts of a finetuning job."
         },
         {
             "name": "PostTrainingJobStatusResponse",
-            "description": "Status of a finetuning job.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/PostTrainingJobStatusResponse\" />"
+            "description": "Status of a finetuning job."
         },
         {
             "name": "PreferenceOptimizeRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/PreferenceOptimizeRequest\" />"
+            "description": ""
         },
         {
             "name": "ProviderInfo",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ProviderInfo\" />"
+            "description": ""
         },
         {
             "name": "QATFinetuningConfig",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/QATFinetuningConfig\" />"
+            "description": ""
         },
         {
             "name": "QueryChunksRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/QueryChunksRequest\" />"
+            "description": ""
         },
         {
             "name": "QueryChunksResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/QueryChunksResponse\" />"
+            "description": ""
         },
         {
             "name": "QueryCondition",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/QueryCondition\" />"
+            "description": ""
         },
         {
             "name": "QueryConditionOp",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/QueryConditionOp\" />"
+            "description": ""
         },
         {
             "name": "QueryRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/QueryRequest\" />"
+            "description": ""
         },
         {
             "name": "QuerySpanTreeResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/QuerySpanTreeResponse\" />"
+            "description": ""
         },
         {
             "name": "QuerySpansResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/QuerySpansResponse\" />"
+            "description": ""
         },
         {
             "name": "QueryTracesResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/QueryTracesResponse\" />"
+            "description": ""
         },
         {
             "name": "RAGDocument",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/RAGDocument\" />"
+            "description": ""
         },
         {
             "name": "RAGQueryConfig",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/RAGQueryConfig\" />"
+            "description": ""
         },
         {
             "name": "RAGQueryGeneratorConfig",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/RAGQueryGeneratorConfig\" />"
+            "description": ""
         },
         {
             "name": "RAGQueryResult",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/RAGQueryResult\" />"
+            "description": ""
         },
         {
             "name": "RegexParserScoringFnParams",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/RegexParserScoringFnParams\" />"
+            "description": ""
         },
         {
             "name": "RegisterDatasetRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/RegisterDatasetRequest\" />"
+            "description": ""
         },
         {
             "name": "RegisterEvalTaskRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/RegisterEvalTaskRequest\" />"
+            "description": ""
         },
         {
             "name": "RegisterModelRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/RegisterModelRequest\" />"
+            "description": ""
         },
         {
             "name": "RegisterScoringFunctionRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/RegisterScoringFunctionRequest\" />"
+            "description": ""
         },
         {
             "name": "RegisterShieldRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/RegisterShieldRequest\" />"
+            "description": ""
         },
         {
             "name": "RegisterToolGroupRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/RegisterToolGroupRequest\" />"
+            "description": ""
         },
         {
             "name": "RegisterVectorDbRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/RegisterVectorDbRequest\" />"
+            "description": ""
         },
         {
             "name": "ResponseFormat",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ResponseFormat\" />"
+            "description": ""
         },
         {
             "name": "RouteInfo",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/RouteInfo\" />"
+            "description": ""
         },
         {
             "name": "RunEvalRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/RunEvalRequest\" />"
+            "description": ""
         },
         {
             "name": "RunShieldRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/RunShieldRequest\" />"
+            "description": ""
         },
         {
             "name": "RunShieldResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/RunShieldResponse\" />"
+            "description": ""
         },
         {
             "name": "Safety"
         },
         {
             "name": "SafetyViolation",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/SafetyViolation\" />"
+            "description": ""
         },
         {
             "name": "SamplingParams",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/SamplingParams\" />"
+            "description": ""
         },
         {
             "name": "SaveSpansToDatasetRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/SaveSpansToDatasetRequest\" />"
+            "description": ""
         },
         {
             "name": "ScoreBatchRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ScoreBatchRequest\" />"
+            "description": ""
         },
         {
             "name": "ScoreBatchResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ScoreBatchResponse\" />"
+            "description": ""
         },
         {
             "name": "ScoreRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ScoreRequest\" />"
+            "description": ""
         },
         {
             "name": "ScoreResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ScoreResponse\" />"
+            "description": ""
         },
         {
             "name": "Scoring"
         },
         {
             "name": "ScoringFn",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ScoringFn\" />"
+            "description": ""
         },
         {
             "name": "ScoringFnParams",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ScoringFnParams\" />"
+            "description": ""
         },
         {
             "name": "ScoringFunctions"
         },
         {
             "name": "ScoringResult",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ScoringResult\" />"
+            "description": ""
         },
         {
             "name": "Session",
-            "description": "A single session of an interaction with an Agentic System.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/Session\" />"
+            "description": "A single session of an interaction with an Agentic System."
         },
         {
             "name": "Shield",
-            "description": "A safety shield resource that can be used to check content\n\n<SchemaDefinition schemaRef=\"#/components/schemas/Shield\" />"
+            "description": "A safety shield resource that can be used to check content"
         },
         {
             "name": "ShieldCallStep",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ShieldCallStep\" />"
+            "description": ""
         },
         {
             "name": "Shields"
         },
         {
             "name": "Span",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/Span\" />"
+            "description": ""
         },
         {
             "name": "SpanEndPayload",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/SpanEndPayload\" />"
+            "description": ""
         },
         {
             "name": "SpanStartPayload",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/SpanStartPayload\" />"
+            "description": ""
         },
         {
             "name": "SpanStatus",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/SpanStatus\" />"
+            "description": ""
         },
         {
             "name": "SpanWithStatus",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/SpanWithStatus\" />"
+            "description": ""
         },
         {
             "name": "StopReason",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/StopReason\" />"
+            "description": ""
         },
         {
             "name": "StringType",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/StringType\" />"
+            "description": ""
         },
         {
             "name": "StructuredLogEvent",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/StructuredLogEvent\" />"
+            "description": ""
         },
         {
             "name": "StructuredLogPayload",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/StructuredLogPayload\" />"
+            "description": ""
         },
         {
             "name": "SupervisedFineTuneRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/SupervisedFineTuneRequest\" />"
+            "description": ""
         },
         {
             "name": "SyntheticDataGenerateRequest",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/SyntheticDataGenerateRequest\" />"
+            "description": ""
         },
         {
             "name": "SyntheticDataGeneration (Coming Soon)"
         },
         {
             "name": "SyntheticDataGenerationResponse",
-            "description": "Response from the synthetic data generation. Batch of (prompt, response, score) tuples that pass the threshold.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/SyntheticDataGenerationResponse\" />"
+            "description": "Response from the synthetic data generation. Batch of (prompt, response, score) tuples that pass the threshold."
         },
         {
             "name": "SystemMessage",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/SystemMessage\" />"
+            "description": ""
         },
         {
             "name": "Telemetry"
         },
         {
             "name": "TextContentItem",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/TextContentItem\" />"
+            "description": ""
         },
         {
             "name": "TextDelta",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/TextDelta\" />"
+            "description": ""
         },
         {
             "name": "TokenLogProbs",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/TokenLogProbs\" />"
+            "description": ""
         },
         {
             "name": "Tool",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/Tool\" />"
+            "description": ""
         },
         {
             "name": "ToolCall",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ToolCall\" />"
+            "description": ""
         },
         {
             "name": "ToolCallDelta",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ToolCallDelta\" />"
+            "description": ""
         },
         {
             "name": "ToolCallParseStatus",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ToolCallParseStatus\" />"
+            "description": ""
         },
         {
             "name": "ToolChoice",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ToolChoice\" />"
+            "description": ""
         },
         {
             "name": "ToolDef",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ToolDef\" />"
+            "description": ""
         },
         {
             "name": "ToolDefinition",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ToolDefinition\" />"
+            "description": ""
         },
         {
             "name": "ToolExecutionStep",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ToolExecutionStep\" />"
+            "description": ""
         },
         {
             "name": "ToolGroup",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ToolGroup\" />"
+            "description": ""
         },
         {
             "name": "ToolGroups"
         },
         {
             "name": "ToolHost",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ToolHost\" />"
+            "description": ""
         },
         {
             "name": "ToolInvocationResult",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ToolInvocationResult\" />"
+            "description": ""
         },
         {
             "name": "ToolParamDefinition",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ToolParamDefinition\" />"
+            "description": ""
         },
         {
             "name": "ToolParameter",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ToolParameter\" />"
+            "description": ""
         },
         {
             "name": "ToolPromptFormat",
-            "description": "This Enum refers to the prompt format for calling custom / zero shot tools\n\n`json` --\n    Refers to the json format for calling tools.\n    The json format takes the form like\n    {\n        \"type\": \"function\",\n        \"function\" : {\n            \"name\": \"function_name\",\n            \"description\": \"function_description\",\n            \"parameters\": {...}\n        }\n    }\n\n`function_tag` --\n    This is an example of how you could define\n    your own user defined format for making tool calls.\n    The function_tag format looks like this,\n    <function=function_name>(parameters)</function>\n\nThe detailed prompts for each of these formats are added to llama cli\n\n<SchemaDefinition schemaRef=\"#/components/schemas/ToolPromptFormat\" />"
+            "description": "This Enum refers to the prompt format for calling custom / zero shot tools\n\n`json` --\n    Refers to the json format for calling tools.\n    The json format takes the form like\n    {\n        \"type\": \"function\",\n        \"function\" : {\n            \"name\": \"function_name\",\n            \"description\": \"function_description\",\n            \"parameters\": {...}\n        }\n    }\n\n`function_tag` --\n    This is an example of how you could define\n    your own user defined format for making tool calls.\n    The function_tag format looks like this,\n    <function=function_name>(parameters)</function>\n\nThe detailed prompts for each of these formats are added to llama cli"
         },
         {
             "name": "ToolResponse",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ToolResponse\" />"
+            "description": ""
         },
         {
             "name": "ToolResponseMessage",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ToolResponseMessage\" />"
+            "description": ""
         },
         {
             "name": "ToolRuntime"
         },
         {
             "name": "TopKSamplingStrategy",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/TopKSamplingStrategy\" />"
+            "description": ""
         },
         {
             "name": "TopPSamplingStrategy",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/TopPSamplingStrategy\" />"
+            "description": ""
         },
         {
             "name": "Trace",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/Trace\" />"
+            "description": ""
         },
         {
             "name": "TrainingConfig",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/TrainingConfig\" />"
+            "description": ""
         },
         {
             "name": "Turn",
-            "description": "A single turn in an interaction with an Agentic System.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/Turn\" />"
+            "description": "A single turn in an interaction with an Agentic System."
         },
         {
             "name": "URL",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/URL\" />"
+            "description": ""
         },
         {
             "name": "UnionType",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/UnionType\" />"
+            "description": ""
         },
         {
             "name": "UnstructuredLogEvent",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/UnstructuredLogEvent\" />"
+            "description": ""
         },
         {
             "name": "UserMessage",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/UserMessage\" />"
+            "description": ""
         },
         {
             "name": "VectorDB",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/VectorDB\" />"
+            "description": ""
         },
         {
             "name": "VectorDBs"
@@ -9917,11 +9917,11 @@
         },
         {
             "name": "VersionInfo",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/VersionInfo\" />"
+            "description": ""
         },
         {
             "name": "ViolationLevel",
-            "description": "<SchemaDefinition schemaRef=\"#/components/schemas/ViolationLevel\" />"
+            "description": ""
         }
     ],
     "x-tagGroups": [

--- a/docs/resources/llama-stack-spec.yaml
+++ b/docs/resources/llama-stack-spec.yaml
@@ -1,3788 +1,77 @@
-components:
-  responses: {}
-  schemas:
-    AgentCandidate:
-      additionalProperties: false
-      properties:
-        config:
-          $ref: '#/components/schemas/AgentConfig'
-        type:
-          const: agent
-          default: agent
-          type: string
-      required:
-      - type
-      - config
-      type: object
-    AgentConfig:
-      additionalProperties: false
-      properties:
-        client_tools:
-          items:
-            $ref: '#/components/schemas/ToolDef'
-          type: array
-        enable_session_persistence:
-          type: boolean
-        input_shields:
-          items:
-            type: string
-          type: array
-        instructions:
-          type: string
-        max_infer_iters:
-          default: 10
-          type: integer
-        model:
-          type: string
-        output_shields:
-          items:
-            type: string
-          type: array
-        sampling_params:
-          $ref: '#/components/schemas/SamplingParams'
-        tool_choice:
-          $ref: '#/components/schemas/ToolChoice'
-          default: auto
-        tool_prompt_format:
-          $ref: '#/components/schemas/ToolPromptFormat'
-        toolgroups:
-          items:
-            $ref: '#/components/schemas/AgentTool'
-          type: array
-      required:
-      - max_infer_iters
-      - model
-      - instructions
-      - enable_session_persistence
-      type: object
-    AgentCreateResponse:
-      additionalProperties: false
-      properties:
-        agent_id:
-          type: string
-      required:
-      - agent_id
-      type: object
-    AgentSessionCreateResponse:
-      additionalProperties: false
-      properties:
-        session_id:
-          type: string
-      required:
-      - session_id
-      type: object
-    AgentStepResponse:
-      additionalProperties: false
-      properties:
-        step:
-          discriminator:
-            mapping:
-              inference: '#/components/schemas/InferenceStep'
-              memory_retrieval: '#/components/schemas/MemoryRetrievalStep'
-              shield_call: '#/components/schemas/ShieldCallStep'
-              tool_execution: '#/components/schemas/ToolExecutionStep'
-            propertyName: step_type
-          oneOf:
-          - $ref: '#/components/schemas/InferenceStep'
-          - $ref: '#/components/schemas/ToolExecutionStep'
-          - $ref: '#/components/schemas/ShieldCallStep'
-          - $ref: '#/components/schemas/MemoryRetrievalStep'
-      required:
-      - step
-      type: object
-    AgentTool:
-      oneOf:
-      - type: string
-      - additionalProperties: false
-        properties:
-          args:
-            additionalProperties:
-              oneOf:
-              - type: 'null'
-              - type: boolean
-              - type: number
-              - type: string
-              - type: array
-              - type: object
-            type: object
-          name:
-            type: string
-        required:
-        - name
-        - args
-        type: object
-    AgentTurnInputType:
-      additionalProperties: false
-      properties:
-        type:
-          const: agent_turn_input
-          default: agent_turn_input
-          type: string
-      required:
-      - type
-      type: object
-    AgentTurnResponseEvent:
-      additionalProperties: false
-      properties:
-        payload:
-          $ref: '#/components/schemas/AgentTurnResponseEventPayload'
-      required:
-      - payload
-      type: object
-    AgentTurnResponseEventPayload:
-      discriminator:
-        mapping:
-          step_complete: '#/components/schemas/AgentTurnResponseStepCompletePayload'
-          step_progress: '#/components/schemas/AgentTurnResponseStepProgressPayload'
-          step_start: '#/components/schemas/AgentTurnResponseStepStartPayload'
-          turn_complete: '#/components/schemas/AgentTurnResponseTurnCompletePayload'
-          turn_start: '#/components/schemas/AgentTurnResponseTurnStartPayload'
-        propertyName: event_type
-      oneOf:
-      - $ref: '#/components/schemas/AgentTurnResponseStepStartPayload'
-      - $ref: '#/components/schemas/AgentTurnResponseStepProgressPayload'
-      - $ref: '#/components/schemas/AgentTurnResponseStepCompletePayload'
-      - $ref: '#/components/schemas/AgentTurnResponseTurnStartPayload'
-      - $ref: '#/components/schemas/AgentTurnResponseTurnCompletePayload'
-    AgentTurnResponseStepCompletePayload:
-      additionalProperties: false
-      properties:
-        event_type:
-          const: step_complete
-          default: step_complete
-          type: string
-        step_details:
-          discriminator:
-            mapping:
-              inference: '#/components/schemas/InferenceStep'
-              memory_retrieval: '#/components/schemas/MemoryRetrievalStep'
-              shield_call: '#/components/schemas/ShieldCallStep'
-              tool_execution: '#/components/schemas/ToolExecutionStep'
-            propertyName: step_type
-          oneOf:
-          - $ref: '#/components/schemas/InferenceStep'
-          - $ref: '#/components/schemas/ToolExecutionStep'
-          - $ref: '#/components/schemas/ShieldCallStep'
-          - $ref: '#/components/schemas/MemoryRetrievalStep'
-        step_id:
-          type: string
-        step_type:
-          enum:
-          - inference
-          - tool_execution
-          - shield_call
-          - memory_retrieval
-          type: string
-      required:
-      - event_type
-      - step_type
-      - step_id
-      - step_details
-      type: object
-    AgentTurnResponseStepProgressPayload:
-      additionalProperties: false
-      properties:
-        delta:
-          $ref: '#/components/schemas/ContentDelta'
-        event_type:
-          const: step_progress
-          default: step_progress
-          type: string
-        step_id:
-          type: string
-        step_type:
-          enum:
-          - inference
-          - tool_execution
-          - shield_call
-          - memory_retrieval
-          type: string
-      required:
-      - event_type
-      - step_type
-      - step_id
-      - delta
-      type: object
-    AgentTurnResponseStepStartPayload:
-      additionalProperties: false
-      properties:
-        event_type:
-          const: step_start
-          default: step_start
-          type: string
-        metadata:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        step_id:
-          type: string
-        step_type:
-          enum:
-          - inference
-          - tool_execution
-          - shield_call
-          - memory_retrieval
-          type: string
-      required:
-      - event_type
-      - step_type
-      - step_id
-      type: object
-    AgentTurnResponseStreamChunk:
-      additionalProperties: false
-      properties:
-        event:
-          $ref: '#/components/schemas/AgentTurnResponseEvent'
-      required:
-      - event
-      title: streamed agent turn completion response.
-      type: object
-    AgentTurnResponseTurnCompletePayload:
-      additionalProperties: false
-      properties:
-        event_type:
-          const: turn_complete
-          default: turn_complete
-          type: string
-        turn:
-          $ref: '#/components/schemas/Turn'
-      required:
-      - event_type
-      - turn
-      type: object
-    AgentTurnResponseTurnStartPayload:
-      additionalProperties: false
-      properties:
-        event_type:
-          const: turn_start
-          default: turn_start
-          type: string
-        turn_id:
-          type: string
-      required:
-      - event_type
-      - turn_id
-      type: object
-    AggregationFunctionType:
-      enum:
-      - average
-      - median
-      - categorical_count
-      - accuracy
-      type: string
-    AlgorithmConfig:
-      discriminator:
-        mapping:
-          LoRA: '#/components/schemas/LoraFinetuningConfig'
-          QAT: '#/components/schemas/QATFinetuningConfig'
-        propertyName: type
-      oneOf:
-      - $ref: '#/components/schemas/LoraFinetuningConfig'
-      - $ref: '#/components/schemas/QATFinetuningConfig'
-    AppEvalTaskConfig:
-      additionalProperties: false
-      properties:
-        eval_candidate:
-          $ref: '#/components/schemas/EvalCandidate'
-        num_examples:
-          type: integer
-        scoring_params:
-          additionalProperties:
-            $ref: '#/components/schemas/ScoringFnParams'
-          type: object
-        type:
-          const: app
-          default: app
-          type: string
-      required:
-      - type
-      - eval_candidate
-      - scoring_params
-      type: object
-    AppendRowsRequest:
-      additionalProperties: false
-      properties:
-        dataset_id:
-          type: string
-        rows:
-          items:
-            additionalProperties:
-              oneOf:
-              - type: 'null'
-              - type: boolean
-              - type: number
-              - type: string
-              - type: array
-              - type: object
-            type: object
-          type: array
-      required:
-      - dataset_id
-      - rows
-      type: object
-    ArrayType:
-      additionalProperties: false
-      properties:
-        type:
-          const: array
-          default: array
-          type: string
-      required:
-      - type
-      type: object
-    BasicScoringFnParams:
-      additionalProperties: false
-      properties:
-        aggregation_functions:
-          items:
-            $ref: '#/components/schemas/AggregationFunctionType'
-          type: array
-        type:
-          const: basic
-          default: basic
-          type: string
-      required:
-      - type
-      type: object
-    BatchChatCompletionRequest:
-      additionalProperties: false
-      properties:
-        logprobs:
-          additionalProperties: false
-          properties:
-            top_k:
-              default: 0
-              type: integer
-          type: object
-        messages_batch:
-          items:
-            items:
-              $ref: '#/components/schemas/Message'
-            type: array
-          type: array
-        model:
-          type: string
-        sampling_params:
-          $ref: '#/components/schemas/SamplingParams'
-        tool_choice:
-          $ref: '#/components/schemas/ToolChoice'
-        tool_prompt_format:
-          $ref: '#/components/schemas/ToolPromptFormat'
-        tools:
-          items:
-            $ref: '#/components/schemas/ToolDefinition'
-          type: array
-      required:
-      - model
-      - messages_batch
-      type: object
-    BatchChatCompletionResponse:
-      additionalProperties: false
-      properties:
-        completion_message_batch:
-          items:
-            $ref: '#/components/schemas/CompletionMessage'
-          type: array
-      required:
-      - completion_message_batch
-      type: object
-    BatchCompletionRequest:
-      additionalProperties: false
-      properties:
-        content_batch:
-          items:
-            $ref: '#/components/schemas/InterleavedContent'
-          type: array
-        logprobs:
-          additionalProperties: false
-          properties:
-            top_k:
-              default: 0
-              type: integer
-          type: object
-        model:
-          type: string
-        sampling_params:
-          $ref: '#/components/schemas/SamplingParams'
-      required:
-      - model
-      - content_batch
-      type: object
-    BatchCompletionResponse:
-      additionalProperties: false
-      properties:
-        completion_message_batch:
-          items:
-            $ref: '#/components/schemas/CompletionMessage'
-          type: array
-      required:
-      - completion_message_batch
-      type: object
-    BenchmarkEvalTaskConfig:
-      additionalProperties: false
-      properties:
-        eval_candidate:
-          $ref: '#/components/schemas/EvalCandidate'
-        num_examples:
-          type: integer
-        type:
-          const: benchmark
-          default: benchmark
-          type: string
-      required:
-      - type
-      - eval_candidate
-      type: object
-    BooleanType:
-      additionalProperties: false
-      properties:
-        type:
-          const: boolean
-          default: boolean
-          type: string
-      required:
-      - type
-      type: object
-    BuiltinTool:
-      enum:
-      - brave_search
-      - wolfram_alpha
-      - photogen
-      - code_interpreter
-      type: string
-    CancelTrainingJobRequest:
-      additionalProperties: false
-      properties:
-        job_uuid:
-          type: string
-      required:
-      - job_uuid
-      type: object
-    ChatCompletionInputType:
-      additionalProperties: false
-      properties:
-        type:
-          const: chat_completion_input
-          default: chat_completion_input
-          type: string
-      required:
-      - type
-      type: object
-    ChatCompletionRequest:
-      additionalProperties: false
-      properties:
-        logprobs:
-          additionalProperties: false
-          properties:
-            top_k:
-              default: 0
-              type: integer
-          type: object
-        messages:
-          items:
-            $ref: '#/components/schemas/Message'
-          type: array
-        model_id:
-          type: string
-        response_format:
-          $ref: '#/components/schemas/ResponseFormat'
-        sampling_params:
-          $ref: '#/components/schemas/SamplingParams'
-        stream:
-          type: boolean
-        tool_choice:
-          $ref: '#/components/schemas/ToolChoice'
-        tool_prompt_format:
-          $ref: '#/components/schemas/ToolPromptFormat'
-        tools:
-          items:
-            $ref: '#/components/schemas/ToolDefinition'
-          type: array
-      required:
-      - model_id
-      - messages
-      type: object
-    ChatCompletionResponse:
-      additionalProperties: false
-      properties:
-        completion_message:
-          $ref: '#/components/schemas/CompletionMessage'
-        logprobs:
-          items:
-            $ref: '#/components/schemas/TokenLogProbs'
-          type: array
-      required:
-      - completion_message
-      title: Chat completion response.
-      type: object
-    ChatCompletionResponseEvent:
-      additionalProperties: false
-      properties:
-        delta:
-          $ref: '#/components/schemas/ContentDelta'
-        event_type:
-          $ref: '#/components/schemas/ChatCompletionResponseEventType'
-        logprobs:
-          items:
-            $ref: '#/components/schemas/TokenLogProbs'
-          type: array
-        stop_reason:
-          $ref: '#/components/schemas/StopReason'
-      required:
-      - event_type
-      - delta
-      title: Chat completion response event.
-      type: object
-    ChatCompletionResponseEventType:
-      enum:
-      - start
-      - complete
-      - progress
-      type: string
-    ChatCompletionResponseStreamChunk:
-      additionalProperties: false
-      properties:
-        event:
-          $ref: '#/components/schemas/ChatCompletionResponseEvent'
-      required:
-      - event
-      title: SSE-stream of these events.
-      type: object
-    Checkpoint:
-      description: Checkpoint created during training runs
-    CompletionInputType:
-      additionalProperties: false
-      properties:
-        type:
-          const: completion_input
-          default: completion_input
-          type: string
-      required:
-      - type
-      type: object
-    CompletionMessage:
-      additionalProperties: false
-      properties:
-        content:
-          $ref: '#/components/schemas/InterleavedContent'
-        role:
-          const: assistant
-          default: assistant
-          type: string
-        stop_reason:
-          $ref: '#/components/schemas/StopReason'
-        tool_calls:
-          items:
-            $ref: '#/components/schemas/ToolCall'
-          type: array
-      required:
-      - role
-      - content
-      - stop_reason
-      - tool_calls
-      type: object
-    CompletionRequest:
-      additionalProperties: false
-      properties:
-        content:
-          $ref: '#/components/schemas/InterleavedContent'
-        logprobs:
-          additionalProperties: false
-          properties:
-            top_k:
-              default: 0
-              type: integer
-          type: object
-        model_id:
-          type: string
-        response_format:
-          $ref: '#/components/schemas/ResponseFormat'
-        sampling_params:
-          $ref: '#/components/schemas/SamplingParams'
-        stream:
-          type: boolean
-      required:
-      - model_id
-      - content
-      type: object
-    CompletionResponse:
-      additionalProperties: false
-      properties:
-        content:
-          type: string
-        logprobs:
-          items:
-            $ref: '#/components/schemas/TokenLogProbs'
-          type: array
-        stop_reason:
-          $ref: '#/components/schemas/StopReason'
-      required:
-      - content
-      - stop_reason
-      title: Completion response.
-      type: object
-    CompletionResponseStreamChunk:
-      additionalProperties: false
-      properties:
-        delta:
-          type: string
-        logprobs:
-          items:
-            $ref: '#/components/schemas/TokenLogProbs'
-          type: array
-        stop_reason:
-          $ref: '#/components/schemas/StopReason'
-      required:
-      - delta
-      title: streamed completion response.
-      type: object
-    ContentDelta:
-      discriminator:
-        mapping:
-          image: '#/components/schemas/ImageDelta'
-          text: '#/components/schemas/TextDelta'
-          tool_call: '#/components/schemas/ToolCallDelta'
-        propertyName: type
-      oneOf:
-      - $ref: '#/components/schemas/TextDelta'
-      - $ref: '#/components/schemas/ImageDelta'
-      - $ref: '#/components/schemas/ToolCallDelta'
-    CreateAgentRequest:
-      additionalProperties: false
-      properties:
-        agent_config:
-          $ref: '#/components/schemas/AgentConfig'
-      required:
-      - agent_config
-      type: object
-    CreateAgentSessionRequest:
-      additionalProperties: false
-      properties:
-        session_name:
-          type: string
-      required:
-      - session_name
-      type: object
-    CreateAgentTurnRequest:
-      additionalProperties: false
-      properties:
-        documents:
-          items:
-            additionalProperties: false
-            properties:
-              content:
-                oneOf:
-                - type: string
-                - $ref: '#/components/schemas/InterleavedContentItem'
-                - items:
-                    $ref: '#/components/schemas/InterleavedContentItem'
-                  type: array
-                - $ref: '#/components/schemas/URL'
-              mime_type:
-                type: string
-            required:
-            - content
-            - mime_type
-            type: object
-          type: array
-        messages:
-          items:
-            oneOf:
-            - $ref: '#/components/schemas/UserMessage'
-            - $ref: '#/components/schemas/ToolResponseMessage'
-          type: array
-        stream:
-          type: boolean
-        toolgroups:
-          items:
-            $ref: '#/components/schemas/AgentTool'
-          type: array
-      required:
-      - messages
-      type: object
-    DPOAlignmentConfig:
-      additionalProperties: false
-      properties:
-        epsilon:
-          type: number
-        gamma:
-          type: number
-        reward_clip:
-          type: number
-        reward_scale:
-          type: number
-      required:
-      - reward_scale
-      - reward_clip
-      - epsilon
-      - gamma
-      type: object
-    DataConfig:
-      additionalProperties: false
-      properties:
-        batch_size:
-          type: integer
-        data_format:
-          $ref: '#/components/schemas/DatasetFormat'
-        dataset_id:
-          type: string
-        packed:
-          default: false
-          type: boolean
-        shuffle:
-          type: boolean
-        train_on_input:
-          default: false
-          type: boolean
-        validation_dataset_id:
-          type: string
-      required:
-      - dataset_id
-      - batch_size
-      - shuffle
-      - data_format
-      type: object
-    Dataset:
-      additionalProperties: false
-      properties:
-        dataset_schema:
-          additionalProperties:
-            $ref: '#/components/schemas/ParamType'
-          type: object
-        identifier:
-          type: string
-        metadata:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        provider_id:
-          type: string
-        provider_resource_id:
-          type: string
-        type:
-          const: dataset
-          default: dataset
-          type: string
-        url:
-          $ref: '#/components/schemas/URL'
-      required:
-      - identifier
-      - provider_resource_id
-      - provider_id
-      - type
-      - dataset_schema
-      - url
-      - metadata
-      type: object
-    DatasetFormat:
-      enum:
-      - instruct
-      - dialog
-      type: string
-    DefaultRAGQueryGeneratorConfig:
-      additionalProperties: false
-      properties:
-        separator:
-          default: ' '
-          type: string
-        type:
-          const: default
-          default: default
-          type: string
-      required:
-      - type
-      - separator
-      type: object
-    EfficiencyConfig:
-      additionalProperties: false
-      properties:
-        enable_activation_checkpointing:
-          default: false
-          type: boolean
-        enable_activation_offloading:
-          default: false
-          type: boolean
-        fsdp_cpu_offload:
-          default: false
-          type: boolean
-        memory_efficient_fsdp_wrap:
-          default: false
-          type: boolean
-      type: object
-    EmbeddingsRequest:
-      additionalProperties: false
-      properties:
-        contents:
-          items:
-            $ref: '#/components/schemas/InterleavedContent'
-          type: array
-        model_id:
-          type: string
-      required:
-      - model_id
-      - contents
-      type: object
-    EmbeddingsResponse:
-      additionalProperties: false
-      properties:
-        embeddings:
-          items:
-            items:
-              type: number
-            type: array
-          type: array
-      required:
-      - embeddings
-      type: object
-    EvalCandidate:
-      discriminator:
-        mapping:
-          agent: '#/components/schemas/AgentCandidate'
-          model: '#/components/schemas/ModelCandidate'
-        propertyName: type
-      oneOf:
-      - $ref: '#/components/schemas/ModelCandidate'
-      - $ref: '#/components/schemas/AgentCandidate'
-    EvalTask:
-      additionalProperties: false
-      properties:
-        dataset_id:
-          type: string
-        identifier:
-          type: string
-        metadata:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        provider_id:
-          type: string
-        provider_resource_id:
-          type: string
-        scoring_functions:
-          items:
-            type: string
-          type: array
-        type:
-          const: eval_task
-          default: eval_task
-          type: string
-      required:
-      - identifier
-      - provider_resource_id
-      - provider_id
-      - type
-      - dataset_id
-      - scoring_functions
-      - metadata
-      type: object
-    EvalTaskConfig:
-      discriminator:
-        mapping:
-          app: '#/components/schemas/AppEvalTaskConfig'
-          benchmark: '#/components/schemas/BenchmarkEvalTaskConfig'
-        propertyName: type
-      oneOf:
-      - $ref: '#/components/schemas/BenchmarkEvalTaskConfig'
-      - $ref: '#/components/schemas/AppEvalTaskConfig'
-    EvaluateResponse:
-      additionalProperties: false
-      properties:
-        generations:
-          items:
-            additionalProperties:
-              oneOf:
-              - type: 'null'
-              - type: boolean
-              - type: number
-              - type: string
-              - type: array
-              - type: object
-            type: object
-          type: array
-        scores:
-          additionalProperties:
-            $ref: '#/components/schemas/ScoringResult'
-          type: object
-      required:
-      - generations
-      - scores
-      type: object
-    EvaluateRowsRequest:
-      additionalProperties: false
-      properties:
-        input_rows:
-          items:
-            additionalProperties:
-              oneOf:
-              - type: 'null'
-              - type: boolean
-              - type: number
-              - type: string
-              - type: array
-              - type: object
-            type: object
-          type: array
-        scoring_functions:
-          items:
-            type: string
-          type: array
-        task_config:
-          $ref: '#/components/schemas/EvalTaskConfig'
-      required:
-      - input_rows
-      - scoring_functions
-      - task_config
-      type: object
-    Event:
-      discriminator:
-        mapping:
-          metric: '#/components/schemas/MetricEvent'
-          structured_log: '#/components/schemas/StructuredLogEvent'
-          unstructured_log: '#/components/schemas/UnstructuredLogEvent'
-        propertyName: type
-      oneOf:
-      - $ref: '#/components/schemas/UnstructuredLogEvent'
-      - $ref: '#/components/schemas/MetricEvent'
-      - $ref: '#/components/schemas/StructuredLogEvent'
-    GrammarResponseFormat:
-      additionalProperties: false
-      properties:
-        bnf:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        type:
-          const: grammar
-          default: grammar
-          type: string
-      required:
-      - type
-      - bnf
-      type: object
-    GreedySamplingStrategy:
-      additionalProperties: false
-      properties:
-        type:
-          const: greedy
-          default: greedy
-          type: string
-      required:
-      - type
-      type: object
-    HealthInfo:
-      additionalProperties: false
-      properties:
-        status:
-          type: string
-      required:
-      - status
-      type: object
-    ImageContentItem:
-      additionalProperties: false
-      properties:
-        image:
-          additionalProperties: false
-          properties:
-            data:
-              contentEncoding: base64
-              type: string
-            url:
-              $ref: '#/components/schemas/URL'
-          type: object
-        type:
-          const: image
-          default: image
-          type: string
-      required:
-      - type
-      - image
-      type: object
-    ImageDelta:
-      additionalProperties: false
-      properties:
-        image:
-          contentEncoding: base64
-          type: string
-        type:
-          const: image
-          default: image
-          type: string
-      required:
-      - type
-      - image
-      type: object
-    InferenceStep:
-      additionalProperties: false
-      properties:
-        completed_at:
-          format: date-time
-          type: string
-        model_response:
-          $ref: '#/components/schemas/CompletionMessage'
-        started_at:
-          format: date-time
-          type: string
-        step_id:
-          type: string
-        step_type:
-          const: inference
-          default: inference
-          type: string
-        turn_id:
-          type: string
-      required:
-      - turn_id
-      - step_id
-      - step_type
-      - model_response
-      type: object
-    InsertChunksRequest:
-      additionalProperties: false
-      properties:
-        chunks:
-          items:
-            additionalProperties: false
-            properties:
-              content:
-                $ref: '#/components/schemas/InterleavedContent'
-              metadata:
-                additionalProperties:
-                  oneOf:
-                  - type: 'null'
-                  - type: boolean
-                  - type: number
-                  - type: string
-                  - type: array
-                  - type: object
-                type: object
-            required:
-            - content
-            - metadata
-            type: object
-          type: array
-        ttl_seconds:
-          type: integer
-        vector_db_id:
-          type: string
-      required:
-      - vector_db_id
-      - chunks
-      type: object
-    InsertRequest:
-      additionalProperties: false
-      properties:
-        chunk_size_in_tokens:
-          type: integer
-        documents:
-          items:
-            $ref: '#/components/schemas/RAGDocument'
-          type: array
-        vector_db_id:
-          type: string
-      required:
-      - documents
-      - vector_db_id
-      - chunk_size_in_tokens
-      type: object
-    InterleavedContent:
-      oneOf:
-      - type: string
-      - $ref: '#/components/schemas/InterleavedContentItem'
-      - items:
-          $ref: '#/components/schemas/InterleavedContentItem'
-        type: array
-    InterleavedContentItem:
-      discriminator:
-        mapping:
-          image: '#/components/schemas/ImageContentItem'
-          text: '#/components/schemas/TextContentItem'
-        propertyName: type
-      oneOf:
-      - $ref: '#/components/schemas/ImageContentItem'
-      - $ref: '#/components/schemas/TextContentItem'
-    InvokeToolRequest:
-      additionalProperties: false
-      properties:
-        kwargs:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        tool_name:
-          type: string
-      required:
-      - tool_name
-      - kwargs
-      type: object
-    Job:
-      additionalProperties: false
-      properties:
-        job_id:
-          type: string
-      required:
-      - job_id
-      type: object
-    JobStatus:
-      enum:
-      - completed
-      - in_progress
-      - failed
-      - scheduled
-      type: string
-    JsonSchemaResponseFormat:
-      additionalProperties: false
-      properties:
-        json_schema:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        type:
-          const: json_schema
-          default: json_schema
-          type: string
-      required:
-      - type
-      - json_schema
-      type: object
-    JsonType:
-      additionalProperties: false
-      properties:
-        type:
-          const: json
-          default: json
-          type: string
-      required:
-      - type
-      type: object
-    LLMAsJudgeScoringFnParams:
-      additionalProperties: false
-      properties:
-        aggregation_functions:
-          items:
-            $ref: '#/components/schemas/AggregationFunctionType'
-          type: array
-        judge_model:
-          type: string
-        judge_score_regexes:
-          items:
-            type: string
-          type: array
-        prompt_template:
-          type: string
-        type:
-          const: llm_as_judge
-          default: llm_as_judge
-          type: string
-      required:
-      - type
-      - judge_model
-      type: object
-    LLMRAGQueryGeneratorConfig:
-      additionalProperties: false
-      properties:
-        model:
-          type: string
-        template:
-          type: string
-        type:
-          const: llm
-          default: llm
-          type: string
-      required:
-      - type
-      - model
-      - template
-      type: object
-    ListDatasetsResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/Dataset'
-          type: array
-      required:
-      - data
-      type: object
-    ListEvalTasksResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/EvalTask'
-          type: array
-      required:
-      - data
-      type: object
-    ListModelsResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/Model'
-          type: array
-      required:
-      - data
-      type: object
-    ListPostTrainingJobsResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            additionalProperties: false
-            properties:
-              job_uuid:
-                type: string
-            required:
-            - job_uuid
-            type: object
-          type: array
-      required:
-      - data
-      type: object
-    ListProvidersResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/ProviderInfo'
-          type: array
-      required:
-      - data
-      type: object
-    ListRoutesResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/RouteInfo'
-          type: array
-      required:
-      - data
-      type: object
-    ListScoringFunctionsResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/ScoringFn'
-          type: array
-      required:
-      - data
-      type: object
-    ListShieldsResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/Shield'
-          type: array
-      required:
-      - data
-      type: object
-    ListToolGroupsResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/ToolGroup'
-          type: array
-      required:
-      - data
-      type: object
-    ListToolsResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/Tool'
-          type: array
-      required:
-      - data
-      type: object
-    ListVectorDBsResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/VectorDB'
-          type: array
-      required:
-      - data
-      type: object
-    LogEventRequest:
-      additionalProperties: false
-      properties:
-        event:
-          $ref: '#/components/schemas/Event'
-        ttl_seconds:
-          type: integer
-      required:
-      - event
-      - ttl_seconds
-      type: object
-    LogSeverity:
-      enum:
-      - verbose
-      - debug
-      - info
-      - warn
-      - error
-      - critical
-      type: string
-    LoraFinetuningConfig:
-      additionalProperties: false
-      properties:
-        alpha:
-          type: integer
-        apply_lora_to_mlp:
-          type: boolean
-        apply_lora_to_output:
-          type: boolean
-        lora_attn_modules:
-          items:
-            type: string
-          type: array
-        quantize_base:
-          default: false
-          type: boolean
-        rank:
-          type: integer
-        type:
-          const: LoRA
-          default: LoRA
-          type: string
-        use_dora:
-          default: false
-          type: boolean
-      required:
-      - type
-      - lora_attn_modules
-      - apply_lora_to_mlp
-      - apply_lora_to_output
-      - rank
-      - alpha
-      type: object
-    MemoryRetrievalStep:
-      additionalProperties: false
-      properties:
-        completed_at:
-          format: date-time
-          type: string
-        inserted_context:
-          $ref: '#/components/schemas/InterleavedContent'
-        started_at:
-          format: date-time
-          type: string
-        step_id:
-          type: string
-        step_type:
-          const: memory_retrieval
-          default: memory_retrieval
-          type: string
-        turn_id:
-          type: string
-        vector_db_ids:
-          type: string
-      required:
-      - turn_id
-      - step_id
-      - step_type
-      - vector_db_ids
-      - inserted_context
-      type: object
-    Message:
-      discriminator:
-        mapping:
-          assistant: '#/components/schemas/CompletionMessage'
-          system: '#/components/schemas/SystemMessage'
-          tool: '#/components/schemas/ToolResponseMessage'
-          user: '#/components/schemas/UserMessage'
-        propertyName: role
-      oneOf:
-      - $ref: '#/components/schemas/UserMessage'
-      - $ref: '#/components/schemas/SystemMessage'
-      - $ref: '#/components/schemas/ToolResponseMessage'
-      - $ref: '#/components/schemas/CompletionMessage'
-    MetricEvent:
-      additionalProperties: false
-      properties:
-        attributes:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        metric:
-          type: string
-        span_id:
-          type: string
-        timestamp:
-          format: date-time
-          type: string
-        trace_id:
-          type: string
-        type:
-          const: metric
-          default: metric
-          type: string
-        unit:
-          type: string
-        value:
-          oneOf:
-          - type: integer
-          - type: number
-      required:
-      - trace_id
-      - span_id
-      - timestamp
-      - type
-      - metric
-      - value
-      - unit
-      type: object
-    Model:
-      additionalProperties: false
-      properties:
-        identifier:
-          type: string
-        metadata:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        model_type:
-          $ref: '#/components/schemas/ModelType'
-          default: llm
-        provider_id:
-          type: string
-        provider_resource_id:
-          type: string
-        type:
-          const: model
-          default: model
-          type: string
-      required:
-      - identifier
-      - provider_resource_id
-      - provider_id
-      - type
-      - metadata
-      - model_type
-      type: object
-    ModelCandidate:
-      additionalProperties: false
-      properties:
-        model:
-          type: string
-        sampling_params:
-          $ref: '#/components/schemas/SamplingParams'
-        system_message:
-          $ref: '#/components/schemas/SystemMessage'
-        type:
-          const: model
-          default: model
-          type: string
-      required:
-      - type
-      - model
-      - sampling_params
-      type: object
-    ModelType:
-      enum:
-      - llm
-      - embedding
-      type: string
-    NumberType:
-      additionalProperties: false
-      properties:
-        type:
-          const: number
-          default: number
-          type: string
-      required:
-      - type
-      type: object
-    ObjectType:
-      additionalProperties: false
-      properties:
-        type:
-          const: object
-          default: object
-          type: string
-      required:
-      - type
-      type: object
-    OptimizerConfig:
-      additionalProperties: false
-      properties:
-        lr:
-          type: number
-        num_warmup_steps:
-          type: integer
-        optimizer_type:
-          $ref: '#/components/schemas/OptimizerType'
-        weight_decay:
-          type: number
-      required:
-      - optimizer_type
-      - lr
-      - weight_decay
-      - num_warmup_steps
-      type: object
-    OptimizerType:
-      enum:
-      - adam
-      - adamw
-      - sgd
-      type: string
-    PaginatedRowsResult:
-      additionalProperties: false
-      properties:
-        next_page_token:
-          type: string
-        rows:
-          items:
-            additionalProperties:
-              oneOf:
-              - type: 'null'
-              - type: boolean
-              - type: number
-              - type: string
-              - type: array
-              - type: object
-            type: object
-          type: array
-        total_count:
-          type: integer
-      required:
-      - rows
-      - total_count
-      type: object
-    ParamType:
-      discriminator:
-        mapping:
-          agent_turn_input: '#/components/schemas/AgentTurnInputType'
-          array: '#/components/schemas/ArrayType'
-          boolean: '#/components/schemas/BooleanType'
-          chat_completion_input: '#/components/schemas/ChatCompletionInputType'
-          completion_input: '#/components/schemas/CompletionInputType'
-          json: '#/components/schemas/JsonType'
-          number: '#/components/schemas/NumberType'
-          object: '#/components/schemas/ObjectType'
-          string: '#/components/schemas/StringType'
-          union: '#/components/schemas/UnionType'
-        propertyName: type
-      oneOf:
-      - $ref: '#/components/schemas/StringType'
-      - $ref: '#/components/schemas/NumberType'
-      - $ref: '#/components/schemas/BooleanType'
-      - $ref: '#/components/schemas/ArrayType'
-      - $ref: '#/components/schemas/ObjectType'
-      - $ref: '#/components/schemas/JsonType'
-      - $ref: '#/components/schemas/UnionType'
-      - $ref: '#/components/schemas/ChatCompletionInputType'
-      - $ref: '#/components/schemas/CompletionInputType'
-      - $ref: '#/components/schemas/AgentTurnInputType'
-    PostTrainingJob:
-      additionalProperties: false
-      properties:
-        job_uuid:
-          type: string
-      required:
-      - job_uuid
-      type: object
-    PostTrainingJobArtifactsResponse:
-      additionalProperties: false
-      properties:
-        checkpoints:
-          items:
-            $ref: '#/components/schemas/Checkpoint'
-          type: array
-        job_uuid:
-          type: string
-      required:
-      - job_uuid
-      - checkpoints
-      title: Artifacts of a finetuning job.
-      type: object
-    PostTrainingJobStatusResponse:
-      additionalProperties: false
-      properties:
-        checkpoints:
-          items:
-            $ref: '#/components/schemas/Checkpoint'
-          type: array
-        completed_at:
-          format: date-time
-          type: string
-        job_uuid:
-          type: string
-        resources_allocated:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        scheduled_at:
-          format: date-time
-          type: string
-        started_at:
-          format: date-time
-          type: string
-        status:
-          $ref: '#/components/schemas/JobStatus'
-      required:
-      - job_uuid
-      - status
-      - checkpoints
-      title: Status of a finetuning job.
-      type: object
-    PreferenceOptimizeRequest:
-      additionalProperties: false
-      properties:
-        algorithm_config:
-          $ref: '#/components/schemas/DPOAlignmentConfig'
-        finetuned_model:
-          type: string
-        hyperparam_search_config:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        job_uuid:
-          type: string
-        logger_config:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        training_config:
-          $ref: '#/components/schemas/TrainingConfig'
-      required:
-      - job_uuid
-      - finetuned_model
-      - algorithm_config
-      - training_config
-      - hyperparam_search_config
-      - logger_config
-      type: object
-    ProviderInfo:
-      additionalProperties: false
-      properties:
-        api:
-          type: string
-        provider_id:
-          type: string
-        provider_type:
-          type: string
-      required:
-      - api
-      - provider_id
-      - provider_type
-      type: object
-    QATFinetuningConfig:
-      additionalProperties: false
-      properties:
-        group_size:
-          type: integer
-        quantizer_name:
-          type: string
-        type:
-          const: QAT
-          default: QAT
-          type: string
-      required:
-      - type
-      - quantizer_name
-      - group_size
-      type: object
-    QueryChunksRequest:
-      additionalProperties: false
-      properties:
-        params:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        query:
-          $ref: '#/components/schemas/InterleavedContent'
-        vector_db_id:
-          type: string
-      required:
-      - vector_db_id
-      - query
-      type: object
-    QueryChunksResponse:
-      additionalProperties: false
-      properties:
-        chunks:
-          items:
-            additionalProperties: false
-            properties:
-              content:
-                $ref: '#/components/schemas/InterleavedContent'
-              metadata:
-                additionalProperties:
-                  oneOf:
-                  - type: 'null'
-                  - type: boolean
-                  - type: number
-                  - type: string
-                  - type: array
-                  - type: object
-                type: object
-            required:
-            - content
-            - metadata
-            type: object
-          type: array
-        scores:
-          items:
-            type: number
-          type: array
-      required:
-      - chunks
-      - scores
-      type: object
-    QueryCondition:
-      additionalProperties: false
-      properties:
-        key:
-          type: string
-        op:
-          $ref: '#/components/schemas/QueryConditionOp'
-        value:
-          oneOf:
-          - type: 'null'
-          - type: boolean
-          - type: number
-          - type: string
-          - type: array
-          - type: object
-      required:
-      - key
-      - op
-      - value
-      type: object
-    QueryConditionOp:
-      enum:
-      - eq
-      - ne
-      - gt
-      - lt
-      type: string
-    QueryRequest:
-      additionalProperties: false
-      properties:
-        content:
-          $ref: '#/components/schemas/InterleavedContent'
-        query_config:
-          $ref: '#/components/schemas/RAGQueryConfig'
-        vector_db_ids:
-          items:
-            type: string
-          type: array
-      required:
-      - content
-      - vector_db_ids
-      type: object
-    QuerySpanTreeResponse:
-      additionalProperties: false
-      properties:
-        data:
-          additionalProperties:
-            $ref: '#/components/schemas/SpanWithStatus'
-          type: object
-      required:
-      - data
-      type: object
-    QuerySpansResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/Span'
-          type: array
-      required:
-      - data
-      type: object
-    QueryTracesResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/Trace'
-          type: array
-      required:
-      - data
-      type: object
-    RAGDocument:
-      additionalProperties: false
-      properties:
-        content:
-          oneOf:
-          - type: string
-          - $ref: '#/components/schemas/InterleavedContentItem'
-          - items:
-              $ref: '#/components/schemas/InterleavedContentItem'
-            type: array
-          - $ref: '#/components/schemas/URL'
-        document_id:
-          type: string
-        metadata:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        mime_type:
-          type: string
-      required:
-      - document_id
-      - content
-      - metadata
-      type: object
-    RAGQueryConfig:
-      additionalProperties: false
-      properties:
-        max_chunks:
-          default: 5
-          type: integer
-        max_tokens_in_context:
-          default: 4096
-          type: integer
-        query_generator_config:
-          $ref: '#/components/schemas/RAGQueryGeneratorConfig'
-      required:
-      - query_generator_config
-      - max_tokens_in_context
-      - max_chunks
-      type: object
-    RAGQueryGeneratorConfig:
-      discriminator:
-        mapping:
-          default: '#/components/schemas/DefaultRAGQueryGeneratorConfig'
-          llm: '#/components/schemas/LLMRAGQueryGeneratorConfig'
-        propertyName: type
-      oneOf:
-      - $ref: '#/components/schemas/DefaultRAGQueryGeneratorConfig'
-      - $ref: '#/components/schemas/LLMRAGQueryGeneratorConfig'
-    RAGQueryResult:
-      additionalProperties: false
-      properties:
-        content:
-          $ref: '#/components/schemas/InterleavedContent'
-      type: object
-    RegexParserScoringFnParams:
-      additionalProperties: false
-      properties:
-        aggregation_functions:
-          items:
-            $ref: '#/components/schemas/AggregationFunctionType'
-          type: array
-        parsing_regexes:
-          items:
-            type: string
-          type: array
-        type:
-          const: regex_parser
-          default: regex_parser
-          type: string
-      required:
-      - type
-      type: object
-    RegisterDatasetRequest:
-      additionalProperties: false
-      properties:
-        dataset_id:
-          type: string
-        dataset_schema:
-          additionalProperties:
-            $ref: '#/components/schemas/ParamType'
-          type: object
-        metadata:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        provider_dataset_id:
-          type: string
-        provider_id:
-          type: string
-        url:
-          $ref: '#/components/schemas/URL'
-      required:
-      - dataset_id
-      - dataset_schema
-      - url
-      type: object
-    RegisterEvalTaskRequest:
-      additionalProperties: false
-      properties:
-        dataset_id:
-          type: string
-        eval_task_id:
-          type: string
-        metadata:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        provider_eval_task_id:
-          type: string
-        provider_id:
-          type: string
-        scoring_functions:
-          items:
-            type: string
-          type: array
-      required:
-      - eval_task_id
-      - dataset_id
-      - scoring_functions
-      type: object
-    RegisterModelRequest:
-      additionalProperties: false
-      properties:
-        metadata:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        model_id:
-          type: string
-        model_type:
-          $ref: '#/components/schemas/ModelType'
-        provider_id:
-          type: string
-        provider_model_id:
-          type: string
-      required:
-      - model_id
-      type: object
-    RegisterScoringFunctionRequest:
-      additionalProperties: false
-      properties:
-        description:
-          type: string
-        params:
-          $ref: '#/components/schemas/ScoringFnParams'
-        provider_id:
-          type: string
-        provider_scoring_fn_id:
-          type: string
-        return_type:
-          $ref: '#/components/schemas/ParamType'
-        scoring_fn_id:
-          type: string
-      required:
-      - scoring_fn_id
-      - description
-      - return_type
-      type: object
-    RegisterShieldRequest:
-      additionalProperties: false
-      properties:
-        params:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        provider_id:
-          type: string
-        provider_shield_id:
-          type: string
-        shield_id:
-          type: string
-      required:
-      - shield_id
-      type: object
-    RegisterToolGroupRequest:
-      additionalProperties: false
-      properties:
-        args:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        mcp_endpoint:
-          $ref: '#/components/schemas/URL'
-        provider_id:
-          type: string
-        toolgroup_id:
-          type: string
-      required:
-      - toolgroup_id
-      - provider_id
-      type: object
-    RegisterVectorDbRequest:
-      additionalProperties: false
-      properties:
-        embedding_dimension:
-          type: integer
-        embedding_model:
-          type: string
-        provider_id:
-          type: string
-        provider_vector_db_id:
-          type: string
-        vector_db_id:
-          type: string
-      required:
-      - vector_db_id
-      - embedding_model
-      type: object
-    ResponseFormat:
-      discriminator:
-        mapping:
-          grammar: '#/components/schemas/GrammarResponseFormat'
-          json_schema: '#/components/schemas/JsonSchemaResponseFormat'
-        propertyName: type
-      oneOf:
-      - $ref: '#/components/schemas/JsonSchemaResponseFormat'
-      - $ref: '#/components/schemas/GrammarResponseFormat'
-    RouteInfo:
-      additionalProperties: false
-      properties:
-        method:
-          type: string
-        provider_types:
-          items:
-            type: string
-          type: array
-        route:
-          type: string
-      required:
-      - route
-      - method
-      - provider_types
-      type: object
-    RunEvalRequest:
-      additionalProperties: false
-      properties:
-        task_config:
-          $ref: '#/components/schemas/EvalTaskConfig'
-      required:
-      - task_config
-      type: object
-    RunShieldRequest:
-      additionalProperties: false
-      properties:
-        messages:
-          items:
-            $ref: '#/components/schemas/Message'
-          type: array
-        params:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        shield_id:
-          type: string
-      required:
-      - shield_id
-      - messages
-      - params
-      type: object
-    RunShieldResponse:
-      additionalProperties: false
-      properties:
-        violation:
-          $ref: '#/components/schemas/SafetyViolation'
-      type: object
-    SafetyViolation:
-      additionalProperties: false
-      properties:
-        metadata:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        user_message:
-          type: string
-        violation_level:
-          $ref: '#/components/schemas/ViolationLevel'
-      required:
-      - violation_level
-      - metadata
-      type: object
-    SamplingParams:
-      additionalProperties: false
-      properties:
-        max_tokens:
-          default: 0
-          type: integer
-        repetition_penalty:
-          default: 1.0
-          type: number
-        strategy:
-          discriminator:
-            mapping:
-              greedy: '#/components/schemas/GreedySamplingStrategy'
-              top_k: '#/components/schemas/TopKSamplingStrategy'
-              top_p: '#/components/schemas/TopPSamplingStrategy'
-            propertyName: type
-          oneOf:
-          - $ref: '#/components/schemas/GreedySamplingStrategy'
-          - $ref: '#/components/schemas/TopPSamplingStrategy'
-          - $ref: '#/components/schemas/TopKSamplingStrategy'
-      required:
-      - strategy
-      type: object
-    SaveSpansToDatasetRequest:
-      additionalProperties: false
-      properties:
-        attribute_filters:
-          items:
-            $ref: '#/components/schemas/QueryCondition'
-          type: array
-        attributes_to_save:
-          items:
-            type: string
-          type: array
-        dataset_id:
-          type: string
-        max_depth:
-          type: integer
-      required:
-      - attribute_filters
-      - attributes_to_save
-      - dataset_id
-      type: object
-    ScoreBatchRequest:
-      additionalProperties: false
-      properties:
-        dataset_id:
-          type: string
-        save_results_dataset:
-          type: boolean
-        scoring_functions:
-          additionalProperties:
-            oneOf:
-            - $ref: '#/components/schemas/ScoringFnParams'
-            - type: 'null'
-          type: object
-      required:
-      - dataset_id
-      - scoring_functions
-      - save_results_dataset
-      type: object
-    ScoreBatchResponse:
-      additionalProperties: false
-      properties:
-        dataset_id:
-          type: string
-        results:
-          additionalProperties:
-            $ref: '#/components/schemas/ScoringResult'
-          type: object
-      required:
-      - results
-      type: object
-    ScoreRequest:
-      additionalProperties: false
-      properties:
-        input_rows:
-          items:
-            additionalProperties:
-              oneOf:
-              - type: 'null'
-              - type: boolean
-              - type: number
-              - type: string
-              - type: array
-              - type: object
-            type: object
-          type: array
-        scoring_functions:
-          additionalProperties:
-            oneOf:
-            - $ref: '#/components/schemas/ScoringFnParams'
-            - type: 'null'
-          type: object
-      required:
-      - input_rows
-      - scoring_functions
-      type: object
-    ScoreResponse:
-      additionalProperties: false
-      properties:
-        results:
-          additionalProperties:
-            $ref: '#/components/schemas/ScoringResult'
-          type: object
-      required:
-      - results
-      type: object
-    ScoringFn:
-      additionalProperties: false
-      properties:
-        description:
-          type: string
-        identifier:
-          type: string
-        metadata:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        params:
-          $ref: '#/components/schemas/ScoringFnParams'
-        provider_id:
-          type: string
-        provider_resource_id:
-          type: string
-        return_type:
-          $ref: '#/components/schemas/ParamType'
-        type:
-          const: scoring_function
-          default: scoring_function
-          type: string
-      required:
-      - identifier
-      - provider_resource_id
-      - provider_id
-      - type
-      - metadata
-      - return_type
-      type: object
-    ScoringFnParams:
-      discriminator:
-        mapping:
-          basic: '#/components/schemas/BasicScoringFnParams'
-          llm_as_judge: '#/components/schemas/LLMAsJudgeScoringFnParams'
-          regex_parser: '#/components/schemas/RegexParserScoringFnParams'
-        propertyName: type
-      oneOf:
-      - $ref: '#/components/schemas/LLMAsJudgeScoringFnParams'
-      - $ref: '#/components/schemas/RegexParserScoringFnParams'
-      - $ref: '#/components/schemas/BasicScoringFnParams'
-    ScoringResult:
-      additionalProperties: false
-      properties:
-        aggregated_results:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        score_rows:
-          items:
-            additionalProperties:
-              oneOf:
-              - type: 'null'
-              - type: boolean
-              - type: number
-              - type: string
-              - type: array
-              - type: object
-            type: object
-          type: array
-      required:
-      - score_rows
-      - aggregated_results
-      type: object
-    Session:
-      additionalProperties: false
-      properties:
-        session_id:
-          type: string
-        session_name:
-          type: string
-        started_at:
-          format: date-time
-          type: string
-        turns:
-          items:
-            $ref: '#/components/schemas/Turn'
-          type: array
-      required:
-      - session_id
-      - session_name
-      - turns
-      - started_at
-      title: A single session of an interaction with an Agentic System.
-      type: object
-    Shield:
-      additionalProperties: false
-      properties:
-        identifier:
-          type: string
-        params:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        provider_id:
-          type: string
-        provider_resource_id:
-          type: string
-        type:
-          const: shield
-          default: shield
-          type: string
-      required:
-      - identifier
-      - provider_resource_id
-      - provider_id
-      - type
-      title: A safety shield resource that can be used to check content
-      type: object
-    ShieldCallStep:
-      additionalProperties: false
-      properties:
-        completed_at:
-          format: date-time
-          type: string
-        started_at:
-          format: date-time
-          type: string
-        step_id:
-          type: string
-        step_type:
-          const: shield_call
-          default: shield_call
-          type: string
-        turn_id:
-          type: string
-        violation:
-          $ref: '#/components/schemas/SafetyViolation'
-      required:
-      - turn_id
-      - step_id
-      - step_type
-      type: object
-    Span:
-      additionalProperties: false
-      properties:
-        attributes:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        end_time:
-          format: date-time
-          type: string
-        name:
-          type: string
-        parent_span_id:
-          type: string
-        span_id:
-          type: string
-        start_time:
-          format: date-time
-          type: string
-        trace_id:
-          type: string
-      required:
-      - span_id
-      - trace_id
-      - name
-      - start_time
-      type: object
-    SpanEndPayload:
-      additionalProperties: false
-      properties:
-        status:
-          $ref: '#/components/schemas/SpanStatus'
-        type:
-          const: span_end
-          default: span_end
-          type: string
-      required:
-      - type
-      - status
-      type: object
-    SpanStartPayload:
-      additionalProperties: false
-      properties:
-        name:
-          type: string
-        parent_span_id:
-          type: string
-        type:
-          const: span_start
-          default: span_start
-          type: string
-      required:
-      - type
-      - name
-      type: object
-    SpanStatus:
-      enum:
-      - ok
-      - error
-      type: string
-    SpanWithStatus:
-      additionalProperties: false
-      properties:
-        attributes:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        end_time:
-          format: date-time
-          type: string
-        name:
-          type: string
-        parent_span_id:
-          type: string
-        span_id:
-          type: string
-        start_time:
-          format: date-time
-          type: string
-        status:
-          $ref: '#/components/schemas/SpanStatus'
-        trace_id:
-          type: string
-      required:
-      - span_id
-      - trace_id
-      - name
-      - start_time
-      type: object
-    StopReason:
-      enum:
-      - end_of_turn
-      - end_of_message
-      - out_of_tokens
-      type: string
-    StringType:
-      additionalProperties: false
-      properties:
-        type:
-          const: string
-          default: string
-          type: string
-      required:
-      - type
-      type: object
-    StructuredLogEvent:
-      additionalProperties: false
-      properties:
-        attributes:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        payload:
-          $ref: '#/components/schemas/StructuredLogPayload'
-        span_id:
-          type: string
-        timestamp:
-          format: date-time
-          type: string
-        trace_id:
-          type: string
-        type:
-          const: structured_log
-          default: structured_log
-          type: string
-      required:
-      - trace_id
-      - span_id
-      - timestamp
-      - type
-      - payload
-      type: object
-    StructuredLogPayload:
-      discriminator:
-        mapping:
-          span_end: '#/components/schemas/SpanEndPayload'
-          span_start: '#/components/schemas/SpanStartPayload'
-        propertyName: type
-      oneOf:
-      - $ref: '#/components/schemas/SpanStartPayload'
-      - $ref: '#/components/schemas/SpanEndPayload'
-    SupervisedFineTuneRequest:
-      additionalProperties: false
-      properties:
-        algorithm_config:
-          $ref: '#/components/schemas/AlgorithmConfig'
-        checkpoint_dir:
-          type: string
-        hyperparam_search_config:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        job_uuid:
-          type: string
-        logger_config:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        model:
-          type: string
-        training_config:
-          $ref: '#/components/schemas/TrainingConfig'
-      required:
-      - job_uuid
-      - training_config
-      - hyperparam_search_config
-      - logger_config
-      - model
-      type: object
-    SyntheticDataGenerateRequest:
-      additionalProperties: false
-      properties:
-        dialogs:
-          items:
-            $ref: '#/components/schemas/Message'
-          type: array
-        filtering_function:
-          enum:
-          - none
-          - random
-          - top_k
-          - top_p
-          - top_k_top_p
-          - sigmoid
-          title: The type of filtering function.
-          type: string
-        model:
-          type: string
-      required:
-      - dialogs
-      - filtering_function
-      type: object
-    SyntheticDataGenerationResponse:
-      additionalProperties: false
-      properties:
-        statistics:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        synthetic_data:
-          items:
-            additionalProperties:
-              oneOf:
-              - type: 'null'
-              - type: boolean
-              - type: number
-              - type: string
-              - type: array
-              - type: object
-            type: object
-          type: array
-      required:
-      - synthetic_data
-      title: Response from the synthetic data generation. Batch of (prompt, response,
-        score) tuples that pass the threshold.
-      type: object
-    SystemMessage:
-      additionalProperties: false
-      properties:
-        content:
-          $ref: '#/components/schemas/InterleavedContent'
-        role:
-          const: system
-          default: system
-          type: string
-      required:
-      - role
-      - content
-      type: object
-    TextContentItem:
-      additionalProperties: false
-      properties:
-        text:
-          type: string
-        type:
-          const: text
-          default: text
-          type: string
-      required:
-      - type
-      - text
-      type: object
-    TextDelta:
-      additionalProperties: false
-      properties:
-        text:
-          type: string
-        type:
-          const: text
-          default: text
-          type: string
-      required:
-      - type
-      - text
-      type: object
-    TokenLogProbs:
-      additionalProperties: false
-      properties:
-        logprobs_by_token:
-          additionalProperties:
-            type: number
-          type: object
-      required:
-      - logprobs_by_token
-      type: object
-    Tool:
-      additionalProperties: false
-      properties:
-        description:
-          type: string
-        identifier:
-          type: string
-        metadata:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        parameters:
-          items:
-            $ref: '#/components/schemas/ToolParameter'
-          type: array
-        provider_id:
-          type: string
-        provider_resource_id:
-          type: string
-        tool_host:
-          $ref: '#/components/schemas/ToolHost'
-        toolgroup_id:
-          type: string
-        type:
-          const: tool
-          default: tool
-          type: string
-      required:
-      - identifier
-      - provider_resource_id
-      - provider_id
-      - type
-      - toolgroup_id
-      - tool_host
-      - description
-      - parameters
-      type: object
-    ToolCall:
-      additionalProperties: false
-      properties:
-        arguments:
-          additionalProperties:
-            oneOf:
-            - type: string
-            - type: integer
-            - type: number
-            - type: boolean
-            - type: 'null'
-            - items:
-                oneOf:
-                - type: string
-                - type: integer
-                - type: number
-                - type: boolean
-                - type: 'null'
-              type: array
-            - additionalProperties:
-                oneOf:
-                - type: string
-                - type: integer
-                - type: number
-                - type: boolean
-                - type: 'null'
-              type: object
-          type: object
-        call_id:
-          type: string
-        tool_name:
-          oneOf:
-          - $ref: '#/components/schemas/BuiltinTool'
-          - type: string
-      required:
-      - call_id
-      - tool_name
-      - arguments
-      type: object
-    ToolCallDelta:
-      additionalProperties: false
-      properties:
-        parse_status:
-          $ref: '#/components/schemas/ToolCallParseStatus'
-        tool_call:
-          oneOf:
-          - type: string
-          - $ref: '#/components/schemas/ToolCall'
-        type:
-          const: tool_call
-          default: tool_call
-          type: string
-      required:
-      - type
-      - tool_call
-      - parse_status
-      type: object
-    ToolCallParseStatus:
-      enum:
-      - started
-      - in_progress
-      - failed
-      - succeeded
-      type: string
-    ToolChoice:
-      enum:
-      - auto
-      - required
-      type: string
-    ToolDef:
-      additionalProperties: false
-      properties:
-        description:
-          type: string
-        metadata:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        name:
-          type: string
-        parameters:
-          items:
-            $ref: '#/components/schemas/ToolParameter'
-          type: array
-      required:
-      - name
-      type: object
-    ToolDefinition:
-      additionalProperties: false
-      properties:
-        description:
-          type: string
-        parameters:
-          additionalProperties:
-            $ref: '#/components/schemas/ToolParamDefinition'
-          type: object
-        tool_name:
-          oneOf:
-          - $ref: '#/components/schemas/BuiltinTool'
-          - type: string
-      required:
-      - tool_name
-      type: object
-    ToolExecutionStep:
-      additionalProperties: false
-      properties:
-        completed_at:
-          format: date-time
-          type: string
-        started_at:
-          format: date-time
-          type: string
-        step_id:
-          type: string
-        step_type:
-          const: tool_execution
-          default: tool_execution
-          type: string
-        tool_calls:
-          items:
-            $ref: '#/components/schemas/ToolCall'
-          type: array
-        tool_responses:
-          items:
-            $ref: '#/components/schemas/ToolResponse'
-          type: array
-        turn_id:
-          type: string
-      required:
-      - turn_id
-      - step_id
-      - step_type
-      - tool_calls
-      - tool_responses
-      type: object
-    ToolGroup:
-      additionalProperties: false
-      properties:
-        args:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        identifier:
-          type: string
-        mcp_endpoint:
-          $ref: '#/components/schemas/URL'
-        provider_id:
-          type: string
-        provider_resource_id:
-          type: string
-        type:
-          const: tool_group
-          default: tool_group
-          type: string
-      required:
-      - identifier
-      - provider_resource_id
-      - provider_id
-      - type
-      type: object
-    ToolHost:
-      enum:
-      - distribution
-      - client
-      - model_context_protocol
-      type: string
-    ToolInvocationResult:
-      additionalProperties: false
-      properties:
-        content:
-          $ref: '#/components/schemas/InterleavedContent'
-        error_code:
-          type: integer
-        error_message:
-          type: string
-      required:
-      - content
-      type: object
-    ToolParamDefinition:
-      additionalProperties: false
-      properties:
-        default:
-          oneOf:
-          - type: 'null'
-          - type: boolean
-          - type: number
-          - type: string
-          - type: array
-          - type: object
-        description:
-          type: string
-        param_type:
-          type: string
-        required:
-          default: true
-          type: boolean
-      required:
-      - param_type
-      type: object
-    ToolParameter:
-      additionalProperties: false
-      properties:
-        default:
-          oneOf:
-          - type: 'null'
-          - type: boolean
-          - type: number
-          - type: string
-          - type: array
-          - type: object
-        description:
-          type: string
-        name:
-          type: string
-        parameter_type:
-          type: string
-        required:
-          default: true
-          type: boolean
-      required:
-      - name
-      - parameter_type
-      - description
-      - required
-      type: object
-    ToolPromptFormat:
-      description: "`json` --\n    Refers to the json format for calling tools.\n\
-        \    The json format takes the form like\n    {\n        \"type\": \"function\"\
-        ,\n        \"function\" : {\n            \"name\": \"function_name\",\n  \
-        \          \"description\": \"function_description\",\n            \"parameters\"\
-        : {...}\n        }\n    }\n\n`function_tag` --\n    This is an example of\
-        \ how you could define\n    your own user defined format for making tool calls.\n\
-        \    The function_tag format looks like this,\n    <function=function_name>(parameters)</function>\n\
-        \nThe detailed prompts for each of these formats are added to llama cli"
-      enum:
-      - json
-      - function_tag
-      - python_list
-      title: This Enum refers to the prompt format for calling custom / zero shot
-        tools
-      type: string
-    ToolResponse:
-      additionalProperties: false
-      properties:
-        call_id:
-          type: string
-        content:
-          $ref: '#/components/schemas/InterleavedContent'
-        tool_name:
-          oneOf:
-          - $ref: '#/components/schemas/BuiltinTool'
-          - type: string
-      required:
-      - call_id
-      - tool_name
-      - content
-      type: object
-    ToolResponseMessage:
-      additionalProperties: false
-      properties:
-        call_id:
-          type: string
-        content:
-          $ref: '#/components/schemas/InterleavedContent'
-        role:
-          const: tool
-          default: tool
-          type: string
-        tool_name:
-          oneOf:
-          - $ref: '#/components/schemas/BuiltinTool'
-          - type: string
-      required:
-      - role
-      - call_id
-      - tool_name
-      - content
-      type: object
-    TopKSamplingStrategy:
-      additionalProperties: false
-      properties:
-        top_k:
-          type: integer
-        type:
-          const: top_k
-          default: top_k
-          type: string
-      required:
-      - type
-      - top_k
-      type: object
-    TopPSamplingStrategy:
-      additionalProperties: false
-      properties:
-        temperature:
-          type: number
-        top_p:
-          default: 0.95
-          type: number
-        type:
-          const: top_p
-          default: top_p
-          type: string
-      required:
-      - type
-      type: object
-    Trace:
-      additionalProperties: false
-      properties:
-        end_time:
-          format: date-time
-          type: string
-        root_span_id:
-          type: string
-        start_time:
-          format: date-time
-          type: string
-        trace_id:
-          type: string
-      required:
-      - trace_id
-      - root_span_id
-      - start_time
-      type: object
-    TrainingConfig:
-      additionalProperties: false
-      properties:
-        data_config:
-          $ref: '#/components/schemas/DataConfig'
-        dtype:
-          default: bf16
-          type: string
-        efficiency_config:
-          $ref: '#/components/schemas/EfficiencyConfig'
-        gradient_accumulation_steps:
-          type: integer
-        max_steps_per_epoch:
-          type: integer
-        max_validation_steps:
-          type: integer
-        n_epochs:
-          type: integer
-        optimizer_config:
-          $ref: '#/components/schemas/OptimizerConfig'
-      required:
-      - n_epochs
-      - max_steps_per_epoch
-      - gradient_accumulation_steps
-      - max_validation_steps
-      - data_config
-      - optimizer_config
-      type: object
-    Turn:
-      additionalProperties: false
-      properties:
-        completed_at:
-          format: date-time
-          type: string
-        input_messages:
-          items:
-            oneOf:
-            - $ref: '#/components/schemas/UserMessage'
-            - $ref: '#/components/schemas/ToolResponseMessage'
-          type: array
-        output_attachments:
-          items:
-            additionalProperties: false
-            properties:
-              content:
-                oneOf:
-                - type: string
-                - $ref: '#/components/schemas/InterleavedContentItem'
-                - items:
-                    $ref: '#/components/schemas/InterleavedContentItem'
-                  type: array
-                - $ref: '#/components/schemas/URL'
-              mime_type:
-                type: string
-            required:
-            - content
-            - mime_type
-            type: object
-          type: array
-        output_message:
-          $ref: '#/components/schemas/CompletionMessage'
-        session_id:
-          type: string
-        started_at:
-          format: date-time
-          type: string
-        steps:
-          items:
-            discriminator:
-              mapping:
-                inference: '#/components/schemas/InferenceStep'
-                memory_retrieval: '#/components/schemas/MemoryRetrievalStep'
-                shield_call: '#/components/schemas/ShieldCallStep'
-                tool_execution: '#/components/schemas/ToolExecutionStep'
-              propertyName: step_type
-            oneOf:
-            - $ref: '#/components/schemas/InferenceStep'
-            - $ref: '#/components/schemas/ToolExecutionStep'
-            - $ref: '#/components/schemas/ShieldCallStep'
-            - $ref: '#/components/schemas/MemoryRetrievalStep'
-          type: array
-        turn_id:
-          type: string
-      required:
-      - turn_id
-      - session_id
-      - input_messages
-      - steps
-      - output_message
-      - output_attachments
-      - started_at
-      title: A single turn in an interaction with an Agentic System.
-      type: object
-    URL:
-      additionalProperties: false
-      properties:
-        uri:
-          type: string
-      required:
-      - uri
-      type: object
-    UnionType:
-      additionalProperties: false
-      properties:
-        type:
-          const: union
-          default: union
-          type: string
-      required:
-      - type
-      type: object
-    UnstructuredLogEvent:
-      additionalProperties: false
-      properties:
-        attributes:
-          additionalProperties:
-            oneOf:
-            - type: 'null'
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        message:
-          type: string
-        severity:
-          $ref: '#/components/schemas/LogSeverity'
-        span_id:
-          type: string
-        timestamp:
-          format: date-time
-          type: string
-        trace_id:
-          type: string
-        type:
-          const: unstructured_log
-          default: unstructured_log
-          type: string
-      required:
-      - trace_id
-      - span_id
-      - timestamp
-      - type
-      - message
-      - severity
-      type: object
-    UserMessage:
-      additionalProperties: false
-      properties:
-        content:
-          $ref: '#/components/schemas/InterleavedContent'
-        context:
-          $ref: '#/components/schemas/InterleavedContent'
-        role:
-          const: user
-          default: user
-          type: string
-      required:
-      - role
-      - content
-      type: object
-    VectorDB:
-      additionalProperties: false
-      properties:
-        embedding_dimension:
-          type: integer
-        embedding_model:
-          type: string
-        identifier:
-          type: string
-        provider_id:
-          type: string
-        provider_resource_id:
-          type: string
-        type:
-          const: vector_db
-          default: vector_db
-          type: string
-      required:
-      - identifier
-      - provider_resource_id
-      - provider_id
-      - type
-      - embedding_model
-      - embedding_dimension
-      type: object
-    VersionInfo:
-      additionalProperties: false
-      properties:
-        version:
-          type: string
-      required:
-      - version
-      type: object
-    ViolationLevel:
-      enum:
-      - info
-      - warn
-      - error
-      type: string
+openapi: 3.1.0
 info:
-  description: "This is the specification of the Llama Stack that provides\n     \
-    \           a set of endpoints and their corresponding interfaces that are tailored\
-    \ to\n                best leverage Llama Models."
   title: Llama Stack Specification
   version: v1
-jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
-openapi: 3.1.0
+  description: "This is the specification of the Llama Stack that provides\n     \
+    \           a set of endpoints and their corresponding interfaces that are tailored
+    to\n                best leverage Llama Models."
+servers:
+  - url: http://any-hosted-llama-stack.com
 paths:
-  /v1/agents:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateAgentRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AgentCreateResponse'
-          description: OK
-      tags:
-      - Agents
-  /v1/agents/{agent_id}:
-    delete:
-      parameters:
-      - in: path
-        name: agent_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          description: OK
-      tags:
-      - Agents
-  /v1/agents/{agent_id}/session:
-    post:
-      parameters:
-      - in: path
-        name: agent_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateAgentSessionRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AgentSessionCreateResponse'
-          description: OK
-      tags:
-      - Agents
-  /v1/agents/{agent_id}/session/{session_id}:
-    delete:
-      parameters:
-      - in: path
-        name: session_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: agent_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          description: OK
-      tags:
-      - Agents
-    get:
-      parameters:
-      - in: path
-        name: session_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: agent_id
-        required: true
-        schema:
-          type: string
-      - in: query
-        name: turn_ids
-        required: false
-        schema:
-          items:
-            type: string
-          type: array
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Session'
-          description: OK
-      tags:
-      - Agents
-  /v1/agents/{agent_id}/session/{session_id}/turn:
-    post:
-      parameters:
-      - in: path
-        name: agent_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: session_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateAgentTurnRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            text/event-stream:
-              schema:
-                oneOf:
-                - $ref: '#/components/schemas/Turn'
-                - $ref: '#/components/schemas/AgentTurnResponseStreamChunk'
-          description: A single turn in an interaction with an Agentic System. **OR**
-            streamed agent turn completion response.
-      tags:
-      - Agents
-  /v1/agents/{agent_id}/session/{session_id}/turn/{turn_id}:
-    get:
-      parameters:
-      - in: path
-        name: agent_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: session_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: turn_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Turn'
-          description: OK
-      tags:
-      - Agents
-  /v1/agents/{agent_id}/session/{session_id}/turn/{turn_id}/step/{step_id}:
-    get:
-      parameters:
-      - in: path
-        name: agent_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: session_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: turn_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: step_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AgentStepResponse'
-          description: OK
-      tags:
-      - Agents
-  /v1/batch-inference/chat-completion:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/BatchChatCompletionRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BatchChatCompletionResponse'
-          description: OK
-      tags:
-      - BatchInference (Coming Soon)
-  /v1/batch-inference/completion:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/BatchCompletionRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BatchCompletionResponse'
-          description: OK
-      tags:
-      - BatchInference (Coming Soon)
   /v1/datasetio/rows:
     get:
-      parameters:
-      - in: query
-        name: dataset_id
-        required: true
-        schema:
-          type: string
-      - in: query
-        name: rows_in_page
-        required: true
-        schema:
-          type: integer
-      - in: query
-        name: page_token
-        required: false
-        schema:
-          type: string
-      - in: query
-        name: filter_condition
-        required: false
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
       responses:
         '200':
+          description: OK
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedRowsResult'
-          description: OK
       tags:
-      - DatasetIO
-    post:
+        - DatasetIO
       parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
+        - name: dataset_id
+        in: query
+        required: true
+        schema:
+          type: string
+        - name: rows_in_page
+        in: query
+        required: true
+        schema:
+          type: integer
+        - name: page_token
+        in: query
         required: false
         schema:
           type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
+        - name: filter_condition
+        in: query
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
         in: header
-        name: X-LlamaStack-Client-Version
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+    post:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - DatasetIO
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
         required: false
         schema:
           type: string
@@ -3792,50 +81,29 @@ paths:
             schema:
               $ref: '#/components/schemas/AppendRowsRequest'
         required: true
+  /v1/batch-inference/chat-completion:
+    post:
       responses:
         '200':
           description: OK
-      tags:
-      - DatasetIO
-  /v1/datasets:
-    get:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListDatasetsResponse'
-          description: OK
+                $ref: '#/components/schemas/BatchChatCompletionResponse'
       tags:
-      - Datasets
-    post:
+        - BatchInference (Coming Soon)
       parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
+        - name: X-LlamaStack-Provider-Data
         in: header
-        name: X-LlamaStack-Provider-Data
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
         required: false
         schema:
           type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
+        - name: X-LlamaStack-Client-Version
         in: header
-        name: X-LlamaStack-Client-Version
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
         required: false
         schema:
           type: string
@@ -3843,111 +111,31 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RegisterDatasetRequest'
+              $ref: '#/components/schemas/BatchChatCompletionRequest'
         required: true
-      responses:
-        '200':
-          description: OK
-      tags:
-      - Datasets
-  /v1/datasets/{dataset_id}:
-    delete:
-      parameters:
-      - in: path
-        name: dataset_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          description: OK
-      tags:
-      - Datasets
-    get:
-      parameters:
-      - in: path
-        name: dataset_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                oneOf:
-                - $ref: '#/components/schemas/Dataset'
-                - type: 'null'
-          description: OK
-      tags:
-      - Datasets
-  /v1/eval-tasks:
-    get:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListEvalTasksResponse'
-          description: OK
-      tags:
-      - EvalTasks
+  /v1/batch-inference/completion:
     post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchCompletionResponse'
+      tags:
+        - BatchInference (Coming Soon)
       parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
+        - name: X-LlamaStack-Provider-Data
         in: header
-        name: X-LlamaStack-Provider-Data
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
         required: false
         schema:
           type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
+        - name: X-LlamaStack-Client-Version
         in: header
-        name: X-LlamaStack-Client-Version
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
         required: false
         schema:
           type: string
@@ -3955,566 +143,27 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RegisterEvalTaskRequest'
+              $ref: '#/components/schemas/BatchCompletionRequest'
         required: true
-      responses:
-        '200':
-          description: OK
-      tags:
-      - EvalTasks
-  /v1/eval-tasks/{eval_task_id}:
-    get:
-      parameters:
-      - in: path
-        name: eval_task_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                oneOf:
-                - $ref: '#/components/schemas/EvalTask'
-                - type: 'null'
-          description: OK
-      tags:
-      - EvalTasks
-  /v1/eval/tasks/{task_id}/evaluations:
-    post:
-      parameters:
-      - in: path
-        name: task_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/EvaluateRowsRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/EvaluateResponse'
-          description: OK
-      tags:
-      - Eval
-  /v1/eval/tasks/{task_id}/jobs:
-    post:
-      parameters:
-      - in: path
-        name: task_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RunEvalRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Job'
-          description: OK
-      tags:
-      - Eval
-  /v1/eval/tasks/{task_id}/jobs/{job_id}:
-    delete:
-      parameters:
-      - in: path
-        name: task_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: job_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          description: OK
-      tags:
-      - Eval
-    get:
-      parameters:
-      - in: path
-        name: task_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: job_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                oneOf:
-                - $ref: '#/components/schemas/JobStatus'
-                - type: 'null'
-          description: OK
-      tags:
-      - Eval
-  /v1/eval/tasks/{task_id}/jobs/{job_id}/result:
-    get:
-      parameters:
-      - in: path
-        name: job_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: task_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/EvaluateResponse'
-          description: OK
-      tags:
-      - Eval
-  /v1/health:
-    get:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HealthInfo'
-          description: OK
-      tags:
-      - Inspect
-  /v1/inference/chat-completion:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ChatCompletionRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            text/event-stream:
-              schema:
-                oneOf:
-                - $ref: '#/components/schemas/ChatCompletionResponse'
-                - $ref: '#/components/schemas/ChatCompletionResponseStreamChunk'
-          description: Chat completion response. **OR** SSE-stream of these events.
-      tags:
-      - Inference
-  /v1/inference/completion:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CompletionRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            text/event-stream:
-              schema:
-                oneOf:
-                - $ref: '#/components/schemas/CompletionResponse'
-                - $ref: '#/components/schemas/CompletionResponseStreamChunk'
-          description: Completion response. **OR** streamed completion response.
-      tags:
-      - Inference
-  /v1/inference/embeddings:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/EmbeddingsRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/EmbeddingsResponse'
-          description: OK
-      tags:
-      - Inference
-  /v1/inspect/providers:
-    get:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListProvidersResponse'
-          description: OK
-      tags:
-      - Inspect
-  /v1/inspect/routes:
-    get:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListRoutesResponse'
-          description: OK
-      tags:
-      - Inspect
-  /v1/models:
-    get:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListModelsResponse'
-          description: OK
-      tags:
-      - Models
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RegisterModelRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Model'
-          description: OK
-      tags:
-      - Models
-  /v1/models/{model_id}:
-    delete:
-      parameters:
-      - in: path
-        name: model_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          description: OK
-      tags:
-      - Models
-    get:
-      parameters:
-      - in: path
-        name: model_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                oneOf:
-                - $ref: '#/components/schemas/Model'
-                - type: 'null'
-          description: OK
-      tags:
-      - Models
-  /v1/post-training/job/artifacts:
-    get:
-      parameters:
-      - in: query
-        name: job_uuid
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                oneOf:
-                - $ref: '#/components/schemas/PostTrainingJobArtifactsResponse'
-                - type: 'null'
-          description: OK
-      tags:
-      - PostTraining (Coming Soon)
   /v1/post-training/job/cancel:
     post:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - PostTraining (Coming Soon)
       parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
+        - name: X-LlamaStack-Provider-Data
         in: header
-        name: X-LlamaStack-Provider-Data
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
         required: false
         schema:
           type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
+        - name: X-LlamaStack-Client-Version
         in: header
-        name: X-LlamaStack-Client-Version
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
         required: false
         schema:
           type: string
@@ -4524,782 +173,1058 @@ paths:
             schema:
               $ref: '#/components/schemas/CancelTrainingJobRequest'
         required: true
+  /v1/inference/chat-completion:
+    post:
+      responses:
+        '200':
+          description: Chat completion response. **OR** SSE-stream of these events.
+          content:
+            text/event-stream:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ChatCompletionResponse'
+                  - $ref: '#/components/schemas/ChatCompletionResponseStreamChunk'
+      tags:
+        - Inference
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChatCompletionRequest'
+        required: true
+  /v1/inference/completion:
+    post:
+      responses:
+        '200':
+          description: Completion response. **OR** streamed completion response.
+          content:
+            text/event-stream:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/CompletionResponse'
+                  - $ref: '#/components/schemas/CompletionResponseStreamChunk'
+      tags:
+        - Inference
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CompletionRequest'
+        required: true
+  /v1/agents:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentCreateResponse'
+      tags:
+        - Agents
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAgentRequest'
+        required: true
+  /v1/agents/{agent_id}/session:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentSessionCreateResponse'
+      tags:
+        - Agents
+      parameters:
+        - name: agent_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAgentSessionRequest'
+        required: true
+  /v1/agents/{agent_id}/session/{session_id}/turn:
+    post:
+      responses:
+        '200':
+          description: A single turn in an interaction with an Agentic System. **OR**
+            streamed agent turn completion response.
+          content:
+            text/event-stream:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/Turn'
+                  - $ref: '#/components/schemas/AgentTurnResponseStreamChunk'
+      tags:
+        - Agents
+      parameters:
+        - name: agent_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: session_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAgentTurnRequest'
+        required: true
+  /v1/agents/{agent_id}:
+    delete:
       responses:
         '200':
           description: OK
       tags:
-      - PostTraining (Coming Soon)
-  /v1/post-training/job/status:
-    get:
+        - Agents
       parameters:
-      - in: query
-        name: job_uuid
+        - name: agent_id
+        in: path
         required: true
         schema:
           type: string
-      - description: JSON-encoded provider data which will be made available to the
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
         required: false
         schema:
           type: string
-      - description: Version of the client making the request. This is used to ensure
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
           that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
+  /v1/agents/{agent_id}/session/{session_id}:
+    get:
       responses:
         '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Session'
+      tags:
+        - Agents
+      parameters:
+        - name: session_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: agent_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: turn_ids
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+    delete:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - Agents
+      parameters:
+        - name: session_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: agent_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+  /v1/inference/embeddings:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmbeddingsResponse'
+      tags:
+        - Inference
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmbeddingsRequest'
+        required: true
+  /v1/eval/tasks/{task_id}/evaluations:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvaluateResponse'
+      tags:
+        - Eval
+      parameters:
+        - name: task_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EvaluateRowsRequest'
+        required: true
+  /v1/agents/{agent_id}/session/{session_id}/turn/{turn_id}/step/{step_id}:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentStepResponse'
+      tags:
+        - Agents
+      parameters:
+        - name: agent_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: session_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: turn_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: step_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+  /v1/agents/{agent_id}/session/{session_id}/turn/{turn_id}:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Turn'
+      tags:
+        - Agents
+      parameters:
+        - name: agent_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: session_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: turn_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+  /v1/datasets/{dataset_id}:
+    get:
+      responses:
+        '200':
+          description: OK
           content:
             application/json:
               schema:
                 oneOf:
-                - $ref: '#/components/schemas/PostTrainingJobStatusResponse'
-                - type: 'null'
+                  - $ref: '#/components/schemas/Dataset'
+                  - type: 'null'
+      tags:
+        - Datasets
+      parameters:
+        - name: dataset_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+    delete:
+      responses:
+        '200':
           description: OK
       tags:
-      - PostTraining (Coming Soon)
-  /v1/post-training/jobs:
+        - Datasets
+      parameters:
+        - name: dataset_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+  /v1/eval-tasks/{eval_task_id}:
     get:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
       responses:
         '200':
+          description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListPostTrainingJobsResponse'
-          description: OK
+                oneOf:
+                  - $ref: '#/components/schemas/EvalTask'
+                  - type: 'null'
       tags:
-      - PostTraining (Coming Soon)
-  /v1/post-training/preference-optimize:
-    post:
+        - EvalTasks
       parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PreferenceOptimizeRequest'
+        - name: eval_task_id
+        in: path
         required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostTrainingJob'
-          description: OK
-      tags:
-      - PostTraining (Coming Soon)
-  /v1/post-training/supervised-fine-tune:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
         required: false
         schema:
           type: string
-      - description: Version of the client making the request. This is used to ensure
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
           that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SupervisedFineTuneRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostTrainingJob'
-          description: OK
-      tags:
-      - PostTraining (Coming Soon)
-  /v1/safety/run-shield:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RunShieldRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RunShieldResponse'
-          description: OK
-      tags:
-      - Safety
-  /v1/scoring-functions:
+  /v1/models/{model_id}:
     get:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
       responses:
         '200':
+          description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListScoringFunctionsResponse'
-          description: OK
+                oneOf:
+                  - $ref: '#/components/schemas/Model'
+                  - type: 'null'
       tags:
-      - ScoringFunctions
-    post:
+        - Models
       parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RegisterScoringFunctionRequest'
+        - name: model_id
+        in: path
         required: true
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+    delete:
       responses:
         '200':
           description: OK
       tags:
-      - ScoringFunctions
+        - Models
+      parameters:
+        - name: model_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
   /v1/scoring-functions/{scoring_fn_id}:
     get:
-      parameters:
-      - in: path
-        name: scoring_fn_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
       responses:
         '200':
+          description: OK
           content:
             application/json:
               schema:
                 oneOf:
-                - $ref: '#/components/schemas/ScoringFn'
-                - type: 'null'
-          description: OK
+                  - $ref: '#/components/schemas/ScoringFn'
+                  - type: 'null'
       tags:
-      - ScoringFunctions
-  /v1/scoring/score:
-    post:
+        - ScoringFunctions
       parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ScoreRequest'
+        - name: scoring_fn_id
+        in: path
         required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ScoreResponse'
-          description: OK
-      tags:
-      - Scoring
-  /v1/scoring/score-batch:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
         required: false
         schema:
           type: string
-      - description: Version of the client making the request. This is used to ensure
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
           that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ScoreBatchRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ScoreBatchResponse'
-          description: OK
-      tags:
-      - Scoring
-  /v1/shields:
-    get:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListShieldsResponse'
-          description: OK
-      tags:
-      - Shields
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RegisterShieldRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Shield'
-          description: OK
-      tags:
-      - Shields
   /v1/shields/{identifier}:
     get:
-      parameters:
-      - in: path
-        name: identifier
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
       responses:
         '200':
+          description: OK
           content:
             application/json:
               schema:
                 oneOf:
-                - $ref: '#/components/schemas/Shield'
-                - type: 'null'
-          description: OK
+                  - $ref: '#/components/schemas/Shield'
+                  - type: 'null'
       tags:
-      - Shields
-  /v1/synthetic-data-generation/generate:
-    post:
+        - Shields
       parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SyntheticDataGenerateRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SyntheticDataGenerationResponse'
-          description: OK
-      tags:
-      - SyntheticDataGeneration (Coming Soon)
-  /v1/telemetry/events:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/LogEventRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-      tags:
-      - Telemetry
-  /v1/telemetry/spans:
-    get:
-      parameters:
-      - in: query
-        name: attribute_filters
-        required: true
-        schema:
-          items:
-            $ref: '#/components/schemas/QueryCondition'
-          type: array
-      - in: query
-        name: attributes_to_return
-        required: true
-        schema:
-          items:
-            type: string
-          type: array
-      - in: query
-        name: max_depth
-        required: false
-        schema:
-          type: integer
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/QuerySpansResponse'
-          description: OK
-      tags:
-      - Telemetry
-  /v1/telemetry/spans/export:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SaveSpansToDatasetRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-      tags:
-      - Telemetry
-  /v1/telemetry/spans/{span_id}/tree:
-    get:
-      parameters:
-      - in: path
-        name: span_id
+        - name: identifier
+        in: path
         required: true
         schema:
           type: string
-      - in: query
-        name: attributes_to_return
-        required: false
-        schema:
-          items:
-            type: string
-          type: array
-      - in: query
-        name: max_depth
-        required: false
-        schema:
-          type: integer
-      - description: JSON-encoded provider data which will be made available to the
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
         required: false
         schema:
           type: string
-      - description: Version of the client making the request. This is used to ensure
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
           that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/QuerySpanTreeResponse'
-          description: OK
-      tags:
-      - Telemetry
-  /v1/telemetry/traces:
-    get:
-      parameters:
-      - in: query
-        name: attribute_filters
-        required: false
-        schema:
-          items:
-            $ref: '#/components/schemas/QueryCondition'
-          type: array
-      - in: query
-        name: limit
-        required: false
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        required: false
-        schema:
-          type: integer
-      - in: query
-        name: order_by
-        required: false
-        schema:
-          items:
-            type: string
-          type: array
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/QueryTracesResponse'
-          description: OK
-      tags:
-      - Telemetry
-  /v1/telemetry/traces/{trace_id}:
-    get:
-      parameters:
-      - in: path
-        name: trace_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Trace'
-          description: OK
-      tags:
-      - Telemetry
   /v1/telemetry/traces/{trace_id}/spans/{span_id}:
     get:
-      parameters:
-      - in: path
-        name: trace_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: span_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
       responses:
         '200':
+          description: OK
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Span'
-          description: OK
       tags:
-      - Telemetry
-  /v1/tool-runtime/invoke:
-    post:
+        - Telemetry
       parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/InvokeToolRequest'
+        - name: trace_id
+        in: path
         required: true
+        schema:
+          type: string
+        - name: span_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+  /v1/telemetry/spans/{span_id}/tree:
+    get:
       responses:
         '200':
+          description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ToolInvocationResult'
-          description: OK
-      summary: Run a tool with the given arguments
+                $ref: '#/components/schemas/QuerySpanTreeResponse'
       tags:
-      - ToolRuntime
-  /v1/tool-runtime/list-tools:
-    get:
+        - Telemetry
       parameters:
-      - in: query
-        name: tool_group_id
-        required: false
+        - name: span_id
+        in: path
+        required: true
         schema:
           type: string
-      - in: query
-        name: mcp_endpoint
+        - name: attributes_to_return
+        in: query
         required: false
         schema:
-          $ref: '#/components/schemas/URL'
-      - description: JSON-encoded provider data which will be made available to the
+          type: array
+          items:
+            type: string
+        - name: max_depth
+        in: query
+        required: false
+        schema:
+          type: integer
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
         required: false
         schema:
           type: string
-      - description: Version of the client making the request. This is used to ensure
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
           that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
+  /v1/tools/{tool_name}:
+    get:
       responses:
         '200':
-          content:
-            application/jsonl:
-              schema:
-                $ref: '#/components/schemas/ToolDef'
           description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tool'
       tags:
-      - ToolRuntime
-  /v1/tool-runtime/rag-tool/insert:
-    post:
+        - ToolGroups
       parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
+        - name: tool_name
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
         in: header
-        name: X-LlamaStack-Provider-Data
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
         required: false
         schema:
           type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
+        - name: X-LlamaStack-Client-Version
         in: header
-        name: X-LlamaStack-Client-Version
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+  /v1/toolgroups/{toolgroup_id}:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ToolGroup'
+      tags:
+        - ToolGroups
+      parameters:
+        - name: toolgroup_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+    delete:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - ToolGroups
+      summary: Unregister a tool group
+      parameters:
+        - name: toolgroup_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+  /v1/telemetry/traces/{trace_id}:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Trace'
+      tags:
+        - Telemetry
+      parameters:
+        - name: trace_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+  /v1/post-training/job/artifacts:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/PostTrainingJobArtifactsResponse'
+                  - type: 'null'
+      tags:
+        - PostTraining (Coming Soon)
+      parameters:
+        - name: job_uuid
+        in: query
+        required: true
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+  /v1/post-training/job/status:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/PostTrainingJobStatusResponse'
+                  - type: 'null'
+      tags:
+        - PostTraining (Coming Soon)
+      parameters:
+        - name: job_uuid
+        in: query
+        required: true
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+  /v1/post-training/jobs:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListPostTrainingJobsResponse'
+      tags:
+        - PostTraining (Coming Soon)
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+  /v1/vector-dbs/{vector_db_id}:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/VectorDB'
+                  - type: 'null'
+      tags:
+        - VectorDBs
+      parameters:
+        - name: vector_db_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+    delete:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - VectorDBs
+      parameters:
+        - name: vector_db_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+  /v1/health:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthInfo'
+      tags:
+        - Inspect
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+  /v1/tool-runtime/rag-tool/insert:
+    post:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - ToolRuntime
+      summary: Index documents so they can be used by the RAG system
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
         required: false
         schema:
           type: string
@@ -5309,351 +1234,25 @@ paths:
             schema:
               $ref: '#/components/schemas/InsertRequest'
         required: true
-      responses:
-        '200':
-          description: OK
-      summary: Index documents so they can be used by the RAG system
-      tags:
-      - ToolRuntime
-  /v1/tool-runtime/rag-tool/query:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/QueryRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RAGQueryResult'
-          description: OK
-      summary: Query the RAG system for context; typically invoked by the agent
-      tags:
-      - ToolRuntime
-  /v1/toolgroups:
-    get:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListToolGroupsResponse'
-          description: OK
-      summary: List tool groups with optional provider
-      tags:
-      - ToolGroups
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RegisterToolGroupRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-      summary: Register a tool group
-      tags:
-      - ToolGroups
-  /v1/toolgroups/{toolgroup_id}:
-    delete:
-      parameters:
-      - in: path
-        name: toolgroup_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          description: OK
-      summary: Unregister a tool group
-      tags:
-      - ToolGroups
-    get:
-      parameters:
-      - in: path
-        name: toolgroup_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ToolGroup'
-          description: OK
-      tags:
-      - ToolGroups
-  /v1/tools:
-    get:
-      parameters:
-      - in: query
-        name: toolgroup_id
-        required: false
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListToolsResponse'
-          description: OK
-      summary: List tools with optional tool group
-      tags:
-      - ToolGroups
-  /v1/tools/{tool_name}:
-    get:
-      parameters:
-      - in: path
-        name: tool_name
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Tool'
-          description: OK
-      tags:
-      - ToolGroups
-  /v1/vector-dbs:
-    get:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListVectorDBsResponse'
-          description: OK
-      tags:
-      - VectorDBs
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RegisterVectorDbRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VectorDB'
-          description: OK
-      tags:
-      - VectorDBs
-  /v1/vector-dbs/{vector_db_id}:
-    delete:
-      parameters:
-      - in: path
-        name: vector_db_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          description: OK
-      tags:
-      - VectorDBs
-    get:
-      parameters:
-      - in: path
-        name: vector_db_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                oneOf:
-                - $ref: '#/components/schemas/VectorDB'
-                - type: 'null'
-          description: OK
-      tags:
-      - VectorDBs
   /v1/vector-io/insert:
     post:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - VectorIO
       parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
+        - name: X-LlamaStack-Provider-Data
         in: header
-        name: X-LlamaStack-Provider-Data
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
         required: false
         schema:
           type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
+        - name: X-LlamaStack-Client-Version
         in: header
-        name: X-LlamaStack-Client-Version
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
         required: false
         schema:
           type: string
@@ -5663,25 +1262,765 @@ paths:
             schema:
               $ref: '#/components/schemas/InsertChunksRequest'
         required: true
+  /v1/tool-runtime/invoke:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ToolInvocationResult'
+      tags:
+        - ToolRuntime
+      summary: Run a tool with the given arguments
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InvokeToolRequest'
+        required: true
+  /v1/eval/tasks/{task_id}/jobs/{job_id}:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/JobStatus'
+                  - type: 'null'
+      tags:
+        - Eval
+      parameters:
+        - name: task_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+    delete:
       responses:
         '200':
           description: OK
       tags:
-      - VectorIO
-  /v1/vector-io/query:
-    post:
+        - Eval
       parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
+        - name: task_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
         in: header
-        name: X-LlamaStack-Provider-Data
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
         required: false
         schema:
           type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
+        - name: X-LlamaStack-Client-Version
         in: header
-        name: X-LlamaStack-Client-Version
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+  /v1/eval/tasks/{task_id}/jobs/{job_id}/result:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvaluateResponse'
+      tags:
+        - Eval
+      parameters:
+        - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: task_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+  /v1/datasets:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListDatasetsResponse'
+      tags:
+        - Datasets
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+    post:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - Datasets
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterDatasetRequest'
+        required: true
+  /v1/eval-tasks:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListEvalTasksResponse'
+      tags:
+        - EvalTasks
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+    post:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - EvalTasks
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterEvalTaskRequest'
+        required: true
+  /v1/models:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListModelsResponse'
+      tags:
+        - Models
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Model'
+      tags:
+        - Models
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterModelRequest'
+        required: true
+  /v1/inspect/providers:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListProvidersResponse'
+      tags:
+        - Inspect
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+  /v1/inspect/routes:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListRoutesResponse'
+      tags:
+        - Inspect
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+  /v1/tool-runtime/list-tools:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/jsonl:
+              schema:
+                $ref: '#/components/schemas/ToolDef'
+      tags:
+        - ToolRuntime
+      parameters:
+        - name: tool_group_id
+        in: query
+        required: false
+        schema:
+          type: string
+        - name: mcp_endpoint
+        in: query
+        required: false
+        schema:
+          $ref: '#/components/schemas/URL'
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+  /v1/scoring-functions:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListScoringFunctionsResponse'
+      tags:
+        - ScoringFunctions
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+    post:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - ScoringFunctions
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterScoringFunctionRequest'
+        required: true
+  /v1/shields:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListShieldsResponse'
+      tags:
+        - Shields
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Shield'
+      tags:
+        - Shields
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterShieldRequest'
+        required: true
+  /v1/toolgroups:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListToolGroupsResponse'
+      tags:
+        - ToolGroups
+      summary: List tool groups with optional provider
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+    post:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - ToolGroups
+      summary: Register a tool group
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterToolGroupRequest'
+        required: true
+  /v1/tools:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListToolsResponse'
+      tags:
+        - ToolGroups
+      summary: List tools with optional tool group
+      parameters:
+        - name: toolgroup_id
+        in: query
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+  /v1/vector-dbs:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListVectorDBsResponse'
+      tags:
+        - VectorDBs
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VectorDB'
+      tags:
+        - VectorDBs
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterVectorDbRequest'
+        required: true
+  /v1/telemetry/events:
+    post:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - Telemetry
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LogEventRequest'
+        required: true
+  /v1/post-training/preference-optimize:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostTrainingJob'
+      tags:
+        - PostTraining (Coming Soon)
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PreferenceOptimizeRequest'
+        required: true
+  /v1/tool-runtime/rag-tool/query:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RAGQueryResult'
+      tags:
+        - ToolRuntime
+      summary: Query the RAG system for context; typically invoked by the agent
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QueryRequest'
+        required: true
+  /v1/vector-io/query:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryChunksResponse'
+      tags:
+        - VectorIO
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
         required: false
         schema:
           type: string
@@ -5691,817 +2030,4447 @@ paths:
             schema:
               $ref: '#/components/schemas/QueryChunksRequest'
         required: true
+  /v1/telemetry/spans:
+    get:
       responses:
         '200':
+          description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/QueryChunksResponse'
-          description: OK
+                $ref: '#/components/schemas/QuerySpansResponse'
       tags:
-      - VectorIO
-  /v1/version:
-    get:
+        - Telemetry
       parameters:
-      - description: JSON-encoded provider data which will be made available to the
+        - name: attribute_filters
+        in: query
+        required: true
+        schema:
+          type: array
+          items:
+            $ref: '#/components/schemas/QueryCondition'
+        - name: attributes_to_return
+        in: query
+        required: true
+        schema:
+          type: array
+          items:
+            type: string
+        - name: max_depth
+        in: query
+        required: false
+        schema:
+          type: integer
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
           adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
         required: false
         schema:
           type: string
-      - description: Version of the client making the request. This is used to ensure
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
           that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
         required: false
         schema:
           type: string
+  /v1/telemetry/traces:
+    get:
       responses:
         '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryTracesResponse'
+      tags:
+        - Telemetry
+      parameters:
+        - name: attribute_filters
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
+            $ref: '#/components/schemas/QueryCondition'
+        - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+        - name: offset
+        in: query
+        required: false
+        schema:
+          type: integer
+        - name: order_by
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+  /v1/eval/tasks/{task_id}/jobs:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Job'
+      tags:
+        - Eval
+      parameters:
+        - name: task_id
+        in: path
+        required: true
+        schema:
+          type: string
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RunEvalRequest'
+        required: true
+  /v1/safety/run-shield:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RunShieldResponse'
+      tags:
+        - Safety
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RunShieldRequest'
+        required: true
+  /v1/telemetry/spans/export:
+    post:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - Telemetry
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SaveSpansToDatasetRequest'
+        required: true
+  /v1/scoring/score:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScoreResponse'
+      tags:
+        - Scoring
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScoreRequest'
+        required: true
+  /v1/scoring/score-batch:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScoreBatchResponse'
+      tags:
+        - Scoring
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScoreBatchRequest'
+        required: true
+  /v1/post-training/supervised-fine-tune:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostTrainingJob'
+      tags:
+        - PostTraining (Coming Soon)
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SupervisedFineTuneRequest'
+        required: true
+  /v1/synthetic-data-generation/generate:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SyntheticDataGenerationResponse'
+      tags:
+        - SyntheticDataGeneration (Coming Soon)
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SyntheticDataGenerateRequest'
+        required: true
+  /v1/version:
+    get:
+      responses:
+        '200':
+          description: OK
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/VersionInfo'
-          description: OK
       tags:
-      - Inspect
+        - Inspect
+      parameters:
+        - name: X-LlamaStack-Provider-Data
+        in: header
+        description: JSON-encoded provider data which will be made available to the
+          adapter servicing the API
+        required: false
+        schema:
+          type: string
+        - name: X-LlamaStack-Client-Version
+        in: header
+        description: Version of the client making the request. This is used to ensure
+          that the client and server are compatible.
+        required: false
+        schema:
+          type: string
+jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
+components:
+  schemas:
+    AppendRowsRequest:
+      type: object
+      properties:
+        dataset_id:
+          type: string
+        rows:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              oneOf:
+                - type: 'null'
+                - type: boolean
+                - type: number
+                - type: string
+                - type: array
+                - type: object
+      additionalProperties: false
+      required:
+        - dataset_id
+        - rows
+    BuiltinTool:
+      type: string
+      enum:
+        - brave_search
+        - wolfram_alpha
+        - photogen
+        - code_interpreter
+    CompletionMessage:
+      type: object
+      properties:
+        role:
+          type: string
+          const: assistant
+          default: assistant
+        content:
+          $ref: '#/components/schemas/InterleavedContent'
+        stop_reason:
+          $ref: '#/components/schemas/StopReason'
+        tool_calls:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolCall'
+      additionalProperties: false
+      required:
+        - role
+        - content
+        - stop_reason
+        - tool_calls
+    GreedySamplingStrategy:
+      type: object
+      properties:
+        type:
+          type: string
+          const: greedy
+          default: greedy
+      additionalProperties: false
+      required:
+        - type
+    ImageContentItem:
+      type: object
+      properties:
+        type:
+          type: string
+          const: image
+          default: image
+        image:
+          type: object
+          properties:
+            url:
+              $ref: '#/components/schemas/URL'
+            data:
+              type: string
+              contentEncoding: base64
+          additionalProperties: false
+      additionalProperties: false
+      required:
+        - type
+        - image
+    InterleavedContent:
+      oneOf:
+        - type: string
+        - $ref: '#/components/schemas/InterleavedContentItem'
+        - type: array
+        items:
+          $ref: '#/components/schemas/InterleavedContentItem'
+    InterleavedContentItem:
+      oneOf:
+        - $ref: '#/components/schemas/ImageContentItem'
+        - $ref: '#/components/schemas/TextContentItem'
+      discriminator:
+        propertyName: type
+        mapping:
+          image: '#/components/schemas/ImageContentItem'
+          text: '#/components/schemas/TextContentItem'
+    Message:
+      oneOf:
+        - $ref: '#/components/schemas/UserMessage'
+        - $ref: '#/components/schemas/SystemMessage'
+        - $ref: '#/components/schemas/ToolResponseMessage'
+        - $ref: '#/components/schemas/CompletionMessage'
+      discriminator:
+        propertyName: role
+        mapping:
+          user: '#/components/schemas/UserMessage'
+          system: '#/components/schemas/SystemMessage'
+          tool: '#/components/schemas/ToolResponseMessage'
+          assistant: '#/components/schemas/CompletionMessage'
+    SamplingParams:
+      type: object
+      properties:
+        strategy:
+          oneOf:
+            - $ref: '#/components/schemas/GreedySamplingStrategy'
+            - $ref: '#/components/schemas/TopPSamplingStrategy'
+            - $ref: '#/components/schemas/TopKSamplingStrategy'
+          discriminator:
+            propertyName: type
+            mapping:
+              greedy: '#/components/schemas/GreedySamplingStrategy'
+              top_p: '#/components/schemas/TopPSamplingStrategy'
+              top_k: '#/components/schemas/TopKSamplingStrategy'
+        max_tokens:
+          type: integer
+          default: 0
+        repetition_penalty:
+          type: number
+          default: 1.0
+      additionalProperties: false
+      required:
+        - strategy
+    StopReason:
+      type: string
+      enum:
+        - end_of_turn
+        - end_of_message
+        - out_of_tokens
+    SystemMessage:
+      type: object
+      properties:
+        role:
+          type: string
+          const: system
+          default: system
+        content:
+          $ref: '#/components/schemas/InterleavedContent'
+      additionalProperties: false
+      required:
+        - role
+        - content
+    TextContentItem:
+      type: object
+      properties:
+        type:
+          type: string
+          const: text
+          default: text
+        text:
+          type: string
+      additionalProperties: false
+      required:
+        - type
+        - text
+    ToolCall:
+      type: object
+      properties:
+        call_id:
+          type: string
+        tool_name:
+          oneOf:
+            - $ref: '#/components/schemas/BuiltinTool'
+            - type: string
+        arguments:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: string
+              - type: integer
+              - type: number
+              - type: boolean
+              - type: 'null'
+              - type: array
+              items:
+                oneOf:
+                  - type: string
+                  - type: integer
+                  - type: number
+                  - type: boolean
+                  - type: 'null'
+              - type: object
+              additionalProperties:
+                oneOf:
+                  - type: string
+                  - type: integer
+                  - type: number
+                  - type: boolean
+                  - type: 'null'
+      additionalProperties: false
+      required:
+        - call_id
+        - tool_name
+        - arguments
+    ToolChoice:
+      type: string
+      enum:
+        - auto
+        - required
+    ToolDefinition:
+      type: object
+      properties:
+        tool_name:
+          oneOf:
+            - $ref: '#/components/schemas/BuiltinTool'
+            - type: string
+        description:
+          type: string
+        parameters:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolParamDefinition'
+      additionalProperties: false
+      required:
+        - tool_name
+    ToolParamDefinition:
+      type: object
+      properties:
+        param_type:
+          type: string
+        description:
+          type: string
+        required:
+          type: boolean
+          default: true
+        default:
+          oneOf:
+            - type: 'null'
+            - type: boolean
+            - type: number
+            - type: string
+            - type: array
+            - type: object
+      additionalProperties: false
+      required:
+        - param_type
+    ToolPromptFormat:
+      type: string
+      enum:
+        - json
+        - function_tag
+        - python_list
+      title: This Enum refers to the prompt format for calling custom / zero shot
+        tools
+      description: "`json` --\n    Refers to the json format for calling tools.\n\
+        \    The json format takes the form like\n    {\n        \"type\": \"function\"\
+        ,\n        \"function\" : {\n            \"name\": \"function_name\",\n  \
+        \          \"description\": \"function_description\",\n            \"parameters\"\
+        : {...}\n        }\n    }\n\n`function_tag` --\n    This is an example of
+        how you could define\n    your own user defined format for making tool calls.\n\
+        \    The function_tag format looks like this,\n    <function=function_name>(parameters)</function>\n
+        \nThe detailed prompts for each of these formats are added to llama cli"
+    ToolResponseMessage:
+      type: object
+      properties:
+        role:
+          type: string
+          const: tool
+          default: tool
+        call_id:
+          type: string
+        tool_name:
+          oneOf:
+            - $ref: '#/components/schemas/BuiltinTool'
+            - type: string
+        content:
+          $ref: '#/components/schemas/InterleavedContent'
+      additionalProperties: false
+      required:
+        - role
+        - call_id
+        - tool_name
+        - content
+    TopKSamplingStrategy:
+      type: object
+      properties:
+        type:
+          type: string
+          const: top_k
+          default: top_k
+        top_k:
+          type: integer
+      additionalProperties: false
+      required:
+        - type
+        - top_k
+    TopPSamplingStrategy:
+      type: object
+      properties:
+        type:
+          type: string
+          const: top_p
+          default: top_p
+        temperature:
+          type: number
+        top_p:
+          type: number
+          default: 0.95
+      additionalProperties: false
+      required:
+        - type
+    URL:
+      type: object
+      properties:
+        uri:
+          type: string
+      additionalProperties: false
+      required:
+        - uri
+    UserMessage:
+      type: object
+      properties:
+        role:
+          type: string
+          const: user
+          default: user
+        content:
+          $ref: '#/components/schemas/InterleavedContent'
+        context:
+          $ref: '#/components/schemas/InterleavedContent'
+      additionalProperties: false
+      required:
+        - role
+        - content
+    BatchChatCompletionRequest:
+      type: object
+      properties:
+        model:
+          type: string
+        messages_batch:
+          type: array
+          items:
+            type: array
+            items:
+              $ref: '#/components/schemas/Message'
+        sampling_params:
+          $ref: '#/components/schemas/SamplingParams'
+        tools:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolDefinition'
+        tool_choice:
+          $ref: '#/components/schemas/ToolChoice'
+        tool_prompt_format:
+          $ref: '#/components/schemas/ToolPromptFormat'
+        logprobs:
+          type: object
+          properties:
+            top_k:
+              type: integer
+              default: 0
+          additionalProperties: false
+      additionalProperties: false
+      required:
+        - model
+        - messages_batch
+    BatchChatCompletionResponse:
+      type: object
+      properties:
+        completion_message_batch:
+          type: array
+          items:
+            $ref: '#/components/schemas/CompletionMessage'
+      additionalProperties: false
+      required:
+        - completion_message_batch
+    BatchCompletionRequest:
+      type: object
+      properties:
+        model:
+          type: string
+        content_batch:
+          type: array
+          items:
+            $ref: '#/components/schemas/InterleavedContent'
+        sampling_params:
+          $ref: '#/components/schemas/SamplingParams'
+        logprobs:
+          type: object
+          properties:
+            top_k:
+              type: integer
+              default: 0
+          additionalProperties: false
+      additionalProperties: false
+      required:
+        - model
+        - content_batch
+    BatchCompletionResponse:
+      type: object
+      properties:
+        completion_message_batch:
+          type: array
+          items:
+            $ref: '#/components/schemas/CompletionMessage'
+      additionalProperties: false
+      required:
+        - completion_message_batch
+    CancelTrainingJobRequest:
+      type: object
+      properties:
+        job_uuid:
+          type: string
+      additionalProperties: false
+      required:
+        - job_uuid
+    GrammarResponseFormat:
+      type: object
+      properties:
+        type:
+          type: string
+          const: grammar
+          default: grammar
+        bnf:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - type
+        - bnf
+    JsonSchemaResponseFormat:
+      type: object
+      properties:
+        type:
+          type: string
+          const: json_schema
+          default: json_schema
+        json_schema:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - type
+        - json_schema
+    ResponseFormat:
+      oneOf:
+        - $ref: '#/components/schemas/JsonSchemaResponseFormat'
+        - $ref: '#/components/schemas/GrammarResponseFormat'
+      discriminator:
+        propertyName: type
+        mapping:
+          json_schema: '#/components/schemas/JsonSchemaResponseFormat'
+          grammar: '#/components/schemas/GrammarResponseFormat'
+    ChatCompletionRequest:
+      type: object
+      properties:
+        model_id:
+          type: string
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/Message'
+        sampling_params:
+          $ref: '#/components/schemas/SamplingParams'
+        tools:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolDefinition'
+        tool_choice:
+          $ref: '#/components/schemas/ToolChoice'
+        tool_prompt_format:
+          $ref: '#/components/schemas/ToolPromptFormat'
+        response_format:
+          $ref: '#/components/schemas/ResponseFormat'
+        stream:
+          type: boolean
+        logprobs:
+          type: object
+          properties:
+            top_k:
+              type: integer
+              default: 0
+          additionalProperties: false
+      additionalProperties: false
+      required:
+        - model_id
+        - messages
+    ChatCompletionResponse:
+      type: object
+      properties:
+        completion_message:
+          $ref: '#/components/schemas/CompletionMessage'
+        logprobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/TokenLogProbs'
+      additionalProperties: false
+      required:
+        - completion_message
+      title: Chat completion response.
+    ChatCompletionResponseEvent:
+      type: object
+      properties:
+        event_type:
+          $ref: '#/components/schemas/ChatCompletionResponseEventType'
+        delta:
+          $ref: '#/components/schemas/ContentDelta'
+        logprobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/TokenLogProbs'
+        stop_reason:
+          $ref: '#/components/schemas/StopReason'
+      additionalProperties: false
+      required:
+        - event_type
+        - delta
+      title: Chat completion response event.
+    ChatCompletionResponseEventType:
+      type: string
+      enum:
+        - start
+        - complete
+        - progress
+    ChatCompletionResponseStreamChunk:
+      type: object
+      properties:
+        event:
+          $ref: '#/components/schemas/ChatCompletionResponseEvent'
+      additionalProperties: false
+      required:
+        - event
+      title: SSE-stream of these events.
+    ContentDelta:
+      oneOf:
+        - $ref: '#/components/schemas/TextDelta'
+        - $ref: '#/components/schemas/ImageDelta'
+        - $ref: '#/components/schemas/ToolCallDelta'
+      discriminator:
+        propertyName: type
+        mapping:
+          text: '#/components/schemas/TextDelta'
+          image: '#/components/schemas/ImageDelta'
+          tool_call: '#/components/schemas/ToolCallDelta'
+    ImageDelta:
+      type: object
+      properties:
+        type:
+          type: string
+          const: image
+          default: image
+        image:
+          type: string
+          contentEncoding: base64
+      additionalProperties: false
+      required:
+        - type
+        - image
+    TextDelta:
+      type: object
+      properties:
+        type:
+          type: string
+          const: text
+          default: text
+        text:
+          type: string
+      additionalProperties: false
+      required:
+        - type
+        - text
+    TokenLogProbs:
+      type: object
+      properties:
+        logprobs_by_token:
+          type: object
+          additionalProperties:
+            type: number
+      additionalProperties: false
+      required:
+        - logprobs_by_token
+    ToolCallDelta:
+      type: object
+      properties:
+        type:
+          type: string
+          const: tool_call
+          default: tool_call
+        tool_call:
+          oneOf:
+            - type: string
+            - $ref: '#/components/schemas/ToolCall'
+        parse_status:
+          $ref: '#/components/schemas/ToolCallParseStatus'
+      additionalProperties: false
+      required:
+        - type
+        - tool_call
+        - parse_status
+    ToolCallParseStatus:
+      type: string
+      enum:
+        - started
+        - in_progress
+        - failed
+        - succeeded
+    CompletionRequest:
+      type: object
+      properties:
+        model_id:
+          type: string
+        content:
+          $ref: '#/components/schemas/InterleavedContent'
+        sampling_params:
+          $ref: '#/components/schemas/SamplingParams'
+        response_format:
+          $ref: '#/components/schemas/ResponseFormat'
+        stream:
+          type: boolean
+        logprobs:
+          type: object
+          properties:
+            top_k:
+              type: integer
+              default: 0
+          additionalProperties: false
+      additionalProperties: false
+      required:
+        - model_id
+        - content
+    CompletionResponse:
+      type: object
+      properties:
+        content:
+          type: string
+        stop_reason:
+          $ref: '#/components/schemas/StopReason'
+        logprobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/TokenLogProbs'
+      additionalProperties: false
+      required:
+        - content
+        - stop_reason
+      title: Completion response.
+    CompletionResponseStreamChunk:
+      type: object
+      properties:
+        delta:
+          type: string
+        stop_reason:
+          $ref: '#/components/schemas/StopReason'
+        logprobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/TokenLogProbs'
+      additionalProperties: false
+      required:
+        - delta
+      title: streamed completion response.
+    AgentConfig:
+      type: object
+      properties:
+        sampling_params:
+          $ref: '#/components/schemas/SamplingParams'
+        input_shields:
+          type: array
+          items:
+            type: string
+        output_shields:
+          type: array
+          items:
+            type: string
+        toolgroups:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentTool'
+        client_tools:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolDef'
+        tool_choice:
+          $ref: '#/components/schemas/ToolChoice'
+          default: auto
+        tool_prompt_format:
+          $ref: '#/components/schemas/ToolPromptFormat'
+        max_infer_iters:
+          type: integer
+          default: 10
+        model:
+          type: string
+        instructions:
+          type: string
+        enable_session_persistence:
+          type: boolean
+        response_format:
+          $ref: '#/components/schemas/ResponseFormat'
+      additionalProperties: false
+      required:
+        - max_infer_iters
+        - model
+        - instructions
+        - enable_session_persistence
+    AgentTool:
+      oneOf:
+        - type: string
+        - type: object
+        properties:
+          name:
+            type: string
+          args:
+            type: object
+            additionalProperties:
+              oneOf:
+                - type: 'null'
+                - type: boolean
+                - type: number
+                - type: string
+                - type: array
+                - type: object
+        additionalProperties: false
+        required:
+          - name
+          - args
+    ToolDef:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        parameters:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolParameter'
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - name
+    ToolParameter:
+      type: object
+      properties:
+        name:
+          type: string
+        parameter_type:
+          type: string
+        description:
+          type: string
+        required:
+          type: boolean
+          default: true
+        default:
+          oneOf:
+            - type: 'null'
+            - type: boolean
+            - type: number
+            - type: string
+            - type: array
+            - type: object
+      additionalProperties: false
+      required:
+        - name
+        - parameter_type
+        - description
+        - required
+    CreateAgentRequest:
+      type: object
+      properties:
+        agent_config:
+          $ref: '#/components/schemas/AgentConfig'
+      additionalProperties: false
+      required:
+        - agent_config
+    AgentCreateResponse:
+      type: object
+      properties:
+        agent_id:
+          type: string
+      additionalProperties: false
+      required:
+        - agent_id
+    CreateAgentSessionRequest:
+      type: object
+      properties:
+        session_name:
+          type: string
+      additionalProperties: false
+      required:
+        - session_name
+    AgentSessionCreateResponse:
+      type: object
+      properties:
+        session_id:
+          type: string
+      additionalProperties: false
+      required:
+        - session_id
+    CreateAgentTurnRequest:
+      type: object
+      properties:
+        messages:
+          type: array
+          items:
+            oneOf:
+              - $ref: '#/components/schemas/UserMessage'
+              - $ref: '#/components/schemas/ToolResponseMessage'
+        stream:
+          type: boolean
+        documents:
+          type: array
+          items:
+            type: object
+            properties:
+              content:
+                oneOf:
+                  - type: string
+                  - $ref: '#/components/schemas/InterleavedContentItem'
+                  - type: array
+                  items:
+                    $ref: '#/components/schemas/InterleavedContentItem'
+                  - $ref: '#/components/schemas/URL'
+              mime_type:
+                type: string
+            additionalProperties: false
+            required:
+              - content
+              - mime_type
+        toolgroups:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentTool'
+      additionalProperties: false
+      required:
+        - messages
+    AgentTurnResponseEvent:
+      type: object
+      properties:
+        payload:
+          $ref: '#/components/schemas/AgentTurnResponseEventPayload'
+      additionalProperties: false
+      required:
+        - payload
+    AgentTurnResponseEventPayload:
+      oneOf:
+        - $ref: '#/components/schemas/AgentTurnResponseStepStartPayload'
+        - $ref: '#/components/schemas/AgentTurnResponseStepProgressPayload'
+        - $ref: '#/components/schemas/AgentTurnResponseStepCompletePayload'
+        - $ref: '#/components/schemas/AgentTurnResponseTurnStartPayload'
+        - $ref: '#/components/schemas/AgentTurnResponseTurnCompletePayload'
+      discriminator:
+        propertyName: event_type
+        mapping:
+          step_start: '#/components/schemas/AgentTurnResponseStepStartPayload'
+          step_progress: '#/components/schemas/AgentTurnResponseStepProgressPayload'
+          step_complete: '#/components/schemas/AgentTurnResponseStepCompletePayload'
+          turn_start: '#/components/schemas/AgentTurnResponseTurnStartPayload'
+          turn_complete: '#/components/schemas/AgentTurnResponseTurnCompletePayload'
+    AgentTurnResponseStepCompletePayload:
+      type: object
+      properties:
+        event_type:
+          type: string
+          const: step_complete
+          default: step_complete
+        step_type:
+          type: string
+          enum:
+            - inference
+            - tool_execution
+            - shield_call
+            - memory_retrieval
+        step_id:
+          type: string
+        step_details:
+          oneOf:
+            - $ref: '#/components/schemas/InferenceStep'
+            - $ref: '#/components/schemas/ToolExecutionStep'
+            - $ref: '#/components/schemas/ShieldCallStep'
+            - $ref: '#/components/schemas/MemoryRetrievalStep'
+          discriminator:
+            propertyName: step_type
+            mapping:
+              inference: '#/components/schemas/InferenceStep'
+              tool_execution: '#/components/schemas/ToolExecutionStep'
+              shield_call: '#/components/schemas/ShieldCallStep'
+              memory_retrieval: '#/components/schemas/MemoryRetrievalStep'
+      additionalProperties: false
+      required:
+        - event_type
+        - step_type
+        - step_id
+        - step_details
+    AgentTurnResponseStepProgressPayload:
+      type: object
+      properties:
+        event_type:
+          type: string
+          const: step_progress
+          default: step_progress
+        step_type:
+          type: string
+          enum:
+            - inference
+            - tool_execution
+            - shield_call
+            - memory_retrieval
+        step_id:
+          type: string
+        delta:
+          $ref: '#/components/schemas/ContentDelta'
+      additionalProperties: false
+      required:
+        - event_type
+        - step_type
+        - step_id
+        - delta
+    AgentTurnResponseStepStartPayload:
+      type: object
+      properties:
+        event_type:
+          type: string
+          const: step_start
+          default: step_start
+        step_type:
+          type: string
+          enum:
+            - inference
+            - tool_execution
+            - shield_call
+            - memory_retrieval
+        step_id:
+          type: string
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - event_type
+        - step_type
+        - step_id
+    AgentTurnResponseStreamChunk:
+      type: object
+      properties:
+        event:
+          $ref: '#/components/schemas/AgentTurnResponseEvent'
+      additionalProperties: false
+      required:
+        - event
+      title: streamed agent turn completion response.
+    AgentTurnResponseTurnCompletePayload:
+      type: object
+      properties:
+        event_type:
+          type: string
+          const: turn_complete
+          default: turn_complete
+        turn:
+          $ref: '#/components/schemas/Turn'
+      additionalProperties: false
+      required:
+        - event_type
+        - turn
+    AgentTurnResponseTurnStartPayload:
+      type: object
+      properties:
+        event_type:
+          type: string
+          const: turn_start
+          default: turn_start
+        turn_id:
+          type: string
+      additionalProperties: false
+      required:
+        - event_type
+        - turn_id
+    InferenceStep:
+      type: object
+      properties:
+        turn_id:
+          type: string
+        step_id:
+          type: string
+        started_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+        step_type:
+          type: string
+          const: inference
+          default: inference
+        model_response:
+          $ref: '#/components/schemas/CompletionMessage'
+      additionalProperties: false
+      required:
+        - turn_id
+        - step_id
+        - step_type
+        - model_response
+    MemoryRetrievalStep:
+      type: object
+      properties:
+        turn_id:
+          type: string
+        step_id:
+          type: string
+        started_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+        step_type:
+          type: string
+          const: memory_retrieval
+          default: memory_retrieval
+        vector_db_ids:
+          type: string
+        inserted_context:
+          $ref: '#/components/schemas/InterleavedContent'
+      additionalProperties: false
+      required:
+        - turn_id
+        - step_id
+        - step_type
+        - vector_db_ids
+        - inserted_context
+    SafetyViolation:
+      type: object
+      properties:
+        violation_level:
+          $ref: '#/components/schemas/ViolationLevel'
+        user_message:
+          type: string
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - violation_level
+        - metadata
+    ShieldCallStep:
+      type: object
+      properties:
+        turn_id:
+          type: string
+        step_id:
+          type: string
+        started_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+        step_type:
+          type: string
+          const: shield_call
+          default: shield_call
+        violation:
+          $ref: '#/components/schemas/SafetyViolation'
+      additionalProperties: false
+      required:
+        - turn_id
+        - step_id
+        - step_type
+    ToolExecutionStep:
+      type: object
+      properties:
+        turn_id:
+          type: string
+        step_id:
+          type: string
+        started_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+        step_type:
+          type: string
+          const: tool_execution
+          default: tool_execution
+        tool_calls:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolCall'
+        tool_responses:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolResponse'
+      additionalProperties: false
+      required:
+        - turn_id
+        - step_id
+        - step_type
+        - tool_calls
+        - tool_responses
+    ToolResponse:
+      type: object
+      properties:
+        call_id:
+          type: string
+        tool_name:
+          oneOf:
+            - $ref: '#/components/schemas/BuiltinTool'
+            - type: string
+        content:
+          $ref: '#/components/schemas/InterleavedContent'
+      additionalProperties: false
+      required:
+        - call_id
+        - tool_name
+        - content
+    Turn:
+      type: object
+      properties:
+        turn_id:
+          type: string
+        session_id:
+          type: string
+        input_messages:
+          type: array
+          items:
+            oneOf:
+              - $ref: '#/components/schemas/UserMessage'
+              - $ref: '#/components/schemas/ToolResponseMessage'
+        steps:
+          type: array
+          items:
+            oneOf:
+              - $ref: '#/components/schemas/InferenceStep'
+              - $ref: '#/components/schemas/ToolExecutionStep'
+              - $ref: '#/components/schemas/ShieldCallStep'
+              - $ref: '#/components/schemas/MemoryRetrievalStep'
+            discriminator:
+              propertyName: step_type
+              mapping:
+                inference: '#/components/schemas/InferenceStep'
+                tool_execution: '#/components/schemas/ToolExecutionStep'
+                shield_call: '#/components/schemas/ShieldCallStep'
+                memory_retrieval: '#/components/schemas/MemoryRetrievalStep'
+        output_message:
+          $ref: '#/components/schemas/CompletionMessage'
+        output_attachments:
+          type: array
+          items:
+            type: object
+            properties:
+              content:
+                oneOf:
+                  - type: string
+                  - $ref: '#/components/schemas/InterleavedContentItem'
+                  - type: array
+                  items:
+                    $ref: '#/components/schemas/InterleavedContentItem'
+                  - $ref: '#/components/schemas/URL'
+              mime_type:
+                type: string
+            additionalProperties: false
+            required:
+              - content
+              - mime_type
+        started_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+      additionalProperties: false
+      required:
+        - turn_id
+        - session_id
+        - input_messages
+        - steps
+        - output_message
+        - output_attachments
+        - started_at
+      title: A single turn in an interaction with an Agentic System.
+    ViolationLevel:
+      type: string
+      enum:
+        - info
+        - warn
+        - error
+    EmbeddingsRequest:
+      type: object
+      properties:
+        model_id:
+          type: string
+        contents:
+          type: array
+          items:
+            $ref: '#/components/schemas/InterleavedContent'
+      additionalProperties: false
+      required:
+        - model_id
+        - contents
+    EmbeddingsResponse:
+      type: object
+      properties:
+        embeddings:
+          type: array
+          items:
+            type: array
+            items:
+              type: number
+      additionalProperties: false
+      required:
+        - embeddings
+    AgentCandidate:
+      type: object
+      properties:
+        type:
+          type: string
+          const: agent
+          default: agent
+        config:
+          $ref: '#/components/schemas/AgentConfig'
+      additionalProperties: false
+      required:
+        - type
+        - config
+    AggregationFunctionType:
+      type: string
+      enum:
+        - average
+        - median
+        - categorical_count
+        - accuracy
+    AppEvalTaskConfig:
+      type: object
+      properties:
+        type:
+          type: string
+          const: app
+          default: app
+        eval_candidate:
+          $ref: '#/components/schemas/EvalCandidate'
+        scoring_params:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ScoringFnParams'
+        num_examples:
+          type: integer
+      additionalProperties: false
+      required:
+        - type
+        - eval_candidate
+        - scoring_params
+    BasicScoringFnParams:
+      type: object
+      properties:
+        type:
+          type: string
+          const: basic
+          default: basic
+        aggregation_functions:
+          type: array
+          items:
+            $ref: '#/components/schemas/AggregationFunctionType'
+      additionalProperties: false
+      required:
+        - type
+    BenchmarkEvalTaskConfig:
+      type: object
+      properties:
+        type:
+          type: string
+          const: benchmark
+          default: benchmark
+        eval_candidate:
+          $ref: '#/components/schemas/EvalCandidate'
+        num_examples:
+          type: integer
+      additionalProperties: false
+      required:
+        - type
+        - eval_candidate
+    EvalCandidate:
+      oneOf:
+        - $ref: '#/components/schemas/ModelCandidate'
+        - $ref: '#/components/schemas/AgentCandidate'
+      discriminator:
+        propertyName: type
+        mapping:
+          model: '#/components/schemas/ModelCandidate'
+          agent: '#/components/schemas/AgentCandidate'
+    EvalTaskConfig:
+      oneOf:
+        - $ref: '#/components/schemas/BenchmarkEvalTaskConfig'
+        - $ref: '#/components/schemas/AppEvalTaskConfig'
+      discriminator:
+        propertyName: type
+        mapping:
+          benchmark: '#/components/schemas/BenchmarkEvalTaskConfig'
+          app: '#/components/schemas/AppEvalTaskConfig'
+    LLMAsJudgeScoringFnParams:
+      type: object
+      properties:
+        type:
+          type: string
+          const: llm_as_judge
+          default: llm_as_judge
+        judge_model:
+          type: string
+        prompt_template:
+          type: string
+        judge_score_regexes:
+          type: array
+          items:
+            type: string
+        aggregation_functions:
+          type: array
+          items:
+            $ref: '#/components/schemas/AggregationFunctionType'
+      additionalProperties: false
+      required:
+        - type
+        - judge_model
+    ModelCandidate:
+      type: object
+      properties:
+        type:
+          type: string
+          const: model
+          default: model
+        model:
+          type: string
+        sampling_params:
+          $ref: '#/components/schemas/SamplingParams'
+        system_message:
+          $ref: '#/components/schemas/SystemMessage'
+      additionalProperties: false
+      required:
+        - type
+        - model
+        - sampling_params
+    RegexParserScoringFnParams:
+      type: object
+      properties:
+        type:
+          type: string
+          const: regex_parser
+          default: regex_parser
+        parsing_regexes:
+          type: array
+          items:
+            type: string
+        aggregation_functions:
+          type: array
+          items:
+            $ref: '#/components/schemas/AggregationFunctionType'
+      additionalProperties: false
+      required:
+        - type
+    ScoringFnParams:
+      oneOf:
+        - $ref: '#/components/schemas/LLMAsJudgeScoringFnParams'
+        - $ref: '#/components/schemas/RegexParserScoringFnParams'
+        - $ref: '#/components/schemas/BasicScoringFnParams'
+      discriminator:
+        propertyName: type
+        mapping:
+          llm_as_judge: '#/components/schemas/LLMAsJudgeScoringFnParams'
+          regex_parser: '#/components/schemas/RegexParserScoringFnParams'
+          basic: '#/components/schemas/BasicScoringFnParams'
+    EvaluateRowsRequest:
+      type: object
+      properties:
+        input_rows:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              oneOf:
+                - type: 'null'
+                - type: boolean
+                - type: number
+                - type: string
+                - type: array
+                - type: object
+        scoring_functions:
+          type: array
+          items:
+            type: string
+        task_config:
+          $ref: '#/components/schemas/EvalTaskConfig'
+      additionalProperties: false
+      required:
+        - input_rows
+        - scoring_functions
+        - task_config
+    EvaluateResponse:
+      type: object
+      properties:
+        generations:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              oneOf:
+                - type: 'null'
+                - type: boolean
+                - type: number
+                - type: string
+                - type: array
+                - type: object
+        scores:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ScoringResult'
+      additionalProperties: false
+      required:
+        - generations
+        - scores
+    ScoringResult:
+      type: object
+      properties:
+        score_rows:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              oneOf:
+                - type: 'null'
+                - type: boolean
+                - type: number
+                - type: string
+                - type: array
+                - type: object
+        aggregated_results:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - score_rows
+        - aggregated_results
+    Session:
+      type: object
+      properties:
+        session_id:
+          type: string
+        session_name:
+          type: string
+        turns:
+          type: array
+          items:
+            $ref: '#/components/schemas/Turn'
+        started_at:
+          type: string
+          format: date-time
+      additionalProperties: false
+      required:
+        - session_id
+        - session_name
+        - turns
+        - started_at
+      title: A single session of an interaction with an Agentic System.
+    AgentStepResponse:
+      type: object
+      properties:
+        step:
+          oneOf:
+            - $ref: '#/components/schemas/InferenceStep'
+            - $ref: '#/components/schemas/ToolExecutionStep'
+            - $ref: '#/components/schemas/ShieldCallStep'
+            - $ref: '#/components/schemas/MemoryRetrievalStep'
+          discriminator:
+            propertyName: step_type
+            mapping:
+              inference: '#/components/schemas/InferenceStep'
+              tool_execution: '#/components/schemas/ToolExecutionStep'
+              shield_call: '#/components/schemas/ShieldCallStep'
+              memory_retrieval: '#/components/schemas/MemoryRetrievalStep'
+      additionalProperties: false
+      required:
+        - step
+    AgentTurnInputType:
+      type: object
+      properties:
+        type:
+          type: string
+          const: agent_turn_input
+          default: agent_turn_input
+      additionalProperties: false
+      required:
+        - type
+    ArrayType:
+      type: object
+      properties:
+        type:
+          type: string
+          const: array
+          default: array
+      additionalProperties: false
+      required:
+        - type
+    BooleanType:
+      type: object
+      properties:
+        type:
+          type: string
+          const: boolean
+          default: boolean
+      additionalProperties: false
+      required:
+        - type
+    ChatCompletionInputType:
+      type: object
+      properties:
+        type:
+          type: string
+          const: chat_completion_input
+          default: chat_completion_input
+      additionalProperties: false
+      required:
+        - type
+    CompletionInputType:
+      type: object
+      properties:
+        type:
+          type: string
+          const: completion_input
+          default: completion_input
+      additionalProperties: false
+      required:
+        - type
+    Dataset:
+      type: object
+      properties:
+        identifier:
+          type: string
+        provider_resource_id:
+          type: string
+        provider_id:
+          type: string
+        type:
+          type: string
+          const: dataset
+          default: dataset
+        dataset_schema:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ParamType'
+        url:
+          $ref: '#/components/schemas/URL'
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - identifier
+        - provider_resource_id
+        - provider_id
+        - type
+        - dataset_schema
+        - url
+        - metadata
+    JsonType:
+      type: object
+      properties:
+        type:
+          type: string
+          const: json
+          default: json
+      additionalProperties: false
+      required:
+        - type
+    NumberType:
+      type: object
+      properties:
+        type:
+          type: string
+          const: number
+          default: number
+      additionalProperties: false
+      required:
+        - type
+    ObjectType:
+      type: object
+      properties:
+        type:
+          type: string
+          const: object
+          default: object
+      additionalProperties: false
+      required:
+        - type
+    ParamType:
+      oneOf:
+        - $ref: '#/components/schemas/StringType'
+        - $ref: '#/components/schemas/NumberType'
+        - $ref: '#/components/schemas/BooleanType'
+        - $ref: '#/components/schemas/ArrayType'
+        - $ref: '#/components/schemas/ObjectType'
+        - $ref: '#/components/schemas/JsonType'
+        - $ref: '#/components/schemas/UnionType'
+        - $ref: '#/components/schemas/ChatCompletionInputType'
+        - $ref: '#/components/schemas/CompletionInputType'
+        - $ref: '#/components/schemas/AgentTurnInputType'
+      discriminator:
+        propertyName: type
+        mapping:
+          string: '#/components/schemas/StringType'
+          number: '#/components/schemas/NumberType'
+          boolean: '#/components/schemas/BooleanType'
+          array: '#/components/schemas/ArrayType'
+          object: '#/components/schemas/ObjectType'
+          json: '#/components/schemas/JsonType'
+          union: '#/components/schemas/UnionType'
+          chat_completion_input: '#/components/schemas/ChatCompletionInputType'
+          completion_input: '#/components/schemas/CompletionInputType'
+          agent_turn_input: '#/components/schemas/AgentTurnInputType'
+    StringType:
+      type: object
+      properties:
+        type:
+          type: string
+          const: string
+          default: string
+      additionalProperties: false
+      required:
+        - type
+    UnionType:
+      type: object
+      properties:
+        type:
+          type: string
+          const: union
+          default: union
+      additionalProperties: false
+      required:
+        - type
+    EvalTask:
+      type: object
+      properties:
+        identifier:
+          type: string
+        provider_resource_id:
+          type: string
+        provider_id:
+          type: string
+        type:
+          type: string
+          const: eval_task
+          default: eval_task
+        dataset_id:
+          type: string
+        scoring_functions:
+          type: array
+          items:
+            type: string
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - identifier
+        - provider_resource_id
+        - provider_id
+        - type
+        - dataset_id
+        - scoring_functions
+        - metadata
+    Model:
+      type: object
+      properties:
+        identifier:
+          type: string
+        provider_resource_id:
+          type: string
+        provider_id:
+          type: string
+        type:
+          type: string
+          const: model
+          default: model
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+        model_type:
+          $ref: '#/components/schemas/ModelType'
+          default: llm
+      additionalProperties: false
+      required:
+        - identifier
+        - provider_resource_id
+        - provider_id
+        - type
+        - metadata
+        - model_type
+    ModelType:
+      type: string
+      enum:
+        - llm
+        - embedding
+    PaginatedRowsResult:
+      type: object
+      properties:
+        rows:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              oneOf:
+                - type: 'null'
+                - type: boolean
+                - type: number
+                - type: string
+                - type: array
+                - type: object
+        total_count:
+          type: integer
+        next_page_token:
+          type: string
+      additionalProperties: false
+      required:
+        - rows
+        - total_count
+    ScoringFn:
+      type: object
+      properties:
+        identifier:
+          type: string
+        provider_resource_id:
+          type: string
+        provider_id:
+          type: string
+        type:
+          type: string
+          const: scoring_function
+          default: scoring_function
+        description:
+          type: string
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+        return_type:
+          $ref: '#/components/schemas/ParamType'
+        params:
+          $ref: '#/components/schemas/ScoringFnParams'
+      additionalProperties: false
+      required:
+        - identifier
+        - provider_resource_id
+        - provider_id
+        - type
+        - metadata
+        - return_type
+    Shield:
+      type: object
+      properties:
+        identifier:
+          type: string
+        provider_resource_id:
+          type: string
+        provider_id:
+          type: string
+        type:
+          type: string
+          const: shield
+          default: shield
+        params:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - identifier
+        - provider_resource_id
+        - provider_id
+        - type
+      title: A safety shield resource that can be used to check content
+    Span:
+      type: object
+      properties:
+        span_id:
+          type: string
+        trace_id:
+          type: string
+        parent_span_id:
+          type: string
+        name:
+          type: string
+        start_time:
+          type: string
+          format: date-time
+        end_time:
+          type: string
+          format: date-time
+        attributes:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - span_id
+        - trace_id
+        - name
+        - start_time
+    SpanStatus:
+      type: string
+      enum:
+        - ok
+        - error
+    SpanWithStatus:
+      type: object
+      properties:
+        span_id:
+          type: string
+        trace_id:
+          type: string
+        parent_span_id:
+          type: string
+        name:
+          type: string
+        start_time:
+          type: string
+          format: date-time
+        end_time:
+          type: string
+          format: date-time
+        attributes:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+        status:
+          $ref: '#/components/schemas/SpanStatus'
+      additionalProperties: false
+      required:
+        - span_id
+        - trace_id
+        - name
+        - start_time
+    QuerySpanTreeResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/SpanWithStatus'
+      additionalProperties: false
+      required:
+        - data
+    Tool:
+      type: object
+      properties:
+        identifier:
+          type: string
+        provider_resource_id:
+          type: string
+        provider_id:
+          type: string
+        type:
+          type: string
+          const: tool
+          default: tool
+        toolgroup_id:
+          type: string
+        tool_host:
+          $ref: '#/components/schemas/ToolHost'
+        description:
+          type: string
+        parameters:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolParameter'
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - identifier
+        - provider_resource_id
+        - provider_id
+        - type
+        - toolgroup_id
+        - tool_host
+        - description
+        - parameters
+    ToolHost:
+      type: string
+      enum:
+        - distribution
+        - client
+        - model_context_protocol
+    ToolGroup:
+      type: object
+      properties:
+        identifier:
+          type: string
+        provider_resource_id:
+          type: string
+        provider_id:
+          type: string
+        type:
+          type: string
+          const: tool_group
+          default: tool_group
+        mcp_endpoint:
+          $ref: '#/components/schemas/URL'
+        args:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - identifier
+        - provider_resource_id
+        - provider_id
+        - type
+    Trace:
+      type: object
+      properties:
+        trace_id:
+          type: string
+        root_span_id:
+          type: string
+        start_time:
+          type: string
+          format: date-time
+        end_time:
+          type: string
+          format: date-time
+      additionalProperties: false
+      required:
+        - trace_id
+        - root_span_id
+        - start_time
+    Checkpoint:
+      description: Checkpoint created during training runs
+    PostTrainingJobArtifactsResponse:
+      type: object
+      properties:
+        job_uuid:
+          type: string
+        checkpoints:
+          type: array
+          items:
+            $ref: '#/components/schemas/Checkpoint'
+      additionalProperties: false
+      required:
+        - job_uuid
+        - checkpoints
+      title: Artifacts of a finetuning job.
+    JobStatus:
+      type: string
+      enum:
+        - completed
+        - in_progress
+        - failed
+        - scheduled
+    PostTrainingJobStatusResponse:
+      type: object
+      properties:
+        job_uuid:
+          type: string
+        status:
+          $ref: '#/components/schemas/JobStatus'
+        scheduled_at:
+          type: string
+          format: date-time
+        started_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+        resources_allocated:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+        checkpoints:
+          type: array
+          items:
+            $ref: '#/components/schemas/Checkpoint'
+      additionalProperties: false
+      required:
+        - job_uuid
+        - status
+        - checkpoints
+      title: Status of a finetuning job.
+    ListPostTrainingJobsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              job_uuid:
+                type: string
+            additionalProperties: false
+            required:
+              - job_uuid
+      additionalProperties: false
+      required:
+        - data
+    VectorDB:
+      type: object
+      properties:
+        identifier:
+          type: string
+        provider_resource_id:
+          type: string
+        provider_id:
+          type: string
+        type:
+          type: string
+          const: vector_db
+          default: vector_db
+        embedding_model:
+          type: string
+        embedding_dimension:
+          type: integer
+      additionalProperties: false
+      required:
+        - identifier
+        - provider_resource_id
+        - provider_id
+        - type
+        - embedding_model
+        - embedding_dimension
+    HealthInfo:
+      type: object
+      properties:
+        status:
+          type: string
+      additionalProperties: false
+      required:
+        - status
+    RAGDocument:
+      type: object
+      properties:
+        document_id:
+          type: string
+        content:
+          oneOf:
+            - type: string
+            - $ref: '#/components/schemas/InterleavedContentItem'
+            - type: array
+            items:
+              $ref: '#/components/schemas/InterleavedContentItem'
+            - $ref: '#/components/schemas/URL'
+        mime_type:
+          type: string
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - document_id
+        - content
+        - metadata
+    InsertRequest:
+      type: object
+      properties:
+        documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/RAGDocument'
+        vector_db_id:
+          type: string
+        chunk_size_in_tokens:
+          type: integer
+      additionalProperties: false
+      required:
+        - documents
+        - vector_db_id
+        - chunk_size_in_tokens
+    InsertChunksRequest:
+      type: object
+      properties:
+        vector_db_id:
+          type: string
+        chunks:
+          type: array
+          items:
+            type: object
+            properties:
+              content:
+                $ref: '#/components/schemas/InterleavedContent'
+              metadata:
+                type: object
+                additionalProperties:
+                  oneOf:
+                    - type: 'null'
+                    - type: boolean
+                    - type: number
+                    - type: string
+                    - type: array
+                    - type: object
+            additionalProperties: false
+            required:
+              - content
+              - metadata
+        ttl_seconds:
+          type: integer
+      additionalProperties: false
+      required:
+        - vector_db_id
+        - chunks
+    InvokeToolRequest:
+      type: object
+      properties:
+        tool_name:
+          type: string
+        kwargs:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - tool_name
+        - kwargs
+    ToolInvocationResult:
+      type: object
+      properties:
+        content:
+          $ref: '#/components/schemas/InterleavedContent'
+        error_message:
+          type: string
+        error_code:
+          type: integer
+      additionalProperties: false
+      required:
+        - content
+    ListDatasetsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Dataset'
+      additionalProperties: false
+      required:
+        - data
+    ListEvalTasksResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvalTask'
+      additionalProperties: false
+      required:
+        - data
+    ListModelsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Model'
+      additionalProperties: false
+      required:
+        - data
+    ProviderInfo:
+      type: object
+      properties:
+        api:
+          type: string
+        provider_id:
+          type: string
+        provider_type:
+          type: string
+      additionalProperties: false
+      required:
+        - api
+        - provider_id
+        - provider_type
+    ListProvidersResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProviderInfo'
+      additionalProperties: false
+      required:
+        - data
+    RouteInfo:
+      type: object
+      properties:
+        route:
+          type: string
+        method:
+          type: string
+        provider_types:
+          type: array
+          items:
+            type: string
+      additionalProperties: false
+      required:
+        - route
+        - method
+        - provider_types
+    ListRoutesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/RouteInfo'
+      additionalProperties: false
+      required:
+        - data
+    ListScoringFunctionsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScoringFn'
+      additionalProperties: false
+      required:
+        - data
+    ListShieldsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Shield'
+      additionalProperties: false
+      required:
+        - data
+    ListToolGroupsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolGroup'
+      additionalProperties: false
+      required:
+        - data
+    ListToolsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Tool'
+      additionalProperties: false
+      required:
+        - data
+    ListVectorDBsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/VectorDB'
+      additionalProperties: false
+      required:
+        - data
+    Event:
+      oneOf:
+        - $ref: '#/components/schemas/UnstructuredLogEvent'
+        - $ref: '#/components/schemas/MetricEvent'
+        - $ref: '#/components/schemas/StructuredLogEvent'
+      discriminator:
+        propertyName: type
+        mapping:
+          unstructured_log: '#/components/schemas/UnstructuredLogEvent'
+          metric: '#/components/schemas/MetricEvent'
+          structured_log: '#/components/schemas/StructuredLogEvent'
+    LogSeverity:
+      type: string
+      enum:
+        - verbose
+        - debug
+        - info
+        - warn
+        - error
+        - critical
+    MetricEvent:
+      type: object
+      properties:
+        trace_id:
+          type: string
+        span_id:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        attributes:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+        type:
+          type: string
+          const: metric
+          default: metric
+        metric:
+          type: string
+        value:
+          oneOf:
+            - type: integer
+            - type: number
+        unit:
+          type: string
+      additionalProperties: false
+      required:
+        - trace_id
+        - span_id
+        - timestamp
+        - type
+        - metric
+        - value
+        - unit
+    SpanEndPayload:
+      type: object
+      properties:
+        type:
+          type: string
+          const: span_end
+          default: span_end
+        status:
+          $ref: '#/components/schemas/SpanStatus'
+      additionalProperties: false
+      required:
+        - type
+        - status
+    SpanStartPayload:
+      type: object
+      properties:
+        type:
+          type: string
+          const: span_start
+          default: span_start
+        name:
+          type: string
+        parent_span_id:
+          type: string
+      additionalProperties: false
+      required:
+        - type
+        - name
+    StructuredLogEvent:
+      type: object
+      properties:
+        trace_id:
+          type: string
+        span_id:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        attributes:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+        type:
+          type: string
+          const: structured_log
+          default: structured_log
+        payload:
+          $ref: '#/components/schemas/StructuredLogPayload'
+      additionalProperties: false
+      required:
+        - trace_id
+        - span_id
+        - timestamp
+        - type
+        - payload
+    StructuredLogPayload:
+      oneOf:
+        - $ref: '#/components/schemas/SpanStartPayload'
+        - $ref: '#/components/schemas/SpanEndPayload'
+      discriminator:
+        propertyName: type
+        mapping:
+          span_start: '#/components/schemas/SpanStartPayload'
+          span_end: '#/components/schemas/SpanEndPayload'
+    UnstructuredLogEvent:
+      type: object
+      properties:
+        trace_id:
+          type: string
+        span_id:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        attributes:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+        type:
+          type: string
+          const: unstructured_log
+          default: unstructured_log
+        message:
+          type: string
+        severity:
+          $ref: '#/components/schemas/LogSeverity'
+      additionalProperties: false
+      required:
+        - trace_id
+        - span_id
+        - timestamp
+        - type
+        - message
+        - severity
+    LogEventRequest:
+      type: object
+      properties:
+        event:
+          $ref: '#/components/schemas/Event'
+        ttl_seconds:
+          type: integer
+      additionalProperties: false
+      required:
+        - event
+        - ttl_seconds
+    DPOAlignmentConfig:
+      type: object
+      properties:
+        reward_scale:
+          type: number
+        reward_clip:
+          type: number
+        epsilon:
+          type: number
+        gamma:
+          type: number
+      additionalProperties: false
+      required:
+        - reward_scale
+        - reward_clip
+        - epsilon
+        - gamma
+    DataConfig:
+      type: object
+      properties:
+        dataset_id:
+          type: string
+        batch_size:
+          type: integer
+        shuffle:
+          type: boolean
+        data_format:
+          $ref: '#/components/schemas/DatasetFormat'
+        validation_dataset_id:
+          type: string
+        packed:
+          type: boolean
+          default: false
+        train_on_input:
+          type: boolean
+          default: false
+      additionalProperties: false
+      required:
+        - dataset_id
+        - batch_size
+        - shuffle
+        - data_format
+    DatasetFormat:
+      type: string
+      enum:
+        - instruct
+        - dialog
+    EfficiencyConfig:
+      type: object
+      properties:
+        enable_activation_checkpointing:
+          type: boolean
+          default: false
+        enable_activation_offloading:
+          type: boolean
+          default: false
+        memory_efficient_fsdp_wrap:
+          type: boolean
+          default: false
+        fsdp_cpu_offload:
+          type: boolean
+          default: false
+      additionalProperties: false
+    OptimizerConfig:
+      type: object
+      properties:
+        optimizer_type:
+          $ref: '#/components/schemas/OptimizerType'
+        lr:
+          type: number
+        weight_decay:
+          type: number
+        num_warmup_steps:
+          type: integer
+      additionalProperties: false
+      required:
+        - optimizer_type
+        - lr
+        - weight_decay
+        - num_warmup_steps
+    OptimizerType:
+      type: string
+      enum:
+        - adam
+        - adamw
+        - sgd
+    TrainingConfig:
+      type: object
+      properties:
+        n_epochs:
+          type: integer
+        max_steps_per_epoch:
+          type: integer
+        gradient_accumulation_steps:
+          type: integer
+        max_validation_steps:
+          type: integer
+        data_config:
+          $ref: '#/components/schemas/DataConfig'
+        optimizer_config:
+          $ref: '#/components/schemas/OptimizerConfig'
+        efficiency_config:
+          $ref: '#/components/schemas/EfficiencyConfig'
+        dtype:
+          type: string
+          default: bf16
+      additionalProperties: false
+      required:
+        - n_epochs
+        - max_steps_per_epoch
+        - gradient_accumulation_steps
+        - max_validation_steps
+        - data_config
+        - optimizer_config
+    PreferenceOptimizeRequest:
+      type: object
+      properties:
+        job_uuid:
+          type: string
+        finetuned_model:
+          type: string
+        algorithm_config:
+          $ref: '#/components/schemas/DPOAlignmentConfig'
+        training_config:
+          $ref: '#/components/schemas/TrainingConfig'
+        hyperparam_search_config:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+        logger_config:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - job_uuid
+        - finetuned_model
+        - algorithm_config
+        - training_config
+        - hyperparam_search_config
+        - logger_config
+    PostTrainingJob:
+      type: object
+      properties:
+        job_uuid:
+          type: string
+      additionalProperties: false
+      required:
+        - job_uuid
+    DefaultRAGQueryGeneratorConfig:
+      type: object
+      properties:
+        type:
+          type: string
+          const: default
+          default: default
+        separator:
+          type: string
+          default: ' '
+      additionalProperties: false
+      required:
+        - type
+        - separator
+    LLMRAGQueryGeneratorConfig:
+      type: object
+      properties:
+        type:
+          type: string
+          const: llm
+          default: llm
+        model:
+          type: string
+        template:
+          type: string
+      additionalProperties: false
+      required:
+        - type
+        - model
+        - template
+    RAGQueryConfig:
+      type: object
+      properties:
+        query_generator_config:
+          $ref: '#/components/schemas/RAGQueryGeneratorConfig'
+        max_tokens_in_context:
+          type: integer
+          default: 4096
+        max_chunks:
+          type: integer
+          default: 5
+      additionalProperties: false
+      required:
+        - query_generator_config
+        - max_tokens_in_context
+        - max_chunks
+    RAGQueryGeneratorConfig:
+      oneOf:
+        - $ref: '#/components/schemas/DefaultRAGQueryGeneratorConfig'
+        - $ref: '#/components/schemas/LLMRAGQueryGeneratorConfig'
+      discriminator:
+        propertyName: type
+        mapping:
+          default: '#/components/schemas/DefaultRAGQueryGeneratorConfig'
+          llm: '#/components/schemas/LLMRAGQueryGeneratorConfig'
+    QueryRequest:
+      type: object
+      properties:
+        content:
+          $ref: '#/components/schemas/InterleavedContent'
+        vector_db_ids:
+          type: array
+          items:
+            type: string
+        query_config:
+          $ref: '#/components/schemas/RAGQueryConfig'
+      additionalProperties: false
+      required:
+        - content
+        - vector_db_ids
+    RAGQueryResult:
+      type: object
+      properties:
+        content:
+          $ref: '#/components/schemas/InterleavedContent'
+      additionalProperties: false
+    QueryChunksRequest:
+      type: object
+      properties:
+        vector_db_id:
+          type: string
+        query:
+          $ref: '#/components/schemas/InterleavedContent'
+        params:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - vector_db_id
+        - query
+    QueryChunksResponse:
+      type: object
+      properties:
+        chunks:
+          type: array
+          items:
+            type: object
+            properties:
+              content:
+                $ref: '#/components/schemas/InterleavedContent'
+              metadata:
+                type: object
+                additionalProperties:
+                  oneOf:
+                    - type: 'null'
+                    - type: boolean
+                    - type: number
+                    - type: string
+                    - type: array
+                    - type: object
+            additionalProperties: false
+            required:
+              - content
+              - metadata
+        scores:
+          type: array
+          items:
+            type: number
+      additionalProperties: false
+      required:
+        - chunks
+        - scores
+    QueryCondition:
+      type: object
+      properties:
+        key:
+          type: string
+        op:
+          $ref: '#/components/schemas/QueryConditionOp'
+        value:
+          oneOf:
+            - type: 'null'
+            - type: boolean
+            - type: number
+            - type: string
+            - type: array
+            - type: object
+      additionalProperties: false
+      required:
+        - key
+        - op
+        - value
+    QueryConditionOp:
+      type: string
+      enum:
+        - eq
+        - ne
+        - gt
+        - lt
+    QuerySpansResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Span'
+      additionalProperties: false
+      required:
+        - data
+    QueryTracesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Trace'
+      additionalProperties: false
+      required:
+        - data
+    RegisterDatasetRequest:
+      type: object
+      properties:
+        dataset_id:
+          type: string
+        dataset_schema:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ParamType'
+        url:
+          $ref: '#/components/schemas/URL'
+        provider_dataset_id:
+          type: string
+        provider_id:
+          type: string
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - dataset_id
+        - dataset_schema
+        - url
+    RegisterEvalTaskRequest:
+      type: object
+      properties:
+        eval_task_id:
+          type: string
+        dataset_id:
+          type: string
+        scoring_functions:
+          type: array
+          items:
+            type: string
+        provider_eval_task_id:
+          type: string
+        provider_id:
+          type: string
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - eval_task_id
+        - dataset_id
+        - scoring_functions
+    RegisterModelRequest:
+      type: object
+      properties:
+        model_id:
+          type: string
+        provider_model_id:
+          type: string
+        provider_id:
+          type: string
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+        model_type:
+          $ref: '#/components/schemas/ModelType'
+      additionalProperties: false
+      required:
+        - model_id
+    RegisterScoringFunctionRequest:
+      type: object
+      properties:
+        scoring_fn_id:
+          type: string
+        description:
+          type: string
+        return_type:
+          $ref: '#/components/schemas/ParamType'
+        provider_scoring_fn_id:
+          type: string
+        provider_id:
+          type: string
+        params:
+          $ref: '#/components/schemas/ScoringFnParams'
+      additionalProperties: false
+      required:
+        - scoring_fn_id
+        - description
+        - return_type
+    RegisterShieldRequest:
+      type: object
+      properties:
+        shield_id:
+          type: string
+        provider_shield_id:
+          type: string
+        provider_id:
+          type: string
+        params:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - shield_id
+    RegisterToolGroupRequest:
+      type: object
+      properties:
+        toolgroup_id:
+          type: string
+        provider_id:
+          type: string
+        mcp_endpoint:
+          $ref: '#/components/schemas/URL'
+        args:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - toolgroup_id
+        - provider_id
+    RegisterVectorDbRequest:
+      type: object
+      properties:
+        vector_db_id:
+          type: string
+        embedding_model:
+          type: string
+        embedding_dimension:
+          type: integer
+        provider_id:
+          type: string
+        provider_vector_db_id:
+          type: string
+      additionalProperties: false
+      required:
+        - vector_db_id
+        - embedding_model
+    RunEvalRequest:
+      type: object
+      properties:
+        task_config:
+          $ref: '#/components/schemas/EvalTaskConfig'
+      additionalProperties: false
+      required:
+        - task_config
+    Job:
+      type: object
+      properties:
+        job_id:
+          type: string
+      additionalProperties: false
+      required:
+        - job_id
+    RunShieldRequest:
+      type: object
+      properties:
+        shield_id:
+          type: string
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/Message'
+        params:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - shield_id
+        - messages
+        - params
+    RunShieldResponse:
+      type: object
+      properties:
+        violation:
+          $ref: '#/components/schemas/SafetyViolation'
+      additionalProperties: false
+    SaveSpansToDatasetRequest:
+      type: object
+      properties:
+        attribute_filters:
+          type: array
+          items:
+            $ref: '#/components/schemas/QueryCondition'
+        attributes_to_save:
+          type: array
+          items:
+            type: string
+        dataset_id:
+          type: string
+        max_depth:
+          type: integer
+      additionalProperties: false
+      required:
+        - attribute_filters
+        - attributes_to_save
+        - dataset_id
+    ScoreRequest:
+      type: object
+      properties:
+        input_rows:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              oneOf:
+                - type: 'null'
+                - type: boolean
+                - type: number
+                - type: string
+                - type: array
+                - type: object
+        scoring_functions:
+          type: object
+          additionalProperties:
+            oneOf:
+              - $ref: '#/components/schemas/ScoringFnParams'
+              - type: 'null'
+      additionalProperties: false
+      required:
+        - input_rows
+        - scoring_functions
+    ScoreResponse:
+      type: object
+      properties:
+        results:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ScoringResult'
+      additionalProperties: false
+      required:
+        - results
+    ScoreBatchRequest:
+      type: object
+      properties:
+        dataset_id:
+          type: string
+        scoring_functions:
+          type: object
+          additionalProperties:
+            oneOf:
+              - $ref: '#/components/schemas/ScoringFnParams'
+              - type: 'null'
+        save_results_dataset:
+          type: boolean
+      additionalProperties: false
+      required:
+        - dataset_id
+        - scoring_functions
+        - save_results_dataset
+    ScoreBatchResponse:
+      type: object
+      properties:
+        dataset_id:
+          type: string
+        results:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ScoringResult'
+      additionalProperties: false
+      required:
+        - results
+    AlgorithmConfig:
+      oneOf:
+        - $ref: '#/components/schemas/LoraFinetuningConfig'
+        - $ref: '#/components/schemas/QATFinetuningConfig'
+      discriminator:
+        propertyName: type
+        mapping:
+          LoRA: '#/components/schemas/LoraFinetuningConfig'
+          QAT: '#/components/schemas/QATFinetuningConfig'
+    LoraFinetuningConfig:
+      type: object
+      properties:
+        type:
+          type: string
+          const: LoRA
+          default: LoRA
+        lora_attn_modules:
+          type: array
+          items:
+            type: string
+        apply_lora_to_mlp:
+          type: boolean
+        apply_lora_to_output:
+          type: boolean
+        rank:
+          type: integer
+        alpha:
+          type: integer
+        use_dora:
+          type: boolean
+          default: false
+        quantize_base:
+          type: boolean
+          default: false
+      additionalProperties: false
+      required:
+        - type
+        - lora_attn_modules
+        - apply_lora_to_mlp
+        - apply_lora_to_output
+        - rank
+        - alpha
+    QATFinetuningConfig:
+      type: object
+      properties:
+        type:
+          type: string
+          const: QAT
+          default: QAT
+        quantizer_name:
+          type: string
+        group_size:
+          type: integer
+      additionalProperties: false
+      required:
+        - type
+        - quantizer_name
+        - group_size
+    SupervisedFineTuneRequest:
+      type: object
+      properties:
+        job_uuid:
+          type: string
+        training_config:
+          $ref: '#/components/schemas/TrainingConfig'
+        hyperparam_search_config:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+        logger_config:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+        model:
+          type: string
+        checkpoint_dir:
+          type: string
+        algorithm_config:
+          $ref: '#/components/schemas/AlgorithmConfig'
+      additionalProperties: false
+      required:
+        - job_uuid
+        - training_config
+        - hyperparam_search_config
+        - logger_config
+        - model
+    SyntheticDataGenerateRequest:
+      type: object
+      properties:
+        dialogs:
+          type: array
+          items:
+            $ref: '#/components/schemas/Message'
+        filtering_function:
+          type: string
+          enum:
+            - none
+            - random
+            - top_k
+            - top_p
+            - top_k_top_p
+            - sigmoid
+          title: The type of filtering function.
+        model:
+          type: string
+      additionalProperties: false
+      required:
+        - dialogs
+        - filtering_function
+    SyntheticDataGenerationResponse:
+      type: object
+      properties:
+        synthetic_data:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              oneOf:
+                - type: 'null'
+                - type: boolean
+                - type: number
+                - type: string
+                - type: array
+                - type: object
+        statistics:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - synthetic_data
+      title: Response from the synthetic data generation. Batch of (prompt, response,
+        score) tuples that pass the threshold.
+    VersionInfo:
+      type: object
+      properties:
+        version:
+          type: string
+      additionalProperties: false
+      required:
+        - version
+  responses: {}
 security:
-- Default: []
-servers:
-- url: http://any-hosted-llama-stack.com
+  - Default: []
 tags:
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentCandidate" />
-  name: AgentCandidate
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentConfig" />
-  name: AgentConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentCreateResponse"
-    />
-  name: AgentCreateResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentSessionCreateResponse"
-    />
-  name: AgentSessionCreateResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentStepResponse"
-    />
-  name: AgentStepResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTool" />
-  name: AgentTool
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnInputType"
-    />
-  name: AgentTurnInputType
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseEvent"
-    />
-  name: AgentTurnResponseEvent
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseEventPayload"
-    />
-  name: AgentTurnResponseEventPayload
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepCompletePayload"
-    />
-  name: AgentTurnResponseStepCompletePayload
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepProgressPayload"
-    />
-  name: AgentTurnResponseStepProgressPayload
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepStartPayload"
-    />
-  name: AgentTurnResponseStepStartPayload
-- description: 'streamed agent turn completion response.
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStreamChunk"
-    />'
-  name: AgentTurnResponseStreamChunk
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseTurnCompletePayload"
-    />
-  name: AgentTurnResponseTurnCompletePayload
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseTurnStartPayload"
-    />
-  name: AgentTurnResponseTurnStartPayload
-- name: Agents
-- description: <SchemaDefinition schemaRef="#/components/schemas/AggregationFunctionType"
-    />
-  name: AggregationFunctionType
-- description: <SchemaDefinition schemaRef="#/components/schemas/AlgorithmConfig"
-    />
-  name: AlgorithmConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/AppEvalTaskConfig"
-    />
-  name: AppEvalTaskConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/AppendRowsRequest"
-    />
-  name: AppendRowsRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/ArrayType" />
-  name: ArrayType
-- description: <SchemaDefinition schemaRef="#/components/schemas/BasicScoringFnParams"
-    />
-  name: BasicScoringFnParams
-- description: <SchemaDefinition schemaRef="#/components/schemas/BatchChatCompletionRequest"
-    />
-  name: BatchChatCompletionRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/BatchChatCompletionResponse"
-    />
-  name: BatchChatCompletionResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/BatchCompletionRequest"
-    />
-  name: BatchCompletionRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/BatchCompletionResponse"
-    />
-  name: BatchCompletionResponse
-- name: BatchInference (Coming Soon)
-- description: <SchemaDefinition schemaRef="#/components/schemas/BenchmarkEvalTaskConfig"
-    />
-  name: BenchmarkEvalTaskConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/BooleanType" />
-  name: BooleanType
-- description: <SchemaDefinition schemaRef="#/components/schemas/BuiltinTool" />
-  name: BuiltinTool
-- description: <SchemaDefinition schemaRef="#/components/schemas/CancelTrainingJobRequest"
-    />
-  name: CancelTrainingJobRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionInputType"
-    />
-  name: ChatCompletionInputType
-- description: <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionRequest"
-    />
-  name: ChatCompletionRequest
-- description: 'Chat completion response.
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionResponse" />'
-  name: ChatCompletionResponse
-- description: 'Chat completion response event.
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionResponseEvent"
-    />'
-  name: ChatCompletionResponseEvent
-- description: <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionResponseEventType"
-    />
-  name: ChatCompletionResponseEventType
-- description: 'SSE-stream of these events.
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionResponseStreamChunk"
-    />'
-  name: ChatCompletionResponseStreamChunk
-- description: 'Checkpoint created during training runs
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/Checkpoint" />'
-  name: Checkpoint
-- description: <SchemaDefinition schemaRef="#/components/schemas/CompletionInputType"
-    />
-  name: CompletionInputType
-- description: <SchemaDefinition schemaRef="#/components/schemas/CompletionMessage"
-    />
-  name: CompletionMessage
-- description: <SchemaDefinition schemaRef="#/components/schemas/CompletionRequest"
-    />
-  name: CompletionRequest
-- description: 'Completion response.
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/CompletionResponse" />'
-  name: CompletionResponse
-- description: 'streamed completion response.
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/CompletionResponseStreamChunk"
-    />'
-  name: CompletionResponseStreamChunk
-- description: <SchemaDefinition schemaRef="#/components/schemas/ContentDelta" />
-  name: ContentDelta
-- description: <SchemaDefinition schemaRef="#/components/schemas/CreateAgentRequest"
-    />
-  name: CreateAgentRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/CreateAgentSessionRequest"
-    />
-  name: CreateAgentSessionRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/CreateAgentTurnRequest"
-    />
-  name: CreateAgentTurnRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/DPOAlignmentConfig"
-    />
-  name: DPOAlignmentConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/DataConfig" />
-  name: DataConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/Dataset" />
-  name: Dataset
-- description: <SchemaDefinition schemaRef="#/components/schemas/DatasetFormat" />
-  name: DatasetFormat
-- name: DatasetIO
-- name: Datasets
-- description: <SchemaDefinition schemaRef="#/components/schemas/DefaultRAGQueryGeneratorConfig"
-    />
-  name: DefaultRAGQueryGeneratorConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/EfficiencyConfig"
-    />
-  name: EfficiencyConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/EmbeddingsRequest"
-    />
-  name: EmbeddingsRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/EmbeddingsResponse"
-    />
-  name: EmbeddingsResponse
-- name: Eval
-- description: <SchemaDefinition schemaRef="#/components/schemas/EvalCandidate" />
-  name: EvalCandidate
-- description: <SchemaDefinition schemaRef="#/components/schemas/EvalTask" />
-  name: EvalTask
-- description: <SchemaDefinition schemaRef="#/components/schemas/EvalTaskConfig" />
-  name: EvalTaskConfig
-- name: EvalTasks
-- description: <SchemaDefinition schemaRef="#/components/schemas/EvaluateResponse"
-    />
-  name: EvaluateResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/EvaluateRowsRequest"
-    />
-  name: EvaluateRowsRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/Event" />
-  name: Event
-- description: <SchemaDefinition schemaRef="#/components/schemas/GrammarResponseFormat"
-    />
-  name: GrammarResponseFormat
-- description: <SchemaDefinition schemaRef="#/components/schemas/GreedySamplingStrategy"
-    />
-  name: GreedySamplingStrategy
-- description: <SchemaDefinition schemaRef="#/components/schemas/HealthInfo" />
-  name: HealthInfo
-- description: <SchemaDefinition schemaRef="#/components/schemas/ImageContentItem"
-    />
-  name: ImageContentItem
-- description: <SchemaDefinition schemaRef="#/components/schemas/ImageDelta" />
-  name: ImageDelta
-- name: Inference
-- description: <SchemaDefinition schemaRef="#/components/schemas/InferenceStep" />
-  name: InferenceStep
-- description: <SchemaDefinition schemaRef="#/components/schemas/InsertChunksRequest"
-    />
-  name: InsertChunksRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/InsertRequest" />
-  name: InsertRequest
-- name: Inspect
-- description: <SchemaDefinition schemaRef="#/components/schemas/InterleavedContent"
-    />
-  name: InterleavedContent
-- description: <SchemaDefinition schemaRef="#/components/schemas/InterleavedContentItem"
-    />
-  name: InterleavedContentItem
-- description: <SchemaDefinition schemaRef="#/components/schemas/InvokeToolRequest"
-    />
-  name: InvokeToolRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/Job" />
-  name: Job
-- description: <SchemaDefinition schemaRef="#/components/schemas/JobStatus" />
-  name: JobStatus
-- description: <SchemaDefinition schemaRef="#/components/schemas/JsonSchemaResponseFormat"
-    />
-  name: JsonSchemaResponseFormat
-- description: <SchemaDefinition schemaRef="#/components/schemas/JsonType" />
-  name: JsonType
-- description: <SchemaDefinition schemaRef="#/components/schemas/LLMAsJudgeScoringFnParams"
-    />
-  name: LLMAsJudgeScoringFnParams
-- description: <SchemaDefinition schemaRef="#/components/schemas/LLMRAGQueryGeneratorConfig"
-    />
-  name: LLMRAGQueryGeneratorConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/ListDatasetsResponse"
-    />
-  name: ListDatasetsResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ListEvalTasksResponse"
-    />
-  name: ListEvalTasksResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ListModelsResponse"
-    />
-  name: ListModelsResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ListPostTrainingJobsResponse"
-    />
-  name: ListPostTrainingJobsResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ListProvidersResponse"
-    />
-  name: ListProvidersResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ListRoutesResponse"
-    />
-  name: ListRoutesResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ListScoringFunctionsResponse"
-    />
-  name: ListScoringFunctionsResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ListShieldsResponse"
-    />
-  name: ListShieldsResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ListToolGroupsResponse"
-    />
-  name: ListToolGroupsResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ListToolsResponse"
-    />
-  name: ListToolsResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ListVectorDBsResponse"
-    />
-  name: ListVectorDBsResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/LogEventRequest"
-    />
-  name: LogEventRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/LogSeverity" />
-  name: LogSeverity
-- description: <SchemaDefinition schemaRef="#/components/schemas/LoraFinetuningConfig"
-    />
-  name: LoraFinetuningConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/MemoryRetrievalStep"
-    />
-  name: MemoryRetrievalStep
-- description: <SchemaDefinition schemaRef="#/components/schemas/Message" />
-  name: Message
-- description: <SchemaDefinition schemaRef="#/components/schemas/MetricEvent" />
-  name: MetricEvent
-- description: <SchemaDefinition schemaRef="#/components/schemas/Model" />
-  name: Model
-- description: <SchemaDefinition schemaRef="#/components/schemas/ModelCandidate" />
-  name: ModelCandidate
-- description: <SchemaDefinition schemaRef="#/components/schemas/ModelType" />
-  name: ModelType
-- name: Models
-- description: <SchemaDefinition schemaRef="#/components/schemas/NumberType" />
-  name: NumberType
-- description: <SchemaDefinition schemaRef="#/components/schemas/ObjectType" />
-  name: ObjectType
-- description: <SchemaDefinition schemaRef="#/components/schemas/OptimizerConfig"
-    />
-  name: OptimizerConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/OptimizerType" />
-  name: OptimizerType
-- description: <SchemaDefinition schemaRef="#/components/schemas/PaginatedRowsResult"
-    />
-  name: PaginatedRowsResult
-- description: <SchemaDefinition schemaRef="#/components/schemas/ParamType" />
-  name: ParamType
-- name: PostTraining (Coming Soon)
-- description: <SchemaDefinition schemaRef="#/components/schemas/PostTrainingJob"
-    />
-  name: PostTrainingJob
-- description: 'Artifacts of a finetuning job.
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/PostTrainingJobArtifactsResponse"
-    />'
-  name: PostTrainingJobArtifactsResponse
-- description: 'Status of a finetuning job.
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/PostTrainingJobStatusResponse"
-    />'
-  name: PostTrainingJobStatusResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/PreferenceOptimizeRequest"
-    />
-  name: PreferenceOptimizeRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/ProviderInfo" />
-  name: ProviderInfo
-- description: <SchemaDefinition schemaRef="#/components/schemas/QATFinetuningConfig"
-    />
-  name: QATFinetuningConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/QueryChunksRequest"
-    />
-  name: QueryChunksRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/QueryChunksResponse"
-    />
-  name: QueryChunksResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/QueryCondition" />
-  name: QueryCondition
-- description: <SchemaDefinition schemaRef="#/components/schemas/QueryConditionOp"
-    />
-  name: QueryConditionOp
-- description: <SchemaDefinition schemaRef="#/components/schemas/QueryRequest" />
-  name: QueryRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/QuerySpanTreeResponse"
-    />
-  name: QuerySpanTreeResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/QuerySpansResponse"
-    />
-  name: QuerySpansResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/QueryTracesResponse"
-    />
-  name: QueryTracesResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/RAGDocument" />
-  name: RAGDocument
-- description: <SchemaDefinition schemaRef="#/components/schemas/RAGQueryConfig" />
-  name: RAGQueryConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/RAGQueryGeneratorConfig"
-    />
-  name: RAGQueryGeneratorConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/RAGQueryResult" />
-  name: RAGQueryResult
-- description: <SchemaDefinition schemaRef="#/components/schemas/RegexParserScoringFnParams"
-    />
-  name: RegexParserScoringFnParams
-- description: <SchemaDefinition schemaRef="#/components/schemas/RegisterDatasetRequest"
-    />
-  name: RegisterDatasetRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/RegisterEvalTaskRequest"
-    />
-  name: RegisterEvalTaskRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/RegisterModelRequest"
-    />
-  name: RegisterModelRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/RegisterScoringFunctionRequest"
-    />
-  name: RegisterScoringFunctionRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/RegisterShieldRequest"
-    />
-  name: RegisterShieldRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/RegisterToolGroupRequest"
-    />
-  name: RegisterToolGroupRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/RegisterVectorDbRequest"
-    />
-  name: RegisterVectorDbRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/ResponseFormat" />
-  name: ResponseFormat
-- description: <SchemaDefinition schemaRef="#/components/schemas/RouteInfo" />
-  name: RouteInfo
-- description: <SchemaDefinition schemaRef="#/components/schemas/RunEvalRequest" />
-  name: RunEvalRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/RunShieldRequest"
-    />
-  name: RunShieldRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/RunShieldResponse"
-    />
-  name: RunShieldResponse
-- name: Safety
-- description: <SchemaDefinition schemaRef="#/components/schemas/SafetyViolation"
-    />
-  name: SafetyViolation
-- description: <SchemaDefinition schemaRef="#/components/schemas/SamplingParams" />
-  name: SamplingParams
-- description: <SchemaDefinition schemaRef="#/components/schemas/SaveSpansToDatasetRequest"
-    />
-  name: SaveSpansToDatasetRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/ScoreBatchRequest"
-    />
-  name: ScoreBatchRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/ScoreBatchResponse"
-    />
-  name: ScoreBatchResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ScoreRequest" />
-  name: ScoreRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/ScoreResponse" />
-  name: ScoreResponse
-- name: Scoring
-- description: <SchemaDefinition schemaRef="#/components/schemas/ScoringFn" />
-  name: ScoringFn
-- description: <SchemaDefinition schemaRef="#/components/schemas/ScoringFnParams"
-    />
-  name: ScoringFnParams
-- name: ScoringFunctions
-- description: <SchemaDefinition schemaRef="#/components/schemas/ScoringResult" />
-  name: ScoringResult
-- description: 'A single session of an interaction with an Agentic System.
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/Session" />'
-  name: Session
-- description: 'A safety shield resource that can be used to check content
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/Shield" />'
-  name: Shield
-- description: <SchemaDefinition schemaRef="#/components/schemas/ShieldCallStep" />
-  name: ShieldCallStep
-- name: Shields
-- description: <SchemaDefinition schemaRef="#/components/schemas/Span" />
-  name: Span
-- description: <SchemaDefinition schemaRef="#/components/schemas/SpanEndPayload" />
-  name: SpanEndPayload
-- description: <SchemaDefinition schemaRef="#/components/schemas/SpanStartPayload"
-    />
-  name: SpanStartPayload
-- description: <SchemaDefinition schemaRef="#/components/schemas/SpanStatus" />
-  name: SpanStatus
-- description: <SchemaDefinition schemaRef="#/components/schemas/SpanWithStatus" />
-  name: SpanWithStatus
-- description: <SchemaDefinition schemaRef="#/components/schemas/StopReason" />
-  name: StopReason
-- description: <SchemaDefinition schemaRef="#/components/schemas/StringType" />
-  name: StringType
-- description: <SchemaDefinition schemaRef="#/components/schemas/StructuredLogEvent"
-    />
-  name: StructuredLogEvent
-- description: <SchemaDefinition schemaRef="#/components/schemas/StructuredLogPayload"
-    />
-  name: StructuredLogPayload
-- description: <SchemaDefinition schemaRef="#/components/schemas/SupervisedFineTuneRequest"
-    />
-  name: SupervisedFineTuneRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/SyntheticDataGenerateRequest"
-    />
-  name: SyntheticDataGenerateRequest
-- name: SyntheticDataGeneration (Coming Soon)
-- description: 'Response from the synthetic data generation. Batch of (prompt, response,
-    score) tuples that pass the threshold.
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/SyntheticDataGenerationResponse"
-    />'
-  name: SyntheticDataGenerationResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/SystemMessage" />
-  name: SystemMessage
-- name: Telemetry
-- description: <SchemaDefinition schemaRef="#/components/schemas/TextContentItem"
-    />
-  name: TextContentItem
-- description: <SchemaDefinition schemaRef="#/components/schemas/TextDelta" />
-  name: TextDelta
-- description: <SchemaDefinition schemaRef="#/components/schemas/TokenLogProbs" />
-  name: TokenLogProbs
-- description: <SchemaDefinition schemaRef="#/components/schemas/Tool" />
-  name: Tool
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolCall" />
-  name: ToolCall
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolCallDelta" />
-  name: ToolCallDelta
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolCallParseStatus"
-    />
-  name: ToolCallParseStatus
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolChoice" />
-  name: ToolChoice
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolDef" />
-  name: ToolDef
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolDefinition" />
-  name: ToolDefinition
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolExecutionStep"
-    />
-  name: ToolExecutionStep
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolGroup" />
-  name: ToolGroup
-- name: ToolGroups
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolHost" />
-  name: ToolHost
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolInvocationResult"
-    />
-  name: ToolInvocationResult
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolParamDefinition"
-    />
-  name: ToolParamDefinition
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolParameter" />
-  name: ToolParameter
-- description: "This Enum refers to the prompt format for calling custom / zero shot\
-    \ tools\n\n`json` --\n    Refers to the json format for calling tools.\n    The\
-    \ json format takes the form like\n    {\n        \"type\": \"function\",\n  \
-    \      \"function\" : {\n            \"name\": \"function_name\",\n          \
-    \  \"description\": \"function_description\",\n            \"parameters\": {...}\n\
-    \        }\n    }\n\n`function_tag` --\n    This is an example of how you could\
-    \ define\n    your own user defined format for making tool calls.\n    The function_tag\
-    \ format looks like this,\n    <function=function_name>(parameters)</function>\n\
-    \nThe detailed prompts for each of these formats are added to llama cli\n\n<SchemaDefinition\
-    \ schemaRef=\"#/components/schemas/ToolPromptFormat\" />"
-  name: ToolPromptFormat
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolResponse" />
-  name: ToolResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolResponseMessage"
-    />
-  name: ToolResponseMessage
-- name: ToolRuntime
-- description: <SchemaDefinition schemaRef="#/components/schemas/TopKSamplingStrategy"
-    />
-  name: TopKSamplingStrategy
-- description: <SchemaDefinition schemaRef="#/components/schemas/TopPSamplingStrategy"
-    />
-  name: TopPSamplingStrategy
-- description: <SchemaDefinition schemaRef="#/components/schemas/Trace" />
-  name: Trace
-- description: <SchemaDefinition schemaRef="#/components/schemas/TrainingConfig" />
-  name: TrainingConfig
-- description: 'A single turn in an interaction with an Agentic System.
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/Turn" />'
-  name: Turn
-- description: <SchemaDefinition schemaRef="#/components/schemas/URL" />
-  name: URL
-- description: <SchemaDefinition schemaRef="#/components/schemas/UnionType" />
-  name: UnionType
-- description: <SchemaDefinition schemaRef="#/components/schemas/UnstructuredLogEvent"
-    />
-  name: UnstructuredLogEvent
-- description: <SchemaDefinition schemaRef="#/components/schemas/UserMessage" />
-  name: UserMessage
-- description: <SchemaDefinition schemaRef="#/components/schemas/VectorDB" />
-  name: VectorDB
-- name: VectorDBs
-- name: VectorIO
-- description: <SchemaDefinition schemaRef="#/components/schemas/VersionInfo" />
-  name: VersionInfo
-- description: <SchemaDefinition schemaRef="#/components/schemas/ViolationLevel" />
-  name: ViolationLevel
+  - name: AgentCandidate
+  description: <SchemaDefinition schemaRef="#/components/schemas/AgentCandidate" />
+  - name: AgentConfig
+  description: <SchemaDefinition schemaRef="#/components/schemas/AgentConfig" />
+  - name: AgentCreateResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/AgentCreateResponse"
+    />
+  - name: AgentSessionCreateResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/AgentSessionCreateResponse"
+    />
+  - name: AgentStepResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/AgentStepResponse"
+    />
+  - name: AgentTool
+  description: <SchemaDefinition schemaRef="#/components/schemas/AgentTool" />
+  - name: AgentTurnInputType
+  description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnInputType"
+    />
+  - name: AgentTurnResponseEvent
+  description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseEvent"
+    />
+  - name: AgentTurnResponseEventPayload
+  description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseEventPayload"
+    />
+  - name: AgentTurnResponseStepCompletePayload
+  description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepCompletePayload"
+    />
+  - name: AgentTurnResponseStepProgressPayload
+  description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepProgressPayload"
+    />
+  - name: AgentTurnResponseStepStartPayload
+  description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepStartPayload"
+    />
+  - name: AgentTurnResponseStreamChunk
+  description: "streamed agent turn completion response.\n\n<SchemaDefinition schemaRef=\"\
+    #/components/schemas/AgentTurnResponseStreamChunk\" />"
+  - name: AgentTurnResponseTurnCompletePayload
+  description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseTurnCompletePayload"
+    />
+  - name: AgentTurnResponseTurnStartPayload
+  description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseTurnStartPayload"
+    />
+  - name: Agents
+  - name: AggregationFunctionType
+  description: <SchemaDefinition schemaRef="#/components/schemas/AggregationFunctionType"
+    />
+  - name: AlgorithmConfig
+  description: <SchemaDefinition schemaRef="#/components/schemas/AlgorithmConfig"
+    />
+  - name: AppEvalTaskConfig
+  description: <SchemaDefinition schemaRef="#/components/schemas/AppEvalTaskConfig"
+    />
+  - name: AppendRowsRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/AppendRowsRequest"
+    />
+  - name: ArrayType
+  description: <SchemaDefinition schemaRef="#/components/schemas/ArrayType" />
+  - name: BasicScoringFnParams
+  description: <SchemaDefinition schemaRef="#/components/schemas/BasicScoringFnParams"
+    />
+  - name: BatchChatCompletionRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/BatchChatCompletionRequest"
+    />
+  - name: BatchChatCompletionResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/BatchChatCompletionResponse"
+    />
+  - name: BatchCompletionRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/BatchCompletionRequest"
+    />
+  - name: BatchCompletionResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/BatchCompletionResponse"
+    />
+  - name: BatchInference (Coming Soon)
+  - name: BenchmarkEvalTaskConfig
+  description: <SchemaDefinition schemaRef="#/components/schemas/BenchmarkEvalTaskConfig"
+    />
+  - name: BooleanType
+  description: <SchemaDefinition schemaRef="#/components/schemas/BooleanType" />
+  - name: BuiltinTool
+  description: <SchemaDefinition schemaRef="#/components/schemas/BuiltinTool" />
+  - name: CancelTrainingJobRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/CancelTrainingJobRequest"
+    />
+  - name: ChatCompletionInputType
+  description: <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionInputType"
+    />
+  - name: ChatCompletionRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionRequest"
+    />
+  - name: ChatCompletionResponse
+  description: "Chat completion response.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/ChatCompletionResponse\"\
+    \ />"
+  - name: ChatCompletionResponseEvent
+  description: "Chat completion response event.\n\n<SchemaDefinition schemaRef=\"\
+    #/components/schemas/ChatCompletionResponseEvent\" />"
+  - name: ChatCompletionResponseEventType
+  description: <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionResponseEventType"
+    />
+  - name: ChatCompletionResponseStreamChunk
+  description: "SSE-stream of these events.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/ChatCompletionResponseStreamChunk\"\
+    \ />"
+  - name: Checkpoint
+  description: "Checkpoint created during training runs\n\n<SchemaDefinition schemaRef=\"\
+    #/components/schemas/Checkpoint\" />"
+  - name: CompletionInputType
+  description: <SchemaDefinition schemaRef="#/components/schemas/CompletionInputType"
+    />
+  - name: CompletionMessage
+  description: <SchemaDefinition schemaRef="#/components/schemas/CompletionMessage"
+    />
+  - name: CompletionRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/CompletionRequest"
+    />
+  - name: CompletionResponse
+  description: "Completion response.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/CompletionResponse\"\
+    \ />"
+  - name: CompletionResponseStreamChunk
+  description: "streamed completion response.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/CompletionResponseStreamChunk\"\
+    \ />"
+  - name: ContentDelta
+  description: <SchemaDefinition schemaRef="#/components/schemas/ContentDelta" />
+  - name: CreateAgentRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/CreateAgentRequest"
+    />
+  - name: CreateAgentSessionRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/CreateAgentSessionRequest"
+    />
+  - name: CreateAgentTurnRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/CreateAgentTurnRequest"
+    />
+  - name: DPOAlignmentConfig
+  description: <SchemaDefinition schemaRef="#/components/schemas/DPOAlignmentConfig"
+    />
+  - name: DataConfig
+  description: <SchemaDefinition schemaRef="#/components/schemas/DataConfig" />
+  - name: Dataset
+  description: <SchemaDefinition schemaRef="#/components/schemas/Dataset" />
+  - name: DatasetFormat
+  description: <SchemaDefinition schemaRef="#/components/schemas/DatasetFormat" />
+  - name: DatasetIO
+  - name: Datasets
+  - name: DefaultRAGQueryGeneratorConfig
+  description: <SchemaDefinition schemaRef="#/components/schemas/DefaultRAGQueryGeneratorConfig"
+    />
+  - name: EfficiencyConfig
+  description: <SchemaDefinition schemaRef="#/components/schemas/EfficiencyConfig"
+    />
+  - name: EmbeddingsRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/EmbeddingsRequest"
+    />
+  - name: EmbeddingsResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/EmbeddingsResponse"
+    />
+  - name: Eval
+  - name: EvalCandidate
+  description: <SchemaDefinition schemaRef="#/components/schemas/EvalCandidate" />
+  - name: EvalTask
+  description: <SchemaDefinition schemaRef="#/components/schemas/EvalTask" />
+  - name: EvalTaskConfig
+  description: <SchemaDefinition schemaRef="#/components/schemas/EvalTaskConfig" />
+  - name: EvalTasks
+  - name: EvaluateResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/EvaluateResponse"
+    />
+  - name: EvaluateRowsRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/EvaluateRowsRequest"
+    />
+  - name: Event
+  description: <SchemaDefinition schemaRef="#/components/schemas/Event" />
+  - name: GrammarResponseFormat
+  description: <SchemaDefinition schemaRef="#/components/schemas/GrammarResponseFormat"
+    />
+  - name: GreedySamplingStrategy
+  description: <SchemaDefinition schemaRef="#/components/schemas/GreedySamplingStrategy"
+    />
+  - name: HealthInfo
+  description: <SchemaDefinition schemaRef="#/components/schemas/HealthInfo" />
+  - name: ImageContentItem
+  description: <SchemaDefinition schemaRef="#/components/schemas/ImageContentItem"
+    />
+  - name: ImageDelta
+  description: <SchemaDefinition schemaRef="#/components/schemas/ImageDelta" />
+  - name: Inference
+  - name: InferenceStep
+  description: <SchemaDefinition schemaRef="#/components/schemas/InferenceStep" />
+  - name: InsertChunksRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/InsertChunksRequest"
+    />
+  - name: InsertRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/InsertRequest" />
+  - name: Inspect
+  - name: InterleavedContent
+  description: <SchemaDefinition schemaRef="#/components/schemas/InterleavedContent"
+    />
+  - name: InterleavedContentItem
+  description: <SchemaDefinition schemaRef="#/components/schemas/InterleavedContentItem"
+    />
+  - name: InvokeToolRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/InvokeToolRequest"
+    />
+  - name: Job
+  description: <SchemaDefinition schemaRef="#/components/schemas/Job" />
+  - name: JobStatus
+  description: <SchemaDefinition schemaRef="#/components/schemas/JobStatus" />
+  - name: JsonSchemaResponseFormat
+  description: <SchemaDefinition schemaRef="#/components/schemas/JsonSchemaResponseFormat"
+    />
+  - name: JsonType
+  description: <SchemaDefinition schemaRef="#/components/schemas/JsonType" />
+  - name: LLMAsJudgeScoringFnParams
+  description: <SchemaDefinition schemaRef="#/components/schemas/LLMAsJudgeScoringFnParams"
+    />
+  - name: LLMRAGQueryGeneratorConfig
+  description: <SchemaDefinition schemaRef="#/components/schemas/LLMRAGQueryGeneratorConfig"
+    />
+  - name: ListDatasetsResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/ListDatasetsResponse"
+    />
+  - name: ListEvalTasksResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/ListEvalTasksResponse"
+    />
+  - name: ListModelsResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/ListModelsResponse"
+    />
+  - name: ListPostTrainingJobsResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/ListPostTrainingJobsResponse"
+    />
+  - name: ListProvidersResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/ListProvidersResponse"
+    />
+  - name: ListRoutesResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/ListRoutesResponse"
+    />
+  - name: ListScoringFunctionsResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/ListScoringFunctionsResponse"
+    />
+  - name: ListShieldsResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/ListShieldsResponse"
+    />
+  - name: ListToolGroupsResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/ListToolGroupsResponse"
+    />
+  - name: ListToolsResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/ListToolsResponse"
+    />
+  - name: ListVectorDBsResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/ListVectorDBsResponse"
+    />
+  - name: LogEventRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/LogEventRequest"
+    />
+  - name: LogSeverity
+  description: <SchemaDefinition schemaRef="#/components/schemas/LogSeverity" />
+  - name: LoraFinetuningConfig
+  description: <SchemaDefinition schemaRef="#/components/schemas/LoraFinetuningConfig"
+    />
+  - name: MemoryRetrievalStep
+  description: <SchemaDefinition schemaRef="#/components/schemas/MemoryRetrievalStep"
+    />
+  - name: Message
+  description: <SchemaDefinition schemaRef="#/components/schemas/Message" />
+  - name: MetricEvent
+  description: <SchemaDefinition schemaRef="#/components/schemas/MetricEvent" />
+  - name: Model
+  description: <SchemaDefinition schemaRef="#/components/schemas/Model" />
+  - name: ModelCandidate
+  description: <SchemaDefinition schemaRef="#/components/schemas/ModelCandidate" />
+  - name: ModelType
+  description: <SchemaDefinition schemaRef="#/components/schemas/ModelType" />
+  - name: Models
+  - name: NumberType
+  description: <SchemaDefinition schemaRef="#/components/schemas/NumberType" />
+  - name: ObjectType
+  description: <SchemaDefinition schemaRef="#/components/schemas/ObjectType" />
+  - name: OptimizerConfig
+  description: <SchemaDefinition schemaRef="#/components/schemas/OptimizerConfig"
+    />
+  - name: OptimizerType
+  description: <SchemaDefinition schemaRef="#/components/schemas/OptimizerType" />
+  - name: PaginatedRowsResult
+  description: <SchemaDefinition schemaRef="#/components/schemas/PaginatedRowsResult"
+    />
+  - name: ParamType
+  description: <SchemaDefinition schemaRef="#/components/schemas/ParamType" />
+  - name: PostTraining (Coming Soon)
+  - name: PostTrainingJob
+  description: <SchemaDefinition schemaRef="#/components/schemas/PostTrainingJob"
+    />
+  - name: PostTrainingJobArtifactsResponse
+  description: "Artifacts of a finetuning job.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/PostTrainingJobArtifactsResponse\"\
+    \ />"
+  - name: PostTrainingJobStatusResponse
+  description: "Status of a finetuning job.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/PostTrainingJobStatusResponse\"\
+    \ />"
+  - name: PreferenceOptimizeRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/PreferenceOptimizeRequest"
+    />
+  - name: ProviderInfo
+  description: <SchemaDefinition schemaRef="#/components/schemas/ProviderInfo" />
+  - name: QATFinetuningConfig
+  description: <SchemaDefinition schemaRef="#/components/schemas/QATFinetuningConfig"
+    />
+  - name: QueryChunksRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/QueryChunksRequest"
+    />
+  - name: QueryChunksResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/QueryChunksResponse"
+    />
+  - name: QueryCondition
+  description: <SchemaDefinition schemaRef="#/components/schemas/QueryCondition" />
+  - name: QueryConditionOp
+  description: <SchemaDefinition schemaRef="#/components/schemas/QueryConditionOp"
+    />
+  - name: QueryRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/QueryRequest" />
+  - name: QuerySpanTreeResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/QuerySpanTreeResponse"
+    />
+  - name: QuerySpansResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/QuerySpansResponse"
+    />
+  - name: QueryTracesResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/QueryTracesResponse"
+    />
+  - name: RAGDocument
+  description: <SchemaDefinition schemaRef="#/components/schemas/RAGDocument" />
+  - name: RAGQueryConfig
+  description: <SchemaDefinition schemaRef="#/components/schemas/RAGQueryConfig" />
+  - name: RAGQueryGeneratorConfig
+  description: <SchemaDefinition schemaRef="#/components/schemas/RAGQueryGeneratorConfig"
+    />
+  - name: RAGQueryResult
+  description: <SchemaDefinition schemaRef="#/components/schemas/RAGQueryResult" />
+  - name: RegexParserScoringFnParams
+  description: <SchemaDefinition schemaRef="#/components/schemas/RegexParserScoringFnParams"
+    />
+  - name: RegisterDatasetRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/RegisterDatasetRequest"
+    />
+  - name: RegisterEvalTaskRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/RegisterEvalTaskRequest"
+    />
+  - name: RegisterModelRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/RegisterModelRequest"
+    />
+  - name: RegisterScoringFunctionRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/RegisterScoringFunctionRequest"
+    />
+  - name: RegisterShieldRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/RegisterShieldRequest"
+    />
+  - name: RegisterToolGroupRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/RegisterToolGroupRequest"
+    />
+  - name: RegisterVectorDbRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/RegisterVectorDbRequest"
+    />
+  - name: ResponseFormat
+  description: <SchemaDefinition schemaRef="#/components/schemas/ResponseFormat" />
+  - name: RouteInfo
+  description: <SchemaDefinition schemaRef="#/components/schemas/RouteInfo" />
+  - name: RunEvalRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/RunEvalRequest" />
+  - name: RunShieldRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/RunShieldRequest"
+    />
+  - name: RunShieldResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/RunShieldResponse"
+    />
+  - name: Safety
+  - name: SafetyViolation
+  description: <SchemaDefinition schemaRef="#/components/schemas/SafetyViolation"
+    />
+  - name: SamplingParams
+  description: <SchemaDefinition schemaRef="#/components/schemas/SamplingParams" />
+  - name: SaveSpansToDatasetRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/SaveSpansToDatasetRequest"
+    />
+  - name: ScoreBatchRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/ScoreBatchRequest"
+    />
+  - name: ScoreBatchResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/ScoreBatchResponse"
+    />
+  - name: ScoreRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/ScoreRequest" />
+  - name: ScoreResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/ScoreResponse" />
+  - name: Scoring
+  - name: ScoringFn
+  description: <SchemaDefinition schemaRef="#/components/schemas/ScoringFn" />
+  - name: ScoringFnParams
+  description: <SchemaDefinition schemaRef="#/components/schemas/ScoringFnParams"
+    />
+  - name: ScoringFunctions
+  - name: ScoringResult
+  description: <SchemaDefinition schemaRef="#/components/schemas/ScoringResult" />
+  - name: Session
+  description: "A single session of an interaction with an Agentic System.\n\n<SchemaDefinition
+    schemaRef=\"#/components/schemas/Session\" />"
+  - name: Shield
+  description: "A safety shield resource that can be used to check content\n\n<SchemaDefinition
+    schemaRef=\"#/components/schemas/Shield\" />"
+  - name: ShieldCallStep
+  description: <SchemaDefinition schemaRef="#/components/schemas/ShieldCallStep" />
+  - name: Shields
+  - name: Span
+  description: <SchemaDefinition schemaRef="#/components/schemas/Span" />
+  - name: SpanEndPayload
+  description: <SchemaDefinition schemaRef="#/components/schemas/SpanEndPayload" />
+  - name: SpanStartPayload
+  description: <SchemaDefinition schemaRef="#/components/schemas/SpanStartPayload"
+    />
+  - name: SpanStatus
+  description: <SchemaDefinition schemaRef="#/components/schemas/SpanStatus" />
+  - name: SpanWithStatus
+  description: <SchemaDefinition schemaRef="#/components/schemas/SpanWithStatus" />
+  - name: StopReason
+  description: <SchemaDefinition schemaRef="#/components/schemas/StopReason" />
+  - name: StringType
+  description: <SchemaDefinition schemaRef="#/components/schemas/StringType" />
+  - name: StructuredLogEvent
+  description: <SchemaDefinition schemaRef="#/components/schemas/StructuredLogEvent"
+    />
+  - name: StructuredLogPayload
+  description: <SchemaDefinition schemaRef="#/components/schemas/StructuredLogPayload"
+    />
+  - name: SupervisedFineTuneRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/SupervisedFineTuneRequest"
+    />
+  - name: SyntheticDataGenerateRequest
+  description: <SchemaDefinition schemaRef="#/components/schemas/SyntheticDataGenerateRequest"
+    />
+  - name: SyntheticDataGeneration (Coming Soon)
+  - name: SyntheticDataGenerationResponse
+  description: "Response from the synthetic data generation. Batch of (prompt, response,
+    score) tuples that pass the threshold.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/SyntheticDataGenerationResponse\"\
+    \ />"
+  - name: SystemMessage
+  description: <SchemaDefinition schemaRef="#/components/schemas/SystemMessage" />
+  - name: Telemetry
+  - name: TextContentItem
+  description: <SchemaDefinition schemaRef="#/components/schemas/TextContentItem"
+    />
+  - name: TextDelta
+  description: <SchemaDefinition schemaRef="#/components/schemas/TextDelta" />
+  - name: TokenLogProbs
+  description: <SchemaDefinition schemaRef="#/components/schemas/TokenLogProbs" />
+  - name: Tool
+  description: <SchemaDefinition schemaRef="#/components/schemas/Tool" />
+  - name: ToolCall
+  description: <SchemaDefinition schemaRef="#/components/schemas/ToolCall" />
+  - name: ToolCallDelta
+  description: <SchemaDefinition schemaRef="#/components/schemas/ToolCallDelta" />
+  - name: ToolCallParseStatus
+  description: <SchemaDefinition schemaRef="#/components/schemas/ToolCallParseStatus"
+    />
+  - name: ToolChoice
+  description: <SchemaDefinition schemaRef="#/components/schemas/ToolChoice" />
+  - name: ToolDef
+  description: <SchemaDefinition schemaRef="#/components/schemas/ToolDef" />
+  - name: ToolDefinition
+  description: <SchemaDefinition schemaRef="#/components/schemas/ToolDefinition" />
+  - name: ToolExecutionStep
+  description: <SchemaDefinition schemaRef="#/components/schemas/ToolExecutionStep"
+    />
+  - name: ToolGroup
+  description: <SchemaDefinition schemaRef="#/components/schemas/ToolGroup" />
+  - name: ToolGroups
+  - name: ToolHost
+  description: <SchemaDefinition schemaRef="#/components/schemas/ToolHost" />
+  - name: ToolInvocationResult
+  description: <SchemaDefinition schemaRef="#/components/schemas/ToolInvocationResult"
+    />
+  - name: ToolParamDefinition
+  description: <SchemaDefinition schemaRef="#/components/schemas/ToolParamDefinition"
+    />
+  - name: ToolParameter
+  description: <SchemaDefinition schemaRef="#/components/schemas/ToolParameter" />
+  - name: ToolPromptFormat
+  description: "This Enum refers to the prompt format for calling custom / zero shot
+    tools\n\n`json` --\n    Refers to the json format for calling tools.\n    The
+    json format takes the form like\n    {\n        \"type\": \"function\",\n    \
+    \    \"function\" : {\n            \"name\": \"function_name\",\n            \"\
+    description\": \"function_description\",\n            \"parameters\": {...}\n\
+    \        }\n    }\n\n`function_tag` --\n    This is an example of how you could
+    define\n    your own user defined format for making tool calls.\n    The function_tag
+    format looks like this,\n    <function=function_name>(parameters)</function>\n
+    \nThe detailed prompts for each of these formats are added to llama cli\n\n<SchemaDefinition
+    schemaRef=\"#/components/schemas/ToolPromptFormat\" />"
+  - name: ToolResponse
+  description: <SchemaDefinition schemaRef="#/components/schemas/ToolResponse" />
+  - name: ToolResponseMessage
+  description: <SchemaDefinition schemaRef="#/components/schemas/ToolResponseMessage"
+    />
+  - name: ToolRuntime
+  - name: TopKSamplingStrategy
+  description: <SchemaDefinition schemaRef="#/components/schemas/TopKSamplingStrategy"
+    />
+  - name: TopPSamplingStrategy
+  description: <SchemaDefinition schemaRef="#/components/schemas/TopPSamplingStrategy"
+    />
+  - name: Trace
+  description: <SchemaDefinition schemaRef="#/components/schemas/Trace" />
+  - name: TrainingConfig
+  description: <SchemaDefinition schemaRef="#/components/schemas/TrainingConfig" />
+  - name: Turn
+  description: "A single turn in an interaction with an Agentic System.\n\n<SchemaDefinition
+    schemaRef=\"#/components/schemas/Turn\" />"
+  - name: URL
+  description: <SchemaDefinition schemaRef="#/components/schemas/URL" />
+  - name: UnionType
+  description: <SchemaDefinition schemaRef="#/components/schemas/UnionType" />
+  - name: UnstructuredLogEvent
+  description: <SchemaDefinition schemaRef="#/components/schemas/UnstructuredLogEvent"
+    />
+  - name: UserMessage
+  description: <SchemaDefinition schemaRef="#/components/schemas/UserMessage" />
+  - name: VectorDB
+  description: <SchemaDefinition schemaRef="#/components/schemas/VectorDB" />
+  - name: VectorDBs
+  - name: VectorIO
+  - name: VersionInfo
+  description: <SchemaDefinition schemaRef="#/components/schemas/VersionInfo" />
+  - name: ViolationLevel
+  description: <SchemaDefinition schemaRef="#/components/schemas/ViolationLevel" />
 x-tagGroups:
-- name: Operations
+  - name: Operations
   tags:
-  - Agents
-  - BatchInference (Coming Soon)
-  - DatasetIO
-  - Datasets
-  - Eval
-  - EvalTasks
-  - Inference
-  - Inspect
-  - Models
-  - PostTraining (Coming Soon)
-  - Safety
-  - Scoring
-  - ScoringFunctions
-  - Shields
-  - SyntheticDataGeneration (Coming Soon)
-  - Telemetry
-  - ToolGroups
-  - ToolRuntime
-  - VectorDBs
-  - VectorIO
-- name: Types
+    - Agents
+    - BatchInference (Coming Soon)
+    - DatasetIO
+    - Datasets
+    - Eval
+    - EvalTasks
+    - Inference
+    - Inspect
+    - Models
+    - PostTraining (Coming Soon)
+    - Safety
+    - Scoring
+    - ScoringFunctions
+    - Shields
+    - SyntheticDataGeneration (Coming Soon)
+    - Telemetry
+    - ToolGroups
+    - ToolRuntime
+    - VectorDBs
+    - VectorIO
+  - name: Types
   tags:
-  - AgentCandidate
-  - AgentConfig
-  - AgentCreateResponse
-  - AgentSessionCreateResponse
-  - AgentStepResponse
-  - AgentTool
-  - AgentTurnInputType
-  - AgentTurnResponseEvent
-  - AgentTurnResponseEventPayload
-  - AgentTurnResponseStepCompletePayload
-  - AgentTurnResponseStepProgressPayload
-  - AgentTurnResponseStepStartPayload
-  - AgentTurnResponseStreamChunk
-  - AgentTurnResponseTurnCompletePayload
-  - AgentTurnResponseTurnStartPayload
-  - AggregationFunctionType
-  - AlgorithmConfig
-  - AppEvalTaskConfig
-  - AppendRowsRequest
-  - ArrayType
-  - BasicScoringFnParams
-  - BatchChatCompletionRequest
-  - BatchChatCompletionResponse
-  - BatchCompletionRequest
-  - BatchCompletionResponse
-  - BenchmarkEvalTaskConfig
-  - BooleanType
-  - BuiltinTool
-  - CancelTrainingJobRequest
-  - ChatCompletionInputType
-  - ChatCompletionRequest
-  - ChatCompletionResponse
-  - ChatCompletionResponseEvent
-  - ChatCompletionResponseEventType
-  - ChatCompletionResponseStreamChunk
-  - Checkpoint
-  - CompletionInputType
-  - CompletionMessage
-  - CompletionRequest
-  - CompletionResponse
-  - CompletionResponseStreamChunk
-  - ContentDelta
-  - CreateAgentRequest
-  - CreateAgentSessionRequest
-  - CreateAgentTurnRequest
-  - DPOAlignmentConfig
-  - DataConfig
-  - Dataset
-  - DatasetFormat
-  - DefaultRAGQueryGeneratorConfig
-  - EfficiencyConfig
-  - EmbeddingsRequest
-  - EmbeddingsResponse
-  - EvalCandidate
-  - EvalTask
-  - EvalTaskConfig
-  - EvaluateResponse
-  - EvaluateRowsRequest
-  - Event
-  - GrammarResponseFormat
-  - GreedySamplingStrategy
-  - HealthInfo
-  - ImageContentItem
-  - ImageDelta
-  - InferenceStep
-  - InsertChunksRequest
-  - InsertRequest
-  - InterleavedContent
-  - InterleavedContentItem
-  - InvokeToolRequest
-  - Job
-  - JobStatus
-  - JsonSchemaResponseFormat
-  - JsonType
-  - LLMAsJudgeScoringFnParams
-  - LLMRAGQueryGeneratorConfig
-  - ListDatasetsResponse
-  - ListEvalTasksResponse
-  - ListModelsResponse
-  - ListPostTrainingJobsResponse
-  - ListProvidersResponse
-  - ListRoutesResponse
-  - ListScoringFunctionsResponse
-  - ListShieldsResponse
-  - ListToolGroupsResponse
-  - ListToolsResponse
-  - ListVectorDBsResponse
-  - LogEventRequest
-  - LogSeverity
-  - LoraFinetuningConfig
-  - MemoryRetrievalStep
-  - Message
-  - MetricEvent
-  - Model
-  - ModelCandidate
-  - ModelType
-  - NumberType
-  - ObjectType
-  - OptimizerConfig
-  - OptimizerType
-  - PaginatedRowsResult
-  - ParamType
-  - PostTrainingJob
-  - PostTrainingJobArtifactsResponse
-  - PostTrainingJobStatusResponse
-  - PreferenceOptimizeRequest
-  - ProviderInfo
-  - QATFinetuningConfig
-  - QueryChunksRequest
-  - QueryChunksResponse
-  - QueryCondition
-  - QueryConditionOp
-  - QueryRequest
-  - QuerySpanTreeResponse
-  - QuerySpansResponse
-  - QueryTracesResponse
-  - RAGDocument
-  - RAGQueryConfig
-  - RAGQueryGeneratorConfig
-  - RAGQueryResult
-  - RegexParserScoringFnParams
-  - RegisterDatasetRequest
-  - RegisterEvalTaskRequest
-  - RegisterModelRequest
-  - RegisterScoringFunctionRequest
-  - RegisterShieldRequest
-  - RegisterToolGroupRequest
-  - RegisterVectorDbRequest
-  - ResponseFormat
-  - RouteInfo
-  - RunEvalRequest
-  - RunShieldRequest
-  - RunShieldResponse
-  - SafetyViolation
-  - SamplingParams
-  - SaveSpansToDatasetRequest
-  - ScoreBatchRequest
-  - ScoreBatchResponse
-  - ScoreRequest
-  - ScoreResponse
-  - ScoringFn
-  - ScoringFnParams
-  - ScoringResult
-  - Session
-  - Shield
-  - ShieldCallStep
-  - Span
-  - SpanEndPayload
-  - SpanStartPayload
-  - SpanStatus
-  - SpanWithStatus
-  - StopReason
-  - StringType
-  - StructuredLogEvent
-  - StructuredLogPayload
-  - SupervisedFineTuneRequest
-  - SyntheticDataGenerateRequest
-  - SyntheticDataGenerationResponse
-  - SystemMessage
-  - TextContentItem
-  - TextDelta
-  - TokenLogProbs
-  - Tool
-  - ToolCall
-  - ToolCallDelta
-  - ToolCallParseStatus
-  - ToolChoice
-  - ToolDef
-  - ToolDefinition
-  - ToolExecutionStep
-  - ToolGroup
-  - ToolHost
-  - ToolInvocationResult
-  - ToolParamDefinition
-  - ToolParameter
-  - ToolPromptFormat
-  - ToolResponse
-  - ToolResponseMessage
-  - TopKSamplingStrategy
-  - TopPSamplingStrategy
-  - Trace
-  - TrainingConfig
-  - Turn
-  - URL
-  - UnionType
-  - UnstructuredLogEvent
-  - UserMessage
-  - VectorDB
-  - VersionInfo
-  - ViolationLevel
+    - AgentCandidate
+    - AgentConfig
+    - AgentCreateResponse
+    - AgentSessionCreateResponse
+    - AgentStepResponse
+    - AgentTool
+    - AgentTurnInputType
+    - AgentTurnResponseEvent
+    - AgentTurnResponseEventPayload
+    - AgentTurnResponseStepCompletePayload
+    - AgentTurnResponseStepProgressPayload
+    - AgentTurnResponseStepStartPayload
+    - AgentTurnResponseStreamChunk
+    - AgentTurnResponseTurnCompletePayload
+    - AgentTurnResponseTurnStartPayload
+    - AggregationFunctionType
+    - AlgorithmConfig
+    - AppEvalTaskConfig
+    - AppendRowsRequest
+    - ArrayType
+    - BasicScoringFnParams
+    - BatchChatCompletionRequest
+    - BatchChatCompletionResponse
+    - BatchCompletionRequest
+    - BatchCompletionResponse
+    - BenchmarkEvalTaskConfig
+    - BooleanType
+    - BuiltinTool
+    - CancelTrainingJobRequest
+    - ChatCompletionInputType
+    - ChatCompletionRequest
+    - ChatCompletionResponse
+    - ChatCompletionResponseEvent
+    - ChatCompletionResponseEventType
+    - ChatCompletionResponseStreamChunk
+    - Checkpoint
+    - CompletionInputType
+    - CompletionMessage
+    - CompletionRequest
+    - CompletionResponse
+    - CompletionResponseStreamChunk
+    - ContentDelta
+    - CreateAgentRequest
+    - CreateAgentSessionRequest
+    - CreateAgentTurnRequest
+    - DPOAlignmentConfig
+    - DataConfig
+    - Dataset
+    - DatasetFormat
+    - DefaultRAGQueryGeneratorConfig
+    - EfficiencyConfig
+    - EmbeddingsRequest
+    - EmbeddingsResponse
+    - EvalCandidate
+    - EvalTask
+    - EvalTaskConfig
+    - EvaluateResponse
+    - EvaluateRowsRequest
+    - Event
+    - GrammarResponseFormat
+    - GreedySamplingStrategy
+    - HealthInfo
+    - ImageContentItem
+    - ImageDelta
+    - InferenceStep
+    - InsertChunksRequest
+    - InsertRequest
+    - InterleavedContent
+    - InterleavedContentItem
+    - InvokeToolRequest
+    - Job
+    - JobStatus
+    - JsonSchemaResponseFormat
+    - JsonType
+    - LLMAsJudgeScoringFnParams
+    - LLMRAGQueryGeneratorConfig
+    - ListDatasetsResponse
+    - ListEvalTasksResponse
+    - ListModelsResponse
+    - ListPostTrainingJobsResponse
+    - ListProvidersResponse
+    - ListRoutesResponse
+    - ListScoringFunctionsResponse
+    - ListShieldsResponse
+    - ListToolGroupsResponse
+    - ListToolsResponse
+    - ListVectorDBsResponse
+    - LogEventRequest
+    - LogSeverity
+    - LoraFinetuningConfig
+    - MemoryRetrievalStep
+    - Message
+    - MetricEvent
+    - Model
+    - ModelCandidate
+    - ModelType
+    - NumberType
+    - ObjectType
+    - OptimizerConfig
+    - OptimizerType
+    - PaginatedRowsResult
+    - ParamType
+    - PostTrainingJob
+    - PostTrainingJobArtifactsResponse
+    - PostTrainingJobStatusResponse
+    - PreferenceOptimizeRequest
+    - ProviderInfo
+    - QATFinetuningConfig
+    - QueryChunksRequest
+    - QueryChunksResponse
+    - QueryCondition
+    - QueryConditionOp
+    - QueryRequest
+    - QuerySpanTreeResponse
+    - QuerySpansResponse
+    - QueryTracesResponse
+    - RAGDocument
+    - RAGQueryConfig
+    - RAGQueryGeneratorConfig
+    - RAGQueryResult
+    - RegexParserScoringFnParams
+    - RegisterDatasetRequest
+    - RegisterEvalTaskRequest
+    - RegisterModelRequest
+    - RegisterScoringFunctionRequest
+    - RegisterShieldRequest
+    - RegisterToolGroupRequest
+    - RegisterVectorDbRequest
+    - ResponseFormat
+    - RouteInfo
+    - RunEvalRequest
+    - RunShieldRequest
+    - RunShieldResponse
+    - SafetyViolation
+    - SamplingParams
+    - SaveSpansToDatasetRequest
+    - ScoreBatchRequest
+    - ScoreBatchResponse
+    - ScoreRequest
+    - ScoreResponse
+    - ScoringFn
+    - ScoringFnParams
+    - ScoringResult
+    - Session
+    - Shield
+    - ShieldCallStep
+    - Span
+    - SpanEndPayload
+    - SpanStartPayload
+    - SpanStatus
+    - SpanWithStatus
+    - StopReason
+    - StringType
+    - StructuredLogEvent
+    - StructuredLogPayload
+    - SupervisedFineTuneRequest
+    - SyntheticDataGenerateRequest
+    - SyntheticDataGenerationResponse
+    - SystemMessage
+    - TextContentItem
+    - TextDelta
+    - TokenLogProbs
+    - Tool
+    - ToolCall
+    - ToolCallDelta
+    - ToolCallParseStatus
+    - ToolChoice
+    - ToolDef
+    - ToolDefinition
+    - ToolExecutionStep
+    - ToolGroup
+    - ToolHost
+    - ToolInvocationResult
+    - ToolParamDefinition
+    - ToolParameter
+    - ToolPromptFormat
+    - ToolResponse
+    - ToolResponseMessage
+    - TopKSamplingStrategy
+    - TopPSamplingStrategy
+    - Trace
+    - TrainingConfig
+    - Turn
+    - URL
+    - UnionType
+    - UnstructuredLogEvent
+    - UserMessage
+    - VectorDB
+    - VersionInfo
+    - ViolationLevel

--- a/docs/resources/llama-stack-spec.yaml
+++ b/docs/resources/llama-stack-spec.yaml
@@ -21,39 +21,39 @@ paths:
         - DatasetIO
       parameters:
         - name: dataset_id
-        in: query
-        required: true
-        schema:
-          type: string
+          in: query
+          required: true
+          schema:
+            type: string
         - name: rows_in_page
-        in: query
-        required: true
-        schema:
-          type: integer
+          in: query
+          required: true
+          schema:
+            type: integer
         - name: page_token
-        in: query
-        required: false
-        schema:
-          type: string
+          in: query
+          required: false
+          schema:
+            type: string
         - name: filter_condition
-        in: query
-        required: false
-        schema:
-          type: string
+          in: query
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
     post:
       responses:
         '200':
@@ -62,19 +62,19 @@ paths:
         - DatasetIO
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -94,19 +94,19 @@ paths:
         - BatchInference (Coming Soon)
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -126,19 +126,19 @@ paths:
         - BatchInference (Coming Soon)
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -154,19 +154,19 @@ paths:
         - PostTraining (Coming Soon)
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -188,19 +188,19 @@ paths:
         - Inference
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -222,19 +222,19 @@ paths:
         - Inference
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -254,19 +254,19 @@ paths:
         - Agents
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -286,24 +286,24 @@ paths:
         - Agents
       parameters:
         - name: agent_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -326,29 +326,29 @@ paths:
         - Agents
       parameters:
         - name: agent_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: session_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -364,24 +364,24 @@ paths:
         - Agents
       parameters:
         - name: agent_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/agents/{agent_id}/session/{session_id}:
     get:
       responses:
@@ -395,36 +395,36 @@ paths:
         - Agents
       parameters:
         - name: session_id
-        in: path
-        required: true
-        schema:
-          type: string
-        - name: agent_id
-        in: path
-        required: true
-        schema:
-          type: string
-        - name: turn_ids
-        in: query
-        required: false
-        schema:
-          type: array
-          items:
+          in: path
+          required: true
+          schema:
             type: string
+        - name: agent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: turn_ids
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
     delete:
       responses:
         '200':
@@ -433,29 +433,29 @@ paths:
         - Agents
       parameters:
         - name: session_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: agent_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/inference/embeddings:
     post:
       responses:
@@ -469,19 +469,19 @@ paths:
         - Inference
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -501,24 +501,24 @@ paths:
         - Eval
       parameters:
         - name: task_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -538,39 +538,39 @@ paths:
         - Agents
       parameters:
         - name: agent_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: session_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: turn_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: step_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/agents/{agent_id}/session/{session_id}/turn/{turn_id}:
     get:
       responses:
@@ -584,34 +584,34 @@ paths:
         - Agents
       parameters:
         - name: agent_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: session_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: turn_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/datasets/{dataset_id}:
     get:
       responses:
@@ -627,24 +627,24 @@ paths:
         - Datasets
       parameters:
         - name: dataset_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
     delete:
       responses:
         '200':
@@ -653,24 +653,24 @@ paths:
         - Datasets
       parameters:
         - name: dataset_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/eval-tasks/{eval_task_id}:
     get:
       responses:
@@ -686,24 +686,24 @@ paths:
         - EvalTasks
       parameters:
         - name: eval_task_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/models/{model_id}:
     get:
       responses:
@@ -719,24 +719,24 @@ paths:
         - Models
       parameters:
         - name: model_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
     delete:
       responses:
         '200':
@@ -745,24 +745,24 @@ paths:
         - Models
       parameters:
         - name: model_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/scoring-functions/{scoring_fn_id}:
     get:
       responses:
@@ -778,24 +778,24 @@ paths:
         - ScoringFunctions
       parameters:
         - name: scoring_fn_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/shields/{identifier}:
     get:
       responses:
@@ -811,24 +811,24 @@ paths:
         - Shields
       parameters:
         - name: identifier
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/telemetry/traces/{trace_id}/spans/{span_id}:
     get:
       responses:
@@ -842,29 +842,29 @@ paths:
         - Telemetry
       parameters:
         - name: trace_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: span_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/telemetry/spans/{span_id}/tree:
     get:
       responses:
@@ -878,36 +878,36 @@ paths:
         - Telemetry
       parameters:
         - name: span_id
-        in: path
-        required: true
-        schema:
-          type: string
-        - name: attributes_to_return
-        in: query
-        required: false
-        schema:
-          type: array
-          items:
+          in: path
+          required: true
+          schema:
             type: string
+        - name: attributes_to_return
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
         - name: max_depth
-        in: query
-        required: false
-        schema:
-          type: integer
+          in: query
+          required: false
+          schema:
+            type: integer
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/tools/{tool_name}:
     get:
       responses:
@@ -921,24 +921,24 @@ paths:
         - ToolGroups
       parameters:
         - name: tool_name
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/toolgroups/{toolgroup_id}:
     get:
       responses:
@@ -952,24 +952,24 @@ paths:
         - ToolGroups
       parameters:
         - name: toolgroup_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
     delete:
       responses:
         '200':
@@ -979,24 +979,24 @@ paths:
       summary: Unregister a tool group
       parameters:
         - name: toolgroup_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/telemetry/traces/{trace_id}:
     get:
       responses:
@@ -1010,24 +1010,24 @@ paths:
         - Telemetry
       parameters:
         - name: trace_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/post-training/job/artifacts:
     get:
       responses:
@@ -1043,24 +1043,24 @@ paths:
         - PostTraining (Coming Soon)
       parameters:
         - name: job_uuid
-        in: query
-        required: true
-        schema:
-          type: string
+          in: query
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/post-training/job/status:
     get:
       responses:
@@ -1076,24 +1076,24 @@ paths:
         - PostTraining (Coming Soon)
       parameters:
         - name: job_uuid
-        in: query
-        required: true
-        schema:
-          type: string
+          in: query
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/post-training/jobs:
     get:
       responses:
@@ -1107,19 +1107,19 @@ paths:
         - PostTraining (Coming Soon)
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/vector-dbs/{vector_db_id}:
     get:
       responses:
@@ -1135,24 +1135,24 @@ paths:
         - VectorDBs
       parameters:
         - name: vector_db_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
     delete:
       responses:
         '200':
@@ -1161,24 +1161,24 @@ paths:
         - VectorDBs
       parameters:
         - name: vector_db_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/health:
     get:
       responses:
@@ -1192,19 +1192,19 @@ paths:
         - Inspect
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/tool-runtime/rag-tool/insert:
     post:
       responses:
@@ -1215,19 +1215,19 @@ paths:
       summary: Index documents so they can be used by the RAG system
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -1243,19 +1243,19 @@ paths:
         - VectorIO
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -1276,19 +1276,19 @@ paths:
       summary: Run a tool with the given arguments
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -1310,29 +1310,29 @@ paths:
         - Eval
       parameters:
         - name: task_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
     delete:
       responses:
         '200':
@@ -1341,29 +1341,29 @@ paths:
         - Eval
       parameters:
         - name: task_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/eval/tasks/{task_id}/jobs/{job_id}/result:
     get:
       responses:
@@ -1377,29 +1377,29 @@ paths:
         - Eval
       parameters:
         - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: task_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/datasets:
     get:
       responses:
@@ -1413,19 +1413,19 @@ paths:
         - Datasets
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
     post:
       responses:
         '200':
@@ -1434,19 +1434,19 @@ paths:
         - Datasets
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -1466,19 +1466,19 @@ paths:
         - EvalTasks
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
     post:
       responses:
         '200':
@@ -1487,19 +1487,19 @@ paths:
         - EvalTasks
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -1519,19 +1519,19 @@ paths:
         - Models
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
     post:
       responses:
         '200':
@@ -1544,19 +1544,19 @@ paths:
         - Models
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -1576,19 +1576,19 @@ paths:
         - Inspect
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/inspect/routes:
     get:
       responses:
@@ -1602,19 +1602,19 @@ paths:
         - Inspect
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/tool-runtime/list-tools:
     get:
       responses:
@@ -1628,29 +1628,29 @@ paths:
         - ToolRuntime
       parameters:
         - name: tool_group_id
-        in: query
-        required: false
-        schema:
-          type: string
+          in: query
+          required: false
+          schema:
+            type: string
         - name: mcp_endpoint
-        in: query
-        required: false
-        schema:
-          $ref: '#/components/schemas/URL'
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/URL'
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/scoring-functions:
     get:
       responses:
@@ -1664,19 +1664,19 @@ paths:
         - ScoringFunctions
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
     post:
       responses:
         '200':
@@ -1685,19 +1685,19 @@ paths:
         - ScoringFunctions
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -1717,19 +1717,19 @@ paths:
         - Shields
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
     post:
       responses:
         '200':
@@ -1742,19 +1742,19 @@ paths:
         - Shields
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -1775,19 +1775,19 @@ paths:
       summary: List tool groups with optional provider
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
     post:
       responses:
         '200':
@@ -1797,19 +1797,19 @@ paths:
       summary: Register a tool group
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -1830,24 +1830,24 @@ paths:
       summary: List tools with optional tool group
       parameters:
         - name: toolgroup_id
-        in: query
-        required: false
-        schema:
-          type: string
+          in: query
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/vector-dbs:
     get:
       responses:
@@ -1861,19 +1861,19 @@ paths:
         - VectorDBs
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
     post:
       responses:
         '200':
@@ -1886,19 +1886,19 @@ paths:
         - VectorDBs
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -1914,19 +1914,19 @@ paths:
         - Telemetry
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -1946,19 +1946,19 @@ paths:
         - PostTraining (Coming Soon)
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -1979,19 +1979,19 @@ paths:
       summary: Query the RAG system for context; typically invoked by the agent
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -2011,19 +2011,19 @@ paths:
         - VectorIO
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -2043,38 +2043,38 @@ paths:
         - Telemetry
       parameters:
         - name: attribute_filters
-        in: query
-        required: true
-        schema:
-          type: array
-          items:
-            $ref: '#/components/schemas/QueryCondition'
+          in: query
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/QueryCondition'
         - name: attributes_to_return
-        in: query
-        required: true
-        schema:
-          type: array
-          items:
-            type: string
+          in: query
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
         - name: max_depth
-        in: query
-        required: false
-        schema:
-          type: integer
+          in: query
+          required: false
+          schema:
+            type: integer
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/telemetry/traces:
     get:
       responses:
@@ -2088,43 +2088,43 @@ paths:
         - Telemetry
       parameters:
         - name: attribute_filters
-        in: query
-        required: false
-        schema:
-          type: array
-          items:
-            $ref: '#/components/schemas/QueryCondition'
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/QueryCondition'
         - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
+          in: query
+          required: false
+          schema:
+            type: integer
         - name: offset
-        in: query
-        required: false
-        schema:
-          type: integer
+          in: query
+          required: false
+          schema:
+            type: integer
         - name: order_by
-        in: query
-        required: false
-        schema:
-          type: array
-          items:
-            type: string
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
   /v1/eval/tasks/{task_id}/jobs:
     post:
       responses:
@@ -2138,24 +2138,24 @@ paths:
         - Eval
       parameters:
         - name: task_id
-        in: path
-        required: true
-        schema:
-          type: string
+          in: path
+          required: true
+          schema:
+            type: string
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -2175,19 +2175,19 @@ paths:
         - Safety
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -2203,19 +2203,19 @@ paths:
         - Telemetry
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -2235,19 +2235,19 @@ paths:
         - Scoring
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -2267,19 +2267,19 @@ paths:
         - Scoring
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -2299,19 +2299,19 @@ paths:
         - PostTraining (Coming Soon)
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -2331,19 +2331,19 @@ paths:
         - SyntheticDataGeneration (Coming Soon)
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -2363,19 +2363,19 @@ paths:
         - Inspect
       parameters:
         - name: X-LlamaStack-Provider-Data
-        in: header
-        description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        required: false
-        schema:
-          type: string
+          in: header
+          description: JSON-encoded provider data which will be made available to
+            the adapter servicing the API
+          required: false
+          schema:
+            type: string
         - name: X-LlamaStack-Client-Version
-        in: header
-        description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        required: false
-        schema:
-          type: string
+          in: header
+          description: Version of the client making the request. This is used to ensure
+            that the client and server are compatible.
+          required: false
+          schema:
+            type: string
 jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
 components:
   schemas:
@@ -2463,8 +2463,8 @@ components:
         - type: string
         - $ref: '#/components/schemas/InterleavedContentItem'
         - type: array
-        items:
-          $ref: '#/components/schemas/InterleavedContentItem'
+          items:
+            $ref: '#/components/schemas/InterleavedContentItem'
     InterleavedContentItem:
       oneOf:
         - $ref: '#/components/schemas/ImageContentItem'
@@ -2561,21 +2561,21 @@ components:
               - type: boolean
               - type: 'null'
               - type: array
-              items:
-                oneOf:
-                  - type: string
-                  - type: integer
-                  - type: number
-                  - type: boolean
-                  - type: 'null'
+                items:
+                  oneOf:
+                    - type: string
+                    - type: integer
+                    - type: number
+                    - type: boolean
+                    - type: 'null'
               - type: object
-              additionalProperties:
-                oneOf:
-                  - type: string
-                  - type: integer
-                  - type: number
-                  - type: boolean
-                  - type: 'null'
+                additionalProperties:
+                  oneOf:
+                    - type: string
+                    - type: integer
+                    - type: number
+                    - type: boolean
+                    - type: 'null'
       additionalProperties: false
       required:
         - call_id
@@ -3099,23 +3099,23 @@ components:
       oneOf:
         - type: string
         - type: object
-        properties:
-          name:
-            type: string
-          args:
-            type: object
-            additionalProperties:
-              oneOf:
-                - type: 'null'
-                - type: boolean
-                - type: number
-                - type: string
-                - type: array
-                - type: object
-        additionalProperties: false
-        required:
-          - name
-          - args
+          properties:
+            name:
+              type: string
+            args:
+              type: object
+              additionalProperties:
+                oneOf:
+                  - type: 'null'
+                  - type: boolean
+                  - type: number
+                  - type: string
+                  - type: array
+                  - type: object
+          additionalProperties: false
+          required:
+            - name
+            - args
     ToolDef:
       type: object
       properties:
@@ -3219,8 +3219,8 @@ components:
                   - type: string
                   - $ref: '#/components/schemas/InterleavedContentItem'
                   - type: array
-                  items:
-                    $ref: '#/components/schemas/InterleavedContentItem'
+                    items:
+                      $ref: '#/components/schemas/InterleavedContentItem'
                   - $ref: '#/components/schemas/URL'
               mime_type:
                 type: string
@@ -3569,8 +3569,8 @@ components:
                   - type: string
                   - $ref: '#/components/schemas/InterleavedContentItem'
                   - type: array
-                  items:
-                    $ref: '#/components/schemas/InterleavedContentItem'
+                    items:
+                      $ref: '#/components/schemas/InterleavedContentItem'
                   - $ref: '#/components/schemas/URL'
               mime_type:
                 type: string
@@ -4529,8 +4529,8 @@ components:
             - type: string
             - $ref: '#/components/schemas/InterleavedContentItem'
             - type: array
-            items:
-              $ref: '#/components/schemas/InterleavedContentItem'
+              items:
+                $ref: '#/components/schemas/InterleavedContentItem'
             - $ref: '#/components/schemas/URL'
         mime_type:
           type: string
@@ -5734,743 +5734,769 @@ security:
   - Default: []
 tags:
   - name: AgentCandidate
-  description: <SchemaDefinition schemaRef="#/components/schemas/AgentCandidate" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/AgentCandidate"
+      />
   - name: AgentConfig
-  description: <SchemaDefinition schemaRef="#/components/schemas/AgentConfig" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/AgentConfig" />
   - name: AgentCreateResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/AgentCreateResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/AgentCreateResponse"
+      />
   - name: AgentSessionCreateResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/AgentSessionCreateResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/AgentSessionCreateResponse"
+      />
   - name: AgentStepResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/AgentStepResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/AgentStepResponse"
+      />
   - name: AgentTool
-  description: <SchemaDefinition schemaRef="#/components/schemas/AgentTool" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/AgentTool" />
   - name: AgentTurnInputType
-  description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnInputType"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnInputType"
+      />
   - name: AgentTurnResponseEvent
-  description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseEvent"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseEvent"
+      />
   - name: AgentTurnResponseEventPayload
-  description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseEventPayload"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseEventPayload"
+      />
   - name: AgentTurnResponseStepCompletePayload
-  description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepCompletePayload"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepCompletePayload"
+      />
   - name: AgentTurnResponseStepProgressPayload
-  description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepProgressPayload"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepProgressPayload"
+      />
   - name: AgentTurnResponseStepStartPayload
-  description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepStartPayload"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepStartPayload"
+      />
   - name: AgentTurnResponseStreamChunk
-  description: "streamed agent turn completion response.\n\n<SchemaDefinition schemaRef=\"\
-    #/components/schemas/AgentTurnResponseStreamChunk\" />"
+    description: "streamed agent turn completion response.\n\n<SchemaDefinition schemaRef=\"\
+      #/components/schemas/AgentTurnResponseStreamChunk\" />"
   - name: AgentTurnResponseTurnCompletePayload
-  description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseTurnCompletePayload"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseTurnCompletePayload"
+      />
   - name: AgentTurnResponseTurnStartPayload
-  description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseTurnStartPayload"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseTurnStartPayload"
+      />
   - name: Agents
   - name: AggregationFunctionType
-  description: <SchemaDefinition schemaRef="#/components/schemas/AggregationFunctionType"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/AggregationFunctionType"
+      />
   - name: AlgorithmConfig
-  description: <SchemaDefinition schemaRef="#/components/schemas/AlgorithmConfig"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/AlgorithmConfig"
+      />
   - name: AppEvalTaskConfig
-  description: <SchemaDefinition schemaRef="#/components/schemas/AppEvalTaskConfig"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/AppEvalTaskConfig"
+      />
   - name: AppendRowsRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/AppendRowsRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/AppendRowsRequest"
+      />
   - name: ArrayType
-  description: <SchemaDefinition schemaRef="#/components/schemas/ArrayType" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ArrayType" />
   - name: BasicScoringFnParams
-  description: <SchemaDefinition schemaRef="#/components/schemas/BasicScoringFnParams"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/BasicScoringFnParams"
+      />
   - name: BatchChatCompletionRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/BatchChatCompletionRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/BatchChatCompletionRequest"
+      />
   - name: BatchChatCompletionResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/BatchChatCompletionResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/BatchChatCompletionResponse"
+      />
   - name: BatchCompletionRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/BatchCompletionRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/BatchCompletionRequest"
+      />
   - name: BatchCompletionResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/BatchCompletionResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/BatchCompletionResponse"
+      />
   - name: BatchInference (Coming Soon)
   - name: BenchmarkEvalTaskConfig
-  description: <SchemaDefinition schemaRef="#/components/schemas/BenchmarkEvalTaskConfig"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/BenchmarkEvalTaskConfig"
+      />
   - name: BooleanType
-  description: <SchemaDefinition schemaRef="#/components/schemas/BooleanType" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/BooleanType" />
   - name: BuiltinTool
-  description: <SchemaDefinition schemaRef="#/components/schemas/BuiltinTool" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/BuiltinTool" />
   - name: CancelTrainingJobRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/CancelTrainingJobRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/CancelTrainingJobRequest"
+      />
   - name: ChatCompletionInputType
-  description: <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionInputType"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionInputType"
+      />
   - name: ChatCompletionRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionRequest"
+      />
   - name: ChatCompletionResponse
-  description: "Chat completion response.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/ChatCompletionResponse\"\
-    \ />"
+    description: "Chat completion response.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/ChatCompletionResponse\"\
+      \ />"
   - name: ChatCompletionResponseEvent
-  description: "Chat completion response event.\n\n<SchemaDefinition schemaRef=\"\
-    #/components/schemas/ChatCompletionResponseEvent\" />"
+    description: "Chat completion response event.\n\n<SchemaDefinition schemaRef=\"\
+      #/components/schemas/ChatCompletionResponseEvent\" />"
   - name: ChatCompletionResponseEventType
-  description: <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionResponseEventType"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionResponseEventType"
+      />
   - name: ChatCompletionResponseStreamChunk
-  description: "SSE-stream of these events.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/ChatCompletionResponseStreamChunk\"\
-    \ />"
+    description: "SSE-stream of these events.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/ChatCompletionResponseStreamChunk\"\
+      \ />"
   - name: Checkpoint
-  description: "Checkpoint created during training runs\n\n<SchemaDefinition schemaRef=\"\
-    #/components/schemas/Checkpoint\" />"
+    description: "Checkpoint created during training runs\n\n<SchemaDefinition schemaRef=\"\
+      #/components/schemas/Checkpoint\" />"
   - name: CompletionInputType
-  description: <SchemaDefinition schemaRef="#/components/schemas/CompletionInputType"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/CompletionInputType"
+      />
   - name: CompletionMessage
-  description: <SchemaDefinition schemaRef="#/components/schemas/CompletionMessage"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/CompletionMessage"
+      />
   - name: CompletionRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/CompletionRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/CompletionRequest"
+      />
   - name: CompletionResponse
-  description: "Completion response.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/CompletionResponse\"\
-    \ />"
+    description: "Completion response.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/CompletionResponse\"\
+      \ />"
   - name: CompletionResponseStreamChunk
-  description: "streamed completion response.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/CompletionResponseStreamChunk\"\
-    \ />"
+    description: "streamed completion response.\n\n<SchemaDefinition schemaRef=\"\
+      #/components/schemas/CompletionResponseStreamChunk\" />"
   - name: ContentDelta
-  description: <SchemaDefinition schemaRef="#/components/schemas/ContentDelta" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ContentDelta" />
   - name: CreateAgentRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/CreateAgentRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/CreateAgentRequest"
+      />
   - name: CreateAgentSessionRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/CreateAgentSessionRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/CreateAgentSessionRequest"
+      />
   - name: CreateAgentTurnRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/CreateAgentTurnRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/CreateAgentTurnRequest"
+      />
   - name: DPOAlignmentConfig
-  description: <SchemaDefinition schemaRef="#/components/schemas/DPOAlignmentConfig"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/DPOAlignmentConfig"
+      />
   - name: DataConfig
-  description: <SchemaDefinition schemaRef="#/components/schemas/DataConfig" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/DataConfig" />
   - name: Dataset
-  description: <SchemaDefinition schemaRef="#/components/schemas/Dataset" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/Dataset" />
   - name: DatasetFormat
-  description: <SchemaDefinition schemaRef="#/components/schemas/DatasetFormat" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/DatasetFormat"
+      />
   - name: DatasetIO
   - name: Datasets
   - name: DefaultRAGQueryGeneratorConfig
-  description: <SchemaDefinition schemaRef="#/components/schemas/DefaultRAGQueryGeneratorConfig"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/DefaultRAGQueryGeneratorConfig"
+      />
   - name: EfficiencyConfig
-  description: <SchemaDefinition schemaRef="#/components/schemas/EfficiencyConfig"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/EfficiencyConfig"
+      />
   - name: EmbeddingsRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/EmbeddingsRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/EmbeddingsRequest"
+      />
   - name: EmbeddingsResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/EmbeddingsResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/EmbeddingsResponse"
+      />
   - name: Eval
   - name: EvalCandidate
-  description: <SchemaDefinition schemaRef="#/components/schemas/EvalCandidate" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/EvalCandidate"
+      />
   - name: EvalTask
-  description: <SchemaDefinition schemaRef="#/components/schemas/EvalTask" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/EvalTask" />
   - name: EvalTaskConfig
-  description: <SchemaDefinition schemaRef="#/components/schemas/EvalTaskConfig" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/EvalTaskConfig"
+      />
   - name: EvalTasks
   - name: EvaluateResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/EvaluateResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/EvaluateResponse"
+      />
   - name: EvaluateRowsRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/EvaluateRowsRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/EvaluateRowsRequest"
+      />
   - name: Event
-  description: <SchemaDefinition schemaRef="#/components/schemas/Event" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/Event" />
   - name: GrammarResponseFormat
-  description: <SchemaDefinition schemaRef="#/components/schemas/GrammarResponseFormat"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/GrammarResponseFormat"
+      />
   - name: GreedySamplingStrategy
-  description: <SchemaDefinition schemaRef="#/components/schemas/GreedySamplingStrategy"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/GreedySamplingStrategy"
+      />
   - name: HealthInfo
-  description: <SchemaDefinition schemaRef="#/components/schemas/HealthInfo" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/HealthInfo" />
   - name: ImageContentItem
-  description: <SchemaDefinition schemaRef="#/components/schemas/ImageContentItem"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ImageContentItem"
+      />
   - name: ImageDelta
-  description: <SchemaDefinition schemaRef="#/components/schemas/ImageDelta" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ImageDelta" />
   - name: Inference
   - name: InferenceStep
-  description: <SchemaDefinition schemaRef="#/components/schemas/InferenceStep" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/InferenceStep"
+      />
   - name: InsertChunksRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/InsertChunksRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/InsertChunksRequest"
+      />
   - name: InsertRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/InsertRequest" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/InsertRequest"
+      />
   - name: Inspect
   - name: InterleavedContent
-  description: <SchemaDefinition schemaRef="#/components/schemas/InterleavedContent"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/InterleavedContent"
+      />
   - name: InterleavedContentItem
-  description: <SchemaDefinition schemaRef="#/components/schemas/InterleavedContentItem"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/InterleavedContentItem"
+      />
   - name: InvokeToolRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/InvokeToolRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/InvokeToolRequest"
+      />
   - name: Job
-  description: <SchemaDefinition schemaRef="#/components/schemas/Job" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/Job" />
   - name: JobStatus
-  description: <SchemaDefinition schemaRef="#/components/schemas/JobStatus" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/JobStatus" />
   - name: JsonSchemaResponseFormat
-  description: <SchemaDefinition schemaRef="#/components/schemas/JsonSchemaResponseFormat"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/JsonSchemaResponseFormat"
+      />
   - name: JsonType
-  description: <SchemaDefinition schemaRef="#/components/schemas/JsonType" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/JsonType" />
   - name: LLMAsJudgeScoringFnParams
-  description: <SchemaDefinition schemaRef="#/components/schemas/LLMAsJudgeScoringFnParams"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/LLMAsJudgeScoringFnParams"
+      />
   - name: LLMRAGQueryGeneratorConfig
-  description: <SchemaDefinition schemaRef="#/components/schemas/LLMRAGQueryGeneratorConfig"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/LLMRAGQueryGeneratorConfig"
+      />
   - name: ListDatasetsResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/ListDatasetsResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ListDatasetsResponse"
+      />
   - name: ListEvalTasksResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/ListEvalTasksResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ListEvalTasksResponse"
+      />
   - name: ListModelsResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/ListModelsResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ListModelsResponse"
+      />
   - name: ListPostTrainingJobsResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/ListPostTrainingJobsResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ListPostTrainingJobsResponse"
+      />
   - name: ListProvidersResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/ListProvidersResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ListProvidersResponse"
+      />
   - name: ListRoutesResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/ListRoutesResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ListRoutesResponse"
+      />
   - name: ListScoringFunctionsResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/ListScoringFunctionsResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ListScoringFunctionsResponse"
+      />
   - name: ListShieldsResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/ListShieldsResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ListShieldsResponse"
+      />
   - name: ListToolGroupsResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/ListToolGroupsResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ListToolGroupsResponse"
+      />
   - name: ListToolsResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/ListToolsResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ListToolsResponse"
+      />
   - name: ListVectorDBsResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/ListVectorDBsResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ListVectorDBsResponse"
+      />
   - name: LogEventRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/LogEventRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/LogEventRequest"
+      />
   - name: LogSeverity
-  description: <SchemaDefinition schemaRef="#/components/schemas/LogSeverity" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/LogSeverity" />
   - name: LoraFinetuningConfig
-  description: <SchemaDefinition schemaRef="#/components/schemas/LoraFinetuningConfig"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/LoraFinetuningConfig"
+      />
   - name: MemoryRetrievalStep
-  description: <SchemaDefinition schemaRef="#/components/schemas/MemoryRetrievalStep"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/MemoryRetrievalStep"
+      />
   - name: Message
-  description: <SchemaDefinition schemaRef="#/components/schemas/Message" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/Message" />
   - name: MetricEvent
-  description: <SchemaDefinition schemaRef="#/components/schemas/MetricEvent" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/MetricEvent" />
   - name: Model
-  description: <SchemaDefinition schemaRef="#/components/schemas/Model" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/Model" />
   - name: ModelCandidate
-  description: <SchemaDefinition schemaRef="#/components/schemas/ModelCandidate" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ModelCandidate"
+      />
   - name: ModelType
-  description: <SchemaDefinition schemaRef="#/components/schemas/ModelType" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ModelType" />
   - name: Models
   - name: NumberType
-  description: <SchemaDefinition schemaRef="#/components/schemas/NumberType" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/NumberType" />
   - name: ObjectType
-  description: <SchemaDefinition schemaRef="#/components/schemas/ObjectType" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ObjectType" />
   - name: OptimizerConfig
-  description: <SchemaDefinition schemaRef="#/components/schemas/OptimizerConfig"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/OptimizerConfig"
+      />
   - name: OptimizerType
-  description: <SchemaDefinition schemaRef="#/components/schemas/OptimizerType" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/OptimizerType"
+      />
   - name: PaginatedRowsResult
-  description: <SchemaDefinition schemaRef="#/components/schemas/PaginatedRowsResult"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/PaginatedRowsResult"
+      />
   - name: ParamType
-  description: <SchemaDefinition schemaRef="#/components/schemas/ParamType" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ParamType" />
   - name: PostTraining (Coming Soon)
   - name: PostTrainingJob
-  description: <SchemaDefinition schemaRef="#/components/schemas/PostTrainingJob"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/PostTrainingJob"
+      />
   - name: PostTrainingJobArtifactsResponse
-  description: "Artifacts of a finetuning job.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/PostTrainingJobArtifactsResponse\"\
-    \ />"
+    description: "Artifacts of a finetuning job.\n\n<SchemaDefinition schemaRef=\"\
+      #/components/schemas/PostTrainingJobArtifactsResponse\" />"
   - name: PostTrainingJobStatusResponse
-  description: "Status of a finetuning job.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/PostTrainingJobStatusResponse\"\
-    \ />"
+    description: "Status of a finetuning job.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/PostTrainingJobStatusResponse\"\
+      \ />"
   - name: PreferenceOptimizeRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/PreferenceOptimizeRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/PreferenceOptimizeRequest"
+      />
   - name: ProviderInfo
-  description: <SchemaDefinition schemaRef="#/components/schemas/ProviderInfo" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ProviderInfo" />
   - name: QATFinetuningConfig
-  description: <SchemaDefinition schemaRef="#/components/schemas/QATFinetuningConfig"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/QATFinetuningConfig"
+      />
   - name: QueryChunksRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/QueryChunksRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/QueryChunksRequest"
+      />
   - name: QueryChunksResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/QueryChunksResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/QueryChunksResponse"
+      />
   - name: QueryCondition
-  description: <SchemaDefinition schemaRef="#/components/schemas/QueryCondition" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/QueryCondition"
+      />
   - name: QueryConditionOp
-  description: <SchemaDefinition schemaRef="#/components/schemas/QueryConditionOp"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/QueryConditionOp"
+      />
   - name: QueryRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/QueryRequest" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/QueryRequest" />
   - name: QuerySpanTreeResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/QuerySpanTreeResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/QuerySpanTreeResponse"
+      />
   - name: QuerySpansResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/QuerySpansResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/QuerySpansResponse"
+      />
   - name: QueryTracesResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/QueryTracesResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/QueryTracesResponse"
+      />
   - name: RAGDocument
-  description: <SchemaDefinition schemaRef="#/components/schemas/RAGDocument" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/RAGDocument" />
   - name: RAGQueryConfig
-  description: <SchemaDefinition schemaRef="#/components/schemas/RAGQueryConfig" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/RAGQueryConfig"
+      />
   - name: RAGQueryGeneratorConfig
-  description: <SchemaDefinition schemaRef="#/components/schemas/RAGQueryGeneratorConfig"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/RAGQueryGeneratorConfig"
+      />
   - name: RAGQueryResult
-  description: <SchemaDefinition schemaRef="#/components/schemas/RAGQueryResult" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/RAGQueryResult"
+      />
   - name: RegexParserScoringFnParams
-  description: <SchemaDefinition schemaRef="#/components/schemas/RegexParserScoringFnParams"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/RegexParserScoringFnParams"
+      />
   - name: RegisterDatasetRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/RegisterDatasetRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/RegisterDatasetRequest"
+      />
   - name: RegisterEvalTaskRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/RegisterEvalTaskRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/RegisterEvalTaskRequest"
+      />
   - name: RegisterModelRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/RegisterModelRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/RegisterModelRequest"
+      />
   - name: RegisterScoringFunctionRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/RegisterScoringFunctionRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/RegisterScoringFunctionRequest"
+      />
   - name: RegisterShieldRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/RegisterShieldRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/RegisterShieldRequest"
+      />
   - name: RegisterToolGroupRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/RegisterToolGroupRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/RegisterToolGroupRequest"
+      />
   - name: RegisterVectorDbRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/RegisterVectorDbRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/RegisterVectorDbRequest"
+      />
   - name: ResponseFormat
-  description: <SchemaDefinition schemaRef="#/components/schemas/ResponseFormat" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ResponseFormat"
+      />
   - name: RouteInfo
-  description: <SchemaDefinition schemaRef="#/components/schemas/RouteInfo" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/RouteInfo" />
   - name: RunEvalRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/RunEvalRequest" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/RunEvalRequest"
+      />
   - name: RunShieldRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/RunShieldRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/RunShieldRequest"
+      />
   - name: RunShieldResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/RunShieldResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/RunShieldResponse"
+      />
   - name: Safety
   - name: SafetyViolation
-  description: <SchemaDefinition schemaRef="#/components/schemas/SafetyViolation"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/SafetyViolation"
+      />
   - name: SamplingParams
-  description: <SchemaDefinition schemaRef="#/components/schemas/SamplingParams" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/SamplingParams"
+      />
   - name: SaveSpansToDatasetRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/SaveSpansToDatasetRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/SaveSpansToDatasetRequest"
+      />
   - name: ScoreBatchRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/ScoreBatchRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ScoreBatchRequest"
+      />
   - name: ScoreBatchResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/ScoreBatchResponse"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ScoreBatchResponse"
+      />
   - name: ScoreRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/ScoreRequest" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ScoreRequest" />
   - name: ScoreResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/ScoreResponse" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ScoreResponse"
+      />
   - name: Scoring
   - name: ScoringFn
-  description: <SchemaDefinition schemaRef="#/components/schemas/ScoringFn" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ScoringFn" />
   - name: ScoringFnParams
-  description: <SchemaDefinition schemaRef="#/components/schemas/ScoringFnParams"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ScoringFnParams"
+      />
   - name: ScoringFunctions
   - name: ScoringResult
-  description: <SchemaDefinition schemaRef="#/components/schemas/ScoringResult" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ScoringResult"
+      />
   - name: Session
-  description: "A single session of an interaction with an Agentic System.\n\n<SchemaDefinition
-    schemaRef=\"#/components/schemas/Session\" />"
+    description: "A single session of an interaction with an Agentic System.\n\n<SchemaDefinition
+      schemaRef=\"#/components/schemas/Session\" />"
   - name: Shield
-  description: "A safety shield resource that can be used to check content\n\n<SchemaDefinition
-    schemaRef=\"#/components/schemas/Shield\" />"
+    description: "A safety shield resource that can be used to check content\n\n<SchemaDefinition
+      schemaRef=\"#/components/schemas/Shield\" />"
   - name: ShieldCallStep
-  description: <SchemaDefinition schemaRef="#/components/schemas/ShieldCallStep" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ShieldCallStep"
+      />
   - name: Shields
   - name: Span
-  description: <SchemaDefinition schemaRef="#/components/schemas/Span" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/Span" />
   - name: SpanEndPayload
-  description: <SchemaDefinition schemaRef="#/components/schemas/SpanEndPayload" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/SpanEndPayload"
+      />
   - name: SpanStartPayload
-  description: <SchemaDefinition schemaRef="#/components/schemas/SpanStartPayload"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/SpanStartPayload"
+      />
   - name: SpanStatus
-  description: <SchemaDefinition schemaRef="#/components/schemas/SpanStatus" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/SpanStatus" />
   - name: SpanWithStatus
-  description: <SchemaDefinition schemaRef="#/components/schemas/SpanWithStatus" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/SpanWithStatus"
+      />
   - name: StopReason
-  description: <SchemaDefinition schemaRef="#/components/schemas/StopReason" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/StopReason" />
   - name: StringType
-  description: <SchemaDefinition schemaRef="#/components/schemas/StringType" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/StringType" />
   - name: StructuredLogEvent
-  description: <SchemaDefinition schemaRef="#/components/schemas/StructuredLogEvent"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/StructuredLogEvent"
+      />
   - name: StructuredLogPayload
-  description: <SchemaDefinition schemaRef="#/components/schemas/StructuredLogPayload"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/StructuredLogPayload"
+      />
   - name: SupervisedFineTuneRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/SupervisedFineTuneRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/SupervisedFineTuneRequest"
+      />
   - name: SyntheticDataGenerateRequest
-  description: <SchemaDefinition schemaRef="#/components/schemas/SyntheticDataGenerateRequest"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/SyntheticDataGenerateRequest"
+      />
   - name: SyntheticDataGeneration (Coming Soon)
   - name: SyntheticDataGenerationResponse
-  description: "Response from the synthetic data generation. Batch of (prompt, response,
-    score) tuples that pass the threshold.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/SyntheticDataGenerationResponse\"\
-    \ />"
+    description: "Response from the synthetic data generation. Batch of (prompt, response,
+      score) tuples that pass the threshold.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/SyntheticDataGenerationResponse\"\
+      \ />"
   - name: SystemMessage
-  description: <SchemaDefinition schemaRef="#/components/schemas/SystemMessage" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/SystemMessage"
+      />
   - name: Telemetry
   - name: TextContentItem
-  description: <SchemaDefinition schemaRef="#/components/schemas/TextContentItem"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/TextContentItem"
+      />
   - name: TextDelta
-  description: <SchemaDefinition schemaRef="#/components/schemas/TextDelta" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/TextDelta" />
   - name: TokenLogProbs
-  description: <SchemaDefinition schemaRef="#/components/schemas/TokenLogProbs" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/TokenLogProbs"
+      />
   - name: Tool
-  description: <SchemaDefinition schemaRef="#/components/schemas/Tool" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/Tool" />
   - name: ToolCall
-  description: <SchemaDefinition schemaRef="#/components/schemas/ToolCall" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ToolCall" />
   - name: ToolCallDelta
-  description: <SchemaDefinition schemaRef="#/components/schemas/ToolCallDelta" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ToolCallDelta"
+      />
   - name: ToolCallParseStatus
-  description: <SchemaDefinition schemaRef="#/components/schemas/ToolCallParseStatus"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ToolCallParseStatus"
+      />
   - name: ToolChoice
-  description: <SchemaDefinition schemaRef="#/components/schemas/ToolChoice" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ToolChoice" />
   - name: ToolDef
-  description: <SchemaDefinition schemaRef="#/components/schemas/ToolDef" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ToolDef" />
   - name: ToolDefinition
-  description: <SchemaDefinition schemaRef="#/components/schemas/ToolDefinition" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ToolDefinition"
+      />
   - name: ToolExecutionStep
-  description: <SchemaDefinition schemaRef="#/components/schemas/ToolExecutionStep"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ToolExecutionStep"
+      />
   - name: ToolGroup
-  description: <SchemaDefinition schemaRef="#/components/schemas/ToolGroup" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ToolGroup" />
   - name: ToolGroups
   - name: ToolHost
-  description: <SchemaDefinition schemaRef="#/components/schemas/ToolHost" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ToolHost" />
   - name: ToolInvocationResult
-  description: <SchemaDefinition schemaRef="#/components/schemas/ToolInvocationResult"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ToolInvocationResult"
+      />
   - name: ToolParamDefinition
-  description: <SchemaDefinition schemaRef="#/components/schemas/ToolParamDefinition"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ToolParamDefinition"
+      />
   - name: ToolParameter
-  description: <SchemaDefinition schemaRef="#/components/schemas/ToolParameter" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ToolParameter"
+      />
   - name: ToolPromptFormat
-  description: "This Enum refers to the prompt format for calling custom / zero shot
-    tools\n\n`json` --\n    Refers to the json format for calling tools.\n    The
-    json format takes the form like\n    {\n        \"type\": \"function\",\n    \
-    \    \"function\" : {\n            \"name\": \"function_name\",\n            \"\
-    description\": \"function_description\",\n            \"parameters\": {...}\n\
-    \        }\n    }\n\n`function_tag` --\n    This is an example of how you could
-    define\n    your own user defined format for making tool calls.\n    The function_tag
-    format looks like this,\n    <function=function_name>(parameters)</function>\n
-    \nThe detailed prompts for each of these formats are added to llama cli\n\n<SchemaDefinition
-    schemaRef=\"#/components/schemas/ToolPromptFormat\" />"
+    description: "This Enum refers to the prompt format for calling custom / zero
+      shot tools\n\n`json` --\n    Refers to the json format for calling tools.\n\
+      \    The json format takes the form like\n    {\n        \"type\": \"function\"\
+      ,\n        \"function\" : {\n            \"name\": \"function_name\",\n    \
+      \        \"description\": \"function_description\",\n            \"parameters\"\
+      : {...}\n        }\n    }\n\n`function_tag` --\n    This is an example of how
+      you could define\n    your own user defined format for making tool calls.\n\
+      \    The function_tag format looks like this,\n    <function=function_name>(parameters)</function>\n
+      \nThe detailed prompts for each of these formats are added to llama cli\n\n
+      <SchemaDefinition schemaRef=\"#/components/schemas/ToolPromptFormat\" />"
   - name: ToolResponse
-  description: <SchemaDefinition schemaRef="#/components/schemas/ToolResponse" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ToolResponse" />
   - name: ToolResponseMessage
-  description: <SchemaDefinition schemaRef="#/components/schemas/ToolResponseMessage"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ToolResponseMessage"
+      />
   - name: ToolRuntime
   - name: TopKSamplingStrategy
-  description: <SchemaDefinition schemaRef="#/components/schemas/TopKSamplingStrategy"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/TopKSamplingStrategy"
+      />
   - name: TopPSamplingStrategy
-  description: <SchemaDefinition schemaRef="#/components/schemas/TopPSamplingStrategy"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/TopPSamplingStrategy"
+      />
   - name: Trace
-  description: <SchemaDefinition schemaRef="#/components/schemas/Trace" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/Trace" />
   - name: TrainingConfig
-  description: <SchemaDefinition schemaRef="#/components/schemas/TrainingConfig" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/TrainingConfig"
+      />
   - name: Turn
-  description: "A single turn in an interaction with an Agentic System.\n\n<SchemaDefinition
-    schemaRef=\"#/components/schemas/Turn\" />"
+    description: "A single turn in an interaction with an Agentic System.\n\n<SchemaDefinition
+      schemaRef=\"#/components/schemas/Turn\" />"
   - name: URL
-  description: <SchemaDefinition schemaRef="#/components/schemas/URL" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/URL" />
   - name: UnionType
-  description: <SchemaDefinition schemaRef="#/components/schemas/UnionType" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/UnionType" />
   - name: UnstructuredLogEvent
-  description: <SchemaDefinition schemaRef="#/components/schemas/UnstructuredLogEvent"
-    />
+    description: <SchemaDefinition schemaRef="#/components/schemas/UnstructuredLogEvent"
+      />
   - name: UserMessage
-  description: <SchemaDefinition schemaRef="#/components/schemas/UserMessage" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/UserMessage" />
   - name: VectorDB
-  description: <SchemaDefinition schemaRef="#/components/schemas/VectorDB" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/VectorDB" />
   - name: VectorDBs
   - name: VectorIO
   - name: VersionInfo
-  description: <SchemaDefinition schemaRef="#/components/schemas/VersionInfo" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/VersionInfo" />
   - name: ViolationLevel
-  description: <SchemaDefinition schemaRef="#/components/schemas/ViolationLevel" />
+    description: <SchemaDefinition schemaRef="#/components/schemas/ViolationLevel"
+      />
 x-tagGroups:
   - name: Operations
-  tags:
-    - Agents
-    - BatchInference (Coming Soon)
-    - DatasetIO
-    - Datasets
-    - Eval
-    - EvalTasks
-    - Inference
-    - Inspect
-    - Models
-    - PostTraining (Coming Soon)
-    - Safety
-    - Scoring
-    - ScoringFunctions
-    - Shields
-    - SyntheticDataGeneration (Coming Soon)
-    - Telemetry
-    - ToolGroups
-    - ToolRuntime
-    - VectorDBs
-    - VectorIO
+    tags:
+      - Agents
+      - BatchInference (Coming Soon)
+      - DatasetIO
+      - Datasets
+      - Eval
+      - EvalTasks
+      - Inference
+      - Inspect
+      - Models
+      - PostTraining (Coming Soon)
+      - Safety
+      - Scoring
+      - ScoringFunctions
+      - Shields
+      - SyntheticDataGeneration (Coming Soon)
+      - Telemetry
+      - ToolGroups
+      - ToolRuntime
+      - VectorDBs
+      - VectorIO
   - name: Types
-  tags:
-    - AgentCandidate
-    - AgentConfig
-    - AgentCreateResponse
-    - AgentSessionCreateResponse
-    - AgentStepResponse
-    - AgentTool
-    - AgentTurnInputType
-    - AgentTurnResponseEvent
-    - AgentTurnResponseEventPayload
-    - AgentTurnResponseStepCompletePayload
-    - AgentTurnResponseStepProgressPayload
-    - AgentTurnResponseStepStartPayload
-    - AgentTurnResponseStreamChunk
-    - AgentTurnResponseTurnCompletePayload
-    - AgentTurnResponseTurnStartPayload
-    - AggregationFunctionType
-    - AlgorithmConfig
-    - AppEvalTaskConfig
-    - AppendRowsRequest
-    - ArrayType
-    - BasicScoringFnParams
-    - BatchChatCompletionRequest
-    - BatchChatCompletionResponse
-    - BatchCompletionRequest
-    - BatchCompletionResponse
-    - BenchmarkEvalTaskConfig
-    - BooleanType
-    - BuiltinTool
-    - CancelTrainingJobRequest
-    - ChatCompletionInputType
-    - ChatCompletionRequest
-    - ChatCompletionResponse
-    - ChatCompletionResponseEvent
-    - ChatCompletionResponseEventType
-    - ChatCompletionResponseStreamChunk
-    - Checkpoint
-    - CompletionInputType
-    - CompletionMessage
-    - CompletionRequest
-    - CompletionResponse
-    - CompletionResponseStreamChunk
-    - ContentDelta
-    - CreateAgentRequest
-    - CreateAgentSessionRequest
-    - CreateAgentTurnRequest
-    - DPOAlignmentConfig
-    - DataConfig
-    - Dataset
-    - DatasetFormat
-    - DefaultRAGQueryGeneratorConfig
-    - EfficiencyConfig
-    - EmbeddingsRequest
-    - EmbeddingsResponse
-    - EvalCandidate
-    - EvalTask
-    - EvalTaskConfig
-    - EvaluateResponse
-    - EvaluateRowsRequest
-    - Event
-    - GrammarResponseFormat
-    - GreedySamplingStrategy
-    - HealthInfo
-    - ImageContentItem
-    - ImageDelta
-    - InferenceStep
-    - InsertChunksRequest
-    - InsertRequest
-    - InterleavedContent
-    - InterleavedContentItem
-    - InvokeToolRequest
-    - Job
-    - JobStatus
-    - JsonSchemaResponseFormat
-    - JsonType
-    - LLMAsJudgeScoringFnParams
-    - LLMRAGQueryGeneratorConfig
-    - ListDatasetsResponse
-    - ListEvalTasksResponse
-    - ListModelsResponse
-    - ListPostTrainingJobsResponse
-    - ListProvidersResponse
-    - ListRoutesResponse
-    - ListScoringFunctionsResponse
-    - ListShieldsResponse
-    - ListToolGroupsResponse
-    - ListToolsResponse
-    - ListVectorDBsResponse
-    - LogEventRequest
-    - LogSeverity
-    - LoraFinetuningConfig
-    - MemoryRetrievalStep
-    - Message
-    - MetricEvent
-    - Model
-    - ModelCandidate
-    - ModelType
-    - NumberType
-    - ObjectType
-    - OptimizerConfig
-    - OptimizerType
-    - PaginatedRowsResult
-    - ParamType
-    - PostTrainingJob
-    - PostTrainingJobArtifactsResponse
-    - PostTrainingJobStatusResponse
-    - PreferenceOptimizeRequest
-    - ProviderInfo
-    - QATFinetuningConfig
-    - QueryChunksRequest
-    - QueryChunksResponse
-    - QueryCondition
-    - QueryConditionOp
-    - QueryRequest
-    - QuerySpanTreeResponse
-    - QuerySpansResponse
-    - QueryTracesResponse
-    - RAGDocument
-    - RAGQueryConfig
-    - RAGQueryGeneratorConfig
-    - RAGQueryResult
-    - RegexParserScoringFnParams
-    - RegisterDatasetRequest
-    - RegisterEvalTaskRequest
-    - RegisterModelRequest
-    - RegisterScoringFunctionRequest
-    - RegisterShieldRequest
-    - RegisterToolGroupRequest
-    - RegisterVectorDbRequest
-    - ResponseFormat
-    - RouteInfo
-    - RunEvalRequest
-    - RunShieldRequest
-    - RunShieldResponse
-    - SafetyViolation
-    - SamplingParams
-    - SaveSpansToDatasetRequest
-    - ScoreBatchRequest
-    - ScoreBatchResponse
-    - ScoreRequest
-    - ScoreResponse
-    - ScoringFn
-    - ScoringFnParams
-    - ScoringResult
-    - Session
-    - Shield
-    - ShieldCallStep
-    - Span
-    - SpanEndPayload
-    - SpanStartPayload
-    - SpanStatus
-    - SpanWithStatus
-    - StopReason
-    - StringType
-    - StructuredLogEvent
-    - StructuredLogPayload
-    - SupervisedFineTuneRequest
-    - SyntheticDataGenerateRequest
-    - SyntheticDataGenerationResponse
-    - SystemMessage
-    - TextContentItem
-    - TextDelta
-    - TokenLogProbs
-    - Tool
-    - ToolCall
-    - ToolCallDelta
-    - ToolCallParseStatus
-    - ToolChoice
-    - ToolDef
-    - ToolDefinition
-    - ToolExecutionStep
-    - ToolGroup
-    - ToolHost
-    - ToolInvocationResult
-    - ToolParamDefinition
-    - ToolParameter
-    - ToolPromptFormat
-    - ToolResponse
-    - ToolResponseMessage
-    - TopKSamplingStrategy
-    - TopPSamplingStrategy
-    - Trace
-    - TrainingConfig
-    - Turn
-    - URL
-    - UnionType
-    - UnstructuredLogEvent
-    - UserMessage
-    - VectorDB
-    - VersionInfo
-    - ViolationLevel
+    tags:
+      - AgentCandidate
+      - AgentConfig
+      - AgentCreateResponse
+      - AgentSessionCreateResponse
+      - AgentStepResponse
+      - AgentTool
+      - AgentTurnInputType
+      - AgentTurnResponseEvent
+      - AgentTurnResponseEventPayload
+      - AgentTurnResponseStepCompletePayload
+      - AgentTurnResponseStepProgressPayload
+      - AgentTurnResponseStepStartPayload
+      - AgentTurnResponseStreamChunk
+      - AgentTurnResponseTurnCompletePayload
+      - AgentTurnResponseTurnStartPayload
+      - AggregationFunctionType
+      - AlgorithmConfig
+      - AppEvalTaskConfig
+      - AppendRowsRequest
+      - ArrayType
+      - BasicScoringFnParams
+      - BatchChatCompletionRequest
+      - BatchChatCompletionResponse
+      - BatchCompletionRequest
+      - BatchCompletionResponse
+      - BenchmarkEvalTaskConfig
+      - BooleanType
+      - BuiltinTool
+      - CancelTrainingJobRequest
+      - ChatCompletionInputType
+      - ChatCompletionRequest
+      - ChatCompletionResponse
+      - ChatCompletionResponseEvent
+      - ChatCompletionResponseEventType
+      - ChatCompletionResponseStreamChunk
+      - Checkpoint
+      - CompletionInputType
+      - CompletionMessage
+      - CompletionRequest
+      - CompletionResponse
+      - CompletionResponseStreamChunk
+      - ContentDelta
+      - CreateAgentRequest
+      - CreateAgentSessionRequest
+      - CreateAgentTurnRequest
+      - DPOAlignmentConfig
+      - DataConfig
+      - Dataset
+      - DatasetFormat
+      - DefaultRAGQueryGeneratorConfig
+      - EfficiencyConfig
+      - EmbeddingsRequest
+      - EmbeddingsResponse
+      - EvalCandidate
+      - EvalTask
+      - EvalTaskConfig
+      - EvaluateResponse
+      - EvaluateRowsRequest
+      - Event
+      - GrammarResponseFormat
+      - GreedySamplingStrategy
+      - HealthInfo
+      - ImageContentItem
+      - ImageDelta
+      - InferenceStep
+      - InsertChunksRequest
+      - InsertRequest
+      - InterleavedContent
+      - InterleavedContentItem
+      - InvokeToolRequest
+      - Job
+      - JobStatus
+      - JsonSchemaResponseFormat
+      - JsonType
+      - LLMAsJudgeScoringFnParams
+      - LLMRAGQueryGeneratorConfig
+      - ListDatasetsResponse
+      - ListEvalTasksResponse
+      - ListModelsResponse
+      - ListPostTrainingJobsResponse
+      - ListProvidersResponse
+      - ListRoutesResponse
+      - ListScoringFunctionsResponse
+      - ListShieldsResponse
+      - ListToolGroupsResponse
+      - ListToolsResponse
+      - ListVectorDBsResponse
+      - LogEventRequest
+      - LogSeverity
+      - LoraFinetuningConfig
+      - MemoryRetrievalStep
+      - Message
+      - MetricEvent
+      - Model
+      - ModelCandidate
+      - ModelType
+      - NumberType
+      - ObjectType
+      - OptimizerConfig
+      - OptimizerType
+      - PaginatedRowsResult
+      - ParamType
+      - PostTrainingJob
+      - PostTrainingJobArtifactsResponse
+      - PostTrainingJobStatusResponse
+      - PreferenceOptimizeRequest
+      - ProviderInfo
+      - QATFinetuningConfig
+      - QueryChunksRequest
+      - QueryChunksResponse
+      - QueryCondition
+      - QueryConditionOp
+      - QueryRequest
+      - QuerySpanTreeResponse
+      - QuerySpansResponse
+      - QueryTracesResponse
+      - RAGDocument
+      - RAGQueryConfig
+      - RAGQueryGeneratorConfig
+      - RAGQueryResult
+      - RegexParserScoringFnParams
+      - RegisterDatasetRequest
+      - RegisterEvalTaskRequest
+      - RegisterModelRequest
+      - RegisterScoringFunctionRequest
+      - RegisterShieldRequest
+      - RegisterToolGroupRequest
+      - RegisterVectorDbRequest
+      - ResponseFormat
+      - RouteInfo
+      - RunEvalRequest
+      - RunShieldRequest
+      - RunShieldResponse
+      - SafetyViolation
+      - SamplingParams
+      - SaveSpansToDatasetRequest
+      - ScoreBatchRequest
+      - ScoreBatchResponse
+      - ScoreRequest
+      - ScoreResponse
+      - ScoringFn
+      - ScoringFnParams
+      - ScoringResult
+      - Session
+      - Shield
+      - ShieldCallStep
+      - Span
+      - SpanEndPayload
+      - SpanStartPayload
+      - SpanStatus
+      - SpanWithStatus
+      - StopReason
+      - StringType
+      - StructuredLogEvent
+      - StructuredLogPayload
+      - SupervisedFineTuneRequest
+      - SyntheticDataGenerateRequest
+      - SyntheticDataGenerationResponse
+      - SystemMessage
+      - TextContentItem
+      - TextDelta
+      - TokenLogProbs
+      - Tool
+      - ToolCall
+      - ToolCallDelta
+      - ToolCallParseStatus
+      - ToolChoice
+      - ToolDef
+      - ToolDefinition
+      - ToolExecutionStep
+      - ToolGroup
+      - ToolHost
+      - ToolInvocationResult
+      - ToolParamDefinition
+      - ToolParameter
+      - ToolPromptFormat
+      - ToolResponse
+      - ToolResponseMessage
+      - TopKSamplingStrategy
+      - TopPSamplingStrategy
+      - Trace
+      - TrainingConfig
+      - Turn
+      - URL
+      - UnionType
+      - UnstructuredLogEvent
+      - UserMessage
+      - VectorDB
+      - VersionInfo
+      - ViolationLevel

--- a/docs/resources/llama-stack-spec.yaml
+++ b/docs/resources/llama-stack-spec.yaml
@@ -1,3 +1,4 @@
+---
 openapi: 3.1.0
 info:
   title: Llama Stack Specification
@@ -5734,508 +5735,373 @@ security:
   - Default: []
 tags:
   - name: AgentCandidate
-    description: <SchemaDefinition schemaRef="#/components/schemas/AgentCandidate"
-      />
+    description: ''
   - name: AgentConfig
-    description: <SchemaDefinition schemaRef="#/components/schemas/AgentConfig" />
+    description: ''
   - name: AgentCreateResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/AgentCreateResponse"
-      />
+    description: ''
   - name: AgentSessionCreateResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/AgentSessionCreateResponse"
-      />
+    description: ''
   - name: AgentStepResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/AgentStepResponse"
-      />
+    description: ''
   - name: AgentTool
-    description: <SchemaDefinition schemaRef="#/components/schemas/AgentTool" />
+    description: ''
   - name: AgentTurnInputType
-    description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnInputType"
-      />
+    description: ''
   - name: AgentTurnResponseEvent
-    description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseEvent"
-      />
+    description: ''
   - name: AgentTurnResponseEventPayload
-    description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseEventPayload"
-      />
+    description: ''
   - name: AgentTurnResponseStepCompletePayload
-    description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepCompletePayload"
-      />
+    description: ''
   - name: AgentTurnResponseStepProgressPayload
-    description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepProgressPayload"
-      />
+    description: ''
   - name: AgentTurnResponseStepStartPayload
-    description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepStartPayload"
-      />
+    description: ''
   - name: AgentTurnResponseStreamChunk
-    description: "streamed agent turn completion response.\n\n<SchemaDefinition schemaRef=\"\
-      #/components/schemas/AgentTurnResponseStreamChunk\" />"
+    description: streamed agent turn completion response.
   - name: AgentTurnResponseTurnCompletePayload
-    description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseTurnCompletePayload"
-      />
+    description: ''
   - name: AgentTurnResponseTurnStartPayload
-    description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseTurnStartPayload"
-      />
+    description: ''
   - name: Agents
   - name: AggregationFunctionType
-    description: <SchemaDefinition schemaRef="#/components/schemas/AggregationFunctionType"
-      />
+    description: ''
   - name: AlgorithmConfig
-    description: <SchemaDefinition schemaRef="#/components/schemas/AlgorithmConfig"
-      />
+    description: ''
   - name: AppEvalTaskConfig
-    description: <SchemaDefinition schemaRef="#/components/schemas/AppEvalTaskConfig"
-      />
+    description: ''
   - name: AppendRowsRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/AppendRowsRequest"
-      />
+    description: ''
   - name: ArrayType
-    description: <SchemaDefinition schemaRef="#/components/schemas/ArrayType" />
+    description: ''
   - name: BasicScoringFnParams
-    description: <SchemaDefinition schemaRef="#/components/schemas/BasicScoringFnParams"
-      />
+    description: ''
   - name: BatchChatCompletionRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/BatchChatCompletionRequest"
-      />
+    description: ''
   - name: BatchChatCompletionResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/BatchChatCompletionResponse"
-      />
+    description: ''
   - name: BatchCompletionRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/BatchCompletionRequest"
-      />
+    description: ''
   - name: BatchCompletionResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/BatchCompletionResponse"
-      />
+    description: ''
   - name: BatchInference (Coming Soon)
   - name: BenchmarkEvalTaskConfig
-    description: <SchemaDefinition schemaRef="#/components/schemas/BenchmarkEvalTaskConfig"
-      />
+    description: ''
   - name: BooleanType
-    description: <SchemaDefinition schemaRef="#/components/schemas/BooleanType" />
+    description: ''
   - name: BuiltinTool
-    description: <SchemaDefinition schemaRef="#/components/schemas/BuiltinTool" />
+    description: ''
   - name: CancelTrainingJobRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/CancelTrainingJobRequest"
-      />
+    description: ''
   - name: ChatCompletionInputType
-    description: <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionInputType"
-      />
+    description: ''
   - name: ChatCompletionRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionRequest"
-      />
+    description: ''
   - name: ChatCompletionResponse
-    description: "Chat completion response.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/ChatCompletionResponse\"\
-      \ />"
+    description: Chat completion response.
   - name: ChatCompletionResponseEvent
-    description: "Chat completion response event.\n\n<SchemaDefinition schemaRef=\"\
-      #/components/schemas/ChatCompletionResponseEvent\" />"
+    description: Chat completion response event.
   - name: ChatCompletionResponseEventType
-    description: <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionResponseEventType"
-      />
+    description: ''
   - name: ChatCompletionResponseStreamChunk
-    description: "SSE-stream of these events.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/ChatCompletionResponseStreamChunk\"\
-      \ />"
+    description: SSE-stream of these events.
   - name: Checkpoint
-    description: "Checkpoint created during training runs\n\n<SchemaDefinition schemaRef=\"\
-      #/components/schemas/Checkpoint\" />"
+    description: Checkpoint created during training runs
   - name: CompletionInputType
-    description: <SchemaDefinition schemaRef="#/components/schemas/CompletionInputType"
-      />
+    description: ''
   - name: CompletionMessage
-    description: <SchemaDefinition schemaRef="#/components/schemas/CompletionMessage"
-      />
+    description: ''
   - name: CompletionRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/CompletionRequest"
-      />
+    description: ''
   - name: CompletionResponse
-    description: "Completion response.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/CompletionResponse\"\
-      \ />"
+    description: Completion response.
   - name: CompletionResponseStreamChunk
-    description: "streamed completion response.\n\n<SchemaDefinition schemaRef=\"\
-      #/components/schemas/CompletionResponseStreamChunk\" />"
+    description: streamed completion response.
   - name: ContentDelta
-    description: <SchemaDefinition schemaRef="#/components/schemas/ContentDelta" />
+    description: ''
   - name: CreateAgentRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/CreateAgentRequest"
-      />
+    description: ''
   - name: CreateAgentSessionRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/CreateAgentSessionRequest"
-      />
+    description: ''
   - name: CreateAgentTurnRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/CreateAgentTurnRequest"
-      />
+    description: ''
   - name: DPOAlignmentConfig
-    description: <SchemaDefinition schemaRef="#/components/schemas/DPOAlignmentConfig"
-      />
+    description: ''
   - name: DataConfig
-    description: <SchemaDefinition schemaRef="#/components/schemas/DataConfig" />
+    description: ''
   - name: Dataset
-    description: <SchemaDefinition schemaRef="#/components/schemas/Dataset" />
+    description: ''
   - name: DatasetFormat
-    description: <SchemaDefinition schemaRef="#/components/schemas/DatasetFormat"
-      />
+    description: ''
   - name: DatasetIO
   - name: Datasets
   - name: DefaultRAGQueryGeneratorConfig
-    description: <SchemaDefinition schemaRef="#/components/schemas/DefaultRAGQueryGeneratorConfig"
-      />
+    description: ''
   - name: EfficiencyConfig
-    description: <SchemaDefinition schemaRef="#/components/schemas/EfficiencyConfig"
-      />
+    description: ''
   - name: EmbeddingsRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/EmbeddingsRequest"
-      />
+    description: ''
   - name: EmbeddingsResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/EmbeddingsResponse"
-      />
+    description: ''
   - name: Eval
   - name: EvalCandidate
-    description: <SchemaDefinition schemaRef="#/components/schemas/EvalCandidate"
-      />
+    description: ''
   - name: EvalTask
-    description: <SchemaDefinition schemaRef="#/components/schemas/EvalTask" />
+    description: ''
   - name: EvalTaskConfig
-    description: <SchemaDefinition schemaRef="#/components/schemas/EvalTaskConfig"
-      />
+    description: ''
   - name: EvalTasks
   - name: EvaluateResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/EvaluateResponse"
-      />
+    description: ''
   - name: EvaluateRowsRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/EvaluateRowsRequest"
-      />
+    description: ''
   - name: Event
-    description: <SchemaDefinition schemaRef="#/components/schemas/Event" />
+    description: ''
   - name: GrammarResponseFormat
-    description: <SchemaDefinition schemaRef="#/components/schemas/GrammarResponseFormat"
-      />
+    description: ''
   - name: GreedySamplingStrategy
-    description: <SchemaDefinition schemaRef="#/components/schemas/GreedySamplingStrategy"
-      />
+    description: ''
   - name: HealthInfo
-    description: <SchemaDefinition schemaRef="#/components/schemas/HealthInfo" />
+    description: ''
   - name: ImageContentItem
-    description: <SchemaDefinition schemaRef="#/components/schemas/ImageContentItem"
-      />
+    description: ''
   - name: ImageDelta
-    description: <SchemaDefinition schemaRef="#/components/schemas/ImageDelta" />
+    description: ''
   - name: Inference
   - name: InferenceStep
-    description: <SchemaDefinition schemaRef="#/components/schemas/InferenceStep"
-      />
+    description: ''
   - name: InsertChunksRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/InsertChunksRequest"
-      />
+    description: ''
   - name: InsertRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/InsertRequest"
-      />
+    description: ''
   - name: Inspect
   - name: InterleavedContent
-    description: <SchemaDefinition schemaRef="#/components/schemas/InterleavedContent"
-      />
+    description: ''
   - name: InterleavedContentItem
-    description: <SchemaDefinition schemaRef="#/components/schemas/InterleavedContentItem"
-      />
+    description: ''
   - name: InvokeToolRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/InvokeToolRequest"
-      />
+    description: ''
   - name: Job
-    description: <SchemaDefinition schemaRef="#/components/schemas/Job" />
+    description: ''
   - name: JobStatus
-    description: <SchemaDefinition schemaRef="#/components/schemas/JobStatus" />
+    description: ''
   - name: JsonSchemaResponseFormat
-    description: <SchemaDefinition schemaRef="#/components/schemas/JsonSchemaResponseFormat"
-      />
+    description: ''
   - name: JsonType
-    description: <SchemaDefinition schemaRef="#/components/schemas/JsonType" />
+    description: ''
   - name: LLMAsJudgeScoringFnParams
-    description: <SchemaDefinition schemaRef="#/components/schemas/LLMAsJudgeScoringFnParams"
-      />
+    description: ''
   - name: LLMRAGQueryGeneratorConfig
-    description: <SchemaDefinition schemaRef="#/components/schemas/LLMRAGQueryGeneratorConfig"
-      />
+    description: ''
   - name: ListDatasetsResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/ListDatasetsResponse"
-      />
+    description: ''
   - name: ListEvalTasksResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/ListEvalTasksResponse"
-      />
+    description: ''
   - name: ListModelsResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/ListModelsResponse"
-      />
+    description: ''
   - name: ListPostTrainingJobsResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/ListPostTrainingJobsResponse"
-      />
+    description: ''
   - name: ListProvidersResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/ListProvidersResponse"
-      />
+    description: ''
   - name: ListRoutesResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/ListRoutesResponse"
-      />
+    description: ''
   - name: ListScoringFunctionsResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/ListScoringFunctionsResponse"
-      />
+    description: ''
   - name: ListShieldsResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/ListShieldsResponse"
-      />
+    description: ''
   - name: ListToolGroupsResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/ListToolGroupsResponse"
-      />
+    description: ''
   - name: ListToolsResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/ListToolsResponse"
-      />
+    description: ''
   - name: ListVectorDBsResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/ListVectorDBsResponse"
-      />
+    description: ''
   - name: LogEventRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/LogEventRequest"
-      />
+    description: ''
   - name: LogSeverity
-    description: <SchemaDefinition schemaRef="#/components/schemas/LogSeverity" />
+    description: ''
   - name: LoraFinetuningConfig
-    description: <SchemaDefinition schemaRef="#/components/schemas/LoraFinetuningConfig"
-      />
+    description: ''
   - name: MemoryRetrievalStep
-    description: <SchemaDefinition schemaRef="#/components/schemas/MemoryRetrievalStep"
-      />
+    description: ''
   - name: Message
-    description: <SchemaDefinition schemaRef="#/components/schemas/Message" />
+    description: ''
   - name: MetricEvent
-    description: <SchemaDefinition schemaRef="#/components/schemas/MetricEvent" />
+    description: ''
   - name: Model
-    description: <SchemaDefinition schemaRef="#/components/schemas/Model" />
+    description: ''
   - name: ModelCandidate
-    description: <SchemaDefinition schemaRef="#/components/schemas/ModelCandidate"
-      />
+    description: ''
   - name: ModelType
-    description: <SchemaDefinition schemaRef="#/components/schemas/ModelType" />
+    description: ''
   - name: Models
   - name: NumberType
-    description: <SchemaDefinition schemaRef="#/components/schemas/NumberType" />
+    description: ''
   - name: ObjectType
-    description: <SchemaDefinition schemaRef="#/components/schemas/ObjectType" />
+    description: ''
   - name: OptimizerConfig
-    description: <SchemaDefinition schemaRef="#/components/schemas/OptimizerConfig"
-      />
+    description: ''
   - name: OptimizerType
-    description: <SchemaDefinition schemaRef="#/components/schemas/OptimizerType"
-      />
+    description: ''
   - name: PaginatedRowsResult
-    description: <SchemaDefinition schemaRef="#/components/schemas/PaginatedRowsResult"
-      />
+    description: ''
   - name: ParamType
-    description: <SchemaDefinition schemaRef="#/components/schemas/ParamType" />
+    description: ''
   - name: PostTraining (Coming Soon)
   - name: PostTrainingJob
-    description: <SchemaDefinition schemaRef="#/components/schemas/PostTrainingJob"
-      />
+    description: ''
   - name: PostTrainingJobArtifactsResponse
-    description: "Artifacts of a finetuning job.\n\n<SchemaDefinition schemaRef=\"\
-      #/components/schemas/PostTrainingJobArtifactsResponse\" />"
+    description: Artifacts of a finetuning job.
   - name: PostTrainingJobStatusResponse
-    description: "Status of a finetuning job.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/PostTrainingJobStatusResponse\"\
-      \ />"
+    description: Status of a finetuning job.
   - name: PreferenceOptimizeRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/PreferenceOptimizeRequest"
-      />
+    description: ''
   - name: ProviderInfo
-    description: <SchemaDefinition schemaRef="#/components/schemas/ProviderInfo" />
+    description: ''
   - name: QATFinetuningConfig
-    description: <SchemaDefinition schemaRef="#/components/schemas/QATFinetuningConfig"
-      />
+    description: ''
   - name: QueryChunksRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/QueryChunksRequest"
-      />
+    description: ''
   - name: QueryChunksResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/QueryChunksResponse"
-      />
+    description: ''
   - name: QueryCondition
-    description: <SchemaDefinition schemaRef="#/components/schemas/QueryCondition"
-      />
+    description: ''
   - name: QueryConditionOp
-    description: <SchemaDefinition schemaRef="#/components/schemas/QueryConditionOp"
-      />
+    description: ''
   - name: QueryRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/QueryRequest" />
+    description: ''
   - name: QuerySpanTreeResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/QuerySpanTreeResponse"
-      />
+    description: ''
   - name: QuerySpansResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/QuerySpansResponse"
-      />
+    description: ''
   - name: QueryTracesResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/QueryTracesResponse"
-      />
+    description: ''
   - name: RAGDocument
-    description: <SchemaDefinition schemaRef="#/components/schemas/RAGDocument" />
+    description: ''
   - name: RAGQueryConfig
-    description: <SchemaDefinition schemaRef="#/components/schemas/RAGQueryConfig"
-      />
+    description: ''
   - name: RAGQueryGeneratorConfig
-    description: <SchemaDefinition schemaRef="#/components/schemas/RAGQueryGeneratorConfig"
-      />
+    description: ''
   - name: RAGQueryResult
-    description: <SchemaDefinition schemaRef="#/components/schemas/RAGQueryResult"
-      />
+    description: ''
   - name: RegexParserScoringFnParams
-    description: <SchemaDefinition schemaRef="#/components/schemas/RegexParserScoringFnParams"
-      />
+    description: ''
   - name: RegisterDatasetRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/RegisterDatasetRequest"
-      />
+    description: ''
   - name: RegisterEvalTaskRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/RegisterEvalTaskRequest"
-      />
+    description: ''
   - name: RegisterModelRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/RegisterModelRequest"
-      />
+    description: ''
   - name: RegisterScoringFunctionRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/RegisterScoringFunctionRequest"
-      />
+    description: ''
   - name: RegisterShieldRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/RegisterShieldRequest"
-      />
+    description: ''
   - name: RegisterToolGroupRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/RegisterToolGroupRequest"
-      />
+    description: ''
   - name: RegisterVectorDbRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/RegisterVectorDbRequest"
-      />
+    description: ''
   - name: ResponseFormat
-    description: <SchemaDefinition schemaRef="#/components/schemas/ResponseFormat"
-      />
+    description: ''
   - name: RouteInfo
-    description: <SchemaDefinition schemaRef="#/components/schemas/RouteInfo" />
+    description: ''
   - name: RunEvalRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/RunEvalRequest"
-      />
+    description: ''
   - name: RunShieldRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/RunShieldRequest"
-      />
+    description: ''
   - name: RunShieldResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/RunShieldResponse"
-      />
+    description: ''
   - name: Safety
   - name: SafetyViolation
-    description: <SchemaDefinition schemaRef="#/components/schemas/SafetyViolation"
-      />
+    description: ''
   - name: SamplingParams
-    description: <SchemaDefinition schemaRef="#/components/schemas/SamplingParams"
-      />
+    description: ''
   - name: SaveSpansToDatasetRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/SaveSpansToDatasetRequest"
-      />
+    description: ''
   - name: ScoreBatchRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/ScoreBatchRequest"
-      />
+    description: ''
   - name: ScoreBatchResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/ScoreBatchResponse"
-      />
+    description: ''
   - name: ScoreRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/ScoreRequest" />
+    description: ''
   - name: ScoreResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/ScoreResponse"
-      />
+    description: ''
   - name: Scoring
   - name: ScoringFn
-    description: <SchemaDefinition schemaRef="#/components/schemas/ScoringFn" />
+    description: ''
   - name: ScoringFnParams
-    description: <SchemaDefinition schemaRef="#/components/schemas/ScoringFnParams"
-      />
+    description: ''
   - name: ScoringFunctions
   - name: ScoringResult
-    description: <SchemaDefinition schemaRef="#/components/schemas/ScoringResult"
-      />
+    description: ''
   - name: Session
-    description: "A single session of an interaction with an Agentic System.\n\n<SchemaDefinition
-      schemaRef=\"#/components/schemas/Session\" />"
+    description: A single session of an interaction with an Agentic System.
   - name: Shield
-    description: "A safety shield resource that can be used to check content\n\n<SchemaDefinition
-      schemaRef=\"#/components/schemas/Shield\" />"
+    description: A safety shield resource that can be used to check content
   - name: ShieldCallStep
-    description: <SchemaDefinition schemaRef="#/components/schemas/ShieldCallStep"
-      />
+    description: ''
   - name: Shields
   - name: Span
-    description: <SchemaDefinition schemaRef="#/components/schemas/Span" />
+    description: ''
   - name: SpanEndPayload
-    description: <SchemaDefinition schemaRef="#/components/schemas/SpanEndPayload"
-      />
+    description: ''
   - name: SpanStartPayload
-    description: <SchemaDefinition schemaRef="#/components/schemas/SpanStartPayload"
-      />
+    description: ''
   - name: SpanStatus
-    description: <SchemaDefinition schemaRef="#/components/schemas/SpanStatus" />
+    description: ''
   - name: SpanWithStatus
-    description: <SchemaDefinition schemaRef="#/components/schemas/SpanWithStatus"
-      />
+    description: ''
   - name: StopReason
-    description: <SchemaDefinition schemaRef="#/components/schemas/StopReason" />
+    description: ''
   - name: StringType
-    description: <SchemaDefinition schemaRef="#/components/schemas/StringType" />
+    description: ''
   - name: StructuredLogEvent
-    description: <SchemaDefinition schemaRef="#/components/schemas/StructuredLogEvent"
-      />
+    description: ''
   - name: StructuredLogPayload
-    description: <SchemaDefinition schemaRef="#/components/schemas/StructuredLogPayload"
-      />
+    description: ''
   - name: SupervisedFineTuneRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/SupervisedFineTuneRequest"
-      />
+    description: ''
   - name: SyntheticDataGenerateRequest
-    description: <SchemaDefinition schemaRef="#/components/schemas/SyntheticDataGenerateRequest"
-      />
+    description: ''
   - name: SyntheticDataGeneration (Coming Soon)
   - name: SyntheticDataGenerationResponse
-    description: "Response from the synthetic data generation. Batch of (prompt, response,
-      score) tuples that pass the threshold.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/SyntheticDataGenerationResponse\"\
-      \ />"
+    description: Response from the synthetic data generation. Batch of (prompt, response,
+      score) tuples that pass the threshold.
   - name: SystemMessage
-    description: <SchemaDefinition schemaRef="#/components/schemas/SystemMessage"
-      />
+    description: ''
   - name: Telemetry
   - name: TextContentItem
-    description: <SchemaDefinition schemaRef="#/components/schemas/TextContentItem"
-      />
+    description: ''
   - name: TextDelta
-    description: <SchemaDefinition schemaRef="#/components/schemas/TextDelta" />
+    description: ''
   - name: TokenLogProbs
-    description: <SchemaDefinition schemaRef="#/components/schemas/TokenLogProbs"
-      />
+    description: ''
   - name: Tool
-    description: <SchemaDefinition schemaRef="#/components/schemas/Tool" />
+    description: ''
   - name: ToolCall
-    description: <SchemaDefinition schemaRef="#/components/schemas/ToolCall" />
+    description: ''
   - name: ToolCallDelta
-    description: <SchemaDefinition schemaRef="#/components/schemas/ToolCallDelta"
-      />
+    description: ''
   - name: ToolCallParseStatus
-    description: <SchemaDefinition schemaRef="#/components/schemas/ToolCallParseStatus"
-      />
+    description: ''
   - name: ToolChoice
-    description: <SchemaDefinition schemaRef="#/components/schemas/ToolChoice" />
+    description: ''
   - name: ToolDef
-    description: <SchemaDefinition schemaRef="#/components/schemas/ToolDef" />
+    description: ''
   - name: ToolDefinition
-    description: <SchemaDefinition schemaRef="#/components/schemas/ToolDefinition"
-      />
+    description: ''
   - name: ToolExecutionStep
-    description: <SchemaDefinition schemaRef="#/components/schemas/ToolExecutionStep"
-      />
+    description: ''
   - name: ToolGroup
-    description: <SchemaDefinition schemaRef="#/components/schemas/ToolGroup" />
+    description: ''
   - name: ToolGroups
   - name: ToolHost
-    description: <SchemaDefinition schemaRef="#/components/schemas/ToolHost" />
+    description: ''
   - name: ToolInvocationResult
-    description: <SchemaDefinition schemaRef="#/components/schemas/ToolInvocationResult"
-      />
+    description: ''
   - name: ToolParamDefinition
-    description: <SchemaDefinition schemaRef="#/components/schemas/ToolParamDefinition"
-      />
+    description: ''
   - name: ToolParameter
-    description: <SchemaDefinition schemaRef="#/components/schemas/ToolParameter"
-      />
+    description: ''
   - name: ToolPromptFormat
     description: "This Enum refers to the prompt format for calling custom / zero
       shot tools\n\n`json` --\n    Refers to the json format for calling tools.\n\
@@ -6245,46 +6111,38 @@ tags:
       : {...}\n        }\n    }\n\n`function_tag` --\n    This is an example of how
       you could define\n    your own user defined format for making tool calls.\n\
       \    The function_tag format looks like this,\n    <function=function_name>(parameters)</function>\n
-      \nThe detailed prompts for each of these formats are added to llama cli\n\n
-      <SchemaDefinition schemaRef=\"#/components/schemas/ToolPromptFormat\" />"
+      \nThe detailed prompts for each of these formats are added to llama cli"
   - name: ToolResponse
-    description: <SchemaDefinition schemaRef="#/components/schemas/ToolResponse" />
+    description: ''
   - name: ToolResponseMessage
-    description: <SchemaDefinition schemaRef="#/components/schemas/ToolResponseMessage"
-      />
+    description: ''
   - name: ToolRuntime
   - name: TopKSamplingStrategy
-    description: <SchemaDefinition schemaRef="#/components/schemas/TopKSamplingStrategy"
-      />
+    description: ''
   - name: TopPSamplingStrategy
-    description: <SchemaDefinition schemaRef="#/components/schemas/TopPSamplingStrategy"
-      />
+    description: ''
   - name: Trace
-    description: <SchemaDefinition schemaRef="#/components/schemas/Trace" />
+    description: ''
   - name: TrainingConfig
-    description: <SchemaDefinition schemaRef="#/components/schemas/TrainingConfig"
-      />
+    description: ''
   - name: Turn
-    description: "A single turn in an interaction with an Agentic System.\n\n<SchemaDefinition
-      schemaRef=\"#/components/schemas/Turn\" />"
+    description: A single turn in an interaction with an Agentic System.
   - name: URL
-    description: <SchemaDefinition schemaRef="#/components/schemas/URL" />
+    description: ''
   - name: UnionType
-    description: <SchemaDefinition schemaRef="#/components/schemas/UnionType" />
+    description: ''
   - name: UnstructuredLogEvent
-    description: <SchemaDefinition schemaRef="#/components/schemas/UnstructuredLogEvent"
-      />
+    description: ''
   - name: UserMessage
-    description: <SchemaDefinition schemaRef="#/components/schemas/UserMessage" />
+    description: ''
   - name: VectorDB
-    description: <SchemaDefinition schemaRef="#/components/schemas/VectorDB" />
+    description: ''
   - name: VectorDBs
   - name: VectorIO
   - name: VersionInfo
-    description: <SchemaDefinition schemaRef="#/components/schemas/VersionInfo" />
+    description: ''
   - name: ViolationLevel
-    description: <SchemaDefinition schemaRef="#/components/schemas/ViolationLevel"
-      />
+    description: ''
 x-tagGroups:
   - name: Operations
     tags:


### PR DESCRIPTION
Stainless ends up reformatting the YAML when we paste it in the Studio. We cannot have that happen if we are going to ever partially automate stainless config updates. 

Try ruamel.yaml, specifically `block_seq_indent` to avoid that.
