### PR TITLE
align with CompletionResponseStreamChunk.delta as str (instead of TextDelta)

### DIFF
--- a/llama_stack/providers/remote/inference/nvidia/openai_utils.py
+++ b/llama_stack/providers/remote/inference/nvidia/openai_utils.py
@@ -632,7 +632,7 @@ async def convert_openai_completion_stream(
     async for chunk in stream:
         choice = chunk.choices[0]
         yield CompletionResponseStreamChunk(
-            delta=TextDelta(text=choice.text),
+            delta=choice.text,
             stop_reason=_convert_openai_finish_reason(choice.finish_reason),
             logprobs=_convert_openai_completion_logprobs(choice.logprobs),
         )


### PR DESCRIPTION
# What does this PR do?

fix type mismatch in /v1/inference/completion

## Test Plan

`llama stack run ./llama_stack/templates/nvidia/run.yaml`

`LLAMA_STACK_BASE_URL="http://localhost:8321" pytest -v tests/client-sdk/inference/test_inference.py`

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Ran pre-commit to handle lint / formatting issues.
- [x] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Updated relevant documentation.
- [ ] Wrote necessary unit or integration tests.
