### PR TITLE
add image support to NVIDIA inference provider

### DIFF
--- a/llama_stack/providers/remote/inference/nvidia/nvidia.py
+++ b/llama_stack/providers/remote/inference/nvidia/nvidia.py
@@ -186,7 +186,7 @@ class NVIDIAInferenceAdapter(Inference, ModelRegistryHelper):
 
         await check_health(self._config)  # this raises errors
 
-        request = convert_chat_completion_request(
+        request = await convert_chat_completion_request(
             request=ChatCompletionRequest(
                 model=self.get_provider_model_id(model_id),
                 messages=messages,

--- a/llama_stack/providers/remote/inference/nvidia/openai_utils.py
+++ b/llama_stack/providers/remote/inference/nvidia/openai_utils.py
@@ -188,7 +188,7 @@ def _convert_message(message: Message | Dict) -> OpenAIChatCompletionMessage:
             elif content.image.data:
                 return OpenAIChatCompletionContentPartImageParam(
                     image_url=OpenAIImageURL(
-                        url=f"data:image/png;base64,{content.image.data.decode()}"  # TODO(mf): how do we know the type?
+                        url=f"data:image/png;base64,{content.image.data}"  # TODO(mf): how do we know the type?
                     ),
                     type="image_url",
                 )

--- a/llama_stack/providers/utils/inference/prompt_adapter.py
+++ b/llama_stack/providers/utils/inference/prompt_adapter.py
@@ -186,6 +186,7 @@ async def localize_image_content(media: ImageContentItem) -> Tuple[bytes, str]:
         return content, format
     else:
         # data is a base64 encoded string, decode it to bytes first
+        # TODO(mf): do this more efficiently, decode less
         data_bytes = base64.b64decode(image.data)
         pil_image = PIL_Image.open(io.BytesIO(data_bytes))
         return data_bytes, pil_image.format


### PR DESCRIPTION
# What does this PR do?

add support to the NVIDIA Inference provider for image inputs


## Test Plan

1. Run local [Llama 3.2 11b vision instruct](https://build.nvidia.com/meta/llama-3.2-11b-vision-instruct?snippet_tab=Docker) NIM
2. Start a stack, e.g. `llama stack run llama_stack/templates/nvidia/run.yaml --env NVIDIA_BASE_URL=http://localhost:8000`
3. Run image tests, e.g. `LLAMA_STACK_BASE_URL=http://localhost:8321 pytest -v tests/client-sdk/inference/test_inference.py --vision-inference-model meta-llama/Llama-3.2-11B-Vision-Instruct -k image`


## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Ran pre-commit to handle lint / formatting issues.
- [x] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Updated relevant documentation.
- [x] Wrote necessary unit or integration tests.
