### PR TITLE
Fix Agents to support code and rag simultaneously

### DIFF
--- a/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
@@ -476,9 +476,6 @@ class ChatAgent(ShieldRunnerMixin):
                 )
                 span.set_attribute("output", retrieved_context)
                 span.set_attribute("tool_name", MEMORY_QUERY_TOOL)
-                if retrieved_context:
-                    last_message = input_messages[-1]
-                    last_message.context = retrieved_context
 
         output_attachments = []
 

--- a/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
@@ -66,6 +66,7 @@ from llama_stack.apis.vector_io import VectorIO
 from llama_stack.providers.utils.kvstore import KVStore
 from llama_stack.providers.utils.memory.vector_store import concat_interleaved_content
 from llama_stack.providers.utils.telemetry import tracing
+
 from .persistence import AgentPersistence
 from .safety import SafetyException, ShieldRunnerMixin
 
@@ -476,6 +477,12 @@ class ChatAgent(ShieldRunnerMixin):
                 )
                 span.set_attribute("output", retrieved_context)
                 span.set_attribute("tool_name", MEMORY_QUERY_TOOL)
+
+                # append retrieved_context to the last user message
+                for message in input_messages[::-1]:
+                    if isinstance(message, UserMessage):
+                        message.context = retrieved_context
+                        break
 
         output_attachments = []
 

--- a/tests/client-sdk/agents/test_agents.py
+++ b/tests/client-sdk/agents/test_agents.py
@@ -357,7 +357,7 @@ def test_rag_and_code_agent(llama_stack_client, agent_config):
     user_prompts = [
         (
             "What are the top 5 topics that were explained? Only list succinct bullet points.",
-            documents,
+            [],
             "query_from_memory",
         ),
         ("What is the average yearly inflation?", [inflation_doc], "code_interpreter"),
@@ -370,11 +370,7 @@ def test_rag_and_code_agent(llama_stack_client, agent_config):
             session_id=session_id,
             documents=docs,
         )
-        logs = []
-        for log in EventLogger().log(response):
-            logs.append(str(log))
-            log.print()
 
-        # logs = [str(log) for log in EventLogger().log(response) if log is not None]
+        logs = [str(log) for log in EventLogger().log(response) if log is not None]
         logs_str = "".join(logs)
         assert f"Tool:{tool_name}" in logs_str


### PR DESCRIPTION
# What does this PR do?

Fixes a bug where agents were not working when both rag and code-interpreter were added as tools. 


## Test Plan

Added a new client_sdk test which tests for this scenario 
```
LLAMA_STACK_CONFIG=together pytest -s -v  tests/client-sdk -k 'test_rag_and_code_agent'
```