### PR TITLE
fix ImageContentItem to take base64 string as image.data

### DIFF
--- a/docs/openapi_generator/strong_typing/schema.py
+++ b/docs/openapi_generator/strong_typing/schema.py
@@ -501,11 +501,6 @@ class JsonSchemaGenerator:
         properties: Dict[str, Schema] = {}
         required: List[str] = []
         for property_name, property_type in get_class_properties(typ):
-            defaults = {}
-            if "model_fields" in members:
-                f = members["model_fields"]
-                defaults = {k: finfo.default for k, finfo in f.items()}
-
             # rename property if an alias name is specified
             alias = get_annotation(property_type, Alias)
             if alias:
@@ -513,12 +508,12 @@ class JsonSchemaGenerator:
             else:
                 output_name = property_name
 
-            # check if there's additional field annotation
+            defaults = {}
             json_schema_extra = None
             if "model_fields" in members:
                 f = members["model_fields"]
-                if output_name in f:
-                    json_schema_extra = f[output_name].json_schema_extra
+                defaults = {k: finfo.default for k, finfo in f.items()}
+                json_schema_extra = f.get(output_name, None).json_schema_extra
 
             if is_type_optional(property_type):
                 optional_type: type = unwrap_optional_type(property_type)

--- a/docs/openapi_generator/strong_typing/schema.py
+++ b/docs/openapi_generator/strong_typing/schema.py
@@ -520,11 +520,6 @@ class JsonSchemaGenerator:
                 if output_name in f:
                     json_schema_extra = f[output_name].json_schema_extra
 
-            if json_schema_extra:
-                from rich.pretty import pprint
-
-                pprint(json_schema_extra)
-
             if is_type_optional(property_type):
                 optional_type: type = unwrap_optional_type(property_type)
                 property_def = self.type_to_schema(
@@ -563,8 +558,6 @@ class JsonSchemaGenerator:
                 property_def["description"] = property_doc
 
             properties[output_name] = property_def
-
-        # print("properties", properties)
 
         schema = {"type": "object"}
         if len(properties) > 0:

--- a/docs/resources/llama-stack-spec.html
+++ b/docs/resources/llama-stack-spec.html
@@ -2439,7 +2439,8 @@
                     "type": {
                         "type": "string",
                         "const": "image",
-                        "default": "image"
+                        "default": "image",
+                        "description": "Discriminator type of the content item. Always \"image\""
                     },
                     "image": {
                         "type": "object",
@@ -2448,18 +2449,19 @@
                                 "$ref": "#/components/schemas/URL"
                             },
                             "data": {
-                                "type": "string",
-                                "contentEncoding": "base64"
+                                "type": "string"
                             }
                         },
-                        "additionalProperties": false
+                        "additionalProperties": false,
+                        "description": "Image as a base64 encoded string or an URL"
                     }
                 },
                 "additionalProperties": false,
                 "required": [
                     "type",
                     "image"
-                ]
+                ],
+                "title": "A image content item"
             },
             "InterleavedContent": {
                 "oneOf": [
@@ -2647,17 +2649,20 @@
                     "type": {
                         "type": "string",
                         "const": "text",
-                        "default": "text"
+                        "default": "text",
+                        "description": "Discriminator type of the content item. Always \"text\""
                     },
                     "text": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Text content"
                     }
                 },
                 "additionalProperties": false,
                 "required": [
                     "type",
                     "text"
-                ]
+                ],
+                "title": "A text content item"
             },
             "ToolCall": {
                 "type": "object",

--- a/docs/resources/llama-stack-spec.html
+++ b/docs/resources/llama-stack-spec.html
@@ -2451,6 +2451,7 @@
                             },
                             "data": {
                                 "type": "string",
+                                "contentEncoding": "base64",
                                 "description": "base64 encoded image data as string"
                             }
                         },

--- a/docs/resources/llama-stack-spec.html
+++ b/docs/resources/llama-stack-spec.html
@@ -2446,10 +2446,12 @@
                         "type": "object",
                         "properties": {
                             "url": {
-                                "$ref": "#/components/schemas/URL"
+                                "$ref": "#/components/schemas/URL",
+                                "description": "A URL of the image or data URL in the format of data:image/{type};base64,{data}. Note that URL could have length limits."
                             },
                             "data": {
-                                "type": "string"
+                                "type": "string",
+                                "description": "base64 encoded image data as string"
                             }
                         },
                         "additionalProperties": false,

--- a/docs/resources/llama-stack-spec.yaml
+++ b/docs/resources/llama-stack-spec.yaml
@@ -1478,6 +1478,7 @@ components:
                 Note that URL could have length limits.
             data:
               type: string
+              contentEncoding: base64
               description: base64 encoded image data as string
           additionalProperties: false
           description: >-

--- a/docs/resources/llama-stack-spec.yaml
+++ b/docs/resources/llama-stack-spec.yaml
@@ -1466,6 +1466,8 @@ components:
           type: string
           const: image
           default: image
+          description: >-
+            Discriminator type of the content item. Always "image"
         image:
           type: object
           properties:
@@ -1473,12 +1475,14 @@ components:
               $ref: '#/components/schemas/URL'
             data:
               type: string
-              contentEncoding: base64
           additionalProperties: false
+          description: >-
+            Image as a base64 encoded string or an URL
       additionalProperties: false
       required:
         - type
         - image
+      title: A image content item
     InterleavedContent:
       oneOf:
         - type: string
@@ -1598,12 +1602,16 @@ components:
           type: string
           const: text
           default: text
+          description: >-
+            Discriminator type of the content item. Always "text"
         text:
           type: string
+          description: Text content
       additionalProperties: false
       required:
         - type
         - text
+      title: A text content item
     ToolCall:
       type: object
       properties:

--- a/docs/resources/llama-stack-spec.yaml
+++ b/docs/resources/llama-stack-spec.yaml
@@ -1473,8 +1473,12 @@ components:
           properties:
             url:
               $ref: '#/components/schemas/URL'
+              description: >-
+                A URL of the image or data URL in the format of data:image/{type};base64,{data}.
+                Note that URL could have length limits.
             data:
               type: string
+              description: base64 encoded image data as string
           additionalProperties: false
           description: >-
             Image as a base64 encoded string or an URL

--- a/llama_stack/apis/common/content_types.py
+++ b/llama_stack/apis/common/content_types.py
@@ -27,8 +27,7 @@ class _URLOrData(BaseModel):
     """
 
     url: Optional[URL] = None
-    # data is a base64 encoded string
-    # TODO: generate contentEncoding="base64" in OpenAPI schema
+    # data is a base64 encoded string, hint with contentEncoding=base64
     data: Optional[str] = Field(contentEncoding="base64", default=None)
 
     @model_validator(mode="before")

--- a/llama_stack/apis/common/content_types.py
+++ b/llama_stack/apis/common/content_types.py
@@ -28,8 +28,8 @@ class _URLOrData(BaseModel):
 
     url: Optional[URL] = None
     # data is a base64 encoded string
-    # TODO: annotate with contentEncoding="base64" in OpenAPI schema
-    data: Optional[str] = None
+    # TODO: generate contentEncoding="base64" in OpenAPI schema
+    data: Optional[str] = Field(contentEncoding="base64", default=None)
 
     @model_validator(mode="before")
     @classmethod

--- a/llama_stack/apis/common/content_types.py
+++ b/llama_stack/apis/common/content_types.py
@@ -19,8 +19,16 @@ class URL(BaseModel):
 
 
 class _URLOrData(BaseModel):
+    """
+    A URL or a base64 encoded string
+
+    :param url: A URL of the image or data URL in the format of data:image/{type};base64,{data}. Note that URL could have length limits.
+    :param data: base64 encoded image data as string
+    """
+
     url: Optional[URL] = None
     # data is a base64 encoded string
+    # TODO: annotate with contentEncoding="base64" in OpenAPI schema
     data: Optional[str] = None
 
     @model_validator(mode="before")

--- a/llama_stack/providers/utils/inference/prompt_adapter.py
+++ b/llama_stack/providers/utils/inference/prompt_adapter.py
@@ -185,8 +185,10 @@ async def localize_image_content(media: ImageContentItem) -> Tuple[bytes, str]:
 
         return content, format
     else:
-        pil_image = PIL_Image.open(io.BytesIO(image.data))
-        return image.data, pil_image.format
+        # data is a base64 encoded string, decode it to bytes first
+        data_bytes = base64.b64decode(image.data)
+        pil_image = PIL_Image.open(io.BytesIO(data_bytes))
+        return data_bytes, pil_image.format
 
 
 async def convert_image_content_to_url(

--- a/llama_stack/providers/utils/inference/prompt_adapter.py
+++ b/llama_stack/providers/utils/inference/prompt_adapter.py
@@ -135,7 +135,8 @@ async def interleaved_content_convert_to_raw(
                 else:
                     raise ValueError("Unsupported URL type")
             elif image.data:
-                data = image.data
+                # data is a base64 encoded string, decode it to bytes for RawMediaItem
+                data = base64.b64decode(image.data)
             else:
                 raise ValueError("No data or URL provided")
 

--- a/tests/client-sdk/inference/test_inference.py
+++ b/tests/client-sdk/inference/test_inference.py
@@ -5,7 +5,7 @@
 # the root directory of this source tree.
 
 import base64
-import os
+import pathlib
 
 import pytest
 from pydantic import BaseModel
@@ -48,14 +48,31 @@ def get_weather_tool_definition():
     }
 
 
+# @pytest.fixture
+# def base64_image_url():
+#     image_path = os.path.join(os.path.dirname(__file__), "dog.png")
+#     with open(image_path, "rb") as image_file:
+#         # Convert the image to base64
+#         base64_string = base64.b64encode(image_file.read()).decode("utf-8")
+#         base64_url = f"data:image/png;base64,{base64_string}"
+#         return base64_url
+
+
 @pytest.fixture
-def base64_image_url():
-    image_path = os.path.join(os.path.dirname(__file__), "dog.png")
-    with open(image_path, "rb") as image_file:
-        # Convert the image to base64
-        base64_string = base64.b64encode(image_file.read()).decode("utf-8")
-        base64_url = f"data:image/png;base64,{base64_string}"
-        return base64_url
+def image_path():
+    return pathlib.Path(__file__).parent / "dog.png"
+
+
+@pytest.fixture
+def base64_image_data(image_path):
+    # Convert the image to base64
+    return base64.b64encode(image_path.read_bytes()).decode("utf-8")
+
+
+@pytest.fixture
+def base64_image_url(base64_image_data, image_path):
+    # suffix includes the ., so we remove it
+    return f"data:image/{image_path.suffix[1:]};base64,{base64_image_data}"
 
 
 def test_text_completion_non_streaming(llama_stack_client, text_model_id):
@@ -353,25 +370,30 @@ def test_image_chat_completion_streaming(llama_stack_client, vision_model_id):
     assert any(expected in streamed_content for expected in {"dog", "puppy", "pup"})
 
 
-def test_image_chat_completion_base64_url(
-    llama_stack_client, vision_model_id, base64_image_url
+@pytest.mark.parametrize("type_", ["url", "data"])
+def test_image_chat_completion_base64(
+    llama_stack_client, vision_model_id, base64_image_data, base64_image_url, type_
 ):
-    message = {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": {
-                    "url": {
-                        "uri": base64_image_url,
-                    },
+    image_spec = {
+        "url": {
+            "type": "image",
+            "image": {
+                "url": {
+                    "uri": base64_image_url,
                 },
             },
-            {
-                "type": "text",
-                "text": "Describe what is in this image.",
+        },
+        "data": {
+            "type": "image",
+            "image": {
+                "data": base64_image_data,
             },
-        ],
+        },
+    }[type_]
+
+    message = {
+        "role": "user",
+        "content": [image_spec],
     }
     response = llama_stack_client.inference.chat_completion(
         model_id=vision_model_id,


### PR DESCRIPTION
# What does this PR do?

- Discussion in https://github.com/meta-llama/llama-stack/pull/906#discussion_r1936260819

- image.data should accept base64 string as input instead of binary bytes, change prompt_adapter to account for that. 

## Test Plan

```
pytest -v tests/client-sdk/inference/test_inference.py
```

with test in https://github.com/meta-llama/llama-stack/pull/906

## Sources

Please link relevant resources if necessary.


## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Ran pre-commit to handle lint / formatting issues.
- [ ] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Updated relevant documentation.
- [ ] Wrote necessary unit or integration tests.
