### PR TITLE
Fix UBI9 image build when installing Python packages via uv

### DIFF
--- a/llama_stack/distribution/build_container.sh
+++ b/llama_stack/distribution/build_container.sh
@@ -63,6 +63,8 @@ RUN microdnf -y update && microdnf install -y iputils net-tools wget \
     vim-minimal python3.11 python3.11-pip python3.11-wheel \
     python3.11-setuptools && ln -s /bin/pip3.11 /bin/pip && ln -s /bin/python3.11 /bin/python && microdnf clean all
 
+ENV UV_SYSTEM_PYTHON=1
+RUN pip install uv
 EOF
 else
   add_to_container << EOF


### PR DESCRIPTION
This was missed in https://github.com/meta-llama/llama-stack/pull/921. 

cc @ashwinb @hardikjshah 