### PR TITLE
Add issue template config with docs and Discord links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,6 +4,9 @@ contact_links:
   - name: Have you read the docs?
     url: https://llama-stack.readthedocs.io/en/latest/index.html
     about: Much help can be found in the docs
+  - name: Start a discussion
+    url: https://github.com/meta-llama/llama-stack/discussions/new
+    about: Start a discussion on a topic
   - name: Chat on Discord
     url: https://discord.gg/llama-stack
     about: Maybe chatting with the community can help

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Have you read the docs?
+    url: https://llama-stack.readthedocs.io/en/latest/index.html
+    about: Much help can be found in the docs
+  - name: Chat on Discord
+    url: https://discord.gg/llama-stack
+    about: Maybe chatting with the community can help


### PR DESCRIPTION
This is similar to what we are doing for other projects, e.g. https://github.com/argoproj/argo-workflows/tree/main/.github/ISSUE_TEMPLATE

The benefits is to give people more options before submitting a bug report or feature request on GitHub.