### PR TITLE
github: ignore non-hidden python virtual environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Package.resolved
 _build
 docs/src
 pyrightconfig.json
+venv/


### PR DESCRIPTION
# What does this PR do?

the llama-stack repo is already ignoring hidden python `.venv/` directories but not `venv/`

- [ ] Addresses issue (#issue)

## Test Plan
N/A

## Sources
N/A

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Ran pre-commit to handle lint / formatting issues.
- [x] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [x] Updated relevant documentation.
- [x] Wrote necessary unit or integration tests.
