### PR TITLE
fix: formatting for ollama note in Quick Start doc

### DIFF
--- a/docs/source/getting_started/index.md
+++ b/docs/source/getting_started/index.md
@@ -15,8 +15,11 @@ ollama run llama3.2:3b-instruct-fp16 --keepalive 60m
 
 By default, Ollama keeps the model loaded in memory for 5 minutes which can be too short. We set the `--keepalive` flag to 60 minutes to ensure the model remains loaded for sometime.
 
-NOTE: If you do not have ollama, you can install it from [here](https://ollama.com/download).
+```{admonition} Note
+:class: tip
 
+If you do not have ollama, you can install it from [here](https://ollama.com/download).
+```
 
 
 ### 2. Pick a client environment


### PR DESCRIPTION
# What does this PR do?
Fixes formatting for Ollama note found here: https://llama-stack.readthedocs.io/en/latest/getting_started/index.html#start-ollama

- [ ] Addresses issue (#issue)

## Test Plan
Ran local docs build as described [here](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md#building-the-documentation)

## Sources
N/A

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Ran pre-commit to handle lint / formatting issues.
- [ ] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Updated relevant documentation.
- [ ] Wrote necessary unit or integration tests.
