### PR TITLE
Add inference token usage metrics

### DIFF
--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -898,6 +898,49 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "name": "start_time",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "end_time",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "step",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "query_type",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/MetricQueryType"
+                        }
+                    },
+                    {
+                        "name": "label_matchers",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/MetricLabelMatcher"
+                            }
+                        }
                     }
                 ]
             }
@@ -3559,6 +3602,12 @@
             "CompletionResponse": {
                 "type": "object",
                 "properties": {
+                    "metrics": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Metric"
+                        }
+                    },
                     "content": {
                         "type": "string",
                         "description": "The generated completion text"
@@ -3926,6 +3975,12 @@
             "CompletionResponseStreamChunk": {
                 "type": "object",
                 "properties": {
+                    "metrics": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Metric"
+                        }
+                    },
                     "delta": {
                         "type": "string",
                         "description": "New content generated since last chunk. This can be one or more tokens."
@@ -5092,6 +5147,12 @@
             "EmbeddingsResponse": {
                 "type": "object",
                 "properties": {
+                    "metrics": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Metric"
+                        }
+                    },
                     "embeddings": {
                         "type": "array",
                         "items": {

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -2236,6 +2236,10 @@ components:
     CompletionResponse:
       type: object
       properties:
+        metrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Metric'
         content:
           type: string
           description: The generated completion text
@@ -2554,6 +2558,10 @@ components:
     CompletionResponseStreamChunk:
       type: object
       properties:
+        metrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Metric'
         delta:
           type: string
           description: >-
@@ -3341,6 +3349,10 @@ components:
     EmbeddingsResponse:
       type: object
       properties:
+        metrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Metric'
         embeddings:
           type: array
           items:

--- a/llama_stack/apis/inference/inference.py
+++ b/llama_stack/apis/inference/inference.py
@@ -17,12 +17,13 @@ from typing import (
     runtime_checkable,
 )
 
+from llama_models.schema_utils import json_schema_type, register_schema, webmethod
 from pydantic import BaseModel, Field, field_validator
 from typing_extensions import Annotated
 
 from llama_stack.apis.common.content_types import ContentDelta, InterleavedContent, InterleavedContentItem
 from llama_stack.apis.models import Model
-from llama_stack.apis.telemetry.telemetry import MetricResponseMixin
+from llama_stack.apis.telemetry.telemetry import MetricsMixin
 from llama_stack.models.llama.datatypes import (
     BuiltinTool,
     SamplingParams,
@@ -285,7 +286,7 @@ class CompletionRequest(BaseModel):
 
 
 @json_schema_type
-class CompletionResponse(BaseModel):
+class CompletionResponse(MetricsMixin, BaseModel):
     """Response from a completion request.
 
     :param content: The generated completion text
@@ -299,7 +300,7 @@ class CompletionResponse(BaseModel):
 
 
 @json_schema_type
-class CompletionResponseStreamChunk(BaseModel):
+class CompletionResponseStreamChunk(MetricsMixin, BaseModel):
     """A chunk of a streamed completion response.
 
     :param delta: New content generated since last chunk. This can be one or more tokens.
@@ -368,7 +369,7 @@ class ChatCompletionRequest(BaseModel):
 
 
 @json_schema_type
-class ChatCompletionResponseStreamChunk(MetricResponseMixin, BaseModel):
+class ChatCompletionResponseStreamChunk(MetricsMixin, BaseModel):
     """A chunk of a streamed chat completion response.
 
     :param event: The event containing the new content
@@ -378,7 +379,7 @@ class ChatCompletionResponseStreamChunk(MetricResponseMixin, BaseModel):
 
 
 @json_schema_type
-class ChatCompletionResponse(MetricResponseMixin, BaseModel):
+class ChatCompletionResponse(MetricsMixin, BaseModel):
     """Response from a chat completion request.
 
     :param completion_message: The complete response message
@@ -390,7 +391,7 @@ class ChatCompletionResponse(MetricResponseMixin, BaseModel):
 
 
 @json_schema_type
-class EmbeddingsResponse(BaseModel):
+class EmbeddingsResponse(MetricsMixin, BaseModel):
     """Response containing generated embeddings.
 
     :param embeddings: List of embedding vectors, one per input content. Each embedding is a list of floats. The dimensionality of the embedding is model-specific; you can check model metadata using /models/{model_id}

--- a/llama_stack/apis/telemetry/telemetry.py
+++ b/llama_stack/apis/telemetry/telemetry.py
@@ -211,6 +211,28 @@ class QuerySpanTreeResponse(BaseModel):
     data: Dict[str, SpanWithStatus]
 
 
+@json_schema_type
+class TokenUsage(BaseModel):
+    type: Literal["token_usage"] = "token_usage"
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+
+
+Metric = register_schema(
+    Annotated[
+        Union[TokenUsage],
+        Field(discriminator="type"),
+    ],
+    name="Metric",
+)
+
+
+@json_schema_type
+class MetricsMixin(BaseModel):
+    metrics: List[Metric] = Field(default_factory=list)
+
+
 @runtime_checkable
 class Telemetry(Protocol):
     @webmethod(route="/telemetry/events", method="POST")

--- a/llama_stack/apis/telemetry/telemetry.py
+++ b/llama_stack/apis/telemetry/telemetry.py
@@ -230,7 +230,7 @@ Metric = register_schema(
 
 @json_schema_type
 class MetricsMixin(BaseModel):
-    metrics: List[Metric] = Field(default_factory=list)
+    metrics: Optional[List[Metric]] = None
 
 
 @runtime_checkable

--- a/llama_stack/apis/telemetry/telemetry.py
+++ b/llama_stack/apis/telemetry/telemetry.py
@@ -235,15 +235,23 @@ class MetricsMixin(BaseModel):
 
 @json_schema_type
 class MetricQueryType(Enum):
-    RANGE = "range"  # Returns data points over time range
-    INSTANT = "instant"  # Returns single data point
+    RANGE = "range"
+    INSTANT = "instant"
+
+
+@json_schema_type
+class MetricLabelOperator(Enum):
+    EQUALS = "="
+    NOT_EQUALS = "!="
+    REGEX_MATCH = "=~"
+    REGEX_NOT_MATCH = "!~"
 
 
 @json_schema_type
 class MetricLabelMatcher(BaseModel):
     name: str
     value: str
-    operator: Literal["=", "!=", "=~", "!~"] = "="  # Prometheus-style operators
+    operator: MetricLabelOperator = MetricLabelOperator.EQUALS
 
 
 @json_schema_type
@@ -313,9 +321,9 @@ class Telemetry(Protocol):
     async def get_metrics(
         self,
         metric_name: str,
-        start_time: int,  # Unix timestamp in seconds
-        end_time: Optional[int] = None,  # Unix timestamp in seconds
-        step: Optional[str] = "1m",  # Prometheus-style duration: 1m, 5m, 1h, etc.
+        start_time: int,
+        end_time: Optional[int] = None,
+        step: Optional[str] = "1m",
         query_type: MetricQueryType = MetricQueryType.RANGE,
         label_matchers: Optional[List[MetricLabelMatcher]] = None,
     ) -> GetMetricsResponse: ...

--- a/llama_stack/distribution/resolver.py
+++ b/llama_stack/distribution/resolver.py
@@ -182,7 +182,9 @@ async def resolve_impls(
                     module="llama_stack.distribution.routers",
                     routing_table_api=info.routing_table_api,
                     api_dependencies=[info.routing_table_api],
-                    deps__=([info.routing_table_api.value]),
+                    # Add telemetry as an optional dependency to all auto-routed providers
+                    optional_api_dependencies=[Api.telemetry],
+                    deps__=([info.routing_table_api.value, Api.telemetry.value]),
                 ),
             )
         }

--- a/llama_stack/distribution/routers/__init__.py
+++ b/llama_stack/distribution/routers/__init__.py
@@ -45,7 +45,7 @@ async def get_routing_table_impl(
     return impl
 
 
-async def get_auto_router_impl(api: Api, routing_table: RoutingTable, _deps: Dict[str, Any]) -> Any:
+async def get_auto_router_impl(api: Api, routing_table: RoutingTable, deps: Dict[str, Any]) -> Any:
     from .routers import (
         DatasetIORouter,
         EvalRouter,
@@ -66,17 +66,16 @@ async def get_auto_router_impl(api: Api, routing_table: RoutingTable, _deps: Dic
         "tool_runtime": ToolRuntimeRouter,
     }
     api_to_deps = {
-        "inference": [Api.telemetry],
+        "inference": {"telemetry": Api.telemetry},
     }
     if api.value not in api_to_routers:
         raise ValueError(f"API {api.value} not found in router map")
 
-    deps = []
-    for dep in api_to_deps.get(api.value, []):
-        if dep not in _deps:
-            raise ValueError(f"Dependency {dep} not found in _deps")
-        deps.append(_deps[dep])
+    api_to_dep_impl = {}
+    for dep_name, dep_api in api_to_deps.get(api.value, {}).items():
+        if dep_api in deps:
+            api_to_dep_impl[dep_name] = deps[dep_api]
 
-    impl = api_to_routers[api.value](routing_table, *deps)
+    impl = api_to_routers[api.value](routing_table, **api_to_dep_impl)
     await impl.initialize()
     return impl

--- a/llama_stack/distribution/routers/__init__.py
+++ b/llama_stack/distribution/routers/__init__.py
@@ -45,7 +45,7 @@ async def get_routing_table_impl(
     return impl
 
 
-async def get_auto_router_impl(api: Api, routing_table: RoutingTable, _deps) -> Any:
+async def get_auto_router_impl(api: Api, routing_table: RoutingTable, _deps: Dict[str, Any]) -> Any:
     from .routers import (
         DatasetIORouter,
         EvalRouter,
@@ -65,9 +65,18 @@ async def get_auto_router_impl(api: Api, routing_table: RoutingTable, _deps) -> 
         "eval": EvalRouter,
         "tool_runtime": ToolRuntimeRouter,
     }
+    api_to_deps = {
+        "inference": [Api.telemetry],
+    }
     if api.value not in api_to_routers:
         raise ValueError(f"API {api.value} not found in router map")
 
-    impl = api_to_routers[api.value](routing_table)
+    deps = []
+    for dep in api_to_deps.get(api.value, []):
+        if dep not in _deps:
+            raise ValueError(f"Dependency {dep} not found in _deps")
+        deps.append(_deps[dep])
+
+    impl = api_to_routers[api.value](routing_table, *deps)
     await impl.initialize()
     return impl

--- a/llama_stack/distribution/routers/routers.py
+++ b/llama_stack/distribution/routers/routers.py
@@ -237,7 +237,8 @@ class InferenceRouter(Inference):
                 completion_text = ""
                 async for chunk in await provider.chat_completion(**params):
                     if chunk.event.event_type == ChatCompletionResponseEventType.progress:
-                        completion_text += chunk.event.delta.text
+                        if chunk.event.delta.type == "text":
+                            completion_text += chunk.event.delta.text
                     if chunk.event.event_type == ChatCompletionResponseEventType.complete:
                         model_output = self.formatter.encode_dialog_prompt(
                             [RawMessage(role="assistant", content=completion_text)],

--- a/llama_stack/distribution/routers/routers.py
+++ b/llama_stack/distribution/routers/routers.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import time
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
 from llama_models.llama3.api.chat_format import ChatFormat
@@ -45,7 +46,7 @@ from llama_stack.apis.scoring import (
     ScoringFnParams,
 )
 from llama_stack.apis.shields import Shield
-from llama_stack.apis.telemetry import TokenUsage
+from llama_stack.apis.telemetry import MetricEvent, Telemetry, TokenUsage
 from llama_stack.apis.tools import (
     RAGDocument,
     RAGQueryConfig,
@@ -57,6 +58,7 @@ from llama_stack.apis.tools import (
 from llama_stack.apis.vector_io import Chunk, QueryChunksResponse, VectorIO
 from llama_stack.providers.datatypes import RoutingTable
 from llama_stack.providers.utils.inference.prompt_adapter import get_default_tool_prompt_format
+from llama_stack.providers.utils.telemetry.tracing import get_current_span
 
 
 class VectorIORouter(VectorIO):
@@ -113,8 +115,10 @@ class InferenceRouter(Inference):
     def __init__(
         self,
         routing_table: RoutingTable,
+        telemetry: Telemetry,
     ) -> None:
         self.routing_table = routing_table
+        self.telemetry = telemetry
         self.tokenizer = Tokenizer.get_instance()
         self.formatter = ChatFormat(self.tokenizer)
 
@@ -217,6 +221,31 @@ class InferenceRouter(Inference):
                     total_tokens=total_tokens,
                 )
             )
+            # Log token usage metrics
+            metrics = [
+                ("prompt_tokens", prompt_tokens),
+                ("completion_tokens", completion_tokens),
+                ("total_tokens", total_tokens),
+            ]
+
+            span = get_current_span()
+            if span:
+                breakpoint()
+                for metric_name, value in metrics:
+                    await self.telemetry.log_event(
+                        MetricEvent(
+                            trace_id=span.trace_id,
+                            span_id=span.span_id,
+                            metric=metric_name,
+                            value=value,
+                            timestamp=time.time(),
+                            unit="tokens",
+                            attributes={
+                                "model_id": model_id,
+                                "provider_id": model.provider_id,
+                            },
+                        )
+                    )
             return response
 
     async def completion(

--- a/llama_stack/providers/inline/telemetry/meta_reference/config.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/config.py
@@ -20,7 +20,7 @@ class TelemetrySink(str, Enum):
 
 class TelemetryConfig(BaseModel):
     otel_endpoint: str = Field(
-        default="http://localhost:4318/v1/traces",
+        default="http://localhost:4318",
         description="The OpenTelemetry collector endpoint URL",
     )
     service_name: str = Field(

--- a/llama_stack/providers/inline/telemetry/meta_reference/config.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/config.py
@@ -23,6 +23,14 @@ class TelemetryConfig(BaseModel):
         default="http://localhost:4318",
         description="The OpenTelemetry collector endpoint URL",
     )
+    prometheus_endpoint: str = Field(
+        default="http://localhost:9090",
+        description="The Prometheus endpoint URL",
+    )
+    prometheus_disable_ssl: bool = Field(
+        default=True,
+        description="Whether to disable SSL for the Prometheus endpoint",
+    )
     service_name: str = Field(
         default="llama-stack",
         description="The service name to use for telemetry",

--- a/llama_stack/providers/inline/telemetry/meta_reference/metrics_store.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/metrics_store.py
@@ -1,0 +1,29 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import List, Optional
+
+from llama_stack.apis.telemetry import (
+    GetMetricsResponse,
+    MetricLabelMatcher,
+    MetricQueryType,
+)
+
+
+class MetricsStore(ABC):
+    @abstractmethod
+    async def get_metrics(
+        self,
+        metric_name: str,
+        start_time: datetime,
+        end_time: Optional[datetime] = None,
+        step: Optional[str] = "15s",
+        query_type: MetricQueryType = MetricQueryType.RANGE,
+        label_matchers: Optional[List[MetricLabelMatcher]] = None,
+    ) -> GetMetricsResponse:
+        pass

--- a/llama_stack/providers/inline/telemetry/meta_reference/prometheus_metrics_store.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/prometheus_metrics_store.py
@@ -1,0 +1,65 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from datetime import datetime
+from typing import List, Optional
+
+from prometheus_api_client import PrometheusConnect
+
+from llama_stack.apis.telemetry import (
+    GetMetricsResponse,
+    MetricDataPoint,
+    MetricLabelMatcher,
+    MetricQueryType,
+    MetricSeries,
+)
+
+from .metrics_store import MetricsStore
+
+
+class PrometheusMetricsStore(MetricsStore):
+    def __init__(self, endpoint: str, disable_ssl: bool = True):
+        self.prom = PrometheusConnect(url=endpoint, disable_ssl=disable_ssl)
+
+    async def get_metrics(
+        self,
+        metric_name: str,
+        start_time: datetime,
+        end_time: Optional[datetime] = None,
+        step: Optional[str] = "15s",
+        query_type: MetricQueryType = MetricQueryType.RANGE,
+        label_matchers: Optional[List[MetricLabelMatcher]] = None,
+    ) -> GetMetricsResponse:
+        try:
+            query = metric_name
+            if label_matchers:
+                matchers = [f'{m.name}{m.operator.value}"{m.value}"' for m in label_matchers]
+                query = f"{metric_name}{{{','.join(matchers)}}}"
+
+            if query_type == MetricQueryType.INSTANT:
+                result = self.prom.custom_query(query=query)
+                result = [{"metric": r["metric"], "values": [[r["value"][0], r["value"][1]]]} for r in result]
+            else:
+                result = self.prom.custom_query_range(
+                    query=query,
+                    start_time=start_time,
+                    end_time=end_time if end_time else None,
+                    step=step,
+                )
+
+            series = []
+            for metric_data in result:
+                values = [
+                    MetricDataPoint(timestamp=datetime.fromtimestamp(point[0]), value=float(point[1]))
+                    for point in metric_data["values"]
+                ]
+                series.append(MetricSeries(metric=metric_name, labels=metric_data.get("metric", {}), values=values))
+
+            return GetMetricsResponse(data=series)
+
+        except Exception as e:
+            print(f"Error querying metrics: {e}")
+            return GetMetricsResponse(data=[])

--- a/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
@@ -268,8 +268,8 @@ class TelemetryAdapter(TelemetryDatasetMixin, Telemetry):
         query_type: MetricQueryType = MetricQueryType.RANGE,
         label_matchers: Optional[List[MetricLabelMatcher]] = None,
     ) -> GetMetricsResponse:
-        if TelemetrySink.OTEL not in self.config.sinks:
-            return GetMetricsResponse(data=[])
+        if self.prom is None:
+            raise ValueError("Prometheus endpoint not configured")
 
         try:
             # Build query with label matchers if provided

--- a/llama_stack/providers/registry/telemetry.py
+++ b/llama_stack/providers/registry/telemetry.py
@@ -23,6 +23,7 @@ def available_providers() -> List[ProviderSpec]:
             pip_packages=[
                 "opentelemetry-sdk",
                 "opentelemetry-exporter-otlp-proto-http",
+                "prometheus-api-client",
             ],
             optional_api_dependencies=[Api.datasetio],
             module="llama_stack.providers.inline.telemetry.meta_reference",


### PR DESCRIPTION
# What does this PR do?

Add token usage metrics for inference API
Changes:
1) Adds a an optional dep on telemetry for all routers
2) Inference Router accepts an optional router
3) Adds a new MetricsMixin which can be used in any response that injects metrics
4) Inference Router computes the prompt and compltion tokens and injects a token_usage metric in response
5) Inference Router then calls telemetry API if provided and logs the metrics
6) Added a new endpoint in telemetry to query metrics. Currently, this is specific to promethues. Can be exteneded to support different backends.

Metrics flow:

Stack -> Open telemetry collector -> prometheus -> grafana

Grafana UI:
![image](https://github.com/user-attachments/assets/80a3f404-499c-4af1-8bce-5ed128a4eb26)


Curl to query metrics:
```
curl --request POST \
  --url http://localhost:8321/v1/telemetry/metrics/completion_tokens_total \
  --header 'content-type: application/json' \
  --data '{
  "start_time": 1738774535,
  "end_time":  1738778135,
  "step": "14s",
  "query_type": "range"
}'

```

Response:
```
{
  "data": [
    {
      "metric": "completion_tokens_total",
      "labels": {
        "__name__": "completion_tokens_total",
        "exported_job": "llama-stack",
        "instance": "otel-collector:8889",
        "job": "otel-collector",
        "model_id": "meta-llama/Llama-3.1-70B-Instruct",
        "provider_id": "together"
      },
      "values": [
        {
          "timestamp": "2025-02-05T09:23:21",
          "value": 4109.0
        },
       .......
      ]
    }
  ]
}
```