### PR TITLE
github: issue templates automatically apply relevant label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,6 @@
 name: 🐛 Bug Report
 description: Create a report to help us reproduce and fix the bug
-
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,6 @@
 name: 🚀 Feature request
 description: Request a new llama-stack feature
-
+labels: ["enhancement"]
 body:
 - type: textarea
   id: feature-pitch


### PR DESCRIPTION
# What does this PR do?
the `bug` and `enhancement` labels will be automatically applied to bugs and feature requests that are opened

## Test Plan
N/A

## Sources
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Ran pre-commit to handle lint / formatting issues.
- [x] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [x] Updated relevant documentation.
- [x] Wrote necessary unit or integration tests.
