### PR TITLE
ci: Add semantic PR title check

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,4 +1,4 @@
-name: Semantic PR
+name: Check semantic PR titles
 
 on:
   pull_request_target:
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check PR Title's semantic conformance
-        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+        uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,21 @@
+name: Semantic PR
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  title-check:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check PR Title's semantic conformance
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   title-check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check PR Title's semantic conformance
         uses: amannn/action-semantic-pull-request@v5


### PR DESCRIPTION
This adds a new workflow to check semantic PR titles to match the [Conventional Commits spec](https://www.conventionalcommits.org/). This will make it easier to browse commit history and enable automation in the future.