### PR TITLE
chore: update return type to Optional[str]

### DIFF
--- a/llama_stack/providers/utils/inference/model_registry.py
+++ b/llama_stack/providers/utils/inference/model_registry.py
@@ -57,17 +57,11 @@ class ModelRegistryHelper(ModelsProtocolPrivate):
             self.alias_to_provider_id_map[alias_obj.llama_model] = alias_obj.provider_model_id
             self.provider_id_to_llama_model_map[alias_obj.provider_model_id] = alias_obj.llama_model
 
-    def get_provider_model_id(self, identifier: str) -> str:
-        if identifier in self.alias_to_provider_id_map:
-            return self.alias_to_provider_id_map[identifier]
-        else:
-            return None
+    def get_provider_model_id(self, identifier: str) -> Optional[str]:
+        return self.alias_to_provider_id_map.get(identifier, None)
 
-    def get_llama_model(self, provider_model_id: str) -> str:
-        if provider_model_id in self.provider_id_to_llama_model_map:
-            return self.provider_id_to_llama_model_map[provider_model_id]
-        else:
-            return None
+    def get_llama_model(self, provider_model_id: str) -> Optional[str]:
+        return self.provider_id_to_llama_model_map.get(provider_model_id, None)
 
     async def register_model(self, model: Model) -> Model:
         if model.model_type == ModelType.embedding:


### PR DESCRIPTION
# What does this PR do?

Updated the return type of the methods `get_provider_model_id` and `get_llama_model` in the `ModelRegistryHelper` class to `Optional[str]` to indicate that they may return a string or None when no match is found. This change improves the clarity of the methods' behavior and supports better type safety.

Signed-off-by: Sébastien Han <seb@redhat.com>

- [ ] Addresses issue (#issue)


## Test Plan

Please describe:
 - tests you ran to verify your changes with result summaries.
 - provide instructions so it can be reproduced.


## Sources

Please link relevant resources if necessary.


## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Ran pre-commit to handle lint / formatting issues.
- [ ] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Updated relevant documentation.
- [ ] Wrote necessary unit or integration tests.
