### PR TITLE
test: replace memory with vector_io fixture

### DIFF
--- a/llama_stack/providers/tests/eval/conftest.py
+++ b/llama_stack/providers/tests/eval/conftest.py
@@ -12,11 +12,11 @@ from ..conftest import get_provider_fixture_overrides
 
 from ..datasetio.fixtures import DATASETIO_FIXTURES
 from ..inference.fixtures import INFERENCE_FIXTURES
-from ..memory.fixtures import MEMORY_FIXTURES
 from ..safety.fixtures import SAFETY_FIXTURES
 from ..scoring.fixtures import SCORING_FIXTURES
 from ..tools.fixtures import TOOL_RUNTIME_FIXTURES
 from .fixtures import EVAL_FIXTURES
+from ..vector_io.fixtures import VECTOR_IO_FIXTURES
 
 DEFAULT_PROVIDER_COMBINATIONS = [
     pytest.param(
@@ -27,7 +27,7 @@ DEFAULT_PROVIDER_COMBINATIONS = [
             "inference": "fireworks",
             "agents": "meta_reference",
             "safety": "llama_guard",
-            "memory": "faiss",
+            "vector_io": "faiss",
             "tool_runtime": "memory_and_search",
         },
         id="meta_reference_eval_fireworks_inference",
@@ -41,7 +41,7 @@ DEFAULT_PROVIDER_COMBINATIONS = [
             "inference": "together",
             "agents": "meta_reference",
             "safety": "llama_guard",
-            "memory": "faiss",
+            "vector_io": "faiss",
             "tool_runtime": "memory_and_search",
         },
         id="meta_reference_eval_together_inference",
@@ -55,7 +55,7 @@ DEFAULT_PROVIDER_COMBINATIONS = [
             "inference": "together",
             "agents": "meta_reference",
             "safety": "llama_guard",
-            "memory": "faiss",
+            "vector_io": "faiss",
             "tool_runtime": "memory_and_search",
         },
         id="meta_reference_eval_together_inference_huggingface_datasetio",
@@ -85,7 +85,7 @@ def pytest_generate_tests(metafunc):
             "inference": INFERENCE_FIXTURES,
             "agents": AGENTS_FIXTURES,
             "safety": SAFETY_FIXTURES,
-            "memory": MEMORY_FIXTURES,
+            "vector_io": VECTOR_IO_FIXTURES,
             "tool_runtime": TOOL_RUNTIME_FIXTURES,
         }
         combinations = (


### PR DESCRIPTION
# What does this PR do?

Replaced references to `memory` with `vector_io` in `DEFAULT_PROVIDER_COMBINATIONS` and adjusted corresponding fixture imports to ensure proper configuration for vector I/O during tests. This change aligns with the new testing structure.

Followup of https://github.com/meta-llama/llama-stack/pull/830 when the memory fixture was removed.

Signed-off-by: Sébastien Han <seb@redhat.com>

## Test Plan

Please describe:
 - tests you ran to verify your changes with result summaries.
 - provide instructions so it can be reproduced.


## Sources

Please link relevant resources if necessary.


## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Ran pre-commit to handle lint / formatting issues.
- [ ] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Updated relevant documentation.
- [ ] Wrote necessary unit or integration tests.
