### PR TITLE
ci: add "Pull Request Labeler" GitHub Action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+documentation:
+  - changed-files:
+    - any-glob-to-any-file:
+      - "*.md"

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,14 @@
+name: Pull Request Labeler
+
+on:
+  pull_request_target:
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+    - name: Labeler Action
+      uses: actions/labeler@v5


### PR DESCRIPTION
# What does this PR do?
Introduces the concept of a PR labeler to llama-stack github repo. Only documentation PRs implemented in this commit but lays the groundwork for further configuration as the project needs evolve.

Similar vein as https://github.com/meta-llama/llama-stack/pull/956

## Test Plan
No way to test this locally, but I've used this successfully elsewhere - happy to provide references if the Maintainers would like

## Sources
https://github.com/actions/labeler

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Ran pre-commit to handle lint / formatting issues.
- [x] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [x] Updated relevant documentation.
- [x] Wrote necessary unit or integration tests.
