### PR TITLE
github: update PR template to use correct syntax to auto-close issues

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,25 @@
 # What does this PR do?
 
-In short, provide a summary of what this PR does and why. Usually, the relevant context should be present in a linked issue.
+<!-- Provide a short summary of what this PR does and why. Usually, the relevant context should be present in a linked issue. -->
 
-- [ ] Addresses issue (#issue)
+<!-- Uncomment this section with the issue number if an issue is being resolved
+**Issue resolved by this Pull Request:**
+Closes #
+--->
 
 
 ## Test Plan
 
+<!--
 Please describe:
  - tests you ran to verify your changes with result summaries.
  - provide instructions so it can be reproduced.
+-->
 
 
 ## Sources
 
-Please link relevant resources if necessary.
+<!-- Please link relevant resources if necessary. -->
 
 
 ## Before submitting


### PR DESCRIPTION
Also, hiding guidance to the author under comments to avoid polluting
the description with ti.

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>

# What does this PR do?

Using `Closes #` syntax in PR template, as per:
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests

```
In short, provide a summary of what this PR does and why. Usually, the relevant context should be present in a linked issue.
```

Hides this ^.

```
Please describe:
 - tests you ran to verify your changes with result summaries.
 - provide instructions so it can be reproduced.
```

And this ^.

```
Please link relevant resources if necessary.
```

And this ^.


## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Ran pre-commit to handle lint / formatting issues.
- [x] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Updated relevant documentation.
- [ ] Wrote necessary unit or integration tests.
