### PR TITLE
github: update PR template so issues are auto-linked

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 In short, provide a summary of what this PR does and why. Usually, the relevant context should be present in a linked issue.
 
-- [ ] Addresses issue (#issue)
+- [ ] Resolves issue (#issue)
 
 
 ## Test Plan


### PR DESCRIPTION
# What does this PR do?
As @booxter noted in https://github.com/meta-llama/llama-stack/issues/971#issuecomment-2640174760 the current PR template doesn't autolink issues that are being resolved by said PR - this PR updates the template so that will happen going forward

## Test Plan
N/A

## Sources
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Ran pre-commit to handle lint / formatting issues.
- [ ] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Updated relevant documentation.
- [ ] Wrote necessary unit or integration tests.
