### PR TITLE
test: rm unused exception alias in pytest.raises

### DIFF
--- a/llama_stack/providers/tests/datasetio/test_datasetio.py
+++ b/llama_stack/providers/tests/datasetio/test_datasetio.py
@@ -95,7 +95,7 @@ class TestDatasetIO:
         assert len(response) == 1
         assert response[0].identifier == "test_dataset"
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(ValueError):
             # unregister a dataset that does not exist
             await datasets_impl.unregister_dataset("test_dataset2")
 
@@ -104,7 +104,7 @@ class TestDatasetIO:
         assert isinstance(response, list)
         assert len(response) == 0
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(ValueError):
             await datasets_impl.unregister_dataset("test_dataset")
 
     @pytest.mark.asyncio

--- a/llama_stack/providers/tests/inference/test_model_registration.py
+++ b/llama_stack/providers/tests/inference/test_model_registration.py
@@ -32,7 +32,7 @@ class TestModelRegistration:
             )
 
         # Try to register a model that's too large for local inference
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError):
             await models_impl.register_model(
                 model_id="Llama3.1-70B-Instruct",
             )
@@ -42,7 +42,7 @@ class TestModelRegistration:
         _, models_impl = inference_stack
 
         # Try to register a non-existent model
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(ValueError):
             await models_impl.register_model(
                 model_id="Llama3-NonExistent-Model",
             )
@@ -59,7 +59,7 @@ class TestModelRegistration:
             },
         )
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError):
             await models_impl.register_model(
                 model_id="custom-model-2",
                 metadata={
@@ -88,7 +88,7 @@ class TestModelRegistration:
     async def test_register_with_invalid_llama_model(self, inference_stack):
         _, models_impl = inference_stack
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError):
             await models_impl.register_model(
                 model_id="custom-model-2",
                 metadata={"llama_model": "invalid-llama-model"},


### PR DESCRIPTION
# What does this PR do?

Refactored tests by removing unused exception alias (as exc_info) in pytest.raises, improving code clarity and reducing lint warnings. exc_info was never used.

Signed-off-by: Sébastien Han <seb@redhat.com>

## Test Plan

Please describe:
 - tests you ran to verify your changes with result summaries.
 - provide instructions so it can be reproduced.


## Sources

Please link relevant resources if necessary.


## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Ran pre-commit to handle lint / formatting issues.
- [ ] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Updated relevant documentation.
- [ ] Wrote necessary unit or integration tests.
