### PR TITLE
feat: Add HTTPS serving option

### DIFF
--- a/llama_stack/cli/stack/run.py
+++ b/llama_stack/cli/stack/run.py
@@ -55,6 +55,16 @@ class StackRun(Subcommand):
             default=[],
             metavar="KEY=VALUE",
         )
+        self.parser.add_argument(
+            "--ssl-keyfile",
+            type=str,
+            help="Path to SSL key file for HTTPS",
+        )
+        self.parser.add_argument(
+            "--ssl-certfile",
+            type=str,
+            help="Path to SSL certificate file for HTTPS",
+        )
 
     def _run_stack_run_cmd(self, args: argparse.Namespace) -> None:
         import importlib.resources
@@ -177,5 +187,8 @@ class StackRun(Subcommand):
                 )
                 return
             run_args.extend(["--env", f"{key}={value}"])
+
+        if args.ssl_keyfile and args.ssl_certfile:
+            run_args.extend(["--ssl-keyfile", args.ssl_keyfile, "--ssl-certfile", args.ssl_certfile])
 
         run_with_pty(run_args)

--- a/llama_stack/cli/stack/run.py
+++ b/llama_stack/cli/stack/run.py
@@ -56,14 +56,14 @@ class StackRun(Subcommand):
             metavar="KEY=VALUE",
         )
         self.parser.add_argument(
-            "--ssl-keyfile",
+            "--tls-keyfile",
             type=str,
-            help="Path to SSL key file for HTTPS",
+            help="Path to TLS key file for HTTPS",
         )
         self.parser.add_argument(
-            "--ssl-certfile",
+            "--tls-certfile",
             type=str,
-            help="Path to SSL certificate file for HTTPS",
+            help="Path to TLS certificate file for HTTPS",
         )
 
     def _run_stack_run_cmd(self, args: argparse.Namespace) -> None:
@@ -188,7 +188,7 @@ class StackRun(Subcommand):
                 return
             run_args.extend(["--env", f"{key}={value}"])
 
-        if args.ssl_keyfile and args.ssl_certfile:
-            run_args.extend(["--ssl-keyfile", args.ssl_keyfile, "--ssl-certfile", args.ssl_certfile])
+        if args.tls_keyfile and args.tls_certfile:
+            run_args.extend(["--tls-keyfile", args.tls_keyfile, "--tls-certfile", args.tls_certfile])
 
         run_with_pty(run_args)

--- a/llama_stack/distribution/datatypes.py
+++ b/llama_stack/distribution/datatypes.py
@@ -121,6 +121,8 @@ class ServerConfig(BaseModel):
     port: int = Field(
         default=8321,
         description="Port to listen on",
+        ge=1024,
+        le=65535,
     )
     ssl_certfile: Optional[str] = Field(
         default=None,

--- a/llama_stack/distribution/datatypes.py
+++ b/llama_stack/distribution/datatypes.py
@@ -124,13 +124,13 @@ class ServerConfig(BaseModel):
         ge=1024,
         le=65535,
     )
-    ssl_certfile: Optional[str] = Field(
+    tls_certfile: Optional[str] = Field(
         default=None,
-        description="Path to SSL certificate file for HTTPS",
+        description="Path to TLS certificate file for HTTPS",
     )
-    ssl_keyfile: Optional[str] = Field(
+    tls_keyfile: Optional[str] = Field(
         default=None,
-        description="Path to SSL key file for HTTPS",
+        description="Path to TLS key file for HTTPS",
     )
 
 

--- a/llama_stack/distribution/datatypes.py
+++ b/llama_stack/distribution/datatypes.py
@@ -117,6 +117,21 @@ class Provider(BaseModel):
     config: Dict[str, Any]
 
 
+class ServerConfig(BaseModel):
+    port: int = Field(
+        default=8321,
+        description="Port to listen on",
+    )
+    ssl_certfile: Optional[str] = Field(
+        default=None,
+        description="Path to SSL certificate file for HTTPS",
+    )
+    ssl_keyfile: Optional[str] = Field(
+        default=None,
+        description="Path to SSL key file for HTTPS",
+    )
+
+
 class StackRunConfig(BaseModel):
     version: str = LLAMA_STACK_RUN_CONFIG_VERSION
 
@@ -158,6 +173,11 @@ a default SQLite store will be used.""",
     scoring_fns: List[ScoringFnInput] = Field(default_factory=list)
     eval_tasks: List[EvalTaskInput] = Field(default_factory=list)
     tool_groups: List[ToolGroupInput] = Field(default_factory=list)
+
+    server: ServerConfig = Field(
+        default_factory=ServerConfig,
+        description="Configuration for the HTTP(S) server",
+    )
 
 
 class BuildConfig(BaseModel):

--- a/llama_stack/distribution/server/server.py
+++ b/llama_stack/distribution/server/server.py
@@ -283,14 +283,14 @@ def main():
         help="Environment variables in KEY=value format. Can be specified multiple times.",
     )
     parser.add_argument(
-        "--ssl-keyfile",
-        help="Path to SSL key file for HTTPS",
-        required="--ssl-certfile" in sys.argv,
+        "--tls-keyfile",
+        help="Path to TLS key file for HTTPS",
+        required="--tls-certfile" in sys.argv,
     )
     parser.add_argument(
-        "--ssl-certfile",
-        help="Path to SSL certificate file for HTTPS",
-        required="--ssl-keyfile" in sys.argv,
+        "--tls-certfile",
+        help="Path to TLS certificate file for HTTPS",
+        required="--tls-keyfile" in sys.argv,
     )
 
     args = parser.parse_args()
@@ -396,12 +396,12 @@ def main():
     port = args.port or config.server.port
 
     ssl_config = None
-    if args.ssl_keyfile:
-        keyfile = args.ssl_keyfile
-        certfile = args.ssl_certfile
+    if args.tls_keyfile:
+        keyfile = args.tls_keyfile
+        certfile = args.tls_certfile
     else:
-        keyfile = config.server.ssl_keyfile
-        certfile = config.server.ssl_certfile
+        keyfile = config.server.tls_keyfile
+        certfile = config.server.tls_certfile
 
     if keyfile and certfile:
         ssl_config = {

--- a/llama_stack/distribution/server/server.py
+++ b/llama_stack/distribution/server/server.py
@@ -285,18 +285,15 @@ def main():
     parser.add_argument(
         "--ssl-keyfile",
         help="Path to SSL key file for HTTPS",
+        required="--ssl-certfile" in sys.argv,
     )
     parser.add_argument(
         "--ssl-certfile",
         help="Path to SSL certificate file for HTTPS",
+        required="--ssl-keyfile" in sys.argv,
     )
 
     args = parser.parse_args()
-
-    if args.ssl_keyfile and not args.ssl_certfile:
-        parser.error("You must provide both --ssl-keyfile and --ssl-certfile when using HTTPS")
-    if args.ssl_certfile and not args.ssl_keyfile:
-        parser.error("You must provide both --ssl-keyfile and --ssl-certfile when using HTTPS")
 
     if args.env:
         for env_pair in args.env:

--- a/llama_stack/distribution/server/server.py
+++ b/llama_stack/distribution/server/server.py
@@ -291,12 +291,13 @@ def main():
         help="Path to SSL certificate file for HTTPS",
     )
 
+    args = parser.parse_args()
+
     if args.ssl_keyfile and not args.ssl_certfile:
         parser.error("You must provide both --ssl-keyfile and --ssl-certfile when using HTTPS")
     if args.ssl_certfile and not args.ssl_keyfile:
         parser.error("You must provide both --ssl-keyfile and --ssl-certfile when using HTTPS")
 
-    args = parser.parse_args()
     if args.env:
         for env_pair in args.env:
             try:

--- a/llama_stack/distribution/start_conda_env.sh
+++ b/llama_stack/distribution/start_conda_env.sh
@@ -34,6 +34,7 @@ shift
 
 # Process environment variables from --env arguments
 env_vars=""
+other_args=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
   --env)
@@ -48,6 +49,7 @@ while [[ $# -gt 0 ]]; do
     fi
     ;;
   *)
+    other_args="$other_args $1"
     shift
     ;;
   esac
@@ -61,4 +63,5 @@ $CONDA_PREFIX/bin/python \
   -m llama_stack.distribution.server.server \
   --yaml-config "$yaml_config" \
   --port "$port" \
-  $env_vars
+  $env_vars \
+  $other_args

--- a/llama_stack/distribution/start_container.sh
+++ b/llama_stack/distribution/start_container.sh
@@ -40,8 +40,12 @@ shift
 port="$1"
 shift
 
+# Initialize other_args
+other_args=""
+
 # Process environment variables from --env arguments
 env_vars=""
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --env)
@@ -55,6 +59,7 @@ while [[ $# -gt 0 ]]; do
             fi
             ;;
         *)
+            other_args="$other_args $1"
             shift
             ;;
     esac
@@ -93,5 +98,8 @@ $CONTAINER_BINARY run $CONTAINER_OPTS -it \
   -v "$yaml_config:/app/config.yaml" \
   $mounts \
   --env LLAMA_STACK_PORT=$port \
-  --entrypoint='["python", "-m", "llama_stack.distribution.server.server", "--yaml-config", "/app/config.yaml"]' \
-  $container_image:$version_tag
+  --entrypoint python \
+  $container_image:$version_tag \
+  -m llama_stack.distribution.server.server \
+  --yaml-config /app/config.yaml \
+  $other_args


### PR DESCRIPTION
# What does this PR do?

Enables HTTPS option for Llama Stack. 

While doing so, introduces a `ServerConfig` sub-structure to house all server related configuration (port, ssl, etc.)

Also simplified the `start_container.sh` entrypoint to simply be `python` instead of a complex bash command line.

## Test Plan

Conda: 

Run:
```bash
$ llama stack build --template together
$ llama stack run --port 8322        # ensure server starts 

$ llama-stack-client configure --endpoint http://localhost:8322
$ llama-stack-client models list
```

Create a self-signed SSL key / cert pair. Then, using a local checkout of `llama-stack-client-python`, change https://github.com/meta-llama/llama-stack-client-python/blob/main/src/llama_stack_client/_base_client.py#L759 to add `kwargs.setdefault("verify", False)` so SSL verification is disabled. Then: 

```bash
$ llama stack run --port 8322 --tls-keyfile <KEYFILE> --tls-certfile <CERTFILE>
$ llama-stack-client configure --endpoint https://localhost:8322  # notice the `https`
$ llama-stack-client models list
```

Also tested with containers (but of course one needs to make sure the cert and key files are appropriately provided to the container.) 