### PR TITLE
fix: enable_session_persistence in AgentConfig should be optional

### DIFF
--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -2724,7 +2724,8 @@
                         "type": "string"
                     },
                     "enable_session_persistence": {
-                        "type": "boolean"
+                        "type": "boolean",
+                        "default": false
                     },
                     "response_format": {
                         "$ref": "#/components/schemas/ResponseFormat"
@@ -2733,8 +2734,7 @@
                 "additionalProperties": false,
                 "required": [
                     "model",
-                    "instructions",
-                    "enable_session_persistence"
+                    "instructions"
                 ]
             },
             "AgentTool": {

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -1660,13 +1660,13 @@ components:
           type: string
         enable_session_persistence:
           type: boolean
+          default: false
         response_format:
           $ref: '#/components/schemas/ResponseFormat'
       additionalProperties: false
       required:
         - model
         - instructions
-        - enable_session_persistence
     AgentTool:
       oneOf:
         - type: string

--- a/llama_stack/apis/agents/agents.py
+++ b/llama_stack/apis/agents/agents.py
@@ -179,7 +179,7 @@ class AgentConfigCommon(BaseModel):
 class AgentConfig(AgentConfigCommon):
     model: str
     instructions: str
-    enable_session_persistence: bool
+    enable_session_persistence: Optional[bool] = False
     response_format: Optional[ResponseFormat] = None
 
 


### PR DESCRIPTION
# What does this PR do?
This issue was discovered in https://github.com/meta-llama/llama-stack/pull/1009#discussion_r1947036518.

## Test Plan

This field is no longer required after the change.

[//]: # (## Documentation)
[//]: # (- [ ] Added a Changelog entry if the change is significant)
