### PR TITLE
test: Use JSON tool prompt format for remote::vllm provider

### DIFF
--- a/tests/client-sdk/inference/test_text_inference.py
+++ b/tests/client-sdk/inference/test_text_inference.py
@@ -11,6 +11,7 @@ PROVIDER_TOOL_PROMPT_FORMAT = {
     "remote::ollama": "json",
     "remote::together": "json",
     "remote::fireworks": "json",
+    "remote::vllm": "json",
 }
 
 PROVIDER_LOGPROBS_TOP_K = set(


### PR DESCRIPTION
# What does this PR do?

This PR removes the warnings when running tests for `remote::vllm` provider:
```
Detected the chat template content format to be 'openai'. You can set `--chat-template-content-format` to override this.
```

## Test Plan

All tests passed without the warning messages shown above.
