### PR TITLE
Fixed the image understanding agent example for LS 0.1.2

### DIFF
--- a/docs/getting_started.ipynb
+++ b/docs/getting_started.ipynb
@@ -3414,7 +3414,9 @@
       "source": [
         "### 4.1 Setup and helpers\n",
         "\n",
-        "Below we install the Llama Stack client 0.1, download the example image, define two image helpers, and set Llama Stack Together server URL and Llama 3.2 model name.\n"
+        "Below we install the Llama Stack client 0.1.0, download the example image, define two image helpers, and set Llama Stack Together server URL and Llama 3.2 model name.\n",
+        "\n",
+        "Note the code below has been tested and works with Llama Stack 0.1.0 and 0.1.2.\n"
       ]
     },
     {
@@ -3424,7 +3426,8 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "!pip install llama-stack-client==0.1.0"
+        "!pip install llama-stack-client==0.1.0\n",
+        "#!pip install llama-stack-client==0.1.2"
       ]
     },
     {

--- a/docs/getting_started.ipynb
+++ b/docs/getting_started.ipynb
@@ -3580,6 +3580,7 @@
         "        model=LLAMA32_11B_INSTRUCT,\n",
         "        instructions=\"You are a helpful assistant\",\n",
         "        enable_session_persistence=False,\n",
+        "        toolgroups=[]\n",
         "    )\n",
         "\n",
         "    agent = Agent(client, agent_config)\n",


### PR DESCRIPTION
# What does this PR do?
[Provide a short summary of what this PR does and why. Link to relevant issues if applicable.]

@amitsangani found that missing the toolgroups in AgentConfig caused the error with LS 0.1.2. 

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan
[Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.*]

[//]: # (## Documentation)
[//]: # (- [ ] Added a Changelog entry if the change is significant)
