### PR TITLE
fix: Added missing `tool_config` arg in SambaNova `chat_completion()`

### DIFF
--- a/llama_stack/providers/remote/inference/sambanova/sambanova.py
+++ b/llama_stack/providers/remote/inference/sambanova/sambanova.py
@@ -116,6 +116,7 @@ class SambaNovaInferenceAdapter(ModelRegistryHelper, Inference):
         tool_choice: Optional[ToolChoice] = ToolChoice.auto,
         tool_prompt_format: Optional[ToolPromptFormat] = ToolPromptFormat.json,
         stream: Optional[bool] = False,
+        tool_config: Optional[ToolConfig] = None,
         logprobs: Optional[LogProbConfig] = None,
     ) -> AsyncGenerator:
         model = await self.model_store.get_model(model_id)


### PR DESCRIPTION
# What does this PR do?

`tool_config` is missing from the signature but is used in `ChatCompletionRequest()`. 


## Test Plan

This is a small fix. I don't have SambaNova to test the change but I doubt that this is currently working.
