### PR TITLE
docs: remove changelog mention from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,3 @@
 [Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.*]
 
 [//]: # (## Documentation)
-[//]: # (- [ ] Added a Changelog entry if the change is significant)


### PR DESCRIPTION
# What does this PR do?

The CHANGELOG.md was removed in
https://github.com/meta-llama/llama-stack/commit/e6c9f2a4856192d6cb57a038d98d21a253c4319a so this mention is not relevant anymore.

Signed-off-by: Sébastien Han <seb@redhat.com>


