### PR TITLE
feat: Support for deploying llama stack to Kubernetes

### DIFF
--- a/.github/workflows/publish-helm.yml
+++ b/.github/workflows/publish-helm.yml
@@ -1,0 +1,36 @@
+name: Publish Helm Chart
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'chart/**'
+      - '.github/workflows/publish-helm.yml'
+jobs:
+  publish-helm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Package and Push Helm Chart
+        run: | # Version is either git tag or git hash
+          if [[ $GITHUB_REF_TYPE == "tag" ]]; then
+            VERSION=$(git describe --tags --abbrev=0 | sed 's/^v//')
+          elif [[ $GITHUB_REF_TYPE == "branch" ]]; then
+            VERSION="0.0.0-$(git rev-parse --short HEAD)"
+          fi
+          helm package chart --version $VERSION
+          helm push llama-stack-${VERSION}.tgz oci://ghcr.io/${GITHUB_REPOSITORY,,}

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ _build
 docs/src
 pyrightconfig.json
 venv/
+*.tgz

--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,26 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+# Ignore examples
+examples/*

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: llama-stack
+version: 0.0.0 # Overriden during `helm package`
+description: A Helm chart for https://github.com/meta-llama/llama-stack

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,0 +1,21 @@
+# Llama Stack on Kubernetes
+
+Llama Stack can be installed into any Kubernetes Cluster using [Helm](https://helm.sh/docs/intro/install/)
+
+### Prerequisites
+
+* A Kubernetes Cluster with appropriate Node (CPU, GPU, etc)
+* [Helm](https://helm.sh/docs/intro/install/)
+
+### Install
+
+```bash
+helm install llama-stack oci://ghcr.io/meta-llama/llama-stack --set distribution=ollama
+```
+
+### Chat with Llama
+
+```bash
+kubectl port-forward svc/llama-stack 8080:80
+llama-stack-client inference chat-completion --message "Hello, what model are you?"
+```

--- a/chart/templates/distributions/ollama/template.yaml
+++ b/chart/templates/distributions/ollama/template.yaml
@@ -1,0 +1,58 @@
+{{- if eq .Values.distribution "ollama" }}
+
+{{- $variables := include "distributions.ollama" . | fromYaml -}}
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ollama
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ollama
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ollama
+    spec:
+      tolerations:
+      - key: "nvidia.com/gpu"
+        operator: "Exists"
+        effect: "NoSchedule"
+      containers:
+        - name: ollama
+          image: "{{ $variables.image.repository }}:{{ $variables.image.tag }}"
+          resources:
+            {{- toYaml .Values.ollama.resources | nindent 12 }}
+          env:
+          - name: OLLAMA_KEEP_ALIVE
+            value: "-1"
+          volumeMounts:
+          - mountPath: /root/.ollama
+            name: ollama-volume
+          ports:
+          - containerPort: 11434
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", "ollama run {{ index $variables.models .Values.model }}"]
+      volumes:
+      - name: ollama-volume
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: ollama
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 11434
+---
+{{ end -}}

--- a/chart/templates/distributions/ollama/validation.tpl
+++ b/chart/templates/distributions/ollama/validation.tpl
@@ -1,0 +1,4 @@
+{{- $variables := include "distributions.ollama" . | fromYaml -}}
+{{- if not (hasKey $variables.models .Values.model) -}}
+  {{- fail (printf ".model '%s' is not supported" .Values.model) -}}
+{{- end -}}

--- a/chart/templates/distributions/ollama/variables.tpl
+++ b/chart/templates/distributions/ollama/variables.tpl
@@ -1,0 +1,7 @@
+{{- define "distributions.ollama" -}}
+image:
+  repository: ollama/ollama
+  tag: 0.5.8
+models:
+  "meta-llama/Llama-3.2-1B-Instruct": "llama3.2:1b-instruct-fp16"
+{{- end -}} 

--- a/chart/templates/template.yaml
+++ b/chart/templates/template.yaml
@@ -1,0 +1,45 @@
+{{- $variables := include "llamaStack" . | fromYaml -}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: {{ .Release.Name }}
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 5000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Release.Name }}
+          image: "{{ index $variables.images .Values.distribution "repository" }}:{{ index $variables.images .Values.distribution "tag" }}"
+          resources:
+            {{- toYaml .Values.llamaStack.resources | nindent 12 }}
+          env:
+            - name: INFERENCE_MODEL
+              value: {{ .Values.model }}
+            - name: OLLAMA_URL
+              value: http://ollama.{{ .Release.Namespace }}.svc.cluster.local
+            - name: LLAMA_STACK_PORT
+              value: "5000"
+          ports:
+            - containerPort: 5000

--- a/chart/templates/variables.tpl
+++ b/chart/templates/variables.tpl
@@ -1,0 +1,12 @@
+{{/* Variables */}}
+{{- define "llamaStack" -}}
+images:
+  ollama:
+    repository: llamastack/distribution-ollama
+    tag: 0.1.2 # TODO paramaterize this from Chart Version, but requires building images with the same tag scheme
+{{- end -}} 
+
+{{/* Validation */}}
+{{- if not .Values.distribution -}}
+  {{- fail "distribution must be defined" -}}
+{{- end -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,13 @@
+distribution: # Required: [ollama, ...], see https://llama-stack.readthedocs.io/en/latest/distributions/selection.html
+model: "meta-llama/Llama-3.2-1B-Instruct"
+llamaStack:
+  resources:
+    requests:
+      cpu: 200m
+      memory: 100Mi
+ollama:
+  resources:
+    requests:
+      cpu: 1
+      memory: 8Gi
+  


### PR DESCRIPTION
# What does this PR do?

Helm Chart for installing Llama Stack onto Kubernetes

1. I chose to make a unified chart with if statements for each dsitribution, rather than duplicate every chart
2. Chart versions are tightly coupled to llama stack repo versions
3. Only support for ollama, as it's the easiest way to pull Llama without a signedurl
4. Missing essential productionization details like resource requests, node selectors, pdbs, etc

## Test Plan
Helm Chart Testing: https://github.com/ellistarn/llama-stack/actions/runs/13274556598/job/37061452339

```
❯ k get pods   
NAME                          READY   STATUS    RESTARTS   AGE
llama-stack-67c7b744c-jzzq5   1/1     Running   0          10m
ollama-7f9f64dfc9-wjqrl       1/1     Running   0          19m
```

```
❯ llama-stack-client inference chat-completion --message "Hello, what model are you?"

ChatCompletionResponse(
    completion_message=CompletionMessage(
        content="I'm an AI assistant, and I don't have a specific model like a human would. I'm a large
language model, which means I was trained on a massive dataset of text from the internet and can generate
human-like responses to a wide range of questions and topics.\n\nMy training data includes information on
various subjects, including science, history, technology, culture, entertainment, and more. However, my
knowledge is not exhaustive, and I may not have in-depth expertise or real-time access to very specific or
up-to-the-minute information.\n\nThat being said, I'm here to help answer any questions you have, provide
information on a wide range of topics, and engage in conversation! What's on your mind?",
        role='assistant',
        stop_reason='end_of_turn',
        tool_calls=[]
    ),
    logprobs=None
)
```
[//]: # (## Documentation)
