### PR TITLE
docs: reflect actual number of spaces for indent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,8 @@ $ uv sync
 ```
 
 ## Coding Style
-* 2 spaces for indentation rather than tabs
+
+* 4 spaces for indentation rather than tabs
 * 80 character line length
 * ...
 


### PR DESCRIPTION
For what I see, it's all 4 spaces (as it should be for pep8[1]).

[1] https://peps.python.org/pep-0008/#indentation

# What does this PR do?

Reflect indent reality.
