### PR TITLE
Docling v0

### DIFF
--- a/llama_stack/providers/inline/tool_runtime/rag/config.py
+++ b/llama_stack/providers/inline/tool_runtime/rag/config.py
@@ -27,11 +27,7 @@ class RagToolRuntimeConfig(BaseModel):
         default_factory=DoclingConfig,
         description="The optional Docling settings",
     )
-    chunker: Optional[str] = Field(
-        default=None,
-        description="The chunker implementation, one of default or docling",
-    )
 
     @classmethod
     def sample_config(cls) -> dict[str, any]:
-        return {"docling": {"export_type": "MARKDOWN"}, "chunker": "default"}
+        return {"docling": {"export_type": "MARKDOWN"}}

--- a/llama_stack/providers/inline/tool_runtime/rag/config.py
+++ b/llama_stack/providers/inline/tool_runtime/rag/config.py
@@ -4,8 +4,34 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from pydantic import BaseModel
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class DoclingConfig(BaseModel):
+    model_config: ConfigDict = ConfigDict(arbitrary_types_allowed=True)
+
+    export_type: Optional[str] = Field(
+        default="MARKDOWN",
+        description="The export type, one of MARKDOWN (default) or JSON",
+    )
+    accelerator_options: Optional[dict[str, any]] = Field(
+        default=None,
+        description="Optional key value arguments passed to the accelerator options",
+    )
 
 
 class RagToolRuntimeConfig(BaseModel):
-    pass
+    docling: Optional[DoclingConfig] = Field(
+        default_factory=DoclingConfig,
+        description="The optional Docling settings",
+    )
+    chunker: Optional[str] = Field(
+        default=None,
+        description="The chunker implementation, one of default or docling",
+    )
+
+    @classmethod
+    def sample_config(cls) -> dict[str, any]:
+        return {"docling": {"export_type": "MARKDOWN"}, "chunker": "default"}

--- a/llama_stack/providers/inline/tool_runtime/rag/memory.py
+++ b/llama_stack/providers/inline/tool_runtime/rag/memory.py
@@ -66,7 +66,7 @@ class MemoryToolRuntimeImpl(ToolsProtocolPrivate, ToolRuntime, RAGToolRuntime):
     ) -> None:
         log.info("HELLO async def insert")
         converter: Converter = Converter.from_config(self.config.docling)
-        chunker: Chunker = Chunker.from_config(self.config.chunker)
+        chunker: Chunker = Chunker.from_config(self.config.docling)
         log.info(f"converter is {converter}")
         log.info(f"chunker is {chunker}")
         chunks = []

--- a/llama_stack/providers/inline/tool_runtime/rag/memory.py
+++ b/llama_stack/providers/inline/tool_runtime/rag/memory.py
@@ -27,8 +27,8 @@ from llama_stack.apis.tools import (
 )
 from llama_stack.apis.vector_io import QueryChunksResponse, VectorIO
 from llama_stack.providers.datatypes import ToolsProtocolPrivate
-from llama_stack.providers.utils.docling.converter import Converter
 from llama_stack.providers.utils.docling.chunker import Chunker
+from llama_stack.providers.utils.docling.converter import Converter
 
 from .config import RagToolRuntimeConfig
 from .context_retriever import generate_rag_query
@@ -64,11 +64,8 @@ class MemoryToolRuntimeImpl(ToolsProtocolPrivate, ToolRuntime, RAGToolRuntime):
         vector_db_id: str,
         chunk_size_in_tokens: int = 512,
     ) -> None:
-        log.info("HELLO async def insert")
         converter: Converter = Converter.from_config(self.config.docling)
         chunker: Chunker = Chunker.from_config(self.config.docling)
-        log.info(f"converter is {converter}")
-        log.info(f"chunker is {chunker}")
         chunks = []
         for doc in documents:
             content = await converter.content_from_doc(doc=doc)

--- a/llama_stack/providers/utils/docling/__init__.py
+++ b/llama_stack/providers/utils/docling/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.

--- a/llama_stack/providers/utils/docling/chunker.py
+++ b/llama_stack/providers/utils/docling/chunker.py
@@ -4,17 +4,19 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from abc import ABC, abstractmethod
-import chardet
 import re
+from abc import ABC, abstractmethod
 
-from ...inline.tool_runtime.rag.config import DoclingConfig
+import chardet
+
+from llama_stack.apis.common.content_types import URL
 from llama_stack.apis.tools import RAGDocument
+from llama_stack.apis.vector_io import Chunk
 from llama_stack.providers.utils.inference.prompt_adapter import (
     interleaved_content_as_str,
 )
-from llama_stack.apis.common.content_types import URL
-from llama_stack.apis.vector_io import Chunk
+
+from ...inline.tool_runtime.rag.config import DoclingConfig
 
 
 class Chunker(ABC):

--- a/llama_stack/providers/utils/docling/chunker.py
+++ b/llama_stack/providers/utils/docling/chunker.py
@@ -1,0 +1,71 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from abc import ABC, abstractmethod
+import chardet
+import re
+
+from llama_stack.apis.tools import RAGDocument
+from llama_stack.providers.utils.inference.prompt_adapter import (
+    interleaved_content_as_str,
+)
+from llama_stack.apis.common.content_types import URL
+from llama_stack.apis.vector_io import Chunk
+
+
+class Chunker(ABC):
+    @abstractmethod
+    def make_overlapped_chunks(self, document_id: str, text: str, window_len: int, overlap_len: int) -> list[Chunk]:
+        raise NotImplementedError()
+
+    @staticmethod
+    def from_config(converter: str) -> "Chunker":
+        if "docling" == converter:
+            from .docling import DoclingConverter
+
+            return DoclingConverter()
+        from .default import DefaultConverter
+
+        return DefaultConverter()
+
+    async def content_from_doc(self, doc: RAGDocument) -> str:
+        doc_url: str | None = None
+        if isinstance(doc.content, URL):
+            doc_url = doc.content.uri
+        else:
+            pattern = re.compile("^(https?://|file://|data:)")
+            if pattern.match(doc.content):
+                doc_url = doc.content
+
+        if doc_url:
+            if doc_url.startswith("data:"):
+                data, encoding, mime_type = self._decode_data(doc_url)
+                # TODO probably not working with docling
+                # Need to save the file first then use the converter
+                return await self.convert_from_data(data, encoding, mime_type)
+            else:
+                return await self.convert_from_url(doc_url, doc.mime_type)
+
+        return interleaved_content_as_str(doc.content)
+
+    def _decode_data(self, data_url: str) -> (str, str, str):
+        parts = parse_data_url(data_url)
+        data = parts["data"]
+
+        if parts["is_base64"]:
+            data = base64.b64decode(data)
+        else:
+            data = unquote(data)
+            encoding = parts["encoding"] or "utf-8"
+            data = data.encode(encoding)
+
+        encoding = parts["encoding"]
+        if not encoding:
+            detected = chardet.detect(data)
+            encoding = detected["encoding"]
+
+        mime_type = parts["mimetype"]
+        return data, encoding, mime_type

--- a/llama_stack/providers/utils/docling/chunker.py
+++ b/llama_stack/providers/utils/docling/chunker.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 import chardet
 import re
 
+from ...inline.tool_runtime.rag.config import DoclingConfig
 from llama_stack.apis.tools import RAGDocument
 from llama_stack.providers.utils.inference.prompt_adapter import (
     interleaved_content_as_str,
@@ -22,11 +23,11 @@ class Chunker(ABC):
         raise NotImplementedError()
 
     @staticmethod
-    def from_config(converter: str) -> "Chunker":
-        if "docling" == converter:
-            from .docling import DoclingConverter
+    def from_config(docling_config: DoclingConfig) -> "Chunker":
+        if docling_config:
+            from .docling import DoclingChunker
 
-            return DoclingConverter()
+            return DoclingChunker(docling_config)
         from .default import DefaultConverter
 
         return DefaultConverter()

--- a/llama_stack/providers/utils/docling/converter.py
+++ b/llama_stack/providers/utils/docling/converter.py
@@ -1,0 +1,75 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from abc import ABC, abstractmethod
+import chardet
+import re
+
+from llama_stack.apis.tools import RAGDocument
+from llama_stack.providers.utils.inference.prompt_adapter import (
+    interleaved_content_as_str,
+)
+from llama_stack.apis.common.content_types import URL
+from ...inline.tool_runtime.rag.config import DoclingConfig
+
+
+class Converter(ABC):
+    @abstractmethod
+    async def convert_from_url(self, data_url: str, mime_type: str | None) -> str:
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def convert_from_data(self, data: bytes, encoding: str, mime_type: str | None) -> str:
+        raise NotImplementedError()
+
+    @staticmethod
+    def from_config(docling_config: DoclingConfig) -> "Converter":
+        if docling_config:
+            from .docling import DoclingConverter
+
+            return DoclingConverter(docling_config)
+        from .default import DefaultConverter
+
+        return DefaultConverter()
+
+    async def content_from_doc(self, doc: RAGDocument) -> str:
+        doc_url: str | None = None
+        if isinstance(doc.content, URL):
+            doc_url = doc.content.uri
+        else:
+            pattern = re.compile("^(https?://|file://|data:)")
+            if pattern.match(doc.content):
+                doc_url = doc.content
+
+        if doc_url:
+            if doc_url.startswith("data:"):
+                data, encoding, mime_type = self._decode_data(doc_url)
+                # TODO probably not working with docling
+                # Need to save the file first then use the converter
+                return await self.convert_from_data(data, encoding, mime_type)
+            else:
+                return await self.convert_from_url(doc_url, doc.mime_type)
+
+        return interleaved_content_as_str(doc.content)
+
+    def _decode_data(self, data_url: str) -> (str, str, str):
+        parts = parse_data_url(data_url)
+        data = parts["data"]
+
+        if parts["is_base64"]:
+            data = base64.b64decode(data)
+        else:
+            data = unquote(data)
+            encoding = parts["encoding"] or "utf-8"
+            data = data.encode(encoding)
+
+        encoding = parts["encoding"]
+        if not encoding:
+            detected = chardet.detect(data)
+            encoding = detected["encoding"]
+
+        mime_type = parts["mimetype"]
+        return data, encoding, mime_type

--- a/llama_stack/providers/utils/docling/converter.py
+++ b/llama_stack/providers/utils/docling/converter.py
@@ -4,15 +4,17 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from abc import ABC, abstractmethod
-import chardet
 import re
+from abc import ABC, abstractmethod
 
+import chardet
+
+from llama_stack.apis.common.content_types import URL
 from llama_stack.apis.tools import RAGDocument
 from llama_stack.providers.utils.inference.prompt_adapter import (
     interleaved_content_as_str,
 )
-from llama_stack.apis.common.content_types import URL
+
 from ...inline.tool_runtime.rag.config import DoclingConfig
 
 

--- a/llama_stack/providers/utils/docling/default.py
+++ b/llama_stack/providers/utils/docling/default.py
@@ -1,0 +1,67 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import httpx
+import io
+
+from .chunker import Chunker
+from .converter import Converter
+from llama_models.llama3.api.tokenizer import Tokenizer
+from llama_stack.apis.vector_io import Chunk
+
+
+class DefaultConverter(Converter):
+    async def convert_from_data(self, data: bytes, encoding: str, mime_type: str | None) -> str:
+        mime_category = mime_type.split("/")[0]
+        if mime_category == "text":
+            # For text-based files (including CSV, MD)
+            return data.decode(encoding)
+
+        elif mime_type == "application/pdf":
+            return self.parse_pdf(data)
+
+        else:
+            log.error("Could not extract content from data_url properly.")
+            return ""
+
+    async def convert_from_url(self, data_url: str, mime_type: str | None) -> str:
+        async with httpx.AsyncClient() as client:
+            r = await client.get(data_url)
+        if mime_type == "application/pdf":
+            return self._parse_pdf(r.content)
+        else:
+            return r.text
+
+    def _parse_pdf(self, data: bytes) -> str:
+        from pypdf import PdfReader
+
+        # For PDF and DOC/DOCX files, we can't reliably convert to string
+        pdf_bytes = io.BytesIO(data)
+        pdf_reader = PdfReader(pdf_bytes)
+        return "\n".join([page.extract_text() for page in pdf_reader.pages])
+
+
+class DefaultChunker(Chunker):
+    def make_overlapped_chunks(self, document_id: str, text: str, window_len: int, overlap_len: int) -> list[Chunk]:
+        tokenizer = Tokenizer.get_instance()
+        tokens = tokenizer.encode(text, bos=False, eos=False)
+
+        chunks = []
+        for i in range(0, len(tokens), window_len - overlap_len):
+            toks = tokens[i : i + window_len]
+            chunk = tokenizer.decode(toks)
+            # chunk is a string
+            chunks.append(
+                Chunk(
+                    content=chunk,
+                    metadata={
+                        "token_count": len(toks),
+                        "document_id": document_id,
+                    },
+                )
+            )
+
+        return chunks

--- a/llama_stack/providers/utils/docling/default.py
+++ b/llama_stack/providers/utils/docling/default.py
@@ -4,13 +4,15 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-import httpx
 import io
+
+import httpx
+from llama_models.llama3.api.tokenizer import Tokenizer
+
+from llama_stack.apis.vector_io import Chunk
 
 from .chunker import Chunker
 from .converter import Converter
-from llama_models.llama3.api.tokenizer import Tokenizer
-from llama_stack.apis.vector_io import Chunk
 
 
 class DefaultConverter(Converter):

--- a/llama_stack/providers/utils/docling/docling.py
+++ b/llama_stack/providers/utils/docling/docling.py
@@ -64,8 +64,6 @@ class DoclingConverter(Converter):
 
     async def convert_from_url(self, data_url: str, mime_type: str | None) -> str:
         try:
-            dl = logging.getLogger("docling")
-            dl.setLevel(logging.DEBUG)
             result = self.doc_converter.convert(data_url, raises_on_error=False)
             # TODO make the output format configurable
             if self.export_type == "JSON":

--- a/llama_stack/providers/utils/docling/docling.py
+++ b/llama_stack/providers/utils/docling/docling.py
@@ -1,0 +1,145 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+# SPDX-License-Identifier: Apache-2.0
+
+# This is the implementation code for the ilab rag convert command, which converts documents from their
+# native format (e.g., PDF) to Docling JSON for use by ilab rag ingest.  See also the code in cli/rag/convert.py
+# which instantiates the CLI command and calls out to the methods in this file.
+
+import json
+import logging
+import tempfile
+from pathlib import Path
+
+from .converter import Converter
+from .chunker import Chunker
+from ...inline.tool_runtime.rag.config import DoclingConfig
+from llama_stack.apis.vector_io import Chunk
+
+
+from docling.datamodel.pipeline_options import AcceleratorDevice, AcceleratorOptions, PdfPipelineOptions  # type: ignore
+from docling.datamodel.base_models import ConversionStatus, InputFormat  # type: ignore
+from docling.datamodel.document import ConversionResult  # type: ignore
+from docling.document_converter import DocumentConverter, PdfFormatOption  # type: ignore
+from docling_core.transforms.chunker.hybrid_chunker import HybridChunker
+from docling_core.types.doc import DoclingDocument
+from pydantic_core._pydantic_core import ValidationError
+
+logger = logging.getLogger(__name__)
+
+
+class DoclingConverter(Converter):
+    def __init__(
+        self,
+        docling_config: DoclingConfig,
+    ) -> None:
+        accelerator_options = AcceleratorOptions(
+            device=AcceleratorDevice.AUTO, **(docling_config.accelerator_options or {})
+        )
+        # # Fix segmentation fault issue
+        # accelerator_options.num_threads = 4
+
+        pipeline_options = PdfPipelineOptions(
+            do_ocr=False,
+            accelerator_options=accelerator_options,
+        )
+        self.doc_converter = DocumentConverter(
+            format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)}
+        )
+        self.export_type = docling_config.export_type
+
+    async def convert_from_data(self, data: bytes, encoding: str, mime_type: str | None) -> str:
+        file_type = mime_type.split("/")[1]  # Guessing
+        with tempfile.NamedTemporaryFile(suffix=f".{file_type}", delete=False) as tmp_pdf:
+            tmp_file.write(pdf_bytes)
+            tmp_file.flush()
+            logger.info(f"Saved as {tmp_file}")
+
+            result = self.doc_converter.convert(tmp_file, raises_on_error=False)
+            return result.document.export_to_dict()
+
+    async def convert_from_url(self, data_url: str, mime_type: str | None) -> str:
+        try:
+            dl = logging.getLogger("docling")
+            dl.setLevel(logging.DEBUG)
+            result = self.doc_converter.convert(data_url, raises_on_error=False)
+            # TODO make the output format configurable
+            if self.export_type == "JSON":
+                result_text = json.dumps(result.document.export_to_dict())
+            else:
+                result_text = result.document.export_to_markdown()
+
+            # TO REMOVE
+            _export_documents(result, Path("./converted_docs"))
+            return result_text
+        except Exception as ex:
+            logger.exception("HERE", ex)
+
+
+class DoclingChunker(Chunker):
+    def __init__(self, docling_config: DoclingConfig) -> None:
+        pass
+
+    def make_overlapped_chunks(self, document_id: str, text: str, window_len: int, overlap_len: int) -> list[Chunk]:
+        self.__chunker = HybridChunker(
+            tokenizer="sentence-transformers/all-MiniLM-L6-v2",
+        )
+        try:
+            document = DoclingDocument.model_validate_json(text)
+            chunks = []
+            for chunk in self.__chunker.chunk(document):
+                chunks.append(
+                    Chunk(
+                        content=chunk.text,
+                        metadata={
+                            "token_count": len(chunk.text),  # TBD???
+                            "document_id": document_id,
+                        },
+                        # Todo adapt chunk.meta instead docling_core.transforms.chunker.DocMeta
+                    )
+                )
+                return chunks
+        except ValidationError as e:
+            logger.error(f"Expected {file_path} to be in docling format, but schema validation failed: {e}")
+            raise e
+
+
+# From the Docling batch conversion example: https://ds4sd.github.io/docling/examples/batch_convert/
+def _export_documents(
+    conversion_result: ConversionResult,
+    output_dir: Path,
+):
+    """
+    TODO
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    success_count = 0
+    failure_count = 0
+    partial_success_count = 0
+
+    if conversion_result.status == ConversionStatus.SUCCESS:
+        success_count += 1
+        doc_filename = conversion_result.input.file.stem
+
+        with (output_dir / f"{doc_filename}.json").open("w") as fp:
+            fp.write(json.dumps(conversion_result.document.export_to_dict()))
+    elif conversion_result.status == ConversionStatus.PARTIAL_SUCCESS:
+        logger.info(f"Document {conversion_result.input.file} was partially converted with the following errors:")
+        for item in conversion_result.errors:
+            print(f"\t{item.error_message}")
+        partial_success_count += 1
+    else:
+        logger.info(f"Document {conversion_result.input.file} failed to convert.")
+        failure_count += 1
+
+    logger.info(
+        f"Processed {success_count + partial_success_count + failure_count} docs, "
+        f"of which {failure_count} failed "
+        f"and {partial_success_count} were partially converted."
+    )
+    return success_count, partial_success_count, failure_count

--- a/llama_stack/providers/utils/memory/vector_store.py
+++ b/llama_stack/providers/utils/memory/vector_store.py
@@ -3,27 +3,19 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
-import base64
-import io
 import logging
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
-from urllib.parse import unquote
 
-import chardet
-import httpx
 import numpy as np
 
-from llama_models.llama3.api.tokenizer import Tokenizer
 
 from llama_stack.apis.common.content_types import (
     InterleavedContent,
     TextContentItem,
-    URL,
 )
-from llama_stack.apis.tools import RAGDocument
 from llama_stack.apis.vector_dbs import VectorDB
 from llama_stack.apis.vector_io import Chunk, QueryChunksResponse
 from llama_stack.providers.datatypes import Api
@@ -32,16 +24,8 @@ from llama_stack.providers.utils.inference.prompt_adapter import (
 )
 from numpy.typing import NDArray
 
-from pypdf import PdfReader
 
 log = logging.getLogger(__name__)
-
-
-def parse_pdf(data: bytes) -> str:
-    # For PDF and DOC/DOCX files, we can't reliably convert to string
-    pdf_bytes = io.BytesIO(data)
-    pdf_reader = PdfReader(pdf_bytes)
-    return "\n".join([page.extract_text() for page in pdf_reader.pages])
 
 
 def parse_data_url(data_url: str):
@@ -64,36 +48,6 @@ def parse_data_url(data_url: str):
     return parts
 
 
-def content_from_data(data_url: str) -> str:
-    parts = parse_data_url(data_url)
-    data = parts["data"]
-
-    if parts["is_base64"]:
-        data = base64.b64decode(data)
-    else:
-        data = unquote(data)
-        encoding = parts["encoding"] or "utf-8"
-        data = data.encode(encoding)
-
-    encoding = parts["encoding"]
-    if not encoding:
-        detected = chardet.detect(data)
-        encoding = detected["encoding"]
-
-    mime_type = parts["mimetype"]
-    mime_category = mime_type.split("/")[0]
-    if mime_category == "text":
-        # For text-based files (including CSV, MD)
-        return data.decode(encoding)
-
-    elif mime_type == "application/pdf":
-        return parse_pdf(data)
-
-    else:
-        log.error("Could not extract content from data_url properly.")
-        return ""
-
-
 def concat_interleaved_content(content: List[InterleavedContent]) -> InterleavedContent:
     """concatenate interleaved content into a single list. ensure that 'str's are converted to TextContentItem when in a list"""
 
@@ -112,55 +66,6 @@ def concat_interleaved_content(content: List[InterleavedContent]) -> Interleaved
         _process(c)
 
     return ret
-
-
-async def content_from_doc(doc: RAGDocument) -> str:
-    if isinstance(doc.content, URL):
-        if doc.content.uri.startswith("data:"):
-            return content_from_data(doc.content.uri)
-        else:
-            async with httpx.AsyncClient() as client:
-                r = await client.get(doc.content.uri)
-            if doc.mime_type == "application/pdf":
-                return parse_pdf(r.content)
-            else:
-                return r.text
-
-    pattern = re.compile("^(https?://|file://|data:)")
-    if pattern.match(doc.content):
-        if doc.content.startswith("data:"):
-            return content_from_data(doc.content)
-        else:
-            async with httpx.AsyncClient() as client:
-                r = await client.get(doc.content)
-            if doc.mime_type == "application/pdf":
-                return parse_pdf(r.content)
-            else:
-                return r.text
-
-    return interleaved_content_as_str(doc.content)
-
-
-def make_overlapped_chunks(document_id: str, text: str, window_len: int, overlap_len: int) -> List[Chunk]:
-    tokenizer = Tokenizer.get_instance()
-    tokens = tokenizer.encode(text, bos=False, eos=False)
-
-    chunks = []
-    for i in range(0, len(tokens), window_len - overlap_len):
-        toks = tokens[i : i + window_len]
-        chunk = tokenizer.decode(toks)
-        # chunk is a string
-        chunks.append(
-            Chunk(
-                content=chunk,
-                metadata={
-                    "token_count": len(toks),
-                    "document_id": document_id,
-                },
-            )
-        )
-
-    return chunks
 
 
 class EmbeddingIndex(ABC):

--- a/llama_stack/templates/ollama/run.yaml
+++ b/llama_stack/templates/ollama/run.yaml
@@ -84,7 +84,13 @@ providers:
     config: {}
   - provider_id: rag-runtime
     provider_type: inline::rag-runtime
-    config: {}
+    config:
+      docling:
+        export_type: JSON # one of JSON, MARKDOWN
+        accelerator_options:
+          num_threads: 1
+      # chunker: default
+      chunker: docling
 metadata_store:
   type: sqlite
   db_path: ${env.SQLITE_STORE_DIR:~/.llama/distributions/ollama}/registry.db

--- a/llama_stack/templates/ollama/run.yaml
+++ b/llama_stack/templates/ollama/run.yaml
@@ -89,8 +89,6 @@ providers:
         export_type: JSON # one of JSON, MARKDOWN
         accelerator_options:
           num_threads: 1
-      # chunker: default
-      chunker: docling
 metadata_store:
   type: sqlite
   db_path: ${env.SQLITE_STORE_DIR:~/.llama/distributions/ollama}/registry.db


### PR DESCRIPTION
# What does this PR do?
[No issue exists for now]

A draft proposal to integrate docling in llama-stack.

Docling is added as a configuration of the `rag-tool` provider:
```yaml
providers:
  tool_runtime:
  - provider_id: rag-runtime
    provider_type: inline::rag-runtime
    config:
      docling:
        export_type: JSON # one of JSON, MARKDOWN
        accelerator_options: # dictionary added as kwargs to create the AcceleratorOption
          num_threads: 1
        tokenizer_model_id: all-MiniLM-L6-v2 ## TODO
```

A better solution could be to integrate as a provider for  new API like `document_processing`. This would allow to have an `inline` and `remote` implementation:

```yaml
providers:
  document_processing:
  - provider_id: docling
    provider_type: inline::docling
    config:
      export_type: JSON # one of JSON, MARKDOWN
      accelerator_options:
        num_threads: 1
      tokenizer_model_id: all-MiniLM-L6-v2 ## TODO
```

New APIs can be added for this provider:
* `POST /v1/document-processing/convert`
* `POST /v1/document-processing/chunk`
The output of the above can be passed to the existing `/insert` APIs to use the pre-processed documents.

The implementation of the `/insert` APIs can verify if an existing provider is configured for the
`document-processing` API and, in case, forward to it the requests to convert and chunk the documents.

## Test Plan
A simple script to run the ingestion of a PDF assuming the server runs at port 8321:
```py
from llama_stack_client.types.shared_params.document import Document
from llama_stack_client import LlamaStackClient

client = LlamaStackClient(
    base_url="http://localhost:8321"
)
print(f"client is {client}")

import uuid
vector_db_id = "my_documents"+uuid.uuid4().hex
response = client.vector_dbs.register(
    vector_db_id=vector_db_id,
    embedding_model="all-MiniLM-L6-v2",
    embedding_dimension=384,
    provider_id="faiss",
)

paths = [
    "https://raw.githubusercontent.com/instructlab/instructlab/main/tests/testdata/temp_taxonomy_repo/knowledge-wiki.pdf"
]

documents = [
    Document(
        document_id=f"num-{i}",
        content=f"{path}",
        mime_type="application/pdf",
    )
    for i, path in enumerate(paths)
]
print(f"Ingesting {documents}")

client.tool_runtime.rag_tool.insert(
    documents=documents,
    vector_db_id=vector_db_id,
    chunk_size_in_tokens=512,
)

results = client.tool_runtime.rag_tool.query(
    vector_db_ids=[vector_db_id],
    content="What is knowledge",
)

for r in results.content:
  print(f"********\n{r.text}")
```

[//]: # (## Documentation)
