### PR TITLE
feat(inspect): add config field to ProviderInfo

### DIFF
--- a/llama_stack/apis/inspect/inspect.py
+++ b/llama_stack/apis/inspect/inspect.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from typing import List, Protocol, runtime_checkable
+from typing import List, Protocol, runtime_checkable, Dict, Any
 
 from llama_models.schema_utils import json_schema_type, webmethod
 from pydantic import BaseModel
@@ -15,6 +15,7 @@ class ProviderInfo(BaseModel):
     api: str
     provider_id: str
     provider_type: str
+    config: Dict[str, Any]
 
 
 @json_schema_type

--- a/llama_stack/distribution/inspect.py
+++ b/llama_stack/distribution/inspect.py
@@ -4,7 +4,9 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import re
 from importlib.metadata import version
+from typing import Any, Dict
 
 from pydantic import BaseModel
 
@@ -50,6 +52,7 @@ class DistributionInspectImpl(Inspect):
                         api=api,
                         provider_id=p.provider_id,
                         provider_type=p.provider_type,
+                        config=_redact_dict(p.config),
                     )
                     for p in providers
                 ]
@@ -82,3 +85,12 @@ class DistributionInspectImpl(Inspect):
 
     async def version(self) -> VersionInfo:
         return VersionInfo(version=version("llama-stack"))
+
+
+def _redact_dict(d: Dict[str, Any]) -> Dict[str, Any]:
+    """Redact sensitive information from dict before printing."""
+    if not isinstance(d, dict):
+        raise TypeError("Expected a dictionary")
+
+    sensitive_patterns = re.compile(r"(api_key|api_token|password|secret|passphrase)", re.IGNORECASE)
+    return {key: "REDACTED" if sensitive_patterns.search(key) else value for key, value in d.items()}


### PR DESCRIPTION
# What does this PR do?
- Added `config` field to `ProviderInfo` model to include provider configuration details.
- Implemented `_redact_dict` function to redact sensitive information from the config dictionary.
- Updated `DistributionInspectImpl` to use `_redact_dict` for redacting sensitive information before printing.

Output:

```
$ curl http://127.0.0.1:5001/v1/inspect/providers
...
...
{
  "api": "tool_runtime",
  "provider_id": "tavily-search",
  "provider_type": "remote::tavily-search",
  "config": {
    "api_key": "REDACTED",
    "max_results": 3
  }
},
...
...
```

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan

Run:

```
curl http://127.0.0.1:5001/v1/inspect/providers
```

Observe the new "config" field.


[//]: # (## Documentation)
