### PR TITLE
fix: show proper help text

### DIFF
--- a/llama_stack/cli/model/model.py
+++ b/llama_stack/cli/model/model.py
@@ -26,6 +26,8 @@ class ModelParser(Subcommand):
             description="Work with llama models",
         )
 
+        self.parser.set_defaults(func=lambda args: self.parser.print_help())
+
         subparsers = self.parser.add_subparsers(title="model_subcommands")
 
         # Add sub-commands

--- a/llama_stack/cli/stack/stack.py
+++ b/llama_stack/cli/stack/stack.py
@@ -31,6 +31,8 @@ class StackParser(Subcommand):
             version=f"{version('llama-stack')}",
         )
 
+        self.parser.set_defaults(func=lambda args: self.parser.print_help())
+
         subparsers = self.parser.add_subparsers(title="stack_subcommands")
 
         # Add sub-commands


### PR DESCRIPTION
# What does this PR do?
when executing a sub-command like `llama model` the improper help text, sub-commands, and flags are displayed. each command group needs to have `.set_defaults` to display this info properly

before: 

```
llama model
usage: llama [-h] {model,stack,download,verify-download} ...

Welcome to the Llama CLI

options:
  -h, --help            show this help message and exit

subcommands:
  {model,stack,download,verify-download}
```

after:

```
llama model
usage: llama model [-h] {download,list,prompt-format,describe,verify-download} ...

Work with llama models

options:
  -h, --help            show this help message and exit

model_subcommands:
  {download,list,prompt-format,describe,verify-download}
```
