### PR TITLE
feat: Chunk sqlite-vec writes

### DIFF
--- a/llama_stack/providers/inline/vector_io/sqlite_vec/config.py
+++ b/llama_stack/providers/inline/vector_io/sqlite_vec/config.py
@@ -18,7 +18,6 @@ from llama_stack.providers.utils.kvstore.config import (
 class SQLiteVectorIOConfig(BaseModel):
     db_path: str
     kvstore: KVStoreConfig
-    batch_size: bool = 500
 
     @classmethod
     def sample_run_config(cls, __distro_dir__: str) -> Dict[str, Any]:

--- a/llama_stack/providers/inline/vector_io/sqlite_vec/config.py
+++ b/llama_stack/providers/inline/vector_io/sqlite_vec/config.py
@@ -18,6 +18,7 @@ from llama_stack.providers.utils.kvstore.config import (
 class SQLiteVectorIOConfig(BaseModel):
     db_path: str
     kvstore: KVStoreConfig
+    batch_size: bool = 500
 
     @classmethod
     def sample_run_config(cls, __distro_dir__: str) -> Dict[str, Any]:

--- a/llama_stack/providers/inline/vector_io/sqlite_vec/sqlite_vec.py
+++ b/llama_stack/providers/inline/vector_io/sqlite_vec/sqlite_vec.py
@@ -100,7 +100,7 @@ class SQLiteVecIndex(EmbeddingIndex):
             logger.error(f"Error inserting into {self.vector_table}: {e}")
 
         finally:
-            cur.close()  # Ensure cursor is closed
+            cur.close()
 
     async def query(self, embedding: NDArray, k: int, score_threshold: float) -> QueryChunksResponse:
         """

--- a/llama_stack/providers/inline/vector_io/sqlite_vec/sqlite_vec.py
+++ b/llama_stack/providers/inline/vector_io/sqlite_vec/sqlite_vec.py
@@ -79,9 +79,10 @@ class SQLiteVecIndex(EmbeddingIndex):
         try:
             # Start transaction
             cur.execute("BEGIN TRANSACTION")
+            # Serialize and insert the chunk metadata.
             chunk_data = [(chunk.model_dump_json(),) for chunk in chunks]
             cur.executemany(f"INSERT INTO {self.metadata_table} (chunk) VALUES (?)", chunk_data)
-            # Fetch the last N inserted row IDs
+            # Fetch the last *n* inserted row_ids -- note: this is more reliable than `row_id = cur.lastrowid`
             cur.execute(f"SELECT rowid FROM {self.metadata_table} ORDER BY rowid DESC LIMIT {len(chunks)}")
             row_ids = [row[0] for row in cur.fetchall()]
             row_ids.reverse()  # Reverse to maintain the correct order of insertion

--- a/llama_stack/providers/inline/vector_io/sqlite_vec/sqlite_vec.py
+++ b/llama_stack/providers/inline/vector_io/sqlite_vec/sqlite_vec.py
@@ -77,7 +77,6 @@ class SQLiteVecIndex(EmbeddingIndex):
         If any insert fails, the transaction is rolled back to maintain consistency.
         """
         cur = self.connection.cursor()
-        print(f"inserting {len(chunks)} chunks: {chunks}")
         try:
             # Start transaction
             cur.execute("BEGIN TRANSACTION")

--- a/llama_stack/providers/inline/vector_io/sqlite_vec/sqlite_vec.py
+++ b/llama_stack/providers/inline/vector_io/sqlite_vec/sqlite_vec.py
@@ -82,7 +82,7 @@ class SQLiteVecIndex(EmbeddingIndex):
         try:
             # Start transaction
             cur.execute("BEGIN TRANSACTION")
-            for k, i in enumerate(range(0, len(chunks), batch_size)):
+            for i in range(0, len(chunks), batch_size):
                 batch_chunks = chunks[i : i + batch_size]
                 batch_embeddings = embeddings[i : i + batch_size]
                 # Prepare metadata inserts

--- a/llama_stack/providers/tests/vector_io/test_sqlite_vec.py
+++ b/llama_stack/providers/tests/vector_io/test_sqlite_vec.py
@@ -1,0 +1,122 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import asyncio
+import sqlite3
+
+import numpy as np
+import pytest
+import sqlite_vec
+
+from llama_stack.apis.vector_dbs import VectorDB
+from llama_stack.apis.vector_io import Chunk, QueryChunksResponse
+from llama_stack.providers.inline.vector_io.sqlite_vec.sqlite_vec import SQLiteVecIndex, SQLiteVecVectorIOAdapter
+
+# How to run this test:
+#
+# pytest llama_stack/providers/tests/vector_io/test_sqlite_vec.py \
+# -v -s --tb=short --disable-warnings --asyncio-mode=auto
+
+
+@pytest.fixture(scope="session")
+def loop():
+    return asyncio.get_event_loop()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def sqlite_connection(loop):
+    conn = sqlite3.connect(":memory:")
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+
+    yield conn
+    conn.close()
+
+
+@pytest.fixture(scope="session", autouse=True)
+async def sqlite_vec_index(sqlite_connection):
+    return await SQLiteVecIndex.create(dimension=384, connection=sqlite_connection, bank_id="test_bank")
+
+
+@pytest.fixture
+def sample_chunks():
+    return [
+        Chunk(
+            content="Python is a high-level programming language.",
+            metadata={"category": "programming", "document_id": "doc 1"},
+        ),
+        Chunk(
+            content="Machine learning is a subset of artificial intelligence.",
+            metadata={"category": "AI", "document_id": "doc 1"},
+        ),
+    ]
+
+
+@pytest.fixture
+def sample_embeddings():
+    np.random.seed(42)
+    return np.array(
+        [
+            np.random.rand(384).astype(np.float32),
+            np.random.rand(384).astype(np.float32),
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_add_chunks(sqlite_vec_index, sample_chunks, sample_embeddings):
+    await sqlite_vec_index.add_chunks(sample_chunks, sample_embeddings)
+    cur = sqlite_vec_index.connection.cursor()
+    cur.execute(f"SELECT COUNT(*) FROM {sqlite_vec_index.metadata_table}")
+    count = cur.fetchone()[0]
+    assert count == len(sample_chunks)
+
+
+@pytest.mark.asyncio
+async def test_query_chunks(sqlite_vec_index, sample_chunks, sample_embeddings):
+    await sqlite_vec_index.add_chunks(sample_chunks, sample_embeddings)
+    query_embedding = np.random.rand(384).astype(np.float32)
+    response = await sqlite_vec_index.query(query_embedding, k=1, score_threshold=0.0)
+    assert isinstance(response, QueryChunksResponse)
+    assert len(response.chunks) > 0
+
+
+@pytest.fixture
+async def sqlite_vec_adapter(sqlite_connection):
+    config = type("Config", (object,), {"db_path": ":memory:"})  # Mock config with in-memory database
+    adapter = SQLiteVecVectorIOAdapter(config=config, inference_api=None)
+    await adapter.initialize()
+    yield adapter
+    await adapter.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_register_vector_db(sqlite_vec_adapter):
+    vector_db = VectorDB(
+        identifier="test_db",
+        embedding_model="all-MiniLM-L6-v2",
+        embedding_dimension=384,
+        metadata={},
+        provider_id="sqlite_vec",
+    )
+    await sqlite_vec_adapter.register_vector_db(vector_db)
+    vector_dbs = await sqlite_vec_adapter.list_vector_dbs()
+    assert any(db.identifier == "test_db" for db in vector_dbs)
+
+
+@pytest.mark.asyncio
+async def test_unregister_vector_db(sqlite_vec_adapter):
+    vector_db = VectorDB(
+        identifier="test_db",
+        embedding_model="all-MiniLM-L6-v2",
+        embedding_dimension=384,
+        metadata={},
+        provider_id="sqlite_vec",
+    )
+    await sqlite_vec_adapter.register_vector_db(vector_db)
+    await sqlite_vec_adapter.unregister_vector_db("test_db")
+    vector_dbs = await sqlite_vec_adapter.list_vector_dbs()
+    assert not any(db.identifier == "test_db" for db in vector_dbs)


### PR DESCRIPTION
# What does this PR do?
1. This PR adds batch inserts into sqlite-vec as requested in https://github.com/meta-llama/llama-stack/pull/1040
   - Note: the inserts uses a uuid generated from the hash of the document id and chunk content.
2. This PR also adds unit tests for sqlite-vec. In a follow up PR, I can add similar tests to Faiss.

## Test Plan
1. Integration tests:
```python
INFERENCE_MODEL=llama3.2:3b-instruct-fp16 LLAMA_STACK_CONFIG=ollama pytest -s -v tests/client-sdk/vector_io/test_vector_io.py
...
PASSED
tests/client-sdk/vector_io/test_vector_io.py::test_vector_db_retrieve[all-MiniLM-L6-v2-sqlite_vec] PASSED
tests/client-sdk/vector_io/test_vector_io.py::test_vector_db_list PASSED
tests/client-sdk/vector_io/test_vector_io.py::test_vector_db_register[all-MiniLM-L6-v2-faiss] PASSED
tests/client-sdk/vector_io/test_vector_io.py::test_vector_db_register[all-MiniLM-L6-v2-sqlite_vec] PASSED
tests/client-sdk/vector_io/test_vector_io.py::test_vector_db_unregister[faiss] PASSED
tests/client-sdk/vector_io/test_vector_io.py::test_vector_db_unregister[sqlite_vec] PASSED
```
3. Unit tests:
```python
pytest llama_stack/providers/tests/vector_io/test_sqlite_vec.py  -v -s --tb=short --disable-warnings --asyncio-mode=auto
...
llama_stack/providers/tests/vector_io/test_sqlite_vec.py::test_add_chunks PASSED
llama_stack/providers/tests/vector_io/test_sqlite_vec.py::test_query_chunks PASSED
llama_stack/providers/tests/vector_io/test_sqlite_vec.py::test_chunk_id_conflict PASSED
llama_stack/providers/tests/vector_io/test_sqlite_vec.py::test_register_vector_db PASSED
llama_stack/providers/tests/vector_io/test_sqlite_vec.py::test_unregister_vector_db PASSED
llama_stack/providers/tests/vector_io/test_sqlite_vec.py::test_generate_chunk_id PASSED
```
I also tested using the same example RAG script in https://github.com/meta-llama/llama-stack/pull/1040 and received the output.
