### PR TITLE
fix: add the missed help description info

### DIFF
--- a/llama_stack/cli/model/describe.py
+++ b/llama_stack/cli/model/describe.py
@@ -34,6 +34,7 @@ class ModelDescribe(Subcommand):
             "--model-id",
             type=str,
             required=True,
+            help="See `llama model list` or `llama model list --show-all` for the list of available models",
         )
 
     def _run_model_describe_cmd(self, args: argparse.Namespace) -> None:


### PR DESCRIPTION
# What does this PR do?
[Provide a short summary of what this PR does and why. Link to relevant issues if applicable.]

Missing the help info, so add it.
```
before:
$ llama model describe --help
usage: llama model describe [-h] -m MODEL_ID

Show details about a llama model

options:
  -h, --help            show this help message and exit
  -m MODEL_ID, --model-id MODEL_ID

after:
$ llama model describe --help
usage: llama model describe [-h] -m MODEL_ID

Show details about a llama model

options:
  -h, --help            show this help message and exit
  -m MODEL_ID, --model-id MODEL_ID
                        See `llama model list` or `llama model list --show-all` for the list of available models <<<
```

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan
[Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.*]

[//]: # (## Documentation)
