### PR TITLE
fix: Update QdrantConfig to QdrantVectorIOConfig

### DIFF
--- a/llama_stack/providers/tests/vector_io/fixtures.py
+++ b/llama_stack/providers/tests/vector_io/fixtures.py
@@ -17,7 +17,7 @@ from llama_stack.providers.inline.vector_io.faiss import FaissVectorIOConfig
 from llama_stack.providers.inline.vector_io.sqlite_vec import SQLiteVectorIOConfig
 from llama_stack.providers.remote.vector_io.chroma import ChromaVectorIOConfig
 from llama_stack.providers.remote.vector_io.pgvector import PGVectorVectorIOConfig
-from llama_stack.providers.remote.vector_io.qdrant import QdrantConfig
+from llama_stack.providers.remote.vector_io.qdrant import QdrantVectorIOConfig
 from llama_stack.providers.remote.vector_io.weaviate import WeaviateVectorIOConfig
 from llama_stack.providers.tests.resolver import construct_stack_for_test
 from llama_stack.providers.utils.kvstore.config import SqliteKVStoreConfig
@@ -132,7 +132,7 @@ def vector_io_chroma() -> ProviderFixture:
 def vector_io_qdrant() -> ProviderFixture:
     url = os.getenv("QDRANT_URL")
     if url:
-        config = QdrantConfig(url=url)
+        config = QdrantVectorIOConfig(url=url)
         provider_type = "remote::qdrant"
     else:
         raise ValueError("QDRANT_URL must be set")


### PR DESCRIPTION
# What does this PR do?

This fixes an import introduced due to merging #1079 before #1039, and thus the changes from #1039 needing to update `QdrantConfig` to `QdrantVectorIOConfig`.


## Test Plan

I ran the remote vllm provider inference tests against the latest main:
```
VLLM_URL="http://localhost:8001/v1" python -m pytest -s -v llama_stack/providers/tests/inference/test_text_inference.py --providers "inference=vllm_remote"
```

That failed with:
```
  File "/home/bbrownin/src/llama-stack/llama_stack/providers/tests/vector_io/fixtures.py", line 20, in <module>
    from llama_stack.providers.remote.vector_io.qdrant import QdrantConfig
ImportError: Error importing plugin "llama_stack.providers.tests.vector_io.fixtures": cannot import name 'QdrantConfig' from 'llama_stack.providers.remote.vector_io.qdrant' (/home/bbrownin/src/llama-stack/llama_stack/providers/remote/vector_io/qdrant/__init__.py)
```

After this change, the import no longer fails and the tests pass.