### PR TITLE
fix(rag-example): add provider_id to avoid llama_stack_client 400 error

### DIFF
--- a/docs/source/getting_started/index.md
+++ b/docs/source/getting_started/index.md
@@ -199,7 +199,8 @@ def create_library_client(template="ollama"):
 
 
 client = (
-    create_library_client()
+    #create_library_client()
+    create_http_client()
 )  # or create_http_client() depending on the environment you picked
 
 # Documents to be used for RAG
@@ -214,10 +215,17 @@ documents = [
     for i, url in enumerate(urls)
 ]
 
+vector_providers = [
+    provider for provider in client.providers.list() 
+    if provider.api == "vector_io"
+]
+provider_id = vector_providers[0].provider_id  # Use first available vector provider
+
 # Register a vector database
 vector_db_id = f"test-vector-db-{uuid.uuid4().hex}"
 client.vector_dbs.register(
     vector_db_id=vector_db_id,
+    provider_id=provider_id,
     embedding_model="all-MiniLM-L6-v2",
     embedding_dimension=384,
 )
@@ -227,17 +235,6 @@ client.tool_runtime.rag_tool.insert(
     documents=documents,
     vector_db_id=vector_db_id,
     chunk_size_in_tokens=512,
-vector_providers = [
-    provider for provider in client.providers.list() if provider.api == "vector_io"
-]
-
-vector_db_id = uuid.uuid4().hex
-vector_db_register_response = client.vector_dbs.register(
-    vector_db_id=vector_db_id,
-    embedding_model="all-MiniLM-L6-v2",
-    embedding_dimension=384,
-    provider_id=vector_providers[0].provider_id,
-)
 )
 
 agent_config = AgentConfig(

--- a/docs/source/getting_started/index.md
+++ b/docs/source/getting_started/index.md
@@ -227,7 +227,17 @@ client.tool_runtime.rag_tool.insert(
     documents=documents,
     vector_db_id=vector_db_id,
     chunk_size_in_tokens=512,
-    provider_id="faiss"
+vector_providers = [
+    provider for provider in client.providers.list() if provider.api == "vector_io"
+]
+
+vector_db_id = uuid.uuid4().hex
+vector_db_register_response = client.vector_dbs.register(
+    vector_db_id=vector_db_id,
+    embedding_model="all-MiniLM-L6-v2",
+    embedding_dimension=384,
+    provider_id=vector_providers[0].provider_id,
+)
 )
 
 agent_config = AgentConfig(

--- a/docs/source/getting_started/index.md
+++ b/docs/source/getting_started/index.md
@@ -215,8 +215,7 @@ documents = [
 ]
 
 vector_providers = [
-    provider for provider in client.providers.list() 
-    if provider.api == "vector_io"
+    provider for provider in client.providers.list() if provider.api == "vector_io"
 ]
 provider_id = vector_providers[0].provider_id  # Use the first available vector provider
 

--- a/docs/source/getting_started/index.md
+++ b/docs/source/getting_started/index.md
@@ -227,6 +227,7 @@ client.tool_runtime.rag_tool.insert(
     documents=documents,
     vector_db_id=vector_db_id,
     chunk_size_in_tokens=512,
+    provider_id="faiss"
 )
 
 agent_config = AgentConfig(

--- a/docs/source/getting_started/index.md
+++ b/docs/source/getting_started/index.md
@@ -199,8 +199,7 @@ def create_library_client(template="ollama"):
 
 
 client = (
-    #create_library_client()
-    create_http_client()
+    create_library_client()
 )  # or create_http_client() depending on the environment you picked
 
 # Documents to be used for RAG
@@ -219,7 +218,7 @@ vector_providers = [
     provider for provider in client.providers.list() 
     if provider.api == "vector_io"
 ]
-provider_id = vector_providers[0].provider_id  # Use first available vector provider
+provider_id = vector_providers[0].provider_id  # Use the first available vector provider
 
 # Register a vector database
 vector_db_id = f"test-vector-db-{uuid.uuid4().hex}"


### PR DESCRIPTION
# What does this PR do?
Add provider_id  to avoid errors using the rag example with llama_stack_client

`llama_stack_client.BadRequestError: Error code: 400 - {'detail': 'Invalid value: No provider specified and multiple providers available. Please specify a provider_id.'}`

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan
[Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.*]

[//]: # (## Documentation)
