### PR TITLE
docs: Fix incorrect link and command for generating API reference

### DIFF
--- a/docs/openapi_generator/README.md
+++ b/docs/openapi_generator/README.md
@@ -1,4 +1,4 @@
-The RFC Specification (OpenAPI format) is generated from the set of API endpoints located in `llama_stack/[<subdir>]/api/endpoints.py` using the `generate.py` utility.
+The RFC Specification (OpenAPI format) is generated from the set of API endpoints located in `llama_stack/distribution/server/endpoints.py` using the `generate.py` utility.
 
 Please install the following packages before running the script:
 
@@ -6,4 +6,4 @@ Please install the following packages before running the script:
 pip install python-openapi json-strong-typing fire PyYAML llama-models
 ```
 
-Then simply run `sh run_openapi_generator.sh <OUTPUT_DIR>`
+Then simply run `sh run_openapi_generator.sh`


### PR DESCRIPTION
# What does this PR do?

These are currently incorrect.

## Test Plan

Re-ran the command and made sure it worked.
