### PR TITLE
fix: Fixing some small issues with the build scripts

### DIFF
--- a/llama_stack/distribution/build_venv.sh
+++ b/llama_stack/distribution/build_venv.sh
@@ -44,7 +44,7 @@ NC='\033[0m' # No Color
 # this is set if we actually create a new conda in which case we need to clean up
 ENVNAME=""
 
-SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 source "$SCRIPT_DIR/common.sh"
 
 # pre-run checks to make sure we can proceed with the installation

--- a/llama_stack/distribution/build_venv.sh
+++ b/llama_stack/distribution/build_venv.sh
@@ -44,7 +44,7 @@ NC='\033[0m' # No Color
 # this is set if we actually create a new conda in which case we need to clean up
 ENVNAME=""
 
-SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 source "$SCRIPT_DIR/common.sh"
 
 # pre-run checks to make sure we can proceed with the installation

--- a/llama_stack/distribution/common.sh
+++ b/llama_stack/distribution/common.sh
@@ -10,12 +10,12 @@ cleanup() {
   set +x
   echo "Cleaning up..."
   conda deactivate
-  conda env remove --name $envname -y
+  conda env remove --name "$envname" -y
 }
 
 handle_int() {
-  if [ -n $ENVNAME ]; then
-    cleanup $ENVNAME
+  if [ -n "$ENVNAME" ]; then
+    cleanup "$ENVNAME"
   fi
   exit 1
 }
@@ -23,8 +23,8 @@ handle_int() {
 handle_exit() {
   if [ $? -ne 0 ]; then
     echo -e "\033[1;31mABORTING.\033[0m"
-    if [ -n $ENVNAME ]; then
-      cleanup $ENVNAME
+    if [ -n "$ENVNAME" ]; then
+      cleanup "$ENVNAME"
     fi
   fi
 }
@@ -33,10 +33,14 @@ setup_cleanup_handlers() {
   trap handle_int INT
   trap handle_exit EXIT
 
-  __conda_setup="$('conda' 'shell.bash' 'hook' 2>/dev/null)"
-  eval "$__conda_setup"
-
-  conda deactivate
+  if is_command_available conda; then
+    __conda_setup="$('conda' 'shell.bash' 'hook' 2>/dev/null)"
+    eval "$__conda_setup"
+    conda deactivate
+  else
+    echo "conda is not available"
+    exit 1
+  fi
 }
 
 # check if a command is present

--- a/llama_stack/distribution/utils/exec.py
+++ b/llama_stack/distribution/utils/exec.py
@@ -34,6 +34,7 @@ def _run_with_pty_unix(command):
     original_sigint = signal.getsignal(signal.SIGINT)
 
     ctrl_c_pressed = False
+    process = None
 
     def sigint_handler(signum, frame):
         nonlocal ctrl_c_pressed
@@ -98,7 +99,7 @@ def _run_with_pty_unix(command):
         signal.signal(signal.SIGINT, original_sigint)
 
         os.close(master)
-        if process.poll() is None:
+        if process and process.poll() is None:
             process.terminate()
             process.wait()
 


### PR DESCRIPTION
# What does this PR do?
I was encountering build issues when building my `ollama` environment  using `llama stack build`

```bash
llama stack build --template ollama --image-type venv
Traceback (most recent call last):
  File "/Users/farceo/dev/llama-stack/.venv/bin/llama", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/farceo/dev/llama-stack/llama_stack/cli/llama.py", line 46, in main
    parser.run(args)
  File "/Users/farceo/dev/llama-stack/llama_stack/cli/llama.py", line 40, in run
    args.func(args)
  File "/Users/farceo/dev/llama-stack/llama_stack/cli/stack/build.py", line 77, in _run_stack_build_command
    return run_stack_build_command(args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/farceo/dev/llama-stack/llama_stack/cli/stack/_build.py", line 180, in run_stack_build_command
    _run_stack_build_command_from_build_config(
  File "/Users/farceo/dev/llama-stack/llama_stack/cli/stack/_build.py", line 272, in _run_stack_build_command_from_build_config
    return_code = build_image(
                  ^^^^^^^^^^^^
  File "/Users/farceo/dev/llama-stack/llama_stack/distribution/build.py", line 137, in build_image
    return_code = run_with_pty(args)
                  ^^^^^^^^^^^^^^^^^^
  File "/Users/farceo/dev/llama-stack/llama_stack/distribution/utils/exec.py", line 22, in run_with_pty
    return _run_with_pty_unix(command)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/farceo/dev/llama-stack/llama_stack/distribution/utils/exec.py", line 53, in _run_with_pty_unix
    process = subprocess.Popen(
              ^^^^^^^^^^^^^^^^^
  File "/Users/farceo/.local/share/uv/python/cpython-3.11.6-macos-aarch64-none/lib/python3.11/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/Users/farceo/.local/share/uv/python/cpython-3.11.6-macos-aarch64-none/lib/python3.11/subprocess.py", line 1950, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/Users/farceo/dev/llama-stack/llama_stack/distribution/build_venv.sh'
make: *** [build-ollama] Error 1
```

I also had to adjust the script when testing the `common.sh` file because it returned:

```bash
> source llama_stack/distribution/common.sh
llama_stack/distribution/common.sh:6: command not found: ^M
llama_stack/distribution/common.sh:50: parse error near `\n'
```
On my branch, I ran:
```bash
sed -i '' 's/\r$//' llama_stack/distribution/common.sh
```
And then I was able to successfully build the environment.

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan
N/A

[//]: # (## Documentation)
N/A