### PR TITLE
feat: Add health check endpoint to inference

### DIFF
--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -1045,6 +1045,27 @@
                 ]
             }
         },
+        "/v1/inference/health": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "A dictionary containing the health status of the inference service.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HealthResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": [
+                    "Inference"
+                ],
+                "description": "Retrieve the health status of the inference service.",
+                "parameters": []
+            }
+        },
         "/v1/models/{model_id}": {
             "get": {
                 "responses": {
@@ -5741,6 +5762,27 @@
                 "required": [
                     "type"
                 ]
+            },
+            "HealthResponse": {
+                "type": "object",
+                "properties": {
+                    "health": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string",
+                            "enum": [
+                                "OK",
+                                "Error",
+                                "Not Implemented"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "health"
+                ],
+                "description": "HealthResponse is a model representing the health status response.\nparam health: A dictionary containing health information."
             },
             "Model": {
                 "type": "object",

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -629,6 +629,21 @@ paths:
           required: true
           schema:
             type: string
+  /v1/inference/health:
+    get:
+      responses:
+        '200':
+          description: >-
+            A dictionary containing the health status of the inference service.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+      tags:
+        - Inference
+      description: >-
+        Retrieve the health status of the inference service.
+      parameters: []
   /v1/models/{model_id}:
     get:
       responses:
@@ -3673,6 +3688,24 @@ components:
       additionalProperties: false
       required:
         - type
+    HealthResponse:
+      type: object
+      properties:
+        health:
+          type: object
+          additionalProperties:
+            type: string
+            enum:
+              - OK
+              - Error
+              - Not Implemented
+      additionalProperties: false
+      required:
+        - health
+      description: >-
+        HealthResponse is a model representing the health status response.
+
+        param health: A dictionary containing health information.
     Model:
       type: object
       properties:

--- a/llama_stack/apis/inference/inference.py
+++ b/llama_stack/apis/inference/inference.py
@@ -389,6 +389,30 @@ class EmbeddingsResponse(BaseModel):
     embeddings: List[List[float]]
 
 
+class HealthStatus(str, Enum):
+    OK = "OK"
+    ERROR = "Error"
+    NOT_IMPLEMENTED = "Not Implemented"
+
+
+@json_schema_type
+class HealthResponse(BaseModel):
+    """
+    HealthResponse is a model representing the health status response.
+
+    param health: A dictionary containing health information.
+    """
+
+    health: Dict[str, HealthStatus]
+
+    @field_validator("health")
+    @classmethod
+    def check_status_present(cls, v):
+        if "status" not in v:
+            raise ValueError("'status' must be present in the health dictionary.")
+        return v
+
+
 class ModelStore(Protocol):
     def get_model(self, identifier: str) -> Model: ...
 
@@ -479,5 +503,13 @@ class Inference(Protocol):
         :param model_id: The identifier of the model to use. The model must be an embedding model registered with Llama Stack and available via the /models endpoint.
         :param contents: List of contents to generate embeddings for. Note that content can be multimodal. The behavior depends on the model and provider. Some models may only support text.
         :returns: An array of embeddings, one for each content. Each embedding is a list of floats. The dimensionality of the embedding is model-specific; you can check model metadata using /models/{model_id}
+        """
+        ...
+
+    @webmethod(route="/inference/health", method="GET")
+    async def get_health(self) -> HealthResponse:
+        """Retrieve the health status of the inference service.
+
+        :returns: A dictionary containing the health status of the inference service.
         """
         ...

--- a/llama_stack/apis/inspect/inspect.py
+++ b/llama_stack/apis/inspect/inspect.py
@@ -28,7 +28,6 @@ class RouteInfo(BaseModel):
 @json_schema_type
 class HealthInfo(BaseModel):
     status: str
-    # TODO: add a provider level status
 
 
 @json_schema_type

--- a/llama_stack/providers/inline/inference/meta_reference/inference.py
+++ b/llama_stack/providers/inline/inference/meta_reference/inference.py
@@ -23,6 +23,7 @@ from llama_stack.apis.inference import (
     CompletionRequest,
     CompletionResponse,
     CompletionResponseStreamChunk,
+    HealthResponse,
     Inference,
     InterleavedContent,
     LogProbConfig,
@@ -428,3 +429,8 @@ class MetaReferenceInferenceImpl(
         else:
             for x in impl():
                 yield x
+
+    async def get_health(
+        self,
+    ) -> HealthResponse:
+        raise NotImplementedError()

--- a/llama_stack/providers/inline/inference/sentence_transformers/sentence_transformers.py
+++ b/llama_stack/providers/inline/inference/sentence_transformers/sentence_transformers.py
@@ -9,6 +9,7 @@ from typing import AsyncGenerator, List, Optional, Union
 
 from llama_stack.apis.inference import (
     CompletionResponse,
+    HealthResponse,
     Inference,
     LogProbConfig,
     Message,
@@ -75,3 +76,8 @@ class SentenceTransformersInferenceImpl(
         tool_config: Optional[ToolConfig] = None,
     ) -> AsyncGenerator:
         raise ValueError("Sentence transformers don't support chat completion")
+
+    async def get_health(
+        self,
+    ) -> HealthResponse:
+        raise NotImplementedError()

--- a/llama_stack/providers/inline/inference/vllm/vllm.py
+++ b/llama_stack/providers/inline/inference/vllm/vllm.py
@@ -23,6 +23,7 @@ from llama_stack.apis.inference import (
     CompletionResponse,
     CompletionResponseStreamChunk,
     EmbeddingsResponse,
+    HealthResponse,
     Inference,
     LogProbConfig,
     Message,
@@ -229,6 +230,11 @@ class VLLMInferenceImpl(Inference, ModelsProtocolPrivate):
         stream = _generate_and_convert_to_openai_compat()
         async for chunk in process_chat_completion_stream_response(stream, self.formatter, request):
             yield chunk
+
+    async def get_health(
+        self,
+    ) -> HealthResponse:
+        raise NotImplementedError()
 
     async def embeddings(self, model_id: str, contents: List[InterleavedContent]) -> EmbeddingsResponse:
         raise NotImplementedError()

--- a/llama_stack/providers/remote/inference/bedrock/bedrock.py
+++ b/llama_stack/providers/remote/inference/bedrock/bedrock.py
@@ -17,6 +17,7 @@ from llama_stack.apis.inference import (
     ChatCompletionResponse,
     ChatCompletionResponseStreamChunk,
     EmbeddingsResponse,
+    HealthResponse,
     Inference,
     LogProbConfig,
     Message,
@@ -198,3 +199,8 @@ class BedrockInferenceAdapter(ModelRegistryHelper, Inference):
             response_body = json.loads(response.get("body").read())
             embeddings.append(response_body.get("embedding"))
         return EmbeddingsResponse(embeddings=embeddings)
+
+    async def get_health(
+        self,
+    ) -> HealthResponse:
+        raise NotImplementedError()

--- a/llama_stack/providers/remote/inference/cerebras/cerebras.py
+++ b/llama_stack/providers/remote/inference/cerebras/cerebras.py
@@ -16,6 +16,7 @@ from llama_stack.apis.inference import (
     CompletionRequest,
     CompletionResponse,
     EmbeddingsResponse,
+    HealthResponse,
     Inference,
     LogProbConfig,
     Message,
@@ -190,4 +191,9 @@ class CerebrasInferenceAdapter(ModelRegistryHelper, Inference):
         model_id: str,
         contents: List[InterleavedContent],
     ) -> EmbeddingsResponse:
+        raise NotImplementedError()
+
+    async def get_health(
+        self,
+    ) -> HealthResponse:
         raise NotImplementedError()

--- a/llama_stack/providers/remote/inference/databricks/databricks.py
+++ b/llama_stack/providers/remote/inference/databricks/databricks.py
@@ -15,6 +15,7 @@ from llama_stack.apis.inference import (
     ChatCompletionRequest,
     ChatCompletionResponse,
     EmbeddingsResponse,
+    HealthResponse,
     Inference,
     LogProbConfig,
     Message,
@@ -139,4 +140,9 @@ class DatabricksInferenceAdapter(ModelRegistryHelper, Inference):
         model: str,
         contents: List[InterleavedContent],
     ) -> EmbeddingsResponse:
+        raise NotImplementedError()
+
+    async def get_health(
+        self,
+    ) -> HealthResponse:
         raise NotImplementedError()

--- a/llama_stack/providers/remote/inference/fireworks/fireworks.py
+++ b/llama_stack/providers/remote/inference/fireworks/fireworks.py
@@ -17,6 +17,7 @@ from llama_stack.apis.inference import (
     CompletionRequest,
     CompletionResponse,
     EmbeddingsResponse,
+    HealthResponse,
     Inference,
     LogProbConfig,
     Message,
@@ -297,3 +298,8 @@ class FireworksInferenceAdapter(ModelRegistryHelper, Inference, NeedsRequestProv
 
         embeddings = [data.embedding for data in response.data]
         return EmbeddingsResponse(embeddings=embeddings)
+
+    async def get_health(
+        self,
+    ) -> HealthResponse:
+        raise NotImplementedError()

--- a/llama_stack/providers/remote/inference/groq/groq.py
+++ b/llama_stack/providers/remote/inference/groq/groq.py
@@ -17,6 +17,7 @@ from llama_stack.apis.inference import (
     CompletionResponse,
     CompletionResponseStreamChunk,
     EmbeddingsResponse,
+    HealthResponse,
     Inference,
     InterleavedContent,
     LogProbConfig,
@@ -154,3 +155,8 @@ class GroqInferenceAdapter(Inference, ModelRegistryHelper, NeedsRequestProviderD
                     'Pass Groq API Key in the header X-LlamaStack-Provider-Data as { "groq_api_key": "<your api key>" }'
                 )
             return Groq(api_key=provider_data.groq_api_key)
+
+    async def get_health(
+        self,
+    ) -> HealthResponse:
+        raise NotImplementedError()

--- a/llama_stack/providers/remote/inference/nvidia/nvidia.py
+++ b/llama_stack/providers/remote/inference/nvidia/nvidia.py
@@ -17,6 +17,7 @@ from llama_stack.apis.inference import (
     CompletionResponse,
     CompletionResponseStreamChunk,
     EmbeddingsResponse,
+    HealthResponse,
     Inference,
     InterleavedContent,
     LogProbConfig,
@@ -201,3 +202,8 @@ class NVIDIAInferenceAdapter(Inference, ModelRegistryHelper):
         else:
             # we pass n=1 to get only one completion
             return convert_openai_chat_completion_choice(response.choices[0])
+
+    async def get_health(
+        self,
+    ) -> HealthResponse:
+        raise NotImplementedError()

--- a/llama_stack/providers/remote/inference/ollama/ollama.py
+++ b/llama_stack/providers/remote/inference/ollama/ollama.py
@@ -22,6 +22,8 @@ from llama_stack.apis.inference import (
     ChatCompletionResponse,
     CompletionRequest,
     EmbeddingsResponse,
+    HealthResponse,
+    HealthStatus,
     Inference,
     LogProbConfig,
     Message,
@@ -368,6 +370,22 @@ class OllamaInferenceAdapter(Inference, ModelsProtocolPrivate):
         await check_model_availability(model.provider_resource_id)
 
         return model
+
+    async def get_health(self) -> HealthResponse:
+        """
+        Performs a health check by initializing the service.
+
+        This method is used by the inspect API endpoint to verify that the service is running
+        correctly.
+
+        Returns:
+            HealthResponse: A dictionary containing the health status.
+        """
+        try:
+            await self.initialize()
+            return HealthResponse(health={"status": HealthStatus.OK})
+        except ConnectionError as e:
+            return HealthResponse(health={"status": HealthStatus.ERROR, "message": str(e)})
 
 
 async def convert_message_to_openai_dict_for_ollama(message: Message) -> List[dict]:

--- a/llama_stack/providers/remote/inference/runpod/runpod.py
+++ b/llama_stack/providers/remote/inference/runpod/runpod.py
@@ -125,3 +125,8 @@ class RunpodInferenceAdapter(ModelRegistryHelper, Inference):
         contents: List[InterleavedTextMedia],
     ) -> EmbeddingsResponse:
         raise NotImplementedError()
+
+    async def get_health(
+        self,
+    ) -> HealthResponse:
+        raise NotImplementedError()

--- a/llama_stack/providers/remote/inference/sambanova/sambanova.py
+++ b/llama_stack/providers/remote/inference/sambanova/sambanova.py
@@ -326,3 +326,8 @@ class SambaNovaInferenceAdapter(ModelRegistryHelper, Inference):
         ]
 
         return compitable_tool_calls
+
+    async def get_health(
+        self,
+    ) -> HealthResponse:
+        raise NotImplementedError()

--- a/llama_stack/providers/remote/inference/tgi/tgi.py
+++ b/llama_stack/providers/remote/inference/tgi/tgi.py
@@ -18,6 +18,7 @@ from llama_stack.apis.inference import (
     ChatCompletionResponse,
     CompletionRequest,
     EmbeddingsResponse,
+    HealthResponse,
     Inference,
     LogProbConfig,
     Message,
@@ -308,3 +309,8 @@ class InferenceEndpointAdapter(_HfAdapter):
         self.client = endpoint.async_client
         self.model_id = endpoint.repository
         self.max_tokens = int(endpoint.raw["model"]["image"]["custom"]["env"]["MAX_TOTAL_TOKENS"])
+
+    async def get_health(
+        self,
+    ) -> HealthResponse:
+        raise NotImplementedError()

--- a/llama_stack/providers/remote/inference/together/together.py
+++ b/llama_stack/providers/remote/inference/together/together.py
@@ -16,6 +16,7 @@ from llama_stack.apis.inference import (
     ChatCompletionResponse,
     CompletionRequest,
     EmbeddingsResponse,
+    HealthResponse,
     Inference,
     LogProbConfig,
     Message,
@@ -274,3 +275,8 @@ class TogetherInferenceAdapter(ModelRegistryHelper, Inference, NeedsRequestProvi
         )
         embeddings = [item.embedding for item in r.data]
         return EmbeddingsResponse(embeddings=embeddings)
+
+    async def get_health(
+        self,
+    ) -> HealthResponse:
+        raise NotImplementedError()

--- a/llama_stack/providers/remote/inference/vllm/vllm.py
+++ b/llama_stack/providers/remote/inference/vllm/vllm.py
@@ -24,6 +24,7 @@ from llama_stack.apis.inference import (
     CompletionResponse,
     CompletionResponseStreamChunk,
     EmbeddingsResponse,
+    HealthResponse,
     Inference,
     LogProbConfig,
     Message,
@@ -375,3 +376,8 @@ class VLLMInferenceAdapter(Inference, ModelsProtocolPrivate):
 
         embeddings = [data.embedding for data in response.data]
         return EmbeddingsResponse(embeddings=embeddings)
+
+    async def get_health(
+        self,
+    ) -> HealthResponse:
+        raise NotImplementedError()

--- a/llama_stack/providers/tests/inference/test_health.py
+++ b/llama_stack/providers/tests/inference/test_health.py
@@ -1,0 +1,22 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import pytest
+
+from llama_stack.apis.inference import HealthResponse
+
+# How to run this test:
+# pytest -v -s llama_stack/providers/tests/inference/test_health.py
+
+
+class TestHeatlh:
+    @pytest.mark.asyncio
+    async def test_health(self, inference_stack):
+        inference_impl, _ = inference_stack
+        response = await inference_impl.health()
+        for key in response:
+            assert isinstance(response[key], HealthResponse)
+            assert response[key].health["status"] == "OK", response


### PR DESCRIPTION
# What does this PR do?
This commit introduces a HealthResponse model to standardize health status responses across the inference service. The health() method has been implemented in the Inference API, allowing the retrieval of system health information.

The InferenceRouter has been updated to aggregate health statuses from various providers, ensuring a comprehensive view of system health. Additionally, the health() method has been added to multiple inference provider implementations, with a default NotImplementedError where necessary.

A new /inference/health endpoint is now available, enabling monitoring and diagnostics of the inference service to improve observability and maintainability.

Test:

```
$ curl http://127.0.0.1:8321/v1/inference/health
{"ollama":{"health":{"status":"OK"}},"sentence-transformers":{"health":{"status":"Not Implemented"}}}
```

Signed-off-by: Sébastien Han <seb@redhat.com>

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan

Run:

```
pytest -vvv -k ollama llama_stack/providers/tests/inference/test_health.py
/Users/leseb/Documents/AI/llama-stack/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py:207: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
======================================= test session starts =======================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0 -- /Users/leseb/Documents/AI/llama-stack/.venv/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.12.8', 'Platform': 'macOS-15.3-arm64-arm-64bit', 'Packages': {'pytest': '8.3.4', 'pluggy': '1.5.0'}, 'Plugins': {'html': '4.1.1', 'metadata': '3.1.1', 'asyncio': '0.25.3', 'anyio': '4.8.0', 'nbval': '0.11.0'}}
rootdir: /Users/leseb/Documents/AI/llama-stack
configfile: pyproject.toml
plugins: html-4.1.1, metadata-3.1.1, asyncio-0.25.3, anyio-4.8.0, nbval-0.11.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None
collected 13 items / 12 deselected / 1 selected                                                   

llama_stack/providers/tests/inference/test_health.py::TestHeatlh::test_health[-ollama] PASSED [100%]

========================== 1 passed, 12 deselected, 2 warnings in 0.20s ===========================
```

TODO:

- [ ] Add Python SDK support