### PR TITLE
test: Enable test_text_chat_completion_with_tool_choice_required for remote::vllm

### DIFF
--- a/tests/client-sdk/inference/test_text_inference.py
+++ b/tests/client-sdk/inference/test_text_inference.py
@@ -250,8 +250,6 @@ def test_text_chat_completion_with_tool_calling_and_streaming(
 def test_text_chat_completion_with_tool_choice_required(
     llama_stack_client, text_model_id, get_weather_tool_definition, provider_tool_format, inference_provider_type
 ):
-    if inference_provider_type == "remote::vllm":
-        pytest.xfail("vllm-project/vllm#13002")
     response = llama_stack_client.inference.chat_completion(
         model_id=text_model_id,
         messages=[


### PR DESCRIPTION
# What does this PR do?


This verifies that https://github.com/meta-llama/llama-stack/pull/1059's test passed for remote::vllm so I am removing the xfail here. 

## Test Plan

Test passed:

```
LLAMA_STACK_BASE_URL=http://localhost:5002 pytest -v tests/client-sdk/inference/test_text_inference.py::test_text_chat_completion_with_tool_choice_required 
=============================================================== test session starts ===============================================================
platform linux -- Python 3.10.16, pytest-8.3.4, pluggy-1.5.0 -- /home/yutang/.conda/envs/distribution-myenv/bin/python3.10
cachedir: .pytest_cache
rootdir: /home/yutang/repos/llama-stack
configfile: pyproject.toml
plugins: anyio-4.8.0
collected 1 item                                                                                                                                  

tests/client-sdk/inference/test_text_inference.py::test_text_chat_completion_with_tool_choice_required[meta-llama/Llama-3.1-8B-Instruct] PASSED [100%]

```