### PR TITLE
fix: llama stack build add --system-install flag to add to current env

### DIFF
--- a/llama_stack/cli/stack/_build.py
+++ b/llama_stack/cli/stack/_build.py
@@ -182,6 +182,7 @@ def run_stack_build_command(args: argparse.Namespace) -> None:
         image_name=image_name,
         config_path=args.config,
         template_name=args.template,
+        system_install=args.system_install,
     )
 
 
@@ -246,6 +247,7 @@ def _run_stack_build_command_from_build_config(
     image_name: Optional[str] = None,
     template_name: Optional[str] = None,
     config_path: Optional[str] = None,
+    system_install: bool = False,
 ) -> None:
     if build_config.image_type == ImageType.container.value:
         if template_name:
@@ -274,6 +276,7 @@ def _run_stack_build_command_from_build_config(
         build_file_path,
         image_name,
         template_or_config=template_name or config_path,
+        system_install=system_install,
     )
     if return_code != 0:
         return

--- a/llama_stack/cli/stack/build.py
+++ b/llama_stack/cli/stack/build.py
@@ -67,6 +67,12 @@ the build. If not specified, currently active Conda environment will be used if 
             action="store_true",
             help="Print the dependencies for the stack only, without building the stack",
         )
+        self.parser.add_argument(
+            "--system-install",
+            default=False,
+            action="store_true",
+            help="Install the dependencies in the same system Python environment. Used when image-type is venv. By default, a new virtual environment will be created.",
+        )
 
     def _run_stack_build_command(self, args: argparse.Namespace) -> None:
         # always keep implementation completely silo-ed away from CLI so CLI

--- a/llama_stack/distribution/build.py
+++ b/llama_stack/distribution/build.py
@@ -122,11 +122,13 @@ def build_image(
             " ".join(normal_deps),
         ]
     elif build_config.image_type == ImageType.venv.value:
+        system_install = True
         script = str(importlib.resources.files("llama_stack") / "distribution/build_venv.sh")
         args = [
             script,
             str(image_name),
             " ".join(normal_deps),
+            str(system_install),
         ]
 
     if special_deps:

--- a/llama_stack/distribution/build.py
+++ b/llama_stack/distribution/build.py
@@ -96,6 +96,7 @@ def build_image(
     build_file_path: Path,
     image_name: str,
     template_or_config: str,
+    system_install: bool = False,
 ):
     container_base = build_config.distribution_spec.container_image or "python:3.10-slim"
 
@@ -122,7 +123,6 @@ def build_image(
             " ".join(normal_deps),
         ]
     elif build_config.image_type == ImageType.venv.value:
-        system_install = True
         script = str(importlib.resources.files("llama_stack") / "distribution/build_venv.sh")
         args = [
             script,

--- a/llama_stack/distribution/build_venv.sh
+++ b/llama_stack/distribution/build_venv.sh
@@ -37,6 +37,9 @@ build_name="$1"
 env_name="llamastack-$build_name"
 pip_dependencies="$2"
 
+# whether we want to install dependencies in current system python environment
+system_install="$4"
+
 # Define color codes
 RED='\033[0;31m'
 NC='\033[0m' # No Color
@@ -73,11 +76,17 @@ run() {
   local env_name="$1"
   local pip_dependencies="$2"
   local special_pip_deps="$3"
+  local system_install="$4"
+  
+  if [ "$SYSTEM_INSTALL" = true ]; then
+    echo "Installing dependencies in system Python environment"
+  else
+    echo "Using virtual environment $env_name"
+    uv venv "$env_name"
+    # shellcheck source=/dev/null
+    source "$env_name/bin/activate"
+  fi
 
-  echo "Using virtual environment $env_name"
-  uv venv "$env_name"
-  # shellcheck source=/dev/null
-  source "$env_name/bin/activate"
   if [ -n "$TEST_PYPI_VERSION" ]; then
     # these packages are damaged in test-pypi, so install them first
     uv pip install fastapi libcst

--- a/llama_stack/distribution/build_venv.sh
+++ b/llama_stack/distribution/build_venv.sh
@@ -29,7 +29,7 @@ if [ "$#" -lt 3 ]; then
   exit 1
 fi
 
-special_pip_deps="$3"
+special_pip_deps="$4"
 
 set -euo pipefail
 
@@ -38,7 +38,7 @@ env_name="llamastack-$build_name"
 pip_dependencies="$2"
 
 # whether we want to install dependencies in current system python environment
-system_install="$4"
+system_install="$3"
 
 # Define color codes
 RED='\033[0;31m'
@@ -75,10 +75,10 @@ pre_run_checks() {
 run() {
   local env_name="$1"
   local pip_dependencies="$2"
-  local special_pip_deps="$3"
-  local system_install="$4"
+  local system_install="$3"
+  local special_pip_deps="$4"
   
-  if [ "$SYSTEM_INSTALL" = true ]; then
+  if [ "$system_install" = "True" ]; then
     echo "Installing dependencies in system Python environment"
   else
     echo "Using virtual environment $env_name"
@@ -147,4 +147,4 @@ run() {
 }
 
 pre_run_checks "$env_name"
-run "$env_name" "$pip_dependencies" "$special_pip_deps"
+run "$env_name" "$pip_dependencies" "$system_install" "$special_pip_deps"


### PR DESCRIPTION
# What does this PR do?
- resolves issue: #1159 
- Root cause: https://github.com/meta-llama/llama-stack/pull/980 forces `build_venv.sh` to install in a venv environment, which do not work on Colab notebook environment

<img width="1004" alt="image" src="https://github.com/user-attachments/assets/1f9be409-5313-4926-b078-74e141cf29eb" />



## Test Plan
[Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.*]

[//]: # (## Documentation)
