### PR TITLE
docs: Remove unused python-openapi and json-strong-typing in openapi_generator

### DIFF
--- a/docs/openapi_generator/README.md
+++ b/docs/openapi_generator/README.md
@@ -3,7 +3,7 @@ The RFC Specification (OpenAPI format) is generated from the set of API endpoint
 Please install the following packages before running the script:
 
 ```
-pip install python-openapi fire PyYAML llama-models
+pip install fire PyYAML llama-models
 ```
 
 Then simply run `sh run_openapi_generator.sh`

--- a/docs/openapi_generator/README.md
+++ b/docs/openapi_generator/README.md
@@ -3,7 +3,7 @@ The RFC Specification (OpenAPI format) is generated from the set of API endpoint
 Please install the following packages before running the script:
 
 ```
-pip install python-openapi json-strong-typing fire PyYAML llama-models
+pip install python-openapi fire PyYAML llama-models
 ```
 
 Then simply run `sh run_openapi_generator.sh`


### PR DESCRIPTION
This is no longer required to generated API reference after https://github.com/meta-llama/llama-stack/commit/5e7904ef6c5483bb3aaf82ec0d687ced4867ef86

