### PR TITLE
chore: Adding unit tests for faiss 

### DIFF
--- a/llama_stack/providers/tests/vector_io/test_faiss.py
+++ b/llama_stack/providers/tests/vector_io/test_faiss.py
@@ -1,0 +1,115 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import asyncio
+
+import numpy as np
+import pytest
+
+from llama_stack.apis.vector_dbs import VectorDB
+from llama_stack.apis.vector_io import Chunk, QueryChunksResponse
+from llama_stack.providers.inline.vector_io.faiss.faiss import (
+    FaissIndex,
+    FaissVectorIOAdapter,
+    FaissVectorIOConfig,
+)
+from llama_stack.providers.utils.kvstore.config import (
+    SqliteKVStoreConfig,
+)
+
+# How to run this test:
+#
+# pytest llama_stack/providers/tests/vector_io/test_faiss.py \
+# -v -s --tb=short --disable-warnings --asyncio-mode=auto
+
+FAISS_PROVIDER = "faiss"
+EMBEDDING_DIMENSION = 384
+EMBEDDING_MODEL = "all-MiniLM-L6-v2"
+
+
+@pytest.fixture(scope="session")
+def loop():
+    return asyncio.new_event_loop()
+
+
+@pytest.fixture(scope="session", autouse=True)
+async def faiss_index():
+    return await FaissIndex.create(dimension=EMBEDDING_DIMENSION, bank_id="test_bank")
+
+
+@pytest.fixture(scope="session")
+def sample_chunks():
+    """Generates chunks that force multiple batches for a single document to expose ID conflicts."""
+    n, k = 10, 3
+    sample = [
+        Chunk(content=f"Sentence {i} from document {j}", metadata={"document_id": f"document-{j}"})
+        for j in range(k)
+        for i in range(n)
+    ]
+    return sample
+
+
+@pytest.fixture(scope="session")
+def sample_embeddings(sample_chunks):
+    np.random.seed(42)
+    return np.array([np.random.rand(EMBEDDING_DIMENSION).astype(np.float32) for _ in sample_chunks])
+
+
+@pytest.mark.asyncio
+async def test_add_chunks(faiss_index, sample_chunks, sample_embeddings):
+    await faiss_index.add_chunks(sample_chunks, sample_embeddings)
+    assert faiss_index.index.ntotal == len(sample_chunks)
+
+
+@pytest.mark.asyncio
+async def test_query_chunks(faiss_index, sample_chunks, sample_embeddings):
+    await faiss_index.add_chunks(sample_chunks, sample_embeddings)
+    query_embedding = np.random.rand(EMBEDDING_DIMENSION).astype(np.float32)
+    response = await faiss_index.query(query_embedding, k=2, score_threshold=0.0)
+    assert isinstance(response, QueryChunksResponse)
+    assert len(response.chunks) == 2
+
+
+@pytest.fixture(scope="session")
+async def faiss_adapter():
+    # Create a mock config with kvstore
+    kvstore_config = SqliteKVStoreConfig(db_path="./faiss_store.db")
+
+    config = FaissVectorIOConfig(kvstore=kvstore_config)
+
+    adapter = FaissVectorIOAdapter(config=config, inference_api=None)
+    await adapter.initialize()
+    yield adapter
+    await adapter.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_register_vector_db(faiss_adapter):
+    vector_db = VectorDB(
+        identifier="test_db",
+        embedding_model=EMBEDDING_MODEL,
+        embedding_dimension=EMBEDDING_DIMENSION,
+        metadata={},
+        provider_id=FAISS_PROVIDER,
+    )
+    await faiss_adapter.register_vector_db(vector_db)
+    vector_dbs = await faiss_adapter.list_vector_dbs()
+    assert any(db.identifier == "test_db" for db in vector_dbs)
+
+
+@pytest.mark.asyncio
+async def test_unregister_vector_db(faiss_adapter):
+    vector_db = VectorDB(
+        identifier="test_db",
+        embedding_model=EMBEDDING_MODEL,
+        embedding_dimension=EMBEDDING_DIMENSION,
+        metadata={},
+        provider_id=FAISS_PROVIDER,
+    )
+    await faiss_adapter.register_vector_db(vector_db)
+    await faiss_adapter.unregister_vector_db("test_db")
+    vector_dbs = await faiss_adapter.list_vector_dbs()
+    assert not any(db.identifier == "test_db" for db in vector_dbs)

--- a/tests/client-sdk/vector_io/test_vector_io.py
+++ b/tests/client-sdk/vector_io/test_vector_io.py
@@ -11,7 +11,7 @@ import pytest
 INLINE_VECTOR_DB_PROVIDERS = [
     "faiss",
     # TODO: add sqlite_vec to templates
-    # "sqlite_vec",
+    "sqlite_vec",
 ]
 
 

--- a/tests/client-sdk/vector_io/test_vector_io.py
+++ b/tests/client-sdk/vector_io/test_vector_io.py
@@ -11,7 +11,7 @@ import pytest
 INLINE_VECTOR_DB_PROVIDERS = [
     "faiss",
     # TODO: add sqlite_vec to templates
-    "sqlite_vec",
+    # "sqlite_vec",
 ]
 
 


### PR DESCRIPTION
# What does this PR do?
Creates unit tests for Faiss that are equivalent to those in sqlite-vec, as discussed in https://github.com/meta-llama/llama-stack/pull/1094.

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan
Added tests to be at parity to sqlite-vec, see results below:

```python
> pytest llama_stack/providers/tests/vector_io/test_sqlite_vec.py  -v -s --tb=short --disable-warnings --asyncio-mode=auto
/Users/farceo/dev/llama-stack/.venv/lib/python3.11/site-packages/pytest_asyncio/plugin.py:207: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
=============================================================================================================================================================================================================================================================== test session starts ===============================================================================================================================================================================================================================================================
platform darwin -- Python 3.11.6, pytest-8.3.4, pluggy-1.5.0 -- /Users/farceo/dev/llama-stack/.venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.11.6', 'Platform': 'macOS-15.3-arm64-arm-64bit', 'Packages': {'pytest': '8.3.4', 'pluggy': '1.5.0'}, 'Plugins': {'html': '4.1.1', 'metadata': '3.1.1', 'asyncio': '0.25.3', 'anyio': '4.8.0', 'nbval': '0.11.0'}}
rootdir: /Users/farceo/dev/llama-stack
configfile: pyproject.toml
plugins: html-4.1.1, metadata-3.1.1, asyncio-0.25.3, anyio-4.8.0, nbval-0.11.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None
collected 6 items                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 

llama_stack/providers/tests/vector_io/test_sqlite_vec.py::test_add_chunks PASSED
llama_stack/providers/tests/vector_io/test_sqlite_vec.py::test_query_chunks PASSED
llama_stack/providers/tests/vector_io/test_sqlite_vec.py::test_chunk_id_conflict PASSED
llama_stack/providers/tests/vector_io/test_sqlite_vec.py::test_register_vector_db PASSED
llama_stack/providers/tests/vector_io/test_sqlite_vec.py::test_unregister_vector_db PASSED
llama_stack/providers/tests/vector_io/test_sqlite_vec.py::test_generate_chunk_id PASSED
```

## Documentation
Will provide in a follow up PR for `faiss` and `sqlite-vec`