### PR TITLE
fix: Unregister a model from registry if not being served

### DIFF
--- a/llama_stack/providers/remote/inference/ollama/ollama.py
+++ b/llama_stack/providers/remote/inference/ollama/ollama.py
@@ -83,7 +83,7 @@ class OllamaInferenceAdapter(Inference, ModelsProtocolPrivate):
         pass
 
     async def unregister_model(self, model_id: str) -> None:
-        pass
+        await self.register_helper.unregister_model(model_id)
 
     async def completion(
         self,
@@ -290,6 +290,7 @@ class OllamaInferenceAdapter(Inference, ModelsProtocolPrivate):
             response = await self.client.ps()
         available_models = [m["model"] for m in response["models"]]
         if model.provider_resource_id not in available_models:
+            await self.unregister_model(model.provider_resource_id)
             raise ValueError(
                 f"Model '{model.provider_resource_id}' is not available in Ollama. Available models: {', '.join(available_models)}"
             )

--- a/llama_stack/providers/remote/inference/vllm/vllm.py
+++ b/llama_stack/providers/remote/inference/vllm/vllm.py
@@ -231,7 +231,7 @@ class VLLMInferenceAdapter(Inference, ModelsProtocolPrivate):
         pass
 
     async def unregister_model(self, model_id: str) -> None:
-        pass
+        await self.register_helper.unregister_model(model_id)
 
     async def completion(
         self,
@@ -342,6 +342,7 @@ class VLLMInferenceAdapter(Inference, ModelsProtocolPrivate):
         res = self.client.models.list()
         available_models = [m.id for m in res]
         if model.provider_resource_id not in available_models:
+            await self.unregister_model(model.provider_resource_id)
             raise ValueError(
                 f"Model {model.provider_resource_id} is not being served by vLLM. "
                 f"Available models: {', '.join(available_models)}"


### PR DESCRIPTION
# What does this PR do?

This ensures that the model is deleted from the registry if it's not actively being served by vLLM remote server.

## Test Plan

All tests in `tests/client-sdk/inference/test_text_inference.py` passed.

```
LLAMA_STACK_BASE_URL=http://localhost:5002 pytest -v tests/client-sdk/inference/test_text_inference.py
=============================================================== test session starts ===============================================================
platform linux -- Python 3.10.16, pytest-8.3.4, pluggy-1.5.0 -- /home/yutang/.conda/envs/distribution-myenv/bin/python3.10
cachedir: .pytest_cache
rootdir: /home/yutang/repos/llama-stack
configfile: pyproject.toml
plugins: anyio-4.8.0
collected 16 items                                                                                                                                

tests/client-sdk/inference/test_text_inference.py::test_text_completion_non_streaming[meta-llama/Llama-3.1-8B-Instruct] PASSED              [  6%]
tests/client-sdk/inference/test_text_inference.py::test_text_completion_streaming[meta-llama/Llama-3.1-8B-Instruct] PASSED                  [ 12%]
tests/client-sdk/inference/test_text_inference.py::test_completion_log_probs_non_streaming[meta-llama/Llama-3.1-8B-Instruct] PASSED         [ 18%]
tests/client-sdk/inference/test_text_inference.py::test_completion_log_probs_streaming[meta-llama/Llama-3.1-8B-Instruct] PASSED             [ 25%]
tests/client-sdk/inference/test_text_inference.py::test_text_completion_structured_output[meta-llama/Llama-3.1-8B-Instruct] PASSED          [ 31%]
tests/client-sdk/inference/test_text_inference.py::test_text_chat_completion_non_streaming[meta-llama/Llama-3.1-8B-Instruct-Which planet do humans live on?-Earth] PASSED [ 37%]
tests/client-sdk/inference/test_text_inference.py::test_text_chat_completion_non_streaming[meta-llama/Llama-3.1-8B-Instruct-Which planet has rings around it with a name starting with letter S?-Saturn] PASSED [ 43%]
tests/client-sdk/inference/test_text_inference.py::test_text_chat_completion_streaming[meta-llama/Llama-3.1-8B-Instruct-What's the name of the Sun in latin?-Sol] PASSED [ 50%]
tests/client-sdk/inference/test_text_inference.py::test_text_chat_completion_streaming[meta-llama/Llama-3.1-8B-Instruct-What is the name of the US captial?-Washington] PASSED [ 56%]
tests/client-sdk/inference/test_text_inference.py::test_text_chat_completion_with_tool_calling_and_non_streaming[meta-llama/Llama-3.1-8B-Instruct] PASSED [ 62%]
tests/client-sdk/inference/test_text_inference.py::test_text_chat_completion_with_tool_calling_and_streaming[meta-llama/Llama-3.1-8B-Instruct] PASSED [ 68%]
tests/client-sdk/inference/test_text_inference.py::test_text_chat_completion_with_tool_choice_required[meta-llama/Llama-3.1-8B-Instruct] PASSED [ 75%]
tests/client-sdk/inference/test_text_inference.py::test_text_chat_completion_with_tool_choice_none[meta-llama/Llama-3.1-8B-Instruct] PASSED [ 81%]
tests/client-sdk/inference/test_text_inference.py::test_text_chat_completion_structured_output[meta-llama/Llama-3.1-8B-Instruct] PASSED     [ 87%]
tests/client-sdk/inference/test_text_inference.py::test_text_chat_completion_tool_calling_tools_not_in_request[meta-llama/Llama-3.1-8B-Instruct-True] PASSED [ 93%]
tests/client-sdk/inference/test_text_inference.py::test_text_chat_completion_tool_calling_tools_not_in_request[meta-llama/Llama-3.1-8B-Instruct-False] PASSED [100%]

==================================================== 16 passed, 1 warning in 586.72s (0:09:46) ====================================================
```
