### PR TITLE
feat(3/n): agent resume_turn

### DIFF
--- a/llama_stack/apis/agents/agents.py
+++ b/llama_stack/apis/agents/agents.py
@@ -298,6 +298,15 @@ class AgentTurnCreateRequest(AgentConfigOverridablePerTurn):
 
 
 @json_schema_type
+class AgentTurnContinueRequest(BaseModel):
+    agent_id: str
+    session_id: str
+    turn_id: str
+    tool_responses: List[ToolResponseMessage]
+    stream: Optional[bool] = False
+
+
+@json_schema_type
 class AgentTurnResponseStreamChunk(BaseModel):
     """streamed agent turn completion response."""
 

--- a/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
@@ -275,6 +275,8 @@ class ChatAgent(ShieldRunnerMixin):
                 steps = turns[-1].steps
 
             # mark tool execution step as complete
+            # if there's no tool execution in progress step (due to storage, or tool call parsing on client),
+            # we'll create a new tool execution step with current time
             in_progress_tool_call_step = await self.storage.get_in_progress_tool_call_step(
                 request.session_id, request.turn_id
             )

--- a/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
@@ -269,6 +269,9 @@ class ChatAgent(ShieldRunnerMixin):
                 messages.extend(self.turn_to_messages(turn))
 
             messages.extend(request.tool_responses)
+            last_turn_messages = [
+                x for x in messages if isinstance(x, UserMessage) or isinstance(x, ToolResponseMessage)
+            ]
 
             # get the steps from the turn id
             steps = []
@@ -326,19 +329,9 @@ class ChatAgent(ShieldRunnerMixin):
 
             assert output_message is not None
 
-            last_turn_messages = []
             last_turn_start_time = datetime.now()
             if len(turns) > 0:
                 last_turn_start_time = turns[-1].started_at
-                last_turn_messages = self.turn_to_messages(turns[-1])
-
-            # add tool responses to the last turn messages
-            last_turn_messages.extend(request.tool_responses)
-            # filter out non User / Tool messages
-            # TODO: should we just keep all message types in Turn.input_messages?
-            last_turn_messages = [
-                m for m in last_turn_messages if isinstance(m, UserMessage) or isinstance(m, ToolResponseMessage)
-            ]
 
             turn = Turn(
                 turn_id=request.turn_id,

--- a/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
@@ -247,8 +247,8 @@ class ChatAgent(ShieldRunnerMixin):
 
             yield chunk
 
-    async def continue_turn(self, request: AgentTurnResumeRequest) -> AsyncGenerator:
-        with tracing.span("continue_turn") as span:
+    async def resume_turn(self, request: AgentTurnResumeRequest) -> AsyncGenerator:
+        with tracing.span("resume_turn") as span:
             span.set_attribute("agent_id", self.agent_id)
             span.set_attribute("session_id", request.session_id)
             span.set_attribute("turn_id", request.turn_id)

--- a/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
@@ -31,6 +31,7 @@ from llama_stack.apis.agents import (
     AgentTurnResponseStepProgressPayload,
     AgentTurnResponseStepStartPayload,
     AgentTurnResponseStreamChunk,
+    AgentTurnResponseTurnAwaitingInputPayload,
     AgentTurnResponseTurnCompletePayload,
     AgentTurnResponseTurnStartPayload,
     Attachment,
@@ -227,13 +228,23 @@ class ChatAgent(ShieldRunnerMixin):
             )
             await self.storage.add_turn_to_session(request.session_id, turn)
 
-            chunk = AgentTurnResponseStreamChunk(
-                event=AgentTurnResponseEvent(
-                    payload=AgentTurnResponseTurnCompletePayload(
-                        turn=turn,
+            if output_message.tool_calls:
+                chunk = AgentTurnResponseStreamChunk(
+                    event=AgentTurnResponseEvent(
+                        payload=AgentTurnResponseTurnAwaitingInputPayload(
+                            turn=turn,
+                        )
                     )
                 )
-            )
+            else:
+                chunk = AgentTurnResponseStreamChunk(
+                    event=AgentTurnResponseEvent(
+                        payload=AgentTurnResponseTurnCompletePayload(
+                            turn=turn,
+                        )
+                    )
+                )
+
             yield chunk
 
     async def continue_turn(self, request: AgentTurnContinueRequest) -> AsyncGenerator:

--- a/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
@@ -23,7 +23,6 @@ from llama_stack.apis.agents import (
     AgentConfig,
     AgentToolGroup,
     AgentToolGroupWithArgs,
-    AgentTurnContinueRequest,
     AgentTurnCreateRequest,
     AgentTurnResponseEvent,
     AgentTurnResponseEventType,
@@ -34,6 +33,7 @@ from llama_stack.apis.agents import (
     AgentTurnResponseTurnAwaitingInputPayload,
     AgentTurnResponseTurnCompletePayload,
     AgentTurnResponseTurnStartPayload,
+    AgentTurnResumeRequest,
     Attachment,
     Document,
     InferenceStep,
@@ -247,7 +247,7 @@ class ChatAgent(ShieldRunnerMixin):
 
             yield chunk
 
-    async def continue_turn(self, request: AgentTurnContinueRequest) -> AsyncGenerator:
+    async def continue_turn(self, request: AgentTurnResumeRequest) -> AsyncGenerator:
         with tracing.span("continue_turn") as span:
             span.set_attribute("agent_id", self.agent_id)
             span.set_attribute("session_id", request.session_id)

--- a/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
@@ -162,7 +162,7 @@ class ChatAgent(ShieldRunnerMixin):
         if self.agent_config.instructions != "":
             messages.append(SystemMessage(content=self.agent_config.instructions))
 
-        for i, turn in enumerate(turns):
+        for turn in turns:
             messages.extend(self.turn_to_messages(turn))
         return messages
 

--- a/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
@@ -289,7 +289,7 @@ class ChatAgent(ShieldRunnerMixin):
                         tool_name=x.tool_name,
                         content=x.content,
                     )
-                    for x in in_progress_tool_call_step.tool_responses
+                    for x in request.tool_responses
                 ],
                 completed_at=datetime.now(),
                 started_at=(in_progress_tool_call_step.started_at if in_progress_tool_call_step else datetime.now()),

--- a/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
@@ -663,11 +663,7 @@ class ChatAgent(ShieldRunnerMixin):
                     input_messages = input_messages + [message]
             else:
                 log.info(f"{str(message)}")
-                tool_call = message.tool_calls[0]
-                if tool_call.tool_name in client_tools:
-                    yield message
-                    return
-
+                # 1. Start the tool execution step and progress
                 step_id = str(uuid.uuid4())
                 yield AgentTurnResponseStreamChunk(
                     event=AgentTurnResponseEvent(
@@ -691,6 +687,13 @@ class ChatAgent(ShieldRunnerMixin):
                     )
                 )
 
+                # If tool is a client tool, yield CompletionMessage and return
+                tool_call = message.tool_calls[0]
+                if tool_call.tool_name in client_tools:
+                    yield message
+                    return
+
+                # If tool is a builtin server tool, execute it
                 tool_name = tool_call.tool_name
                 if isinstance(tool_name, BuiltinTool):
                     tool_name = tool_name.value

--- a/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
@@ -280,6 +280,7 @@ class ChatAgent(ShieldRunnerMixin):
             in_progress_tool_call_step = await self.storage.get_in_progress_tool_call_step(
                 request.session_id, request.turn_id
             )
+            now = datetime.now()
             tool_execution_step = ToolExecutionStep(
                 step_id=(in_progress_tool_call_step.step_id if in_progress_tool_call_step else str(uuid.uuid4())),
                 turn_id=request.turn_id,
@@ -292,8 +293,8 @@ class ChatAgent(ShieldRunnerMixin):
                     )
                     for x in request.tool_responses
                 ],
-                completed_at=datetime.now(),
-                started_at=(in_progress_tool_call_step.started_at if in_progress_tool_call_step else datetime.now()),
+                completed_at=now,
+                started_at=(in_progress_tool_call_step.started_at if in_progress_tool_call_step else now),
             )
             steps.append(tool_execution_step)
             yield AgentTurnResponseStreamChunk(

--- a/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
@@ -268,7 +268,7 @@ class ChatAgent(ShieldRunnerMixin):
             for i, turn in enumerate(turns):
                 messages.extend(self.turn_to_messages(turn))
 
-            messages.extend(request.messages)
+            messages.extend(request.tool_responses)
 
             # steps = []
             # output_message = None
@@ -673,6 +673,7 @@ class ChatAgent(ShieldRunnerMixin):
                         )
                     )
                 )
+                tool_call = message.tool_calls[0]
                 yield AgentTurnResponseStreamChunk(
                     event=AgentTurnResponseEvent(
                         payload=AgentTurnResponseStepProgressPayload(
@@ -688,7 +689,6 @@ class ChatAgent(ShieldRunnerMixin):
                 )
 
                 # If tool is a client tool, yield CompletionMessage and return
-                tool_call = message.tool_calls[0]
                 if tool_call.tool_name in client_tools:
                     yield message
                     return

--- a/llama_stack/providers/inline/agents/meta_reference/agents.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agents.py
@@ -20,6 +20,7 @@ from llama_stack.apis.agents import (
     AgentSessionCreateResponse,
     AgentStepResponse,
     AgentToolGroup,
+    AgentTurnContinueRequest,
     AgentTurnCreateRequest,
     Document,
     Session,
@@ -177,7 +178,18 @@ class MetaReferenceAgentsImpl(Agents):
         tool_responses: List[ToolResponseMessage],
         stream: Optional[bool] = False,
     ) -> AsyncGenerator:
-        pass
+        if stream:
+            return self._continue_agent_turn_streaming(request)
+        else:
+            raise NotImplementedError("Non-streaming agent turns not yet implemented")
+
+    async def _continue_agent_turn_streaming(
+        self,
+        request: AgentTurnContinueRequest,
+    ) -> AsyncGenerator:
+        agent = await self.get_agent(request.agent_id)
+        async for event in agent.continue_turn(request):
+            yield event
 
     async def get_agents_turn(self, agent_id: str, session_id: str, turn_id: str) -> Turn:
         turn = await self.persistence_store.get(f"session:{agent_id}:{session_id}:{turn_id}")

--- a/llama_stack/providers/inline/agents/meta_reference/agents.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agents.py
@@ -20,8 +20,8 @@ from llama_stack.apis.agents import (
     AgentSessionCreateResponse,
     AgentStepResponse,
     AgentToolGroup,
-    AgentTurnContinueRequest,
     AgentTurnCreateRequest,
+    AgentTurnResumeRequest,
     Document,
     Session,
     Turn,
@@ -178,7 +178,7 @@ class MetaReferenceAgentsImpl(Agents):
         tool_responses: List[ToolResponseMessage],
         stream: Optional[bool] = False,
     ) -> AsyncGenerator:
-        request = AgentTurnContinueRequest(
+        request = AgentTurnResumeRequest(
             agent_id=agent_id,
             session_id=session_id,
             turn_id=turn_id,
@@ -192,7 +192,7 @@ class MetaReferenceAgentsImpl(Agents):
 
     async def _continue_agent_turn_streaming(
         self,
-        request: AgentTurnContinueRequest,
+        request: AgentTurnResumeRequest,
     ) -> AsyncGenerator:
         agent = await self.get_agent(request.agent_id)
         async for event in agent.continue_turn(request):

--- a/llama_stack/providers/inline/agents/meta_reference/agents.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agents.py
@@ -195,7 +195,7 @@ class MetaReferenceAgentsImpl(Agents):
         request: AgentTurnResumeRequest,
     ) -> AsyncGenerator:
         agent = await self.get_agent(request.agent_id)
-        async for event in agent.continue_turn(request):
+        async for event in agent.resume_turn(request):
             yield event
 
     async def get_agents_turn(self, agent_id: str, session_id: str, turn_id: str) -> Turn:

--- a/llama_stack/providers/inline/agents/meta_reference/agents.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agents.py
@@ -178,6 +178,13 @@ class MetaReferenceAgentsImpl(Agents):
         tool_responses: List[ToolResponseMessage],
         stream: Optional[bool] = False,
     ) -> AsyncGenerator:
+        request = AgentTurnContinueRequest(
+            agent_id=agent_id,
+            session_id=session_id,
+            turn_id=turn_id,
+            tool_responses=tool_responses,
+            stream=stream,
+        )
         if stream:
             return self._continue_agent_turn_streaming(request)
         else:


### PR DESCRIPTION
# What does this PR do?
- https://github.com/meta-llama/llama-stack/pull/1178
- https://github.com/meta-llama/llama-stack/pull/1187
- https://github.com/meta-llama/llama-stack/pull/1194

**client changes**
- https://github.com/meta-llama/llama-stack-client-python/pull/157
- https://github.com/meta-llama/llama-stack-client-python/pull/158

## Test Plan
```
LLAMA_STACK_BASE_URL=http://localhost:8321 pytest -v tests/client-sdk/agents/test_agents.py --inference-model meta-llama/Llama-3.1-8B-Instruct
```

```
LLAMA_STACK_CONFIG=fireworks pytest -v tests/client-sdk/agents/test_agents.py --inference-model meta-llama/Llama-3.1-8B-Instruct
```

<img width="1080" alt="image" src="https://github.com/user-attachments/assets/6c48e062-5d00-4fed-98de-ecca627e5195" />

**llama-stack-apps**
```
python -m examples.agents.react_agent localhost 8321
```

- Test with script: https://gist.github.com/yanxi0830/f2e407527f468998a700cd29fd271b15

**Output Before**: we have 2 `turn_id` with 2 turns
- https://gist.github.com/yanxi0830/9fbd7a80fcddc784a28c59d4a9c1d943

**Output After**: we have 1 `turn_id`, the final turn have all 3 steps
- https://gist.github.com/yanxi0830/17754d56d08ccbeaec419b693137500c

<img width="622" alt="image" src="https://github.com/user-attachments/assets/ed7f42ca-41c8-4ee9-b6fa-2299901cafb4" />

**Telemetry**
<img width="1389" alt="image" src="https://github.com/user-attachments/assets/031bf6ab-959c-46a7-aa85-70a511cba296" />


[//]: # (## Documentation)
