### PR TITLE
docs: Add missing uv command for docs generation in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,7 @@ If you modify or add new API endpoints, update the API documentation accordingly
 
 ```bash
 $ uv sync --extra dev
-$ ./docs/openapi_generator/run_openapi_generator.sh
+$ uv run ./docs/openapi_generator/run_openapi_generator.sh
 ```
 
 The generated API documentation will be available in `docs/_static/`. Make sure to review the changes before committing.


### PR DESCRIPTION
# What does this PR do?

```
make html
/bin/sh: line 1: sphinx-build: command not found
make: *** [Makefile:20: html] Error 127
```

## Test Plan

Tested the command `uv run ./docs/openapi_generator/run_openapi_generator.sh` successfully.
