### PR TITLE
test(client-sdk): Update embedding test types to use latest imports

### DIFF
--- a/llama_stack/providers/remote/inference/nvidia/models.py
+++ b/llama_stack/providers/remote/inference/nvidia/models.py
@@ -52,7 +52,7 @@ _MODEL_ENTRIES = [
         provider_model_id="baai/bge-m3",
         model_type=ModelType.embedding,
         metadata={
-            "embedding_dimensions": 1024,
+            "embedding_dimension": 1024,
             "context_length": 8192,
         },
     ),

--- a/llama_stack/templates/nvidia/run.yaml
+++ b/llama_stack/templates/nvidia/run.yaml
@@ -136,7 +136,7 @@ models:
   provider_model_id: meta/llama-3.2-90b-vision-instruct
   model_type: llm
 - metadata:
-    embedding_dimensions: 1024
+    embedding_dimension: 1024
     context_length: 8192
   model_id: baai/bge-m3
   provider_id: nvidia

--- a/tests/client-sdk/inference/test_embedding.py
+++ b/tests/client-sdk/inference/test_embedding.py
@@ -47,9 +47,9 @@
 import pytest
 from llama_stack_client.types import EmbeddingsResponse
 from llama_stack_client.types.shared.interleaved_content import (
-    URL,
     ImageContentItem,
     ImageContentItemImage,
+    ImageContentItemImageURL,
     TextContentItem,
 )
 
@@ -59,7 +59,7 @@ DUMMY_TEXT = TextContentItem(text=DUMMY_STRING, type="text")
 DUMMY_TEXT2 = TextContentItem(text=DUMMY_STRING2, type="text")
 # TODO(mf): add a real image URL and base64 string
 DUMMY_IMAGE_URL = ImageContentItem(
-    image=ImageContentItemImage(url=URL(uri="https://example.com/image.jpg")), type="image"
+    image=ImageContentItemImage(url=ImageContentItemImageURL(uri="https://example.com/image.jpg")), type="image"
 )
 DUMMY_IMAGE_BASE64 = ImageContentItem(image=ImageContentItemImage(data="base64string"), type="image")
 


### PR DESCRIPTION
# What does this PR do?
- Updates ImageContentItemImageURL import
- fixes `embedding_dimensions` metadata param

## Test Plan
- Ran pytest locally, verified embedding tests pass with new types

![Screenshot 2025-02-21 at 6 54 27 PM](https://github.com/user-attachments/assets/f80e3785-04c3-415e-9276-88aa8136bf00)

cc: @dglogo @sumitb
