### PR TITLE
fix: remove list of list tests, no longer relevant after #1161

### DIFF
--- a/tests/client-sdk/inference/test_embedding.py
+++ b/tests/client-sdk/inference/test_embedding.py
@@ -12,7 +12,6 @@
 #   - array of a string
 #   - array of a image (ImageContentItem, either URL or base64 string)
 #   - array of a text (TextContentItem)
-#   - array of array of texts, images, or both
 #  Types of output:
 #   - list of list of floats
 #
@@ -23,9 +22,6 @@
 #      - empty string
 #      - empty text
 #      - empty image
-#      - list of empty texts
-#      - list of empty images
-#      - list of empty texts and images
 #    - long
 #      - long string
 #      - long text
@@ -36,7 +32,6 @@
 #    - invalid
 #      - invalid URL
 #      - invalid base64
-#      - list of list of strings
 #
 # Notes:
 #  - use llama_stack_client fixture


### PR DESCRIPTION
# What does this PR do?

#1161 updated the embedding signature making the nested list tests irrelevant

