### PR TITLE
chore: add subcommands description in help

### DIFF
--- a/llama_stack/cli/llama.py
+++ b/llama_stack/cli/llama.py
@@ -9,6 +9,7 @@ import argparse
 from .download import Download
 from .model import ModelParser
 from .stack import StackParser
+from .utils import print_subcommand_description
 from .verify_download import VerifyDownload
 
 
@@ -34,20 +35,13 @@ class LlamaCLIParser:
         Download.create(subparsers)
         VerifyDownload.create(subparsers)
 
-        self.print_subcommand_description(subparsers)
+        print_subcommand_description(self.parser, subparsers)
 
     def parse_args(self) -> argparse.Namespace:
         return self.parser.parse_args()
 
     def run(self, args: argparse.Namespace) -> None:
         args.func(args)
-
-    def print_subcommand_description(self, subparsers: argparse._SubParsersAction):
-        description_text = ""
-        for name, subcommand in subparsers.choices.items():
-            description = subcommand.description
-            description_text += f"  {name:<21} {description}\n"
-        self.parser.epilog = description_text
 
 
 def main():

--- a/llama_stack/cli/llama.py
+++ b/llama_stack/cli/llama.py
@@ -20,6 +20,7 @@ class LlamaCLIParser:
             prog="llama",
             description="Welcome to the Llama CLI",
             add_help=True,
+            formatter_class=argparse.RawTextHelpFormatter,
         )
 
         # Default command is to print help
@@ -33,11 +34,20 @@ class LlamaCLIParser:
         Download.create(subparsers)
         VerifyDownload.create(subparsers)
 
+        self.print_subcommand_description(subparsers)
+
     def parse_args(self) -> argparse.Namespace:
         return self.parser.parse_args()
 
     def run(self, args: argparse.Namespace) -> None:
         args.func(args)
+
+    def print_subcommand_description(self, subparsers: argparse._SubParsersAction):
+        description_text = ""
+        for name, subcommand in subparsers.choices.items():
+            description = subcommand.description
+            description_text += f"  {name:<21} {description}\n"
+        self.parser.epilog = description_text
 
 
 def main():

--- a/llama_stack/cli/model/model.py
+++ b/llama_stack/cli/model/model.py
@@ -13,6 +13,7 @@ from llama_stack.cli.model.prompt_format import ModelPromptFormat
 from llama_stack.cli.model.remove import ModelRemove
 from llama_stack.cli.model.verify_download import ModelVerifyDownload
 from llama_stack.cli.subcommand import Subcommand
+from llama_stack.cli.utils import print_subcommand_description
 
 
 class ModelParser(Subcommand):
@@ -39,11 +40,4 @@ class ModelParser(Subcommand):
         ModelVerifyDownload.create(subparsers)
         ModelRemove.create(subparsers)
 
-        self.print_subcommand_description(subparsers)
-
-    def print_subcommand_description(self, subparsers: argparse._SubParsersAction):
-        description_text = ""
-        for name, subcommand in subparsers.choices.items():
-            description = subcommand.description
-            description_text += f"  {name:<21} {description}\n"
-        self.parser.epilog = description_text
+        print_subcommand_description(self.parser, subparsers)

--- a/llama_stack/cli/model/model.py
+++ b/llama_stack/cli/model/model.py
@@ -24,6 +24,7 @@ class ModelParser(Subcommand):
             "model",
             prog="llama model",
             description="Work with llama models",
+            formatter_class=argparse.RawTextHelpFormatter,
         )
 
         self.parser.set_defaults(func=lambda args: self.parser.print_help())
@@ -37,3 +38,12 @@ class ModelParser(Subcommand):
         ModelDescribe.create(subparsers)
         ModelVerifyDownload.create(subparsers)
         ModelRemove.create(subparsers)
+
+        self.print_subcommand_description(subparsers)
+
+    def print_subcommand_description(self, subparsers: argparse._SubParsersAction):
+        description_text = ""
+        for name, subcommand in subparsers.choices.items():
+            description = subcommand.description
+            description_text += f"  {name:<21} {description}\n"
+        self.parser.epilog = description_text

--- a/llama_stack/cli/stack/stack.py
+++ b/llama_stack/cli/stack/stack.py
@@ -22,6 +22,7 @@ class StackParser(Subcommand):
             "stack",
             prog="llama stack",
             description="Operations for the Llama Stack / Distributions",
+            formatter_class=argparse.RawTextHelpFormatter,
         )
 
         self.parser.add_argument(
@@ -39,3 +40,12 @@ class StackParser(Subcommand):
         StackListApis.create(subparsers)
         StackListProviders.create(subparsers)
         StackRun.create(subparsers)
+
+        self.print_subcommand_description(subparsers)
+
+    def print_subcommand_description(self, subparsers: argparse._SubParsersAction):
+        description_text = ""
+        for name, subcommand in subparsers.choices.items():
+            description = subcommand.description
+            description_text += f"  {name:<21} {description}\n"
+        self.parser.epilog = description_text

--- a/llama_stack/cli/stack/stack.py
+++ b/llama_stack/cli/stack/stack.py
@@ -8,6 +8,7 @@ import argparse
 from importlib.metadata import version
 
 from llama_stack.cli.subcommand import Subcommand
+from llama_stack.cli.utils import print_subcommand_description
 
 from .build import StackBuild
 from .list_apis import StackListApis
@@ -41,11 +42,4 @@ class StackParser(Subcommand):
         StackListProviders.create(subparsers)
         StackRun.create(subparsers)
 
-        self.print_subcommand_description(subparsers)
-
-    def print_subcommand_description(self, subparsers: argparse._SubParsersAction):
-        description_text = ""
-        for name, subcommand in subparsers.choices.items():
-            description = subcommand.description
-            description_text += f"  {name:<21} {description}\n"
-        self.parser.epilog = description_text
+        print_subcommand_description(self.parser, subparsers)

--- a/llama_stack/cli/stack/utils.py
+++ b/llama_stack/cli/stack/utils.py
@@ -1,0 +1,14 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+
+def print_subcommand_description(parser, subparsers):
+    """Print descriptions of subcommands."""
+    description_text = ""
+    for name, subcommand in subparsers.choices.items():
+        description = subcommand.description
+        description_text += f"  {name:<21} {description}\n"
+    parser.epilog = description_text


### PR DESCRIPTION
# What does this PR do?
[Provide a short summary of what this PR does and why. Link to relevant issues if applicable.]

```
before:
$ llama
usage: llama [-h] {model,stack,download,verify-download} ...

Welcome to the Llama CLI

options:
  -h, --help            show this help message and exit

subcommands:
  {model,stack,download,verify-download}

$ llama model --help
usage: llama model [-h] {download,list,prompt-format,describe,verify-download,remove} ...

Work with llama models

options:
  -h, --help            show this help message and exit

model_subcommands:
  {download,list,prompt-format,describe,verify-download,remove}

$ llama stack --help
usage: llama stack [-h] [--version] {build,list-apis,list-providers,run} ...

Operations for the Llama Stack / Distributions

options:
  -h, --help            show this help message and exit
  --version             show program's version number and exit

stack_subcommands:
  {build,list-apis,list-providers,run}

===================
after:
$ llama
usage: llama [-h] {model,stack,download,verify-download} ...

Welcome to the Llama CLI

options:
  -h, --help            show this help message and exit

subcommands:
  {model,stack,download,verify-download}

  model                 Work with llama models
  stack                 Operations for the Llama Stack / Distributions
  download              Download a model from llama.meta.com or Hugging Face Hub
  verify-download       Verify integrity of downloaded model files

$ llama model --help
usage: llama model [-h] {download,list,prompt-format,describe,verify-download,remove} ...

Work with llama models

options:
  -h, --help            show this help message and exit

model_subcommands:
  {download,list,prompt-format,describe,verify-download,remove}

  download              Download a model from llama.meta.com or Hugging Face Hub
  list                  Show available llama models
  prompt-format         Show llama model message formats
  describe              Show details about a llama model
  verify-download       Verify the downloaded checkpoints' checksums for models downloaded from Meta
  remove                Remove the downloaded llama model

$ llama stack --help
usage: llama stack [-h] [--version] {build,list-apis,list-providers,run} ...

Operations for the Llama Stack / Distributions

options:
  -h, --help            show this help message and exit
  --version             show program's version number and exit

stack_subcommands:
  {build,list-apis,list-providers,run}

  build                 Build a Llama stack container
  list-apis             List APIs part of the Llama Stack implementation
  list-providers        Show available Llama Stack Providers for an API
  run                   Start the server for a Llama Stack Distribution. You should have already built (or downloaded) and configured the distribution.
```

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan
[Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.*]

[//]: # (## Documentation)
