### PR TITLE
fix: fix the describe table display issue

### DIFF
--- a/llama_stack/cli/model/describe.py
+++ b/llama_stack/cli/model/describe.py
@@ -7,8 +7,6 @@
 import argparse
 import json
 
-from termcolor import colored
-
 from llama_stack.cli.subcommand import Subcommand
 from llama_stack.cli.table import print_table
 from llama_stack.models.llama.sku_list import resolve_model
@@ -52,11 +50,12 @@ class ModelDescribe(Subcommand):
             )
             return
 
+        headers = [
+            "Model",
+            model.descriptor(),
+        ]
+
         rows = [
-            (
-                colored("Model", "white", attrs=["bold"]),
-                colored(model.descriptor(), "white", attrs=["bold"]),
-            ),
             ("Hugging Face ID", model.huggingface_repo or "<Not Available>"),
             ("Description", model.description),
             ("Context Length", f"{model.max_seq_length // 1024}K tokens"),
@@ -77,5 +76,6 @@ class ModelDescribe(Subcommand):
 
         print_table(
             rows,
+            headers,
             separate_rows=True,
         )


### PR DESCRIPTION
# What does this PR do?
[Provide a short summary of what this PR does and why. Link to relevant issues if applicable.]

If not passed the `headers`, it will display empty for the first row, also might break the second row, make the `Model` row as `headers`.
```
Before:
$ llama model describe -m Llama3.1-70B
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃                             ┃                                ┃ <<<---------
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ Model             │ Llama3.1-70B         │   <<<---------
├─────────────────────────────┼────────────────────────────────┤
│ Hugging Face ID             │ meta-llama/Llama-3.1-70B       │
├─────────────────────────────┼────────────────────────────────┤
│ Description                 │ Llama 3.1 70b model            │
├─────────────────────────────┼────────────────────────────────┤
......

after:
$ llama model describe -m Llama3.1-70B
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Model                       ┃ Llama3.1-70B                   ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ Hugging Face ID             │ meta-llama/Llama-3.1-70B       │
├─────────────────────────────┼────────────────────────────────┤
│ Description                 │ Llama 3.1 70b model            │
├─────────────────────────────┼────────────────────────────────┤
......
```

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan
[Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.*]

[//]: # (## Documentation)
