### PR TITLE
fix: image_name defaults to none

### DIFF
--- a/llama_stack/cli/stack/_build.py
+++ b/llama_stack/cli/stack/_build.py
@@ -71,6 +71,10 @@ def run_stack_build_command(args: argparse.Namespace) -> None:
     else:
         image_name = args.image_name
 
+    if not image_name:
+        image_name = f"llamastack-{args.image_type}"
+        print(f"No image name provided and could not detect one from environment. Using image_name: {image_name}")
+
     if args.template:
         available_templates = available_templates_specs()
         if args.template not in available_templates:


### PR DESCRIPTION
# What does this PR do?

since `--image-name` has a default of None, often a user can get `llamastack-None` when using environments like venv and container.

currently, the image_name is llamastack- with the value of the flag or the current conda environment. Change this to be either the value of the flag OR the current image_type. So now the default image names are things like:

`llamastack-venv`
`llamastack-conda`
`llamastack-container`

Closes #1131 

## Test Plan

tested locally and checked created environments