### PR TITLE
Ensure build_container does not fail on missing special_pip_deps

### DIFF
--- a/llama_stack/distribution/build_container.sh
+++ b/llama_stack/distribution/build_container.sh
@@ -24,6 +24,8 @@ if [ "$#" -lt 6 ]; then
   exit 1
 fi
 
+special_pip_deps="$7"
+
 set -euo pipefail
 
 template_or_config="$1"
@@ -32,7 +34,6 @@ container_base="$3"
 build_file_path="$4"
 host_build_dir="$5"
 pip_dependencies="$6"
-special_pip_deps="$7"
 
 
 # Define color codes


### PR DESCRIPTION
special_pip_deps is option. By setting "set -u" after reading it allows the build_container.sh to not fail in case it is not set.
