### PR TITLE
build: Merge redundant "files" field for codegen check in .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,8 +91,7 @@ repos:
         language: python
         pass_filenames: false
         require_serial: true
-        files: ^llama_stack/templates/.*$
-        files: ^llama_stack/providers/.*/inference/.*/models\.py$
+        files: ^llama_stack/templates/.*$|^llama_stack/providers/.*/inference/.*/models\.py$
 
 ci:
     autofix_commit_msg: 🎨 [pre-commit.ci] Auto format from pre-commit.com hooks

--- a/distributions/dependencies.json
+++ b/distributions/dependencies.json
@@ -200,9 +200,7 @@
     "sentencepiece",
     "tqdm",
     "transformers",
-    "uvicorn",
-    "sentence-transformers --no-deps",
-    "torch torchvision --index-url https://download.pytorch.org/whl/cpu"
+    "uvicorn"
   ],
   "hf-endpoint": [
     "aiohttp",


### PR DESCRIPTION
# What does this PR do?

Merges the two "files" field for codegen check. This also fixes the broken main branch CI build.

## Test Plan


```
Distribution Template Codegen............................................Passed
- hook id: distro-codegen
- duration: 367.44s

```