### PR TITLE
fix(agent): Raise exception when tool call has empty name

### DIFF
--- a/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
@@ -1077,6 +1077,8 @@ async def execute_tool_call_maybe(
     tool_to_group: Dict[str, str],
 ) -> ToolInvocationResult:
     name = tool_call.tool_name
+    if not name:
+        raise ValueError("Tool call has an empty name. Tool call may not have been invoked.")
     group_name = tool_to_group.get(name, None)
     if group_name is None:
         raise ValueError(f"Tool {name} not found in any tool group")


### PR DESCRIPTION
# What does this PR do?

This fixes an issue where tool call is not invoked and results in empty tool call name with the error `ValueError: Tool  not found in any tool group`. This happens when the prompt is not explicit and `tool_choice="auto"`. The model has enough knowledge to answer the question without calling the tool. 

```
logs from llamastack server:
    raise ValueError(f"Tool {name} not found in any tool group")
ValueError: Tool  not found in any tool group


logs from client:
inference> The result of 25 plus 15 is 40.
ERROR:__main__:Error during agent turn: 'NoneType' object has no attribute 'payload'
Traceback (most recent call last):
  File "/Users/hveeradh/bbrowning/llama-stack/custom-tool.py", line 110, in <module>
    fire.Fire(main)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/fire/core.py", line 143, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/fire/core.py", line 477, in _Fire
    component, remaining_args = _CallAndUpdateTrace(
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/fire/core.py", line 693, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
  File "/Users/hveeradh/bbrowning/llama-stack/custom-tool.py", line 107, in main
    asyncio.run(run_main())
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "/Users/hveeradh/bbrowning/llama-stack/custom-tool.py", line 93, in run_main
    for chunk in event_logger.log(response_gen):
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/llama_stack_client/lib/agents/event_logger.py", line 167, in log
    for chunk in event_generator:
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/llama_stack_client/lib/agents/agent.py", line 157, in _create_turn_streaming
    tool_calls = self._get_tool_calls(chunk)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/llama_stack_client/lib/agents/agent.py", line 58, in _get_tool_calls
    if chunk.event.payload.event_type != "turn_complete":
AttributeError: 'NoneType' object has no attribute 'payload'
DEBUG:httpcore.connection:close.started
DEBUG:httpcore.connection:close.complete
DEBUG:httpcore.http11:receive_response_body.failed exception=GeneratorExit()
DEBUG:httpcore.http11:response_closed.started
DEBUG:httpcore.http11:response_closed.complete
```

Reproducible example:
```

@client_tool
def calculator(x: str, y: str, operation: str) -> dict:
    """Simple calculator tool that performs basic math operations.

    :param x: First number to perform operation on
    :param y: Second number to perform operation on
    :param operation: Mathematical operation to perform ('add', 'subtract', 'multiply', 'divide')
    :returns: Dictionary containing success status and result or error message
    """
    logger.debug(f"Calculator called with: x={x}, y={y}, operation={operation}")
    try:
        if operation == "add":
            result = float(x) + float(y)
        elif operation == "subtract":
            result = float(x) - float(y)
        elif operation == "multiply":
            result = float(x) * float(y)
        elif operation == "divide":
            if float(y) == 0:
                return {"success": False, "error": "Cannot divide by zero"}
            result = float(x) / float(y)
        else:
            return {"success": False, "error": "Invalid operation"}

        logger.debug(f"Calculator result: {result}")
        return {"success": True, "result": result}
    except Exception as e:
        logger.error(f"Calculator error: {str(e)}")
        return {"success": False, "error": str(e)}

agent_config = AgentConfig(
    model=os.getenv("INFERENCE_MODEL"),
    enable_session_persistence = False,
    instructions = """You are a calculator assistant""",    
    toolgroups=[],
    client_tools = [calculator.get_tool_definition()],
    tool_choice="auto",
    tool_prompt_format="json",
    )
```

Note that the instructions are pretty light and ` tool_choice="auto"`. 

## Test Plan

After this PR, the error message is more informative to the user.
