### PR TITLE
fix: Avoid unexpected keyword argument for sentence_transformers

### DIFF
--- a/llama_stack/providers/inline/inference/sentence_transformers/config.py
+++ b/llama_stack/providers/inline/inference/sentence_transformers/config.py
@@ -11,5 +11,5 @@ from pydantic import BaseModel
 
 class SentenceTransformersInferenceConfig(BaseModel):
     @classmethod
-    def sample_run_config(cls) -> Dict[str, Any]:
+    def sample_run_config(cls, **kwargs) -> Dict[str, Any]:
         return {}


### PR DESCRIPTION
Now that remote-vllm include inline::sentence_transformers there is an issue building the image:
Error building stack: SentenceTransformersInferenceConfig.sample_run_config() got an unexpected keyword argument '__distro_dir__'     

To avoid that issue this fix extends the sample_run_config to accept extra kwargs