### PR TITLE
fix(cli): Missing default for --image-type in stack run command

### DIFF
--- a/llama_stack/cli/stack/run.py
+++ b/llama_stack/cli/stack/run.py
@@ -73,6 +73,7 @@ class StackRun(Subcommand):
             type=str,
             help="Image Type used during the build. This can be either conda or container or venv.",
             choices=["conda", "container", "venv"],
+            default="conda",
         )
 
     def _run_stack_run_cmd(self, args: argparse.Namespace) -> None:


### PR DESCRIPTION
# What does this PR do?

I think this got accidentally removed as part of https://github.com/meta-llama/llama-stack/pull/1250. cc @leseb 

## Test Plan

After the change, this arg is no longer required.