### PR TITLE
fix: always include the type field in requests

### DIFF
--- a/llama_stack/providers/utils/inference/openai_compat.py
+++ b/llama_stack/providers/utils/inference/openai_compat.py
@@ -527,6 +527,7 @@ async def convert_message_to_openai_dict_new(message: Message | Dict) -> OpenAIC
         elif isinstance(content, TextContentItem):
             return OpenAIChatCompletionContentPartTextParam(
                 text=content.text,
+                type="text",
             )
         elif isinstance(content, ImageContentItem):
             return OpenAIChatCompletionContentPartImageParam(


### PR DESCRIPTION
# What does this PR do?

some endpoints, e.g. nvidia's hosted meta/llama-3.2-11b-vision-instruct, are strict about input schema. they require messages to include the type field, i.e. {"text": ..., "type": "text"}.
    
the type field needs to be specified at construction time for it to be included in the request.

## Test Plan

`LLAMA_STACK_BASE_URL=http://localhost:8321 pytest -s -v tests/client-sdk/inference/test_vision_inference.py --vision-inference-model=meta/llama-3.2-90b-vision-instruct`