### PR TITLE
feat: update the post training notebook

### DIFF
--- a/docs/notebooks/Alpha_Llama_Stack_Post_Training.ipynb
+++ b/docs/notebooks/Alpha_Llama_Stack_Post_Training.ipynb
@@ -3,6 +3,8 @@
     {
       "cell_type": "markdown",
       "source": [
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/meta-llama/llama-stack/blob/main/docs/notebooks/Alpha_Llama_Stack_Post_Training.ipynb)\n",
+        "\n",
         "# [Alpha] Llama Stack Post Training\n",
         "This notebook will use a real world problem (improve LLM as tax preparer) to walk through the main sets of APIs we offer with Llama stack for post training to improve the LLM performance for agentic apps (We support supervised finetune now, RLHF and knowledge distillation will come soon!).\n",
         "\n",
@@ -64,7 +66,7 @@
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "Collecting git+https://github.com/meta-llama/llama-stack.git@hf_format_checkpointer\n",
+            "Collecting git+https://github.com/meta-llama/llama-stack.git\n",
             "  Cloning https://github.com/meta-llama/llama-stack.git (to revision hf_format_checkpointer) to /tmp/pip-req-build-j_1bxqzm\n",
             "  Running command git clone --filter=blob:none --quiet https://github.com/meta-llama/llama-stack.git /tmp/pip-req-build-j_1bxqzm\n",
             "  Running command git checkout -b hf_format_checkpointer --track origin/hf_format_checkpointer\n",

--- a/docs/notebooks/Alpha_Llama_Stack_Post_Training.ipynb
+++ b/docs/notebooks/Alpha_Llama_Stack_Post_Training.ipynb
@@ -78,7 +78,7 @@
         }
       ],
       "source": [
-        "!pip install git+https://github.com/meta-llama/llama-stack.git@hf_format_checkpointer"
+        "!pip install git+https://github.com/meta-llama/llama-stack.git #TODO: update this after the next pkg release"
       ]
     },
     {


### PR DESCRIPTION
##  What does this PR do?
- add 'open in colab' icon that links to the notebook
- update the pip install llama-stack pkg part

## test
preview
 
<img width="938" alt="Screenshot 2025-02-26 at 1 25 34 PM" src="https://github.com/user-attachments/assets/951b7f0f-a15e-4618-ad02-07c77c65a5ad" />

<img width="934" alt="Screenshot 2025-02-26 at 1 25 38 PM" src="https://github.com/user-attachments/assets/de872530-84b9-4f8b-ae93-06aa7d2e5bd8" />


