### PR TITLE
chore: upgrade uv pre-commit version, uv-sync -> uv-lock

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,8 +42,9 @@ repos:
         - black==24.3.0
 
 -   repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.5.26
+    rev: 0.6.3
     hooks:
+    -   id: uv-lock
     -   id: uv-export
         args: [
             "--frozen",
@@ -51,8 +52,6 @@ repos:
             "--no-emit-project",
             "--output-file=requirements.txt"
         ]
-        files: ^pyproject\.toml$
-    -   id: uv-sync
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.15.0


### PR DESCRIPTION
See https://github.com/astral-sh/uv-pre-commit/blob/main/.pre-commit-hooks.yaml#L31-L40

`uv-sync` is supposed to be used on "post-checkout, post-rebase" etc. The intention here is decidedly not that. The desire is if you changed pyproject.toml, you should update `uv.lock` (and then also export it to requirements.txt via uv-export).