### PR TITLE
feat: don't silently ignore incorrect toolgroup

### DIFF
--- a/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
@@ -803,6 +803,11 @@ class ChatAgent(ShieldRunnerMixin):
 
             toolgroup_name, tool_name = self._parse_toolgroup_name(toolgroup_name_with_maybe_tool_name)
             tools = await self.tool_groups_api.list_tools(toolgroup_id=toolgroup_name)
+            if not tools.data:
+                available_tool_groups = ", ".join(
+                    [t.identifier for t in (await self.tool_groups_api.list_tool_groups()).data]
+                )
+                raise ValueError(f"Toolgroup {toolgroup_name} not found, available toolgroups: {available_tool_groups}")
             if tool_name is not None and not any(tool.identifier == tool_name for tool in tools.data):
                 raise ValueError(
                     f"Tool {tool_name} not found in toolgroup {toolgroup_name}. Available tools: {', '.join([tool.identifier for tool in tools.data])}"


### PR DESCRIPTION

Summary:

Test Plan:

run with a non-existing tool group
<img width="1052" alt="image" src="https://github.com/user-attachments/assets/9cefa7f9-8e62-44dd-a916-9968221e13f3" />

