### PR TITLE
chore: remove vector_db_id from AgentSessionInfo

### DIFF
--- a/llama_stack/providers/inline/agents/meta_reference/persistence.py
+++ b/llama_stack/providers/inline/agents/meta_reference/persistence.py
@@ -21,8 +21,6 @@ log = logging.getLogger(__name__)
 class AgentSessionInfo(BaseModel):
     session_id: str
     session_name: str
-    # TODO: is this used anywhere?
-    vector_db_id: Optional[str] = None
     started_at: datetime
 
 


### PR DESCRIPTION
# What does this PR do?

- It is not being used anywhere and doesn't make sense to have 1 single vector_db_id in an agent session
- See https://github.com/meta-llama/llama-stack/pull/1286#discussion_r1972569881

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan

- See https://github.com/meta-llama/llama-stack/pull/1286#discussion_r1972569881

[//]: # (## Documentation)
