### PR TITLE
fix: Structured outputs for recursive models

### DIFF
--- a/llama_stack/providers/tests/test_cases/inference/chat_completion.json
+++ b/llama_stack/providers/tests/test_cases/inference/chat_completion.json
@@ -111,7 +111,8 @@
         "first_name": "Michael",
         "last_name": "Jordan",
         "year_of_birth": 1963,
-        "num_seasons_in_nba": 15
+        "num_seasons_in_nba": 15,
+        "year_for_draft": 1984
       }
     }
   },

--- a/llama_stack/providers/utils/inference/litellm_openai_mixin.py
+++ b/llama_stack/providers/utils/inference/litellm_openai_mixin.py
@@ -131,7 +131,6 @@ class LiteLLMOpenAIMixin(
         Recursively add additionalProperties: False to all object schemas
         """
         if isinstance(schema, dict):
-            # If this is an object schema
             if schema.get("type") == "object":
                 schema["additionalProperties"] = False
 
@@ -139,12 +138,10 @@ class LiteLLMOpenAIMixin(
                 if "properties" in schema and schema["properties"]:
                     schema["required"] = list(schema["properties"].keys())
 
-            # Handle properties within objects
             if "properties" in schema:
                 for prop_schema in schema["properties"].values():
                     self._add_additional_properties_recursive(prop_schema)
 
-            # Handle anyOf/allOf/oneOf/not
             for key in ["anyOf", "allOf", "oneOf"]:
                 if key in schema:
                     for sub_schema in schema[key]:

--- a/tests/client-sdk/inference/test_text_inference.py
+++ b/tests/client-sdk/inference/test_text_inference.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+
 import pytest
 from pydantic import BaseModel
 
@@ -342,11 +343,15 @@ def test_text_chat_completion_with_tool_choice_none(client_with_models, text_mod
     ],
 )
 def test_text_chat_completion_structured_output(client_with_models, text_model_id, test_case):
+    class NBAStats(BaseModel):
+        year_for_draft: int
+        num_seasons_in_nba: int
+
     class AnswerFormat(BaseModel):
         first_name: str
         last_name: str
         year_of_birth: int
-        num_seasons_in_nba: int
+        nba_stats: NBAStats
 
     tc = TestCase(test_case)
 
@@ -364,7 +369,8 @@ def test_text_chat_completion_structured_output(client_with_models, text_model_i
     assert answer.first_name == expected["first_name"]
     assert answer.last_name == expected["last_name"]
     assert answer.year_of_birth == expected["year_of_birth"]
-    assert answer.num_seasons_in_nba == expected["num_seasons_in_nba"]
+    assert answer.nba_stats.num_seasons_in_nba == expected["num_seasons_in_nba"]
+    assert answer.nba_stats.year_for_draft == expected["year_for_draft"]
 
 
 @pytest.mark.parametrize("streaming", [True, False])


### PR DESCRIPTION
Handle recursive nature in the structured response_formats. 

Update test to include 1 nested model.

```
 LLAMA_STACK_CONFIG=dev pytest -s -v tests/client-sdk/inference/test_text_inference.py --inference-model "openai/gpt-4o-mini" -k test_text_chat_completion_structured_output
```