### PR TITLE
fix: [Litellm]Do not swallow first token

### DIFF
--- a/llama_stack/providers/utils/inference/openai_compat.py
+++ b/llama_stack/providers/utils/inference/openai_compat.py
@@ -841,12 +841,12 @@ async def convert_openai_chat_completion_stream(
     Convert a stream of OpenAI chat completion chunks into a stream
     of ChatCompletionResponseStreamChunk.
     """
-
-    # generate a stream of ChatCompletionResponseEventType: start -> progress -> progress -> ...
-    # def _event_type_generator() -> Generator[ChatCompletionResponseEventType, None, None]:
-    #     yield ChatCompletionResponseEventType.start
-    #     while True:
-    #         yield ChatCompletionResponseEventType.progress
+    yield ChatCompletionResponseStreamChunk(
+        event=ChatCompletionResponseEvent(
+            event_type=ChatCompletionResponseEventType.start,
+            delta=TextDelta(text=""),
+        )
+    )
     event_type = ChatCompletionResponseEventType.progress
 
     stop_reason = None


### PR DESCRIPTION
`ChatCompletionResponseEventType: start` is ignored and not yielded in the agent_instance as we expect that to not have any content. 

However, litellm sends first event as `ChatCompletionResponseEventType: start` with content ( which was the first token that we were skipping ) 

```
LLAMA_STACK_CONFIG=dev pytest -s -v tests/client-sdk/agents/test_agents.py --inference-model "openai/gpt-4o-mini" -k test_agent_simple
``` 
This was failing before ( since the word hello was not in the final response ) 