### PR TITLE
fix: update getting_started notebook to pass nbeval

### DIFF
--- a/docs/getting_started.ipynb
+++ b/docs/getting_started.ipynb
@@ -1145,6 +1145,7 @@
         }
       ],
       "source": [
+        "# NBVAL_SKIP\n",
         "from pydantic import BaseModel\n",
         "\n",
         "\n",
@@ -2885,7 +2886,6 @@
         }
       ],
       "source": [
-        "# NBVAL_SKIP\n",
         "from llama_stack_client.lib.agents.agent import Agent\n",
         "from llama_stack_client.lib.agents.event_logger import EventLogger\n",
         "from llama_stack_client.types.agent_create_params import AgentConfig\n",
@@ -4326,7 +4326,7 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "toolchain",
+      "display_name": "master",
       "language": "python",
       "name": "python3"
     },


### PR DESCRIPTION
# What does this PR do?

- See https://github.com/meta-llama/llama-stack-ops/actions/runs/13580825399/job/37966677766
- Together's structured decoding API is flaky, add skip to cell
- Enable cell 21 to pass cell 21-23

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan


<img width="652" alt="image" src="https://github.com/user-attachments/assets/a1e4b94b-c1ce-4869-ba0d-0860bfe33460" />


[//]: # (## Documentation)
