### PR TITLE
docs: Update llama-stack version in README.md

### DIFF
--- a/docs/zero_to_hero_guide/README.md
+++ b/docs/zero_to_hero_guide/README.md
@@ -73,7 +73,7 @@ If you're looking for more specific topics, we have a [Zero to Hero Guide](#next
    Open a new terminal and install `llama-stack`:
    ```bash
    conda activate ollama
-   pip install llama-stack==0.1.3
+   pip install -U llama-stack
    ```
 
 ---

--- a/docs/zero_to_hero_guide/README.md
+++ b/docs/zero_to_hero_guide/README.md
@@ -73,7 +73,7 @@ If you're looking for more specific topics, we have a [Zero to Hero Guide](#next
    Open a new terminal and install `llama-stack`:
    ```bash
    conda activate ollama
-   pip install llama-stack==0.1.0
+   pip install llama-stack==0.1.3
    ```
 
 ---


### PR DESCRIPTION
# What does this PR do?
This PR updates the version in the [README.md](https://github.com/meta-llama/llama-stack/blob/main/docs/zero_to_hero_guide/README.md) to reflect the latest changes in Llama Stack setup.

Previously, using **llama-stack==0.1.0** caused an error when running:
```bash
llama stack build --template ollama --image-type conda
```
Upgrading to llama-stack==0.1.3 resolves this issue.

## Test Plan
- Verified that `llama stack build --template ollama --image-type conda` works correctly.
