### PR TITLE
fix: raise error when request param failed to convert

### DIFF
--- a/llama_stack/distribution/library_client.py
+++ b/llama_stack/distribution/library_client.py
@@ -104,7 +104,7 @@ def convert_to_pydantic(annotation: Any, value: Any) -> Any:
             logger.warning(
                 f"Warning: direct client failed to convert parameter {value} into {annotation}: {e}",
             )
-        return value
+        raise ValueError(f"Failed to convert parameter {value} into {annotation}: {e}") from e
 
 
 class LlamaStackAsLibraryClient(LlamaStackClient):


### PR DESCRIPTION
# Summary:
This led to extremely hard to debug messages.
Before:

llama_stack/distribution/library_client.py:275: in request
    response = await self._call_non_streaming(
llama_stack/distribution/library_client.py:322: in _call_non_streaming
    result = await matched_func(**body)
llama_stack/providers/utils/telemetry/trace_protocol.py:102: in async_wrapper
    result = await method(self, *args, **kwargs)
llama_stack/providers/inline/agents/meta_reference/agents.py:80: in create_agent
    value=agent_config.model_dump_json(),
E   AttributeError: 'dict' object has no attribute 'model_dump_json'

After:

E   ValueError: Failed to convert parameter {'model': 'meta-llama/Llama-3.1-8B-Instruct', 'instructions': 'You are a helpful assistant', 'sampling_params': {'strategy': {'type': 'top_p', 'temperature': 0.0001, 'top_p': 0.9}}, 'toolgroups': [{'name': 'builtin::rag'}], 'input_shields': ['meta-llama/Llama-Guard-3-8B'], 'output_shields': ['meta-llama/Llama-Guard-3-8B'], 'enable_session_persistence': False} into <class 'llama_stack.apis.agents.agents.AgentConfig'>: 2 validation errors for AgentConfig
E   toolgroups.0.str
E     Input should be a valid string [type=string_type, input_value={'name': 'builtin::rag'}, input_type=dict]
E       For further information visit https://errors.pydantic.dev/2.10/v/string_type
E   toolgroups.0.AgentToolGroupWithArgs.args
E     Field required [type=missing, input_value={'name': 'builtin::rag'}, input_type=dict]
E       For further information visit https://errors.pydantic.dev/2.10/v/missing

# Test Plan:
LLAMA_STACK_CONFIG=fireworks pytest -s -v tests/client-sdk/ --safety-shield meta-llama/Llama-Guard-3-8B

