### PR TITLE
fix: not check for docker available when running with venv/conda

### DIFF
--- a/llama_stack/distribution/start_stack.sh
+++ b/llama_stack/distribution/start_stack.sh
@@ -100,11 +100,6 @@ esac
 
 set -x
 
-# Check if container command is available
-if ! is_command_available $CONTAINER_BINARY; then
-  printf "${RED}Error: ${CONTAINER_BINARY} command not found. Is ${CONTAINER_BINARY} installed and in your PATH?${NC}" >&2
-  exit 1
-fi
 
 if [[ "$env_type" == "venv" || "$env_type" == "conda" ]]; then
     $PYTHON_BINARY -m llama_stack.distribution.server.server \
@@ -113,6 +108,12 @@ if [[ "$env_type" == "venv" || "$env_type" == "conda" ]]; then
     $env_vars \
     $other_args
 elif [[ "$env_type" == "container" ]]; then
+    # Check if container command is available
+    if ! is_command_available $CONTAINER_BINARY; then
+        printf "${RED}Error: ${CONTAINER_BINARY} command not found. Is ${CONTAINER_BINARY} installed and in your PATH?${NC}" >&2
+        exit 1
+    fi
+
     if is_command_available selinuxenabled &> /dev/null && selinuxenabled; then
         # Disable SELinux labels
         CONTAINER_OPTS="$CONTAINER_OPTS --security-opt label=disable"


### PR DESCRIPTION
# What does this PR do?

When using `llama stack run --image-type venv`, we should not require `docker` to be available. 
<img width="758" alt="Screenshot 2025-03-02 at 3 58 38 PM" src="https://github.com/user-attachments/assets/4456aa6f-903f-4910-8e92-432352cb3538" />



[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan
```
llama stack run ./llama_stack/templates/dev/run.yaml --image-type venv
```
[//]: # (## Documentation)
