### PR TITLE
docs: add notes to websearch tool and two extra example scripts

### DIFF
--- a/docs/source/building_applications/tools.md
+++ b/docs/source/building_applications/tools.md
@@ -217,16 +217,15 @@ client = LlamaStackClient(
     base_url=f"http://localhost:8321",
     provider_data = {"tavily_search_api_key": "your_TAVILY_SEARCH_API_KEY"})  
 
-agent_config = AgentConfig(
+agent = Agent(
+    client, 
     model="meta-llama/Llama-3.2-3B-Instruct",
     instructions=(
         "You are a highly knowledgeable and helpful web search assistant. "
-        "Your primary goal is to provide accurate and reliable information to the user. "
         "Whenever you encounter a query, make sure to use the websearch tools to look up the most current and precise information available. "
     ),
-    toolgroups=["builtin::websearch"], 
-)
-agent = Agent(client, agent_config)
+    tools=["builtin::websearch"], 
+    )
 
 session_id = agent.create_session("websearch-session")
 
@@ -245,15 +244,17 @@ from llama_stack_client.types.agent_create_params import AgentConfig
 from llama_stack_client.lib.agents.event_logger import EventLogger
 from llama_stack_client import LlamaStackClient
 
-client = LlamaStackClient(base_url=f"http://localhost:8321")  
+client = LlamaStackClient(
+        base_url=f"http://localhost:8321", 
+        provider_data = {"wolfram_alpha_api_key": "your_wolfram_api_key"}
+    )
 
-agent_config = AgentConfig(
+agent = Agent(
+    client, 
     model="meta-llama/Llama-3.2-3B-Instruct",
     instructions="You are a helpful wolfram_alpha assistant, use wolfram_alpha tool as external source validation.",
-    toolgroups=["builtin::wolfram_alpha"],
-    wolfram_api_key="your_WOLFRAM_ALPHA_API_KEY",  
-)
-agent = Agent(client, agent_config)
+    tools=["builtin::wolfram_alpha"],
+    )
 
 session_id = agent.create_session("wolframa-alpha-session")
 

--- a/docs/source/building_applications/tools.md
+++ b/docs/source/building_applications/tools.md
@@ -221,8 +221,7 @@ agent = Agent(
     client, 
     model="meta-llama/Llama-3.2-3B-Instruct",
     instructions=(
-        "You are a highly knowledgeable and helpful web search assistant. "
-        "Whenever you encounter a query, make sure to use the websearch tools to look up the most current and precise information available. "
+        "You are a web search assistant, must use websearch tool to look up the most current and precise information available. "
     ),
     tools=["builtin::websearch"], 
     )
@@ -230,7 +229,7 @@ agent = Agent(
 session_id = agent.create_session("websearch-session")
 
 response = agent.create_turn(
-    messages=[{"role": "user", "content": "How US performed in the olympics?"}],
+    messages=[{"role": "user", "content": "How US performed in the latest olympics?"}],
     session_id=session_id,
 )
 for log in EventLogger().log(response):
@@ -252,14 +251,14 @@ client = LlamaStackClient(
 agent = Agent(
     client, 
     model="meta-llama/Llama-3.2-3B-Instruct",
-    instructions="You are a helpful wolfram_alpha assistant, use wolfram_alpha tool as external source validation.",
+    instructions="You are a helpful wolfram_alpha assistant, must use wolfram_alpha tool as external source validation.",
     tools=["builtin::wolfram_alpha"],
     )
 
 session_id = agent.create_session("wolframa-alpha-session")
 
 response = agent.create_turn(
-    messages=[{"role": "user", "content": "Tell me 10 densest elemental metals"}],
+    messages=[{"role": "user", "content": "solve x^2 + 2x + 1 = 0"}],
     session_id=session_id,
 )
 for log in EventLogger().log(response):

--- a/docs/source/building_applications/tools.md
+++ b/docs/source/building_applications/tools.md
@@ -41,7 +41,7 @@ client.toolgroups.register(
 
 The tool requires an API key which can be provided either in the configuration or through the request header `X-LlamaStack-Provider-Data`. The format of the header is `{"<provider_name>_api_key": <your api key>}`.
 
-
+> **NOTE:** When using Tavily Search and Bing Search, the inference output will still display "Brave Search." This is because Llama models have been trained with Brave Search as a built-in tool. Tavily and bing is just being used in lieu of Brave search.
 
 #### Code Interpreter
 
@@ -205,4 +205,62 @@ response = agent.create_turn(
     messages=[{"role": "user", "content": "Run this code: print(3 ** 4 - 5 * 2)"}],
     session_id=session_id,
 )
+```
+## Simple Example2: Using an Agent with the websearch Tool
+```python
+from llama_stack_client.lib.agents.agent import Agent
+from llama_stack_client.types.agent_create_params import AgentConfig
+from llama_stack_client.lib.agents.event_logger import EventLogger
+from llama_stack_client import LlamaStackClient
+
+client = LlamaStackClient(
+    base_url=f"http://localhost:8321",
+    provider_data = {"tavily_search_api_key": "your_TAVILY_SEARCH_API_KEY"})  
+
+agent_config = AgentConfig(
+    model="meta-llama/Llama-3.2-3B-Instruct",
+    instructions=(
+        "You are a highly knowledgeable and helpful web search assistant. "
+        "Your primary goal is to provide accurate and reliable information to the user. "
+        "Whenever you encounter a query, make sure to use the websearch tools to look up the most current and precise information available. "
+    ),
+    toolgroups=["builtin::websearch"], 
+)
+agent = Agent(client, agent_config)
+
+session_id = agent.create_session("websearch-session")
+
+response = agent.create_turn(
+    messages=[{"role": "user", "content": "How US performed in the olympics?"}],
+    session_id=session_id,
+)
+for log in EventLogger().log(response):
+    log.print()
+```
+
+## Simple Example3: Using an Agent with the WolframAlpha Tool
+```python
+from llama_stack_client.lib.agents.agent import Agent
+from llama_stack_client.types.agent_create_params import AgentConfig
+from llama_stack_client.lib.agents.event_logger import EventLogger
+from llama_stack_client import LlamaStackClient
+
+client = LlamaStackClient(base_url=f"http://localhost:8321")  
+
+agent_config = AgentConfig(
+    model="meta-llama/Llama-3.2-3B-Instruct",
+    instructions="You are a helpful wolfram_alpha assistant, use wolfram_alpha tool as external source validation.",
+    toolgroups=["builtin::wolfram_alpha"],
+    wolfram_api_key="your_WOLFRAM_ALPHA_API_KEY",  
+)
+agent = Agent(client, agent_config)
+
+session_id = agent.create_session("wolframa-alpha-session")
+
+response = agent.create_turn(
+    messages=[{"role": "user", "content": "Tell me 10 densest elemental metals"}],
+    session_id=session_id,
+)
+for log in EventLogger().log(response):
+    log.print()
 ```

--- a/docs/source/building_applications/tools.md
+++ b/docs/source/building_applications/tools.md
@@ -206,16 +206,20 @@ response = agent.create_turn(
     session_id=session_id,
 )
 ```
-## Simple Example2: Using an Agent with the websearch Tool
+## Simple Example 2: Using an Agent with the Web Search Tool
+1. Start by registering a Tavily API key at [Tavily](https://tavily.com/). 
+2. When starting the Llama Stack server, ensure the API key is provided as an environment variable:
+```
+--env TAVILY_SEARCH_API_KEY=${TAVILY_SEARCH_API_KEY}
+```
+3. run the following script.
 ```python
 from llama_stack_client.lib.agents.agent import Agent
 from llama_stack_client.types.agent_create_params import AgentConfig
 from llama_stack_client.lib.agents.event_logger import EventLogger
 from llama_stack_client import LlamaStackClient
 
-client = LlamaStackClient(
-    base_url=f"http://localhost:8321",
-    provider_data = {"tavily_search_api_key": "your_TAVILY_SEARCH_API_KEY"})  
+client = LlamaStackClient(base_url=f"http://localhost:8321")  
 
 agent = Agent(
     client, 
@@ -229,7 +233,7 @@ agent = Agent(
 session_id = agent.create_session("websearch-session")
 
 response = agent.create_turn(
-    messages=[{"role": "user", "content": "How US performed in the latest olympics?"}],
+    messages=[{"role": "user", "content": "How did the USA perform in the last Olympics?"}],
     session_id=session_id,
 )
 for log in EventLogger().log(response):
@@ -237,30 +241,17 @@ for log in EventLogger().log(response):
 ```
 
 ## Simple Example3: Using an Agent with the WolframAlpha Tool
-```python
-from llama_stack_client.lib.agents.agent import Agent
-from llama_stack_client.types.agent_create_params import AgentConfig
-from llama_stack_client.lib.agents.event_logger import EventLogger
-from llama_stack_client import LlamaStackClient
-
-client = LlamaStackClient(
-        base_url=f"http://localhost:8321", 
-        provider_data = {"wolfram_alpha_api_key": "your_wolfram_api_key"}
+1. Start by registering for a WolframAlpha API key at [WolframAlpha Developer Portal](https://developer.wolframalpha.com/access).
+2. When starting the Llama Stack server, ensure the API key is provided as an environment variable:
+    ```bash
+    --env WOLFRAM_ALPHA_API_KEY=${WOLFRAM_ALPHA_API_KEY}
+    ```
+3. Configure the tools in the Agent by setting `tools=["builtin::wolfram_alpha"]`.
+4. Example user query:
+    ```python
+    response = agent.create_turn(
+         messages=[{"role": "user", "content": "Solve x^2 + 2x + 1 = 0 using WolframAlpha"}],
+         session_id=session_id,
     )
-
-agent = Agent(
-    client, 
-    model="meta-llama/Llama-3.2-3B-Instruct",
-    instructions="You are a helpful wolfram_alpha assistant, must use wolfram_alpha tool as external source validation.",
-    tools=["builtin::wolfram_alpha"],
-    )
-
-session_id = agent.create_session("wolframa-alpha-session")
-
-response = agent.create_turn(
-    messages=[{"role": "user", "content": "solve x^2 + 2x + 1 = 0"}],
-    session_id=session_id,
-)
-for log in EventLogger().log(response):
-    log.print()
+    ```
 ```

--- a/docs/source/building_applications/tools.md
+++ b/docs/source/building_applications/tools.md
@@ -208,18 +208,24 @@ response = agent.create_turn(
 ```
 ## Simple Example 2: Using an Agent with the Web Search Tool
 1. Start by registering a Tavily API key at [Tavily](https://tavily.com/). 
-2. When starting the Llama Stack server, ensure the API key is provided as an environment variable:
+2. [Optional] Provide the API key directly to the Llama Stack server
+```bash
+export TAVILY_SEARCH_API_KEY="your key"
 ```
+```bash
 --env TAVILY_SEARCH_API_KEY=${TAVILY_SEARCH_API_KEY}
 ```
-3. run the following script.
+3. Run the following script.
 ```python
 from llama_stack_client.lib.agents.agent import Agent
 from llama_stack_client.types.agent_create_params import AgentConfig
 from llama_stack_client.lib.agents.event_logger import EventLogger
 from llama_stack_client import LlamaStackClient
 
-client = LlamaStackClient(base_url=f"http://localhost:8321")  
+client = LlamaStackClient(
+    base_url=f"http://localhost:8321",
+    provider_data = {"tavily_search_api_key": "your_TAVILY_SEARCH_API_KEY"}  # Set this from the client side. No need to provide it if it has already been configured on the Llama Stack server.
+    )   
 
 agent = Agent(
     client, 
@@ -242,9 +248,16 @@ for log in EventLogger().log(response):
 
 ## Simple Example3: Using an Agent with the WolframAlpha Tool
 1. Start by registering for a WolframAlpha API key at [WolframAlpha Developer Portal](https://developer.wolframalpha.com/access).
-2. When starting the Llama Stack server, ensure the API key is provided as an environment variable:
+2. Provide the API key either when starting the Llama Stack server:
     ```bash
     --env WOLFRAM_ALPHA_API_KEY=${WOLFRAM_ALPHA_API_KEY}
+    ```
+    or from the client side:
+    ```python
+    client = LlamaStackClient(
+        base_url="http://localhost:8321",
+        provider_data={"wolfram_alpha_api_key": wolfram_api_key}
+    )
     ```
 3. Configure the tools in the Agent by setting `tools=["builtin::wolfram_alpha"]`.
 4. Example user query:


### PR DESCRIPTION
# What does this PR do?

- Adds a note about unexpected Brave Search output appearing even when Tavily Search is called. This behavior is expected for now and is a work in progress https://github.com/meta-llama/llama-stack/issues/1229. The note aims to clear any confusion for new users.
- Adds two example scripts demonstrating how to build an agent using:
    1. WebSearch tool
    2. WolframAlpha tool
    These examples provide new users with an instant understanding of how to integrate these tools.

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan
Tested these example scripts using following steps:
step 1. `ollama run llama3.2:3b-instruct-fp16 --keepalive 60m`
step 2. 
```
export INFERENCE_MODEL="meta-llama/Llama-3.2-3B-Instruct"
export LLAMA_STACK_PORT=8321
```
step 3: `llama stack run --image-type conda ~/llama-stack/llama_stack/templates/ollama/run.yaml`
step 4: run the example script with your api keys.

expected output:
![image](https://github.com/user-attachments/assets/308ddb17-a087-4cf2-8622-b085174ea0ab)
![image](https://github.com/user-attachments/assets/639f239f-8966-433d-943c-ee6b304c0d71)


[//]: # (## Documentation)
