### PR TITLE
feat: add --log-level to `llama stack`

### DIFF
--- a/docs/source/distributions/building_distro.md
+++ b/docs/source/distributions/building_distro.md
@@ -183,9 +183,10 @@ Now, let's start the Llama Stack Distribution Server. You will need the YAML con
 
 ```
 llama stack run -h
-usage: llama stack run [-h] [--port PORT] [--image-name IMAGE_NAME] [--disable-ipv6] [--env KEY=VALUE] [--tls-keyfile TLS_KEYFILE]
-                       [--tls-certfile TLS_CERTFILE] [--image-type {conda,container,venv}]
+usage: llama stack run [-h] [--port PORT] [--image-name IMAGE_NAME] [--disable-ipv6] [--env KEY=VALUE] [--tls-keyfile TLS_KEYFILE] [--tls-certfile TLS_CERTFILE]
+                       [--image-type {conda,container,venv}]
                        config
+
 
 Start the server for a Llama Stack Distribution. You should have already built (or downloaded) and configured the distribution.
 

--- a/llama_stack/cli/stack/_build.py
+++ b/llama_stack/cli/stack/_build.py
@@ -212,7 +212,7 @@ def run_stack_build_command(args: argparse.Namespace) -> None:
         config_dict = yaml.safe_load(run_config.read_text())
         config = parse_and_maybe_upgrade_config(config_dict)
         run_args = formulate_run_args(args.image_type, args.image_name, config, args.template)
-        run_args.extend([run_config, str(os.getenv("LLAMA_STACK_PORT", 8321))])
+        run_args.extend([run_config, str(os.getenv("LLAMA_STACK_PORT", 8321)), "info"])
         run_with_pty(run_args)
 
 

--- a/llama_stack/cli/stack/run.py
+++ b/llama_stack/cli/stack/run.py
@@ -133,7 +133,8 @@ class StackRun(Subcommand):
 
         run_args = formulate_run_args(args.image_type, args.image_name, config, template_name)
 
-        run_args.extend([str(config_file), str(args.port)])
+        run_args.extend([str(config_file), str(args.port), str(args.log_level)])
+        print(run_args)
         if args.disable_ipv6:
             run_args.append("--disable-ipv6")
 

--- a/llama_stack/cli/stack/stack.py
+++ b/llama_stack/cli/stack/stack.py
@@ -32,6 +32,14 @@ class StackParser(Subcommand):
             version=f"{version('llama-stack')}",
         )
 
+        self.parser.add_argument(
+            "--log-level",
+            type=str,
+            choices=["debug", "info", "warning", "critical", "error"],
+            default="info",
+            help="Log level for the stack to use.",
+        )
+
         self.parser.set_defaults(func=lambda args: self.parser.print_help())
 
         subparsers = self.parser.add_subparsers(title="stack_subcommands")

--- a/llama_stack/distribution/server/server.py
+++ b/llama_stack/distribution/server/server.py
@@ -313,8 +313,6 @@ class ClientVersionMiddleware:
 
 
 def main():
-    logcat.init()
-
     """Start the LlamaStack server."""
     parser = argparse.ArgumentParser(description="Start the LlamaStack server.")
     parser.add_argument(
@@ -347,8 +345,19 @@ def main():
         help="Path to TLS certificate file for HTTPS",
         required="--tls-keyfile" in sys.argv,
     )
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        choices=["debug", "info", "warning", "critical", "error"],
+        default="info",
+        help="Log level for the running server to use.",
+    )
 
     args = parser.parse_args()
+
+    # convert info, debug, warning, critical, or error to valid logging level
+    log_level = logging._nameToLevel.get(args.log_level.upper(), logging.INFO)
+    logcat.init(default_level=log_level)
 
     if args.env:
         for env_pair in args.env:

--- a/llama_stack/distribution/start_stack.sh
+++ b/llama_stack/distribution/start_stack.sh
@@ -27,7 +27,7 @@ error_handler() {
 trap 'error_handler ${LINENO}' ERR
 
 if [ $# -lt 3 ]; then
-  echo "Usage: $0 <env_type> <env_path_or_name> <yaml_config> <port> <script_args...>"
+  echo "Usage: $0 <env_type> <env_path_or_name> <yaml_config> <port> <log_level> <script_args...>"
   exit 1
 fi
 
@@ -42,6 +42,9 @@ yaml_config="$1"
 shift
 
 port="$1"
+shift
+
+log_level="$1"
 shift
 
 SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
@@ -103,6 +106,7 @@ if [[ "$env_type" == "venv" || "$env_type" == "conda" ]]; then
     $PYTHON_BINARY -m llama_stack.distribution.server.server \
     --yaml-config "$yaml_config" \
     --port "$port" \
+    --log-level "$log_level" \
     $env_vars \
     $other_args
 elif [[ "$env_type" == "container" ]]; then


### PR DESCRIPTION
# What does this PR do?

logcat uses logging.INFO unless an environment variable is properly read in. Allow the user to pass `--log-level` with one of the valid stringified logging levels at run time

## Test Plan

tested locally with all available log levels and saw different output like: 

```console
DEBUG   15:42:01.306 server.py:448        server Serving API telemetry
DEBUG   15:42:01.310 server.py:448        server Serving API datasets
DEBUG   15:42:01.312 server.py:448        server Serving API benchmarks
DEBUG   15:42:01.321 server.py:448        server Serving API eval
DEBUG   15:42:01.324 server.py:448        server Serving API vector_io
DEBUG   15:42:01.327 server.py:448        server Serving API models
DEBUG   15:42:01.329 server.py:448        server Serving API safety
DEBUG   15:42:01.333 server.py:448        server Serving API scoring
DEBUG   15:42:01.335 server.py:448        server Serving API vector_dbs
DEBUG   15:42:01.372 server.py:448        server Serving API scoring_functions
DEBUG   15:42:01.383 server.py:448        server Serving API inference
DEBUG   15:42:01.387 server.py:448        server Serving API tool_runtime
DEBUG   15:42:01.388 server.py:448        server Serving API shields
DEBUG   15:42:01.389 server.py:448        server Serving API tool_groups
DEBUG   15:42:01.390 server.py:448        server Serving API datasetio
DEBUG   15:42:01.398 server.py:448        server Serving API agents
DEBUG   15:42:01.398 server.py:448        server Serving API inspect
```
with debug level, vs without a log-level specific or using `warning` or `info`, there were less logs.