### PR TITLE
feat: [WIP][RFC] simplify post training apis

### DIFF
--- a/llama_stack/apis/post_training/post_training.py
+++ b/llama_stack/apis/post_training/post_training.py
@@ -43,7 +43,7 @@ class OptimizerConfig(BaseModel):
 @json_schema_type
 class TrainingConfig(BaseModel):
     data_config: DataConfig
-    optimizer_config: OptimizerConfig
+    optimizer_config: Optional[OptimizerConfig] = OptimizerConfig()
     n_epochs: Optional[int] = 1
     max_steps_per_epoch: Optional[int] = None
     gradient_accumulation_steps: Optional[int] = 1
@@ -159,8 +159,6 @@ class PostTraining(Protocol):
         self,
         job_uuid: str,
         training_config: TrainingConfig,
-        hyperparam_search_config: Dict[str, Any],
-        logger_config: Dict[str, Any],
         model: str = Field(
             default="Llama3.2-3B-Instruct",
             description="Model descriptor from `llama model list`",

--- a/llama_stack/apis/post_training/post_training.py
+++ b/llama_stack/apis/post_training/post_training.py
@@ -18,13 +18,6 @@ from llama_stack.schema_utils import json_schema_type, register_schema, webmetho
 
 
 @json_schema_type
-class OptimizerType(Enum):
-    adam = "adam"
-    adamw = "adamw"
-    sgd = "sgd"
-
-
-@json_schema_type
 class DatasetFormat(Enum):
     instruct = "instruct"
     dialog = "dialog"
@@ -33,50 +26,39 @@ class DatasetFormat(Enum):
 @json_schema_type
 class DataConfig(BaseModel):
     dataset_id: str
-    batch_size: int
-    shuffle: bool
-    data_format: DatasetFormat
+    batch_size: Optional[int] = 1
+    shuffle: Optional[bool] = True
+    data_format: Optional[DatasetFormat] = DatasetFormat.instruct
     validation_dataset_id: Optional[str] = None
-    packed: Optional[bool] = False
     train_on_input: Optional[bool] = False
 
 
 @json_schema_type
 class OptimizerConfig(BaseModel):
-    optimizer_type: OptimizerType
-    lr: float
-    weight_decay: float
-    num_warmup_steps: int
-
-
-@json_schema_type
-class EfficiencyConfig(BaseModel):
-    enable_activation_checkpointing: Optional[bool] = False
-    enable_activation_offloading: Optional[bool] = False
-    memory_efficient_fsdp_wrap: Optional[bool] = False
-    fsdp_cpu_offload: Optional[bool] = False
+    lr: Optional[float] = 2e-5
+    weight_decay: Optional[float] = 0.1
+    num_warmup_steps: Optional[int] = 20
 
 
 @json_schema_type
 class TrainingConfig(BaseModel):
-    n_epochs: int
-    max_steps_per_epoch: int
-    gradient_accumulation_steps: int
-    max_validation_steps: int
     data_config: DataConfig
     optimizer_config: OptimizerConfig
-    efficiency_config: Optional[EfficiencyConfig] = None
+    n_epochs: Optional[int] = 1
+    max_steps_per_epoch: Optional[int] = None
+    gradient_accumulation_steps: Optional[int] = 1
+    max_validation_steps: Optional[int] = None
     dtype: Optional[str] = "bf16"
 
 
 @json_schema_type
 class LoraFinetuningConfig(BaseModel):
     type: Literal["LoRA"] = "LoRA"
-    lora_attn_modules: List[str]
-    apply_lora_to_mlp: bool
-    apply_lora_to_output: bool
-    rank: int
-    alpha: int
+    lora_attn_modules: Optional[List[str]] = ["q_proj", "v_proj", "output_proj"]
+    apply_lora_to_mlp: Optional[bool] = True
+    apply_lora_to_output: Optional[bool] = False
+    rank: Optional[int] = 8
+    alpha: Optional[int] = 16
     use_dora: Optional[bool] = False
     quantize_base: Optional[bool] = False
 

--- a/llama_stack/apis/post_training/post_training.py
+++ b/llama_stack/apis/post_training/post_training.py
@@ -19,7 +19,7 @@ from llama_stack.schema_utils import json_schema_type, register_schema, webmetho
 @json_schema_type
 class TrainingStrategy(BaseModel):
     # params that control Optimizer
-    lr: Optional[Union[float, Literal["auto"]]] = "auto" 
+    learning_rate: Optional[Union[float, Literal["auto"]]] = "auto" 
     weight_decay: Optional[float] = 0.1
     num_warmup_steps: Optional[Union[int, Literal["auto"]]] = "auto" 
     

--- a/llama_stack/apis/post_training/post_training.py
+++ b/llama_stack/apis/post_training/post_training.py
@@ -19,19 +19,19 @@ from llama_stack.schema_utils import json_schema_type, register_schema, webmetho
 @json_schema_type
 class TrainingStrategy(BaseModel):
     # params that control Optimizer
-    lr: Optional[float] = 2e-5
+    lr: Optional[Union[float, Literal["auto"]]] = "auto" 
     weight_decay: Optional[float] = 0.1
-    num_warmup_steps: Optional[int] = 0
+    num_warmup_steps: Optional[Union[int, Literal["auto"]]] = "auto" 
     
     # paramas that control how data is fed for training
-    batch_size: Optional[int] = 1
+    batch_size: Optional[Union[int, Literal["auto"]]] = "auto" 
     shuffle: Optional[bool] = True
     n_epochs: Optional[int] = 3
     
     # training loop control params
     max_training_steps: Optional[int] = None
     max_validation_steps: Optional[int] = None
-    gradient_accumulation_steps: Optional[int] = 1
+    gradient_accumulation_steps: Optional[Union[int, Literal["auto"]]] = "auto" 
     
     # precision for training
     dtype: Optional[str] = "bf16"


### PR DESCRIPTION
## What does this PR do?

### update per conversation with @hardikjshah 
- consolidate the 2 SFT dataset type to 1  (list of messages. For instruct format, length of the message is 1. For dialog format, length of the message < 1)
- Further cutdown the hyperparameters num and simplify the api structure
- make several params as auto to automatically calculate those values based on GPU type, training data size / distribution etc



---------------------------------------

We think the current post training api design is over complicated and not amateur developer friendly. In this RFC, we proposed to make 2 changes: 
- Remove OptimizerType, EfficiencyConfig, hyperparam_search_config and logger_config. Rational behind this:
  - OptimizerType: Almost all the llm training are using AdamW as optimizer. We barely see developes need to change optimize type during post training or have the expertise to know the difference between optimizer types
  - EfficiencyConfig: It's needed deep post training infra knowledge and is too specific to torchtune. We should config the optimal setting for efficiency without exposing it to developers. 
  - hyperparam_search_config and logger_config: We don't support these 2 now.
- Make other params optional and provider default value for them. 
  -  We'd like to streamline the most basic developer experience as developer only need to provider dataset and base model and they can kick off a sft job
  - We still want to expose certainly params to expert developers that they can control their post training job as much as possible
  - We believe it can balance the flexibility and user-friendliness

**todo**: after we align on the changes, we will change the torchtune provider implementation accordingly to accommodate this change 