### PR TITLE
fix: remove ruff N999

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -3,4 +3,3 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
-# ruff: noqa: N999

--- a/tests/integration/agents/__init__.py
+++ b/tests/integration/agents/__init__.py
@@ -3,4 +3,3 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
-# ruff: noqa: N999

--- a/tests/integration/inference/__init__.py
+++ b/tests/integration/inference/__init__.py
@@ -3,4 +3,3 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
-# ruff: noqa: N999

--- a/tests/integration/safety/__init__.py
+++ b/tests/integration/safety/__init__.py
@@ -3,4 +3,3 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
-# ruff: noqa: N999

--- a/tests/integration/vector_io/__init__.py
+++ b/tests/integration/vector_io/__init__.py
@@ -3,4 +3,3 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
-# ruff: noqa: N999


### PR DESCRIPTION
# What does this PR do?

Since we moved the move tests/client-sdk to tests/api in https://github.com/meta-llama/llama-stack/pull/1376. The N999 rule is not needed anymore. And furthermore in
https://github.com/meta-llama/llama-stack/commit/abfbaf3c1baa067a7b5feb0866ac8ab565119a3c

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan
[Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.*]

[//]: # (## Documentation)
