### PR TITLE
feat: add metrics query API

### DIFF
--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -1251,6 +1251,58 @@
                 ]
             }
         },
+        "/v1/telemetry/metrics/{metric_name}": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetMetricsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest400"
+                    },
+                    "429": {
+                        "$ref": "#/components/responses/TooManyRequests429"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError500"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultError"
+                    }
+                },
+                "tags": [
+                    "Telemetry"
+                ],
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "metric_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/GetMetricsRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                }
+            }
+        },
         "/v1/models/{model_id}": {
             "get": {
                 "responses": {
@@ -7558,6 +7610,127 @@
                 ],
                 "title": "FileResponse",
                 "description": "Response representing a file entry."
+            },
+            "GetMetricsRequest": {
+                "type": "object",
+                "properties": {
+                    "start_time": {
+                        "type": "integer"
+                    },
+                    "end_time": {
+                        "type": "integer"
+                    },
+                    "step": {
+                        "type": "string"
+                    },
+                    "query_type": {
+                        "type": "string",
+                        "enum": [
+                            "range",
+                            "instant"
+                        ],
+                        "title": "MetricQueryType"
+                    },
+                    "label_matchers": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "operator": {
+                                    "type": "string",
+                                    "enum": [
+                                        "=",
+                                        "!=",
+                                        "=~",
+                                        "!~"
+                                    ],
+                                    "title": "MetricLabelOperator",
+                                    "default": "="
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value",
+                                "operator"
+                            ],
+                            "title": "MetricLabelMatcher"
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "start_time",
+                    "query_type"
+                ],
+                "title": "GetMetricsRequest"
+            },
+            "MetricDataPoint": {
+                "type": "object",
+                "properties": {
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "value": {
+                        "type": "number"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "timestamp",
+                    "value"
+                ],
+                "title": "MetricDataPoint"
+            },
+            "MetricSeries": {
+                "type": "object",
+                "properties": {
+                    "metric": {
+                        "type": "string"
+                    },
+                    "labels": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "values": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MetricDataPoint"
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "metric",
+                    "labels",
+                    "values"
+                ],
+                "title": "MetricSeries"
+            },
+            "GetMetricsResponse": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MetricSeries"
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "data"
+                ],
+                "title": "GetMetricsResponse"
             },
             "Model": {
                 "type": "object",

--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -4945,7 +4945,11 @@
                     "metrics": {
                         "type": "array",
                         "items": {
+<<<<<<< HEAD
                             "$ref": "#/components/schemas/MetricInResponse"
+=======
+                            "$ref": "#/components/schemas/MetricEvent"
+>>>>>>> 6ab59fb65 (return metric labels as list)
                         }
                     },
                     "content": {
@@ -5273,7 +5277,11 @@
                     "metrics": {
                         "type": "array",
                         "items": {
+<<<<<<< HEAD
                             "$ref": "#/components/schemas/MetricInResponse"
+=======
+                            "$ref": "#/components/schemas/MetricEvent"
+>>>>>>> 6ab59fb65 (return metric labels as list)
                         }
                     },
                     "delta": {
@@ -7967,6 +7975,301 @@
                     }
                 }
             },
+<<<<<<< HEAD
+=======
+            "StringType": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "const": "string",
+                        "default": "string"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "type"
+                ],
+                "title": "StringType"
+            },
+            "UnionType": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "const": "union",
+                        "default": "union"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "type"
+                ],
+                "title": "UnionType"
+            },
+            "MetricLabelMatcher": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "string"
+                    },
+                    "operator": {
+                        "$ref": "#/components/schemas/MetricLabelOperator",
+                        "default": "="
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "value",
+                    "operator"
+                ],
+                "title": "MetricLabelMatcher"
+            },
+            "MetricLabelOperator": {
+                "type": "string",
+                "enum": [
+                    "=",
+                    "!=",
+                    "=~",
+                    "!~"
+                ],
+                "title": "MetricLabelOperator"
+            },
+            "MetricQueryType": {
+                "type": "string",
+                "enum": [
+                    "range",
+                    "instant"
+                ],
+                "title": "MetricQueryType"
+            },
+            "GetMetricsRequest": {
+                "type": "object",
+                "properties": {
+                    "start_time": {
+                        "type": "integer"
+                    },
+                    "end_time": {
+                        "type": "integer"
+                    },
+                    "step": {
+                        "type": "string"
+                    },
+                    "query_type": {
+                        "$ref": "#/components/schemas/MetricQueryType"
+                    },
+                    "label_matchers": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MetricLabelMatcher"
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "start_time",
+                    "query_type"
+                ],
+                "title": "GetMetricsRequest"
+            },
+            "GetMetricsResponse": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MetricSeries"
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "data"
+                ],
+                "title": "GetMetricsResponse"
+            },
+            "MetricDataPoint": {
+                "type": "object",
+                "properties": {
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "value": {
+                        "type": "number"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "timestamp",
+                    "value"
+                ],
+                "title": "MetricDataPoint"
+            },
+            "MetricLabel": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "value"
+                ],
+                "title": "MetricLabel"
+            },
+            "MetricSeries": {
+                "type": "object",
+                "properties": {
+                    "metric": {
+                        "type": "string"
+                    },
+                    "labels": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MetricLabel"
+                        }
+                    },
+                    "values": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MetricDataPoint"
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "metric",
+                    "labels",
+                    "values"
+                ],
+                "title": "MetricSeries"
+            },
+            "Model": {
+                "type": "object",
+                "properties": {
+                    "identifier": {
+                        "type": "string"
+                    },
+                    "provider_resource_id": {
+                        "type": "string"
+                    },
+                    "provider_id": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string",
+                        "const": "model",
+                        "default": "model"
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "type": "boolean"
+                                },
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    },
+                    "model_type": {
+                        "$ref": "#/components/schemas/ModelType",
+                        "default": "llm"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "identifier",
+                    "provider_resource_id",
+                    "provider_id",
+                    "type",
+                    "metadata",
+                    "model_type"
+                ],
+                "title": "Model"
+            },
+            "ModelType": {
+                "type": "string",
+                "enum": [
+                    "llm",
+                    "embedding"
+                ],
+                "title": "ModelType"
+            },
+            "PaginatedRowsResult": {
+                "type": "object",
+                "properties": {
+                    "rows": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "oneOf": [
+                                    {
+                                        "type": "null"
+                                    },
+                                    {
+                                        "type": "boolean"
+                                    },
+                                    {
+                                        "type": "number"
+                                    },
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "object"
+                                    }
+                                ]
+                            }
+                        },
+                        "description": "The rows in the current page."
+                    },
+                    "total_count": {
+                        "type": "integer",
+                        "description": "The total number of rows in the dataset."
+                    },
+                    "next_page_token": {
+                        "type": "string",
+                        "description": "The token to get the next page of rows."
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "rows",
+                    "total_count"
+                ],
+                "title": "PaginatedRowsResult",
+                "description": "A paginated list of rows from a dataset."
+            },
+>>>>>>> 6ab59fb65 (return metric labels as list)
             "ScoringFn": {
                 "type": "object",
                 "properties": {

--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -1251,58 +1251,6 @@
                 ]
             }
         },
-        "/v1/telemetry/metrics/{metric_name}": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/GetMetricsResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/BadRequest400"
-                    },
-                    "429": {
-                        "$ref": "#/components/responses/TooManyRequests429"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError500"
-                    },
-                    "default": {
-                        "$ref": "#/components/responses/DefaultError"
-                    }
-                },
-                "tags": [
-                    "Telemetry"
-                ],
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "metric_name",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/GetMetricsRequest"
-                            }
-                        }
-                    },
-                    "required": true
-                }
-            }
-        },
         "/v1/models/{model_id}": {
             "get": {
                 "responses": {
@@ -3483,6 +3431,58 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/QueryChunksRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                }
+            }
+        },
+        "/v1/telemetry/metrics/{metric_name}": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/QueryMetricsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest400"
+                    },
+                    "429": {
+                        "$ref": "#/components/responses/TooManyRequests429"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError500"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultError"
+                    }
+                },
+                "tags": [
+                    "Telemetry"
+                ],
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "metric_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/QueryMetricsRequest"
                             }
                         }
                     },
@@ -7611,143 +7611,6 @@
                 "title": "FileResponse",
                 "description": "Response representing a file entry."
             },
-            "GetMetricsRequest": {
-                "type": "object",
-                "properties": {
-                    "start_time": {
-                        "type": "integer"
-                    },
-                    "end_time": {
-                        "type": "integer"
-                    },
-                    "granularity": {
-                        "type": "string"
-                    },
-                    "query_type": {
-                        "type": "string",
-                        "enum": [
-                            "range",
-                            "instant"
-                        ],
-                        "title": "MetricQueryType"
-                    },
-                    "label_matchers": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                },
-                                "value": {
-                                    "type": "string"
-                                },
-                                "operator": {
-                                    "type": "string",
-                                    "enum": [
-                                        "=",
-                                        "!=",
-                                        "=~",
-                                        "!~"
-                                    ],
-                                    "title": "MetricLabelOperator",
-                                    "default": "="
-                                }
-                            },
-                            "additionalProperties": false,
-                            "required": [
-                                "name",
-                                "value",
-                                "operator"
-                            ],
-                            "title": "MetricLabelMatcher"
-                        }
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "start_time",
-                    "query_type"
-                ],
-                "title": "GetMetricsRequest"
-            },
-            "MetricDataPoint": {
-                "type": "object",
-                "properties": {
-                    "timestamp": {
-                        "type": "integer"
-                    },
-                    "value": {
-                        "type": "number"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "timestamp",
-                    "value"
-                ],
-                "title": "MetricDataPoint"
-            },
-            "MetricLabel": {
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "value": {
-                        "type": "string"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "name",
-                    "value"
-                ],
-                "title": "MetricLabel"
-            },
-            "MetricSeries": {
-                "type": "object",
-                "properties": {
-                    "metric": {
-                        "type": "string"
-                    },
-                    "labels": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/MetricLabel"
-                        }
-                    },
-                    "values": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/MetricDataPoint"
-                        }
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "metric",
-                    "labels",
-                    "values"
-                ],
-                "title": "MetricSeries"
-            },
-            "GetMetricsResponse": {
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/MetricSeries"
-                        }
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "data"
-                ],
-                "title": "GetMetricsResponse"
-            },
             "Model": {
                 "type": "object",
                 "properties": {
@@ -11248,6 +11111,143 @@
                     "scores"
                 ],
                 "title": "QueryChunksResponse"
+            },
+            "QueryMetricsRequest": {
+                "type": "object",
+                "properties": {
+                    "start_time": {
+                        "type": "integer"
+                    },
+                    "end_time": {
+                        "type": "integer"
+                    },
+                    "granularity": {
+                        "type": "string"
+                    },
+                    "query_type": {
+                        "type": "string",
+                        "enum": [
+                            "range",
+                            "instant"
+                        ],
+                        "title": "MetricQueryType"
+                    },
+                    "label_matchers": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "operator": {
+                                    "type": "string",
+                                    "enum": [
+                                        "=",
+                                        "!=",
+                                        "=~",
+                                        "!~"
+                                    ],
+                                    "title": "MetricLabelOperator",
+                                    "default": "="
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "value",
+                                "operator"
+                            ],
+                            "title": "MetricLabelMatcher"
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "start_time",
+                    "query_type"
+                ],
+                "title": "QueryMetricsRequest"
+            },
+            "MetricDataPoint": {
+                "type": "object",
+                "properties": {
+                    "timestamp": {
+                        "type": "integer"
+                    },
+                    "value": {
+                        "type": "number"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "timestamp",
+                    "value"
+                ],
+                "title": "MetricDataPoint"
+            },
+            "MetricLabel": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "value"
+                ],
+                "title": "MetricLabel"
+            },
+            "MetricSeries": {
+                "type": "object",
+                "properties": {
+                    "metric": {
+                        "type": "string"
+                    },
+                    "labels": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MetricLabel"
+                        }
+                    },
+                    "values": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MetricDataPoint"
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "metric",
+                    "labels",
+                    "values"
+                ],
+                "title": "MetricSeries"
+            },
+            "QueryMetricsResponse": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MetricSeries"
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "data"
+                ],
+                "title": "QueryMetricsResponse"
             },
             "QueryCondition": {
                 "type": "object",

--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -4945,11 +4945,7 @@
                     "metrics": {
                         "type": "array",
                         "items": {
-<<<<<<< HEAD
                             "$ref": "#/components/schemas/MetricInResponse"
-=======
-                            "$ref": "#/components/schemas/MetricEvent"
->>>>>>> 6ab59fb65 (return metric labels as list)
                         }
                     },
                     "content": {
@@ -5277,11 +5273,7 @@
                     "metrics": {
                         "type": "array",
                         "items": {
-<<<<<<< HEAD
                             "$ref": "#/components/schemas/MetricInResponse"
-=======
-                            "$ref": "#/components/schemas/MetricEvent"
->>>>>>> 6ab59fb65 (return metric labels as list)
                         }
                     },
                     "delta": {
@@ -7628,7 +7620,7 @@
                     "end_time": {
                         "type": "integer"
                     },
-                    "step": {
+                    "granularity": {
                         "type": "string"
                     },
                     "query_type": {
@@ -7683,8 +7675,7 @@
                 "type": "object",
                 "properties": {
                     "timestamp": {
-                        "type": "string",
-                        "format": "date-time"
+                        "type": "integer"
                     },
                     "value": {
                         "type": "number"
@@ -7697,6 +7688,23 @@
                 ],
                 "title": "MetricDataPoint"
             },
+            "MetricLabel": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "value"
+                ],
+                "title": "MetricLabel"
+            },
             "MetricSeries": {
                 "type": "object",
                 "properties": {
@@ -7704,9 +7712,9 @@
                         "type": "string"
                     },
                     "labels": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "string"
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MetricLabel"
                         }
                     },
                     "values": {
@@ -7975,301 +7983,6 @@
                     }
                 }
             },
-<<<<<<< HEAD
-=======
-            "StringType": {
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "const": "string",
-                        "default": "string"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "type"
-                ],
-                "title": "StringType"
-            },
-            "UnionType": {
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "const": "union",
-                        "default": "union"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "type"
-                ],
-                "title": "UnionType"
-            },
-            "MetricLabelMatcher": {
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "value": {
-                        "type": "string"
-                    },
-                    "operator": {
-                        "$ref": "#/components/schemas/MetricLabelOperator",
-                        "default": "="
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "name",
-                    "value",
-                    "operator"
-                ],
-                "title": "MetricLabelMatcher"
-            },
-            "MetricLabelOperator": {
-                "type": "string",
-                "enum": [
-                    "=",
-                    "!=",
-                    "=~",
-                    "!~"
-                ],
-                "title": "MetricLabelOperator"
-            },
-            "MetricQueryType": {
-                "type": "string",
-                "enum": [
-                    "range",
-                    "instant"
-                ],
-                "title": "MetricQueryType"
-            },
-            "GetMetricsRequest": {
-                "type": "object",
-                "properties": {
-                    "start_time": {
-                        "type": "integer"
-                    },
-                    "end_time": {
-                        "type": "integer"
-                    },
-                    "step": {
-                        "type": "string"
-                    },
-                    "query_type": {
-                        "$ref": "#/components/schemas/MetricQueryType"
-                    },
-                    "label_matchers": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/MetricLabelMatcher"
-                        }
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "start_time",
-                    "query_type"
-                ],
-                "title": "GetMetricsRequest"
-            },
-            "GetMetricsResponse": {
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/MetricSeries"
-                        }
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "data"
-                ],
-                "title": "GetMetricsResponse"
-            },
-            "MetricDataPoint": {
-                "type": "object",
-                "properties": {
-                    "timestamp": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "value": {
-                        "type": "number"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "timestamp",
-                    "value"
-                ],
-                "title": "MetricDataPoint"
-            },
-            "MetricLabel": {
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "value": {
-                        "type": "string"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "name",
-                    "value"
-                ],
-                "title": "MetricLabel"
-            },
-            "MetricSeries": {
-                "type": "object",
-                "properties": {
-                    "metric": {
-                        "type": "string"
-                    },
-                    "labels": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/MetricLabel"
-                        }
-                    },
-                    "values": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/MetricDataPoint"
-                        }
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "metric",
-                    "labels",
-                    "values"
-                ],
-                "title": "MetricSeries"
-            },
-            "Model": {
-                "type": "object",
-                "properties": {
-                    "identifier": {
-                        "type": "string"
-                    },
-                    "provider_resource_id": {
-                        "type": "string"
-                    },
-                    "provider_id": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "type": "string",
-                        "const": "model",
-                        "default": "model"
-                    },
-                    "metadata": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "oneOf": [
-                                {
-                                    "type": "null"
-                                },
-                                {
-                                    "type": "boolean"
-                                },
-                                {
-                                    "type": "number"
-                                },
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "object"
-                                }
-                            ]
-                        }
-                    },
-                    "model_type": {
-                        "$ref": "#/components/schemas/ModelType",
-                        "default": "llm"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "identifier",
-                    "provider_resource_id",
-                    "provider_id",
-                    "type",
-                    "metadata",
-                    "model_type"
-                ],
-                "title": "Model"
-            },
-            "ModelType": {
-                "type": "string",
-                "enum": [
-                    "llm",
-                    "embedding"
-                ],
-                "title": "ModelType"
-            },
-            "PaginatedRowsResult": {
-                "type": "object",
-                "properties": {
-                    "rows": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "oneOf": [
-                                    {
-                                        "type": "null"
-                                    },
-                                    {
-                                        "type": "boolean"
-                                    },
-                                    {
-                                        "type": "number"
-                                    },
-                                    {
-                                        "type": "string"
-                                    },
-                                    {
-                                        "type": "array"
-                                    },
-                                    {
-                                        "type": "object"
-                                    }
-                                ]
-                            }
-                        },
-                        "description": "The rows in the current page."
-                    },
-                    "total_count": {
-                        "type": "integer",
-                        "description": "The total number of rows in the dataset."
-                    },
-                    "next_page_token": {
-                        "type": "string",
-                        "description": "The token to get the next page of rows."
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "rows",
-                    "total_count"
-                ],
-                "title": "PaginatedRowsResult",
-                "description": "A paginated list of rows from a dataset."
-            },
->>>>>>> 6ab59fb65 (return metric labels as list)
             "ScoringFn": {
                 "type": "object",
                 "properties": {

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -857,40 +857,6 @@ paths:
           required: true
           schema:
             type: string
-  /v1/telemetry/metrics/{metric_name}:
-    post:
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetMetricsResponse'
-        '400':
-          $ref: '#/components/responses/BadRequest400'
-        '429':
-          $ref: >-
-            #/components/responses/TooManyRequests429
-        '500':
-          $ref: >-
-            #/components/responses/InternalServerError500
-        default:
-          $ref: '#/components/responses/DefaultError'
-      tags:
-        - Telemetry
-      description: ''
-      parameters:
-        - name: metric_name
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/GetMetricsRequest'
-        required: true
   /v1/models/{model_id}:
     get:
       responses:
@@ -2404,6 +2370,40 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/QueryChunksRequest'
+        required: true
+  /v1/telemetry/metrics/{metric_name}:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryMetricsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+        '429':
+          $ref: >-
+            #/components/responses/TooManyRequests429
+        '500':
+          $ref: >-
+            #/components/responses/InternalServerError500
+        default:
+          $ref: '#/components/responses/DefaultError'
+      tags:
+        - Telemetry
+      description: ''
+      parameters:
+        - name: metric_name
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QueryMetricsRequest'
         required: true
   /v1/telemetry/spans:
     post:
@@ -5307,104 +5307,6 @@ components:
         - created_at
       title: FileResponse
       description: Response representing a file entry.
-    GetMetricsRequest:
-      type: object
-      properties:
-        start_time:
-          type: integer
-        end_time:
-          type: integer
-        granularity:
-          type: string
-        query_type:
-          type: string
-          enum:
-            - range
-            - instant
-          title: MetricQueryType
-        label_matchers:
-          type: array
-          items:
-            type: object
-            properties:
-              name:
-                type: string
-              value:
-                type: string
-              operator:
-                type: string
-                enum:
-                  - '='
-                  - '!='
-                  - =~
-                  - '!~'
-                title: MetricLabelOperator
-                default: '='
-            additionalProperties: false
-            required:
-              - name
-              - value
-              - operator
-            title: MetricLabelMatcher
-      additionalProperties: false
-      required:
-        - start_time
-        - query_type
-      title: GetMetricsRequest
-    MetricDataPoint:
-      type: object
-      properties:
-        timestamp:
-          type: integer
-        value:
-          type: number
-      additionalProperties: false
-      required:
-        - timestamp
-        - value
-      title: MetricDataPoint
-    MetricLabel:
-      type: object
-      properties:
-        name:
-          type: string
-        value:
-          type: string
-      additionalProperties: false
-      required:
-        - name
-        - value
-      title: MetricLabel
-    MetricSeries:
-      type: object
-      properties:
-        metric:
-          type: string
-        labels:
-          type: array
-          items:
-            $ref: '#/components/schemas/MetricLabel'
-        values:
-          type: array
-          items:
-            $ref: '#/components/schemas/MetricDataPoint'
-      additionalProperties: false
-      required:
-        - metric
-        - labels
-        - values
-      title: MetricSeries
-    GetMetricsResponse:
-      type: object
-      properties:
-        data:
-          type: array
-          items:
-            $ref: '#/components/schemas/MetricSeries'
-      additionalProperties: false
-      required:
-        - data
-      title: GetMetricsResponse
     Model:
       type: object
       properties:
@@ -7711,6 +7613,104 @@ components:
         - chunks
         - scores
       title: QueryChunksResponse
+    QueryMetricsRequest:
+      type: object
+      properties:
+        start_time:
+          type: integer
+        end_time:
+          type: integer
+        granularity:
+          type: string
+        query_type:
+          type: string
+          enum:
+            - range
+            - instant
+          title: MetricQueryType
+        label_matchers:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              value:
+                type: string
+              operator:
+                type: string
+                enum:
+                  - '='
+                  - '!='
+                  - =~
+                  - '!~'
+                title: MetricLabelOperator
+                default: '='
+            additionalProperties: false
+            required:
+              - name
+              - value
+              - operator
+            title: MetricLabelMatcher
+      additionalProperties: false
+      required:
+        - start_time
+        - query_type
+      title: QueryMetricsRequest
+    MetricDataPoint:
+      type: object
+      properties:
+        timestamp:
+          type: integer
+        value:
+          type: number
+      additionalProperties: false
+      required:
+        - timestamp
+        - value
+      title: MetricDataPoint
+    MetricLabel:
+      type: object
+      properties:
+        name:
+          type: string
+        value:
+          type: string
+      additionalProperties: false
+      required:
+        - name
+        - value
+      title: MetricLabel
+    MetricSeries:
+      type: object
+      properties:
+        metric:
+          type: string
+        labels:
+          type: array
+          items:
+            $ref: '#/components/schemas/MetricLabel'
+        values:
+          type: array
+          items:
+            $ref: '#/components/schemas/MetricDataPoint'
+      additionalProperties: false
+      required:
+        - metric
+        - labels
+        - values
+      title: MetricSeries
+    QueryMetricsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/MetricSeries'
+      additionalProperties: false
+      required:
+        - data
+      title: QueryMetricsResponse
     QueryCondition:
       type: object
       properties:

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -3434,11 +3434,7 @@ components:
         metrics:
           type: array
           items:
-<<<<<<< HEAD
             $ref: '#/components/schemas/MetricInResponse'
-=======
-            $ref: '#/components/schemas/MetricEvent'
->>>>>>> 6ab59fb65 (return metric labels as list)
         content:
           type: string
           description: The generated completion text
@@ -3712,11 +3708,7 @@ components:
         metrics:
           type: array
           items:
-<<<<<<< HEAD
             $ref: '#/components/schemas/MetricInResponse'
-=======
-            $ref: '#/components/schemas/MetricEvent'
->>>>>>> 6ab59fb65 (return metric labels as list)
         delta:
           type: string
           description: >-
@@ -5322,7 +5314,7 @@ components:
           type: integer
         end_time:
           type: integer
-        step:
+        granularity:
           type: string
         query_type:
           type: string
@@ -5363,8 +5355,7 @@ components:
       type: object
       properties:
         timestamp:
-          type: string
-          format: date-time
+          type: integer
         value:
           type: number
       additionalProperties: false
@@ -5372,15 +5363,27 @@ components:
         - timestamp
         - value
       title: MetricDataPoint
+    MetricLabel:
+      type: object
+      properties:
+        name:
+          type: string
+        value:
+          type: string
+      additionalProperties: false
+      required:
+        - name
+        - value
+      title: MetricLabel
     MetricSeries:
       type: object
       properties:
         metric:
           type: string
         labels:
-          type: object
-          additionalProperties:
-            type: string
+          type: array
+          items:
+            $ref: '#/components/schemas/MetricLabel'
         values:
           type: array
           items:
@@ -5556,205 +5559,6 @@ components:
           chat_completion_input: '#/components/schemas/ChatCompletionInputType'
           completion_input: '#/components/schemas/CompletionInputType'
           agent_turn_input: '#/components/schemas/AgentTurnInputType'
-<<<<<<< HEAD
-=======
-    StringType:
-      type: object
-      properties:
-        type:
-          type: string
-          const: string
-          default: string
-      additionalProperties: false
-      required:
-        - type
-      title: StringType
-    UnionType:
-      type: object
-      properties:
-        type:
-          type: string
-          const: union
-          default: union
-      additionalProperties: false
-      required:
-        - type
-      title: UnionType
-    MetricLabelMatcher:
-      type: object
-      properties:
-        name:
-          type: string
-        value:
-          type: string
-        operator:
-          $ref: '#/components/schemas/MetricLabelOperator'
-          default: '='
-      additionalProperties: false
-      required:
-        - name
-        - value
-        - operator
-      title: MetricLabelMatcher
-    MetricLabelOperator:
-      type: string
-      enum:
-        - '='
-        - '!='
-        - =~
-        - '!~'
-      title: MetricLabelOperator
-    MetricQueryType:
-      type: string
-      enum:
-        - range
-        - instant
-      title: MetricQueryType
-    GetMetricsRequest:
-      type: object
-      properties:
-        start_time:
-          type: integer
-        end_time:
-          type: integer
-        step:
-          type: string
-        query_type:
-          $ref: '#/components/schemas/MetricQueryType'
-        label_matchers:
-          type: array
-          items:
-            $ref: '#/components/schemas/MetricLabelMatcher'
-      additionalProperties: false
-      required:
-        - start_time
-        - query_type
-      title: GetMetricsRequest
-    GetMetricsResponse:
-      type: object
-      properties:
-        data:
-          type: array
-          items:
-            $ref: '#/components/schemas/MetricSeries'
-      additionalProperties: false
-      required:
-        - data
-      title: GetMetricsResponse
-    MetricDataPoint:
-      type: object
-      properties:
-        timestamp:
-          type: string
-          format: date-time
-        value:
-          type: number
-      additionalProperties: false
-      required:
-        - timestamp
-        - value
-      title: MetricDataPoint
-    MetricLabel:
-      type: object
-      properties:
-        name:
-          type: string
-        value:
-          type: string
-      additionalProperties: false
-      required:
-        - name
-        - value
-      title: MetricLabel
-    MetricSeries:
-      type: object
-      properties:
-        metric:
-          type: string
-        labels:
-          type: array
-          items:
-            $ref: '#/components/schemas/MetricLabel'
-        values:
-          type: array
-          items:
-            $ref: '#/components/schemas/MetricDataPoint'
-      additionalProperties: false
-      required:
-        - metric
-        - labels
-        - values
-      title: MetricSeries
-    Model:
-      type: object
-      properties:
-        identifier:
-          type: string
-        provider_resource_id:
-          type: string
-        provider_id:
-          type: string
-        type:
-          type: string
-          const: model
-          default: model
-        metadata:
-          type: object
-          additionalProperties:
-            oneOf:
-              - type: 'null'
-              - type: boolean
-              - type: number
-              - type: string
-              - type: array
-              - type: object
-        model_type:
-          $ref: '#/components/schemas/ModelType'
-          default: llm
-      additionalProperties: false
-      required:
-        - identifier
-        - provider_resource_id
-        - provider_id
-        - type
-        - metadata
-        - model_type
-      title: Model
-    ModelType:
-      type: string
-      enum:
-        - llm
-        - embedding
-      title: ModelType
-    PaginatedRowsResult:
-      type: object
-      properties:
-        rows:
-          type: array
-          items:
-            type: object
-            additionalProperties:
-              oneOf:
-                - type: 'null'
-                - type: boolean
-                - type: number
-                - type: string
-                - type: array
-                - type: object
-          description: The rows in the current page.
-        total_count:
-          type: integer
-          description: The total number of rows in the dataset.
-        next_page_token:
-          type: string
-          description: The token to get the next page of rows.
-      additionalProperties: false
-      required:
-        - rows
-        - total_count
-      title: PaginatedRowsResult
-      description: A paginated list of rows from a dataset.
->>>>>>> 6ab59fb65 (return metric labels as list)
     ScoringFn:
       type: object
       properties:

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -857,6 +857,40 @@ paths:
           required: true
           schema:
             type: string
+  /v1/telemetry/metrics/{metric_name}:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetMetricsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+        '429':
+          $ref: >-
+            #/components/responses/TooManyRequests429
+        '500':
+          $ref: >-
+            #/components/responses/InternalServerError500
+        default:
+          $ref: '#/components/responses/DefaultError'
+      tags:
+        - Telemetry
+      description: ''
+      parameters:
+        - name: metric_name
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetMetricsRequest'
+        required: true
   /v1/models/{model_id}:
     get:
       responses:
@@ -5273,6 +5307,93 @@ components:
         - created_at
       title: FileResponse
       description: Response representing a file entry.
+    GetMetricsRequest:
+      type: object
+      properties:
+        start_time:
+          type: integer
+        end_time:
+          type: integer
+        step:
+          type: string
+        query_type:
+          type: string
+          enum:
+            - range
+            - instant
+          title: MetricQueryType
+        label_matchers:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              value:
+                type: string
+              operator:
+                type: string
+                enum:
+                  - '='
+                  - '!='
+                  - =~
+                  - '!~'
+                title: MetricLabelOperator
+                default: '='
+            additionalProperties: false
+            required:
+              - name
+              - value
+              - operator
+            title: MetricLabelMatcher
+      additionalProperties: false
+      required:
+        - start_time
+        - query_type
+      title: GetMetricsRequest
+    MetricDataPoint:
+      type: object
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+        value:
+          type: number
+      additionalProperties: false
+      required:
+        - timestamp
+        - value
+      title: MetricDataPoint
+    MetricSeries:
+      type: object
+      properties:
+        metric:
+          type: string
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+        values:
+          type: array
+          items:
+            $ref: '#/components/schemas/MetricDataPoint'
+      additionalProperties: false
+      required:
+        - metric
+        - labels
+        - values
+      title: MetricSeries
+    GetMetricsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/MetricSeries'
+      additionalProperties: false
+      required:
+        - data
+      title: GetMetricsResponse
     Model:
       type: object
       properties:

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -3434,7 +3434,11 @@ components:
         metrics:
           type: array
           items:
+<<<<<<< HEAD
             $ref: '#/components/schemas/MetricInResponse'
+=======
+            $ref: '#/components/schemas/MetricEvent'
+>>>>>>> 6ab59fb65 (return metric labels as list)
         content:
           type: string
           description: The generated completion text
@@ -3708,7 +3712,11 @@ components:
         metrics:
           type: array
           items:
+<<<<<<< HEAD
             $ref: '#/components/schemas/MetricInResponse'
+=======
+            $ref: '#/components/schemas/MetricEvent'
+>>>>>>> 6ab59fb65 (return metric labels as list)
         delta:
           type: string
           description: >-
@@ -5548,6 +5556,205 @@ components:
           chat_completion_input: '#/components/schemas/ChatCompletionInputType'
           completion_input: '#/components/schemas/CompletionInputType'
           agent_turn_input: '#/components/schemas/AgentTurnInputType'
+<<<<<<< HEAD
+=======
+    StringType:
+      type: object
+      properties:
+        type:
+          type: string
+          const: string
+          default: string
+      additionalProperties: false
+      required:
+        - type
+      title: StringType
+    UnionType:
+      type: object
+      properties:
+        type:
+          type: string
+          const: union
+          default: union
+      additionalProperties: false
+      required:
+        - type
+      title: UnionType
+    MetricLabelMatcher:
+      type: object
+      properties:
+        name:
+          type: string
+        value:
+          type: string
+        operator:
+          $ref: '#/components/schemas/MetricLabelOperator'
+          default: '='
+      additionalProperties: false
+      required:
+        - name
+        - value
+        - operator
+      title: MetricLabelMatcher
+    MetricLabelOperator:
+      type: string
+      enum:
+        - '='
+        - '!='
+        - =~
+        - '!~'
+      title: MetricLabelOperator
+    MetricQueryType:
+      type: string
+      enum:
+        - range
+        - instant
+      title: MetricQueryType
+    GetMetricsRequest:
+      type: object
+      properties:
+        start_time:
+          type: integer
+        end_time:
+          type: integer
+        step:
+          type: string
+        query_type:
+          $ref: '#/components/schemas/MetricQueryType'
+        label_matchers:
+          type: array
+          items:
+            $ref: '#/components/schemas/MetricLabelMatcher'
+      additionalProperties: false
+      required:
+        - start_time
+        - query_type
+      title: GetMetricsRequest
+    GetMetricsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/MetricSeries'
+      additionalProperties: false
+      required:
+        - data
+      title: GetMetricsResponse
+    MetricDataPoint:
+      type: object
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+        value:
+          type: number
+      additionalProperties: false
+      required:
+        - timestamp
+        - value
+      title: MetricDataPoint
+    MetricLabel:
+      type: object
+      properties:
+        name:
+          type: string
+        value:
+          type: string
+      additionalProperties: false
+      required:
+        - name
+        - value
+      title: MetricLabel
+    MetricSeries:
+      type: object
+      properties:
+        metric:
+          type: string
+        labels:
+          type: array
+          items:
+            $ref: '#/components/schemas/MetricLabel'
+        values:
+          type: array
+          items:
+            $ref: '#/components/schemas/MetricDataPoint'
+      additionalProperties: false
+      required:
+        - metric
+        - labels
+        - values
+      title: MetricSeries
+    Model:
+      type: object
+      properties:
+        identifier:
+          type: string
+        provider_resource_id:
+          type: string
+        provider_id:
+          type: string
+        type:
+          type: string
+          const: model
+          default: model
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+        model_type:
+          $ref: '#/components/schemas/ModelType'
+          default: llm
+      additionalProperties: false
+      required:
+        - identifier
+        - provider_resource_id
+        - provider_id
+        - type
+        - metadata
+        - model_type
+      title: Model
+    ModelType:
+      type: string
+      enum:
+        - llm
+        - embedding
+      title: ModelType
+    PaginatedRowsResult:
+      type: object
+      properties:
+        rows:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              oneOf:
+                - type: 'null'
+                - type: boolean
+                - type: number
+                - type: string
+                - type: array
+                - type: object
+          description: The rows in the current page.
+        total_count:
+          type: integer
+          description: The total number of rows in the dataset.
+        next_page_token:
+          type: string
+          description: The token to get the next page of rows.
+      additionalProperties: false
+      required:
+        - rows
+        - total_count
+      title: PaginatedRowsResult
+      description: A paginated list of rows from a dataset.
+>>>>>>> 6ab59fb65 (return metric labels as list)
     ScoringFn:
       type: object
       properties:

--- a/llama_stack/apis/telemetry/telemetry.py
+++ b/llama_stack/apis/telemetry/telemetry.py
@@ -229,7 +229,7 @@ class MetricLabel(BaseModel):
 
 @json_schema_type
 class MetricDataPoint(BaseModel):
-    timestamp: datetime
+    timestamp: int
     value: float
 
 
@@ -295,7 +295,7 @@ class Telemetry(Protocol):
         metric_name: str,
         start_time: int,
         end_time: int | None = None,
-        step: str | None = "1d",
+        granularity: str | None = "1d",
         query_type: MetricQueryType = MetricQueryType.RANGE,
         label_matchers: list[MetricLabelMatcher] | None = None,
     ) -> GetMetricsResponse: ...

--- a/llama_stack/apis/telemetry/telemetry.py
+++ b/llama_stack/apis/telemetry/telemetry.py
@@ -222,6 +222,12 @@ class MetricLabelMatcher(BaseModel):
 
 
 @json_schema_type
+class MetricLabel(BaseModel):
+    name: str
+    value: str
+
+
+@json_schema_type
 class MetricDataPoint(BaseModel):
     timestamp: datetime
     value: float
@@ -230,7 +236,7 @@ class MetricDataPoint(BaseModel):
 @json_schema_type
 class MetricSeries(BaseModel):
     metric: str
-    labels: dict[str, str]
+    labels: list[MetricLabel]
     values: list[MetricDataPoint]
 
 

--- a/llama_stack/apis/telemetry/telemetry.py
+++ b/llama_stack/apis/telemetry/telemetry.py
@@ -240,7 +240,7 @@ class MetricSeries(BaseModel):
     values: list[MetricDataPoint]
 
 
-class GetMetricsResponse(BaseModel):
+class QueryMetricsResponse(BaseModel):
     data: list[MetricSeries]
 
 
@@ -290,7 +290,7 @@ class Telemetry(Protocol):
     ) -> None: ...
 
     @webmethod(route="/telemetry/metrics/{metric_name}", method="POST")
-    async def get_metrics(
+    async def query_metrics(
         self,
         metric_name: str,
         start_time: int,
@@ -298,4 +298,4 @@ class Telemetry(Protocol):
         granularity: str | None = "1d",
         query_type: MetricQueryType = MetricQueryType.RANGE,
         label_matchers: list[MetricLabelMatcher] | None = None,
-    ) -> GetMetricsResponse: ...
+    ) -> QueryMetricsResponse: ...

--- a/llama_stack/apis/telemetry/telemetry.py
+++ b/llama_stack/apis/telemetry/telemetry.py
@@ -203,13 +203,11 @@ class QuerySpanTreeResponse(BaseModel):
     data: dict[str, SpanWithStatus]
 
 
-@json_schema_type
 class MetricQueryType(Enum):
     RANGE = "range"
     INSTANT = "instant"
 
 
-@json_schema_type
 class MetricLabelOperator(Enum):
     EQUALS = "="
     NOT_EQUALS = "!="
@@ -217,7 +215,6 @@ class MetricLabelOperator(Enum):
     REGEX_NOT_MATCH = "!~"
 
 
-@json_schema_type
 class MetricLabelMatcher(BaseModel):
     name: str
     value: str
@@ -233,13 +230,12 @@ class MetricDataPoint(BaseModel):
 @json_schema_type
 class MetricSeries(BaseModel):
     metric: str
-    labels: Dict[str, str]
-    values: List[MetricDataPoint]
+    labels: dict[str, str]
+    values: list[MetricDataPoint]
 
 
-@json_schema_type
 class GetMetricsResponse(BaseModel):
-    data: List[MetricSeries]
+    data: list[MetricSeries]
 
 
 @runtime_checkable
@@ -292,8 +288,8 @@ class Telemetry(Protocol):
         self,
         metric_name: str,
         start_time: int,
-        end_time: Optional[int] = None,
-        step: Optional[str] = "1d",
+        end_time: int | None = None,
+        step: str | None = "1d",
         query_type: MetricQueryType = MetricQueryType.RANGE,
-        label_matchers: Optional[List[MetricLabelMatcher]] = None,
+        label_matchers: list[MetricLabelMatcher] | None = None,
     ) -> GetMetricsResponse: ...

--- a/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
@@ -19,7 +19,10 @@ from opentelemetry.semconv.resource import ResourceAttributes
 
 from llama_stack.apis.telemetry import (
     Event,
+    GetMetricsResponse,
     MetricEvent,
+    MetricLabelMatcher,
+    MetricQueryType,
     QueryCondition,
     QuerySpanTreeResponse,
     QueryTracesResponse,
@@ -122,6 +125,17 @@ class TelemetryAdapter(TelemetryDatasetMixin, Telemetry):
             self._log_structured(event, ttl_seconds)
         else:
             raise ValueError(f"Unknown event type: {event}")
+
+    async def get_metrics(
+        self,
+        metric_name: str,
+        start_time: int,
+        end_time: Optional[int] = None,
+        step: Optional[str] = "1d",
+        query_type: MetricQueryType = MetricQueryType.RANGE,
+        label_matchers: Optional[List[MetricLabelMatcher]] = None,
+    ) -> GetMetricsResponse:
+        pass
 
     def _log_unstructured(self, event: UnstructuredLogEvent, ttl_seconds: int) -> None:
         with self._lock:

--- a/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
@@ -19,11 +19,11 @@ from opentelemetry.semconv.resource import ResourceAttributes
 
 from llama_stack.apis.telemetry import (
     Event,
-    GetMetricsResponse,
     MetricEvent,
     MetricLabelMatcher,
     MetricQueryType,
     QueryCondition,
+    QueryMetricsResponse,
     QuerySpanTreeResponse,
     QueryTracesResponse,
     Span,
@@ -126,16 +126,16 @@ class TelemetryAdapter(TelemetryDatasetMixin, Telemetry):
         else:
             raise ValueError(f"Unknown event type: {event}")
 
-    async def get_metrics(
+    async def query_metrics(
         self,
         metric_name: str,
         start_time: int,
-        end_time: Optional[int] = None,
-        step: Optional[str] = "1d",
+        end_time: int | None = None,
+        step: str | None = "1d",
         query_type: MetricQueryType = MetricQueryType.RANGE,
-        label_matchers: Optional[List[MetricLabelMatcher]] = None,
-    ) -> GetMetricsResponse:
-        pass
+        label_matchers: list[MetricLabelMatcher] | None = None,
+    ) -> QueryMetricsResponse:
+        raise NotImplementedError("Querying metrics is not implemented")
 
     def _log_unstructured(self, event: UnstructuredLogEvent, ttl_seconds: int) -> None:
         with self._lock:

--- a/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
@@ -131,7 +131,7 @@ class TelemetryAdapter(TelemetryDatasetMixin, Telemetry):
         metric_name: str,
         start_time: int,
         end_time: int | None = None,
-        step: str | None = "1d",
+        granularity: str | None = "1d",
         query_type: MetricQueryType = MetricQueryType.RANGE,
         label_matchers: list[MetricLabelMatcher] | None = None,
     ) -> QueryMetricsResponse:


### PR DESCRIPTION
# What does this PR do?
Adds the API to query metrics from telemetry.

## Test Plan
llama stack run ~/.llama/distributions/fireworks/fireworks-run.yaml