### PR TITLE
feat(1/n): scoring function registration for llm-as-judge

### DIFF
--- a/llama_stack/providers/inline/scoring/llm_as_judge/scoring.py
+++ b/llama_stack/providers/inline/scoring/llm_as_judge/scoring.py
@@ -25,7 +25,7 @@ from llama_stack.providers.utils.common.data_schema_validator import (
 from .config import LlmAsJudgeScoringConfig
 from .scoring_fn.llm_as_judge_scoring_fn import LlmAsJudgeScoringFn
 
-LLM_JUDGE_FNS = [LlmAsJudgeScoringFn]
+LLM_JUDGE_FN = LlmAsJudgeScoringFn
 
 
 class LlmAsJudgeScoringImpl(
@@ -46,11 +46,10 @@ class LlmAsJudgeScoringImpl(
         self.scoring_fn_id_impls = {}
 
     async def initialize(self) -> None:
-        for fn in LLM_JUDGE_FNS:
-            impl = fn(inference_api=self.inference_api)
-            for fn_defs in impl.get_supported_scoring_fn_defs():
-                self.scoring_fn_id_impls[fn_defs.identifier] = impl
-                self.llm_as_judge_fn = impl
+        impl = LLM_JUDGE_FN(inference_api=self.inference_api)
+        for fn_defs in impl.get_supported_scoring_fn_defs():
+            self.scoring_fn_id_impls[fn_defs.identifier] = impl
+            self.llm_as_judge_fn = impl
 
     async def shutdown(self) -> None: ...
 
@@ -67,7 +66,8 @@ class LlmAsJudgeScoringImpl(
         return scoring_fn_defs_list
 
     async def register_scoring_function(self, function_def: ScoringFn) -> None:
-        raise NotImplementedError("Register scoring function not implemented yet")
+        self.llm_as_judge_fn.register_scoring_fn_def(function_def)
+        # raise NotImplementedError("Register scoring function not implemented yet")
 
     async def score_batch(
         self,

--- a/llama_stack/providers/inline/scoring/llm_as_judge/scoring.py
+++ b/llama_stack/providers/inline/scoring/llm_as_judge/scoring.py
@@ -67,7 +67,6 @@ class LlmAsJudgeScoringImpl(
 
     async def register_scoring_function(self, function_def: ScoringFn) -> None:
         self.llm_as_judge_fn.register_scoring_fn_def(function_def)
-        # raise NotImplementedError("Register scoring function not implemented yet")
 
     async def score_batch(
         self,


### PR DESCRIPTION
# What does this PR do?

- add ability to register a llm-as-judge scoring function with custom judge prompts / params. 
- Closes https://github.com/meta-llama/llama-stack/issues/1395

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan
**Via CLI**
```
llama-stack-client scoring_functions register \ 
--scoring-fn-id "llm-as-judge::my-prompt" \
--description "my custom judge" \
--return-type '{"type": "string"}' \
--provider-id "llm-as-judge" \
--provider-scoring-fn-id "my-prompt" \
--params '{"type": "llm_as_judge", "judge_model": "meta-llama/Llama-3.2-3B-Instruct", "prompt_template": "always output 1.0"}'
```

<img width="1373" alt="image" src="https://github.com/user-attachments/assets/7c6fc0ae-64fe-4581-8927-a9d8d746bd72" />

- Unit test will be addressed with https://github.com/meta-llama/llama-stack/issues/1396


[//]: # (## Documentation)
