### PR TITLE
chore: Get sqlite_vec and vector_store unit tests passing

### DIFF
--- a/tests/unit/providers/vector_io/test_sqlite_vec.py
+++ b/tests/unit/providers/vector_io/test_sqlite_vec.py
@@ -9,6 +9,7 @@ import sqlite3
 
 import numpy as np
 import pytest
+import pytest_asyncio
 import sqlite_vec
 
 from llama_stack.apis.vector_io import Chunk, QueryChunksResponse
@@ -48,7 +49,7 @@ def sqlite_connection(loop):
         conn.close()
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest_asyncio.fixture(scope="session", autouse=True)
 async def sqlite_vec_index(sqlite_connection):
     return await SQLiteVecIndex.create(dimension=EMBEDDING_DIMENSION, connection=sqlite_connection, bank_id="test_bank")
 

--- a/tests/unit/rag/test_vector_store.py
+++ b/tests/unit/rag/test_vector_store.py
@@ -15,6 +15,8 @@ from llama_stack.apis.tools import RAGDocument
 from llama_stack.providers.utils.memory.vector_store import URL, content_from_doc
 
 DUMMY_PDF_PATH = Path(os.path.abspath(__file__)).parent / "fixtures" / "dummy.pdf"
+# Depending on the machine, this can get parsed a couple of ways
+DUMMY_PDF_TEXT_CHOICES = ["Dummy PDF file", "Dumm y PDF file"]
 
 
 def read_file(file_path: str) -> bytes:
@@ -45,7 +47,7 @@ class TestVectorStore:
             metadata={},
         )
         content = await content_from_doc(doc)
-        assert content == "Dumm y PDF file"
+        assert content in DUMMY_PDF_TEXT_CHOICES
 
     @pytest.mark.asyncio
     async def test_downloads_pdf_and_returns_content(self):
@@ -58,7 +60,7 @@ class TestVectorStore:
             metadata={},
         )
         content = await content_from_doc(doc)
-        assert content == "Dumm y PDF file"
+        assert content in DUMMY_PDF_TEXT_CHOICES
 
     @pytest.mark.asyncio
     async def test_downloads_pdf_and_returns_content_with_url_object(self):
@@ -73,4 +75,4 @@ class TestVectorStore:
             metadata={},
         )
         content = await content_from_doc(doc)
-        assert content == "Dumm y PDF file"
+        assert content in DUMMY_PDF_TEXT_CHOICES


### PR DESCRIPTION
# What does this PR do?

This fixes two tests that fail for me locally:
- tests/unit/providers/vector_io/test_sqlite_vec.py
- tests/unit/rag/test_vector_store.py

## Test Plan

The error with test_sqlite_vec.py was:

```
    @pytest.mark.asyncio
    async def test_add_chunks(sqlite_vec_index, sample_chunks, sample_embeddings):
>       await sqlite_vec_index.add_chunks(sample_chunks, sample_embeddings, batch_size=2)
E       AttributeError: 'coroutine' object has no attribute 'add_chunks'

tests/unit/providers/vector_io/test_sqlite_vec.py:76: AttributeError
```

The reason for that error is the sqlite_vec_index fixture was not marked as `@pytest_asyncio.fixture` and instead was marked as `@pytest.fixture`. Thus, it was returning a coroutine from the fixture instead of the actual fixture.

The error with test_vector_store.py was:

```
>       assert content == "Dumm y PDF file"
E       AssertionError: assert 'Dummy PDF file' == 'Dumm y PDF file'
E
E         - Dumm y PDF file
E         ?     -
E         + Dummy PDF file

tests/unit/rag/test_vector_store.py:76: AssertionError

```

The reason for this error is that, on my machine, the dummy PDF file is properly extracting the text as "Dummy PDF file". However, it looks like from the commit history that on other's machines this was returning "Dumm y PDF file". So, the test now allows either of those options as valid parsing of that PDF file for the purposes of the test passing.

With both of these changes, the entire unit test suite passes for me locally (assuming all necessary test dependencies are installed) with:

```
python -m pytest -v tests/unit/
```

