### PR TITLE
fix: Fix unit tests of datasetio providers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
 #        args: ['--branch=main']
 
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.4
+    rev: v1.5.5
     hooks:
     -   id: insert-license
         files: \.py$|\.sh$
@@ -27,7 +27,7 @@ repos:
           - docs/license_header.txt
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.4
+    rev: v0.9.9
     hooks:
     -   id: ruff
         args: [ --fix ]
@@ -35,14 +35,14 @@ repos:
     -   id: ruff-format
 
 -   repo: https://github.com/adamchainz/blacken-docs
-    rev: 1.19.0
+    rev: 1.19.1
     hooks:
     -   id: blacken-docs
         additional_dependencies:
         - black==24.3.0
 
 -   repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.6.3
+    rev: 0.6.4
     hooks:
     -   id: uv-lock
     -   id: uv-export

--- a/llama_stack/providers/tests/datasetio/fixtures.py
+++ b/llama_stack/providers/tests/datasetio/fixtures.py
@@ -44,8 +44,7 @@ def datasetio_huggingface() -> ProviderFixture:
     )
 
 
-DATASETIO_FIXTURES = ["localfs", "remote", "huggingface"]
-
+DATASETIO_FIXTURES = ["localfs", "huggingface"]
 
 @pytest_asyncio.fixture(scope="session")
 async def datasetio_stack(request):

--- a/llama_stack/providers/tests/datasetio/test_datasetio.py
+++ b/llama_stack/providers/tests/datasetio/test_datasetio.py
@@ -13,12 +13,11 @@ import pytest
 
 from llama_stack.apis.common.content_types import URL
 from llama_stack.apis.common.type_system import ChatCompletionInputType, StringType
-from llama_stack.apis.datasets import Datasets
+from llama_stack.apis.datasets import Datasets, ListDatasetsResponse
 
 # How to run this test:
 #
 # pytest llama_stack/providers/tests/datasetio/test_datasetio.py
-#   -m "meta_reference"
 #   -v -s --tb=short --disable-warnings
 
 
@@ -83,17 +82,19 @@ class TestDatasetIO:
         # but so far we don't have an unregister API unfortunately, so be careful
         _, datasets_impl = datasetio_stack
         response = await datasets_impl.list_datasets()
-        assert isinstance(response, list)
-        assert len(response) == 0
+        assert isinstance(response, ListDatasetsResponse)
+        assert isinstance(response.data, list)
+        assert len(response.data) == 0
 
     @pytest.mark.asyncio
     async def test_register_dataset(self, datasetio_stack):
         _, datasets_impl = datasetio_stack
         await register_dataset(datasets_impl)
         response = await datasets_impl.list_datasets()
-        assert isinstance(response, list)
-        assert len(response) == 1
-        assert response[0].identifier == "test_dataset"
+        assert isinstance(response, ListDatasetsResponse)
+        assert isinstance(response.data, list)
+        assert len(response.data) == 1
+        assert response.data[0].identifier == "test_dataset"
 
         with pytest.raises(ValueError):
             # unregister a dataset that does not exist
@@ -101,8 +102,9 @@ class TestDatasetIO:
 
         await datasets_impl.unregister_dataset("test_dataset")
         response = await datasets_impl.list_datasets()
-        assert isinstance(response, list)
-        assert len(response) == 0
+        assert isinstance(response, ListDatasetsResponse)
+        assert isinstance(response.data, list)
+        assert len(response.data) == 0
 
         with pytest.raises(ValueError):
             await datasets_impl.unregister_dataset("test_dataset")


### PR DESCRIPTION
# What does this PR do?
This PR fixes the unit tests for datasetio 

[//]: # (If resolving an issue, uncomment and update the line below)
### Closes #1412 

## Test Plan
Executed the unit tests as documented (with a change that selects them all)
`pytest llama_stack/providers/tests/datasetio/test_datasetio.py  -v -s --tb=short --disable-warnings`

[//]: # (## Documentation)
