### PR TITLE
fix(deps): move chardet and pypdf imports inline where used

### DIFF
--- a/llama_stack/providers/utils/memory/vector_store.py
+++ b/llama_stack/providers/utils/memory/vector_store.py
@@ -12,11 +12,9 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 from urllib.parse import unquote
 
-import chardet
 import httpx
 import numpy as np
 from numpy.typing import NDArray
-from pypdf import PdfReader
 
 from llama_stack.apis.common.content_types import (
     URL,
@@ -38,6 +36,8 @@ log = logging.getLogger(__name__)
 def parse_pdf(data: bytes) -> str:
     # For PDF and DOC/DOCX files, we can't reliably convert to string
     pdf_bytes = io.BytesIO(data)
+    from pypdf import PdfReader
+
     pdf_reader = PdfReader(pdf_bytes)
     return "\n".join([page.extract_text() for page in pdf_reader.pages])
 
@@ -75,6 +75,8 @@ def content_from_data(data_url: str) -> str:
 
     encoding = parts["encoding"]
     if not encoding:
+        import chardet
+
         detected = chardet.detect(data)
         encoding = detected["encoding"]
 


### PR DESCRIPTION
# What does this PR do?

Fix import errors due to `chardet` and `pypdf` not being installed while imported from `url_utils.py`.

Closes #1432

## Test Plan

Now able to run the server with the config.

[//]: # (## Documentation)
