### PR TITLE
fix: resolve pydantic warning on .dict() usage

### DIFF
--- a/llama_stack/cli/model/describe.py
+++ b/llama_stack/cli/model/describe.py
@@ -64,7 +64,7 @@ class ModelDescribe(Subcommand):
         ]
 
         if model.recommended_sampling_params is not None:
-            sampling_params = model.recommended_sampling_params.dict()
+            sampling_params = model.recommended_sampling_params.model_dump()
             for k in ("max_tokens", "repetition_penalty"):
                 del sampling_params[k]
             rows.append(

--- a/llama_stack/distribution/configure.py
+++ b/llama_stack/distribution/configure.py
@@ -39,7 +39,7 @@ def configure_single_provider(registry: Dict[str, ProviderSpec], provider: Provi
     return Provider(
         provider_id=provider.provider_id,
         provider_type=provider.provider_type,
-        config=cfg.dict(),
+        config=cfg.model_dump(),
     )
 
 


### PR DESCRIPTION
# What does this PR do?

The method "dict" in class "BaseModel" is deprecated we should use model_dump instead.