### PR TITLE
docs: add back eval concept doc

### DIFF
--- a/docs/source/concepts/index.md
+++ b/docs/source/concepts/index.md
@@ -64,3 +64,10 @@ While there is a lot of flexibility to mix-and-match providers, often users will
 
 
 **On-device Distro**: Finally, you may want to run Llama Stack directly on an edge device (mobile phone or a tablet.) We provide Distros for iOS and Android (coming soon.)
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+evaluation_concepts
+```

--- a/docs/source/concepts/index.md
+++ b/docs/source/concepts/index.md
@@ -1,5 +1,13 @@
 # Core Concepts
 
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+evaluation_concepts
+```
+
 Given Llama Stack's service-oriented philosophy, a few concepts and workflows arise which may not feel completely natural in the LLM landscape, especially if you are coming with a background in other frameworks.
 
 
@@ -64,10 +72,3 @@ While there is a lot of flexibility to mix-and-match providers, often users will
 
 
 **On-device Distro**: Finally, you may want to run Llama Stack directly on an edge device (mobile phone or a tablet.) We provide Distros for iOS and Android (coming soon.)
-
-```{toctree}
-:maxdepth: 1
-:hidden:
-
-evaluation_concepts
-```


### PR DESCRIPTION
# What does this PR do?

- add eval concept doc in Core Concept tab

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan

<img width="1266" alt="image" src="https://github.com/user-attachments/assets/8eb06a49-3c04-4899-805c-1b5349471f1f" />

cc @SLR722 

[//]: # (## Documentation)
