### PR TITLE
ci: enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# GitHub Dependabot configuration
+version: 2
+updates:
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/" # Will use the default workflow location of `.github/workflows`
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
# What does this PR do?

Add a Dependabot configuration file (.github/dependabot.yml) to enable automated dependency updates for GitHub Actions. This ensures workflows stay up to date with the latest versions, improving security and reliability.

Dependabot is configured to:
- Monitor GitHub Actions dependencies.
- Check for updates in the workflow directory
- Run updates on a daily schedule.
