### PR TITLE
chore: add pytest-report.xml to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ _build
 docs/src
 pyrightconfig.json
 venv/
+pytest-report.xml


### PR DESCRIPTION
# What does this PR do?

Ignores `pytest-report.xml`. The file is produced by the unit tests github workflow.

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan

Not needed.

[//]: # (## Documentation)
