### PR TITLE
test: fix recordable mocks cache key

### DIFF
--- a/tests/integration/fixtures/recordable_mock.py
+++ b/tests/integration/fixtures/recordable_mock.py
@@ -121,6 +121,9 @@ class RecordableMock:
         # Replace temporary file paths created by tempfile.mkdtemp()
         key = re.sub(r"/var/folders/[^,'\"\s]+", "<TEMP_FILE>", key)
 
+        # Replace /tmp/ paths which are also commonly used for temporary files
+        key = re.sub(r"/tmp/[^,'\"\s]+", "<TEMP_FILE>", key)
+
         return key
 
     def _save_cache(self):


### PR DESCRIPTION

Summary:

CI writes files to /tmp

 [{"__module__": "llama_stack.apis.inference.inference", "__pydantic__": "SystemMessage", "data": {"content": "You are a helpful assistant", "role": "system"}}, {"__module__": "llama_stack.apis.inference.inference", "__pydantic__": "UserMessage", "data": {"content": "Here is a csv file, can you describe it?", "context": null, "role": "user"}}, {"__module__": "llama_stack.apis.inference.inference", "__pydantic__": "ToolResponseMessage", "data": {"call_id": "", "content": [{"text": "# User provided a file accessible to you at \\"/tmp/tmp7k7dg6qk/gcDtT5M8inflation.csv\\"\\nYou can use code_interpreter to load and inspect it.", "type": "text"}], "role": "tool", "tool_name": {"__enum__": "BuiltinTool", "__module__": "llama_stack.models.llama.datatypes", "value": "code_interpreter"}}}]], {"response_format": null, "sa

Test Plan:
