### PR TITLE
fix: handle log errors

### DIFF
--- a/llama_stack/log.py
+++ b/llama_stack/log.py
@@ -11,6 +11,7 @@ from typing import Dict
 
 from rich.console import Console
 from rich.logging import RichHandler
+from rich.errors import MarkupError
 
 # Default log level
 DEFAULT_LOG_LEVEL = logging.INFO
@@ -81,6 +82,18 @@ class CustomRichHandler(RichHandler):
     def __init__(self, *args, **kwargs):
         kwargs["console"] = Console(width=120)
         super().__init__(*args, **kwargs)
+
+    def emit(self, record):
+        """Override emit to handle markup errors gracefully."""
+        try:
+            super().emit(record)
+        except MarkupError:
+            original_markup = self.markup
+            self.markup = False
+            try:
+                super().emit(record)
+            finally:
+                self.markup = original_markup
 
 
 def setup_logging(category_levels: Dict[str, int]) -> None:

--- a/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
@@ -16,7 +16,6 @@ from typing import Any, AsyncGenerator, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 import httpx
-from rich.markup import escape
 
 from llama_stack.apis.agents import (
     AgentConfig,
@@ -1030,7 +1029,7 @@ async def execute_tool_call_maybe(
             **toolgroup_args.get(group_name, {}),
         },
     )
-    logger.info(f"tool call {name} completed with result: {escape(str(result))}")
+    logger.info(f"tool call {name} completed with result: {result}")
     return result
 
 


### PR DESCRIPTION

Summary:
  |   File "/Users/erichuang/projects/llama-stack/llama_stack/distribution/server/server.py", line 213, in sse_generator
    |     logger.exception(f"Error in sse_generator: {e}")
    |   File "/opt/homebrew/Caskroom/miniconda/base/envs/myenv/lib/python3.10/logging/__init__.py", line 1864, in exception
    |     self.log(ERROR, msg, *args, exc_info=exc_info, **kwargs)
    |   File "/opt/homebrew/Caskroom/miniconda/base/envs/myenv/lib/python3.10/logging/__init__.py", line 1879, in log
    |     self.logger.log(level, msg, *args, **kwargs)
    |   File "/opt/homebrew/Caskroom/miniconda/base/envs/myenv/lib/python3.10/logging/__init__.py", line 1547, in log
    |     self._log(level, msg, args, **kwargs)
    |   File "/opt/homebrew/Caskroom/miniconda/base/envs/myenv/lib/python3.10/logging/__init__.py", line 1624, in _log
    |     self.handle(record)
    |   File "/opt/homebrew/Caskroom/miniconda/base/envs/myenv/lib/python3.10/logging/__init__.py", line 1634, in handle
    |     self.callHandlers(record)
    |   File "/opt/homebrew/Caskroom/miniconda/base/envs/myenv/lib/python3.10/logging/__init__.py", line 1696, in callHandlers
    |     hdlr.handle(record)
    |   File "/opt/homebrew/Caskroom/miniconda/base/envs/myenv/lib/python3.10/logging/__init__.py", line 968, in handle
    |     self.emit(record)
    |   File "/opt/homebrew/Caskroom/miniconda/base/envs/myenv/lib/python3.10/site-packages/rich/logging.py", line 167, in emit
    |     message_renderable = self.render_message(record, message)
    |   File "/opt/homebrew/Caskroom/miniconda/base/envs/myenv/lib/python3.10/site-packages/rich/logging.py", line 193, in render_message
    |     message_text = Text.from_markup(message) if use_markup else Text(message)
    |   File "/opt/homebrew/Caskroom/miniconda/base/envs/myenv/lib/python3.10/site-packages/rich/text.py", line 287, in from_markup
    |     rendered_text = render(text, style, emoji=emoji, emoji_variant=emoji_variant)
    |   File "/opt/homebrew/Caskroom/miniconda/base/envs/myenv/lib/python3.10/site-packages/rich/markup.py", line 167, in render
    |     raise MarkupError(
    | rich.errors.MarkupError: closing tag '[/INST]' at position 105 doesn't match any open tag


Test Plan:
reran failing rag_with_vector_db example
