### PR TITLE
fix: Use `--with-editable` to capture accurate code coverage reporting

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Run unit tests
         run: |
-          uv run -p 3.10.16 --with . --with ".[dev]" --with ".[unit]" pytest --cov=. -s -v tests/unit/ --junitxml=pytest-report.xml
+          uv run -p 3.10.16 --with-editable . --with-editable ".[dev]" --with-editable ".[unit]" pytest --cov=llama_stack -s -v tests/unit/ --junitxml=pytest-report.xml
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
# What does this PR do?
I created a PR earlier today, but I realized the code coverage reporting isn't correct: #1512

Essentially, we need to use `--with-editable` to enable develop/editable mode through `uv`. Using editable mode will create a package.egg-link file, and that allows pytest to accurately capture code coverage.

Before, some files had "0%" or "100%" coverage, which isn't accurate:

<img width="1455" alt="Screenshot 2025-03-10 at 10 01 53 AM" src="https://github.com/user-attachments/assets/c425515a-9ecd-4962-a2d4-18cd16d12f25" />

More info on `--with-editable`: https://docs.astral.sh/uv/reference/cli/#uv-run--with-editable

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan
Tested locally

<img width="775" alt="Screenshot 2025-03-10 at 7 00 14 PM" src="https://github.com/user-attachments/assets/31141318-5cf6-4666-8676-b5d8c8d2e719" />

Screenshot from CI:

<img width="1000" alt="Screenshot 2025-03-10 at 7 07 57 PM" src="https://github.com/user-attachments/assets/47092909-ff8d-4e97-80dc-2a16d948405a" />

[//]: # (## Documentation)
