### PR TITLE
feat: Convert `config` positional arg to `--config` in `llama stack run`

### DIFF
--- a/llama_stack/cli/stack/run.py
+++ b/llama_stack/cli/stack/run.py
@@ -30,7 +30,7 @@ class StackRun(Subcommand):
 
     def _add_arguments(self):
         self.parser.add_argument(
-            "config",
+            "--config",
             type=str,
             help="Path to config file to use for the run",
         )


### PR DESCRIPTION
# What does this PR do?
`llama stack build` uses `--config` to pass in configuration files, while `llama stack run` uses `config` to pass in configuration files. This PR changes `config` to `--config` in `llama stack run` to align with the behavior/design pattern for the `llama stack` subparser.

See here:

https://github.com/meta-llama/llama-stack/blob/e3edca77391ebc73af7fad0ea4b5d4132961c067/llama_stack/cli/stack/build.py#L26

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan
[Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.*]

[//]: # (## Documentation)
