### PR TITLE
ci: run unit tests on all supported python versions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,29 +8,37 @@ on:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: ${{ matrix.python }}
 
       - uses: astral-sh/setup-uv@v5
         with:
-          python-version: '3.10'
+          python-version: ${{ matrix.python }}
           enable-cache: false
 
       - name: Run unit tests
         run: |
-          uv run -p 3.10 --with-editable . --with-editable ".[dev]" --with-editable ".[unit]" pytest --cov=llama_stack -s -v tests/unit/ --junitxml=pytest-report.xml
+          uv run --python ${{ matrix.python }} --with-editable . --with-editable ".[dev]" --with-editable ".[unit]" pytest --cov=llama_stack -s -v tests/unit/ --junitxml=pytest-report-${{ matrix.python }}.xml
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: test-results-${{ matrix.python }}
           path: |
             .pytest_cache/
-            pytest-report.xml
+            pytest-report-${{ matrix.python }}.xml
           retention-days: 7


### PR DESCRIPTION
# What does this PR do?
python unit tests running via GitHub Actions were only running with python 3.10

the project supports all python versions greater than or equal to 3.10

this commit adds 3.11, 3.12, and 3.13 to the test matrix for better coverage and confidence for non-3.10 users

## Test Plan
All tests pass locally with python 3.11, 3.12, and 3.13
