### PR TITLE
fix: to allow mcp_endpoint from yaml config

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [**Quick Start**](https://llama-stack.readthedocs.io/en/latest/getting_started/index.html) | [**Documentation**](https://llama-stack.readthedocs.io/en/latest/index.html) | [**Colab Notebook**](./docs/getting_started.ipynb)
 
-Llama Stack standardizes the core building blocks that simplify AI application development. It codifies best practices across the Llama ecosystem. More specifically, it provides:
+Llama Stack standardizes the core building blocks that simplify AI application development. It codifies best practices across the Llama ecosystem. More specifically, it provides
 
 - **Unified API layer** for Inference, RAG, Agents, Tools, Safety, Evals, and Telemetry.
 - **Plugin architecture** to support the rich ecosystem of different API implementations in various environments, including local development, on-premises, cloud, and mobile.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [**Quick Start**](https://llama-stack.readthedocs.io/en/latest/getting_started/index.html) | [**Documentation**](https://llama-stack.readthedocs.io/en/latest/index.html) | [**Colab Notebook**](./docs/getting_started.ipynb)
 
-Llama Stack standardizes the core building blocks that simplify AI application development. It codifies best practices across the Llama ecosystem. More specifically, it provides
+Llama Stack standardizes the core building blocks that simplify AI application development. It codifies best practices across the Llama ecosystem. More specifically, it provides:
 
 - **Unified API layer** for Inference, RAG, Agents, Tools, Safety, Evals, and Telemetry.
 - **Plugin architecture** to support the rich ecosystem of different API implementations in various environments, including local development, on-premises, cloud, and mobile.

--- a/llama_stack/providers/remote/tool_runtime/model_context_protocol/model_context_protocol.py
+++ b/llama_stack/providers/remote/tool_runtime/model_context_protocol/model_context_protocol.py
@@ -36,7 +36,7 @@ class ModelContextProtocolToolRuntimeImpl(ToolsProtocolPrivate, ToolRuntime):
             raise ValueError("mcp_endpoint is required")
 
         tools = []
-        async with sse_client(mcp_endpoint.uri) as streams:
+        async with sse_client(mcp_endpoint["uri"]) as streams:
             async with ClientSession(*streams) as session:
                 await session.initialize()
                 tools_result = await session.list_tools()
@@ -56,7 +56,7 @@ class ModelContextProtocolToolRuntimeImpl(ToolsProtocolPrivate, ToolRuntime):
                             description=tool.description,
                             parameters=parameters,
                             metadata={
-                                "endpoint": mcp_endpoint.uri,
+                                "endpoint": mcp_endpoint["uri"],
                             },
                         )
                     )


### PR DESCRIPTION
# What does this PR do?
This PR provides a fix to issue https://github.com/meta-llama/llama-stack/issues/1586

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan
I added a toolgroup to my config yaml e.g.
```
- toolgroup_id: mcp::weather
  provider_id: model-context-protocol
  mcp_endpoint: 
    uri: "http://localhost:8000/sse"
```

I then started the Llama-stack server and ran: `llama-stack-client toolgroups list`

I got these results showing the toolgroup registered correctly

```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ identifier                ┃ provider_id            ┃ args ┃ mcp_endpoint                             ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ builtin::code_interpreter │ code-interpreter       │ None │ None                                     │
│ builtin::rag              │ rag-runtime            │ None │ None                                     │
│ builtin::websearch        │ tavily-search          │ None │ None                                     │
│ mcp::weather              │ model-context-protocol │ None │ McpEndpoint(uri='http://localhost:8000/… │
└───────────────────────────┴────────────────────────┴──────┴──────────────────────────────────────────┘
```


[//]: # (## Documentation)
