### PR TITLE
feat: Add new compact MetricInResponse type

### DIFF
--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -4630,8 +4630,6 @@
                 },
                 "additionalProperties": false,
                 "required": [
-                    "trace_id",
-                    "span_id",
                     "timestamp",
                     "type",
                     "metric",
@@ -8450,8 +8448,6 @@
                 },
                 "additionalProperties": false,
                 "required": [
-                    "trace_id",
-                    "span_id",
                     "timestamp",
                     "type",
                     "payload"
@@ -8524,8 +8520,6 @@
                 },
                 "additionalProperties": false,
                 "required": [
-                    "trace_id",
-                    "span_id",
                     "timestamp",
                     "type",
                     "message",

--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -4549,7 +4549,7 @@
                     "metrics": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/MetricEvent"
+                            "$ref": "#/components/schemas/MetricInResponse"
                         }
                     },
                     "completion_message": {
@@ -4571,46 +4571,9 @@
                 "title": "ChatCompletionResponse",
                 "description": "Response from a chat completion request."
             },
-            "MetricEvent": {
+            "MetricInResponse": {
                 "type": "object",
                 "properties": {
-                    "trace_id": {
-                        "type": "string"
-                    },
-                    "span_id": {
-                        "type": "string"
-                    },
-                    "timestamp": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "oneOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "integer"
-                                },
-                                {
-                                    "type": "number"
-                                },
-                                {
-                                    "type": "boolean"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ]
-                        }
-                    },
-                    "type": {
-                        "type": "string",
-                        "const": "metric",
-                        "default": "metric"
-                    },
                     "metric": {
                         "type": "string"
                     },
@@ -4630,13 +4593,10 @@
                 },
                 "additionalProperties": false,
                 "required": [
-                    "timestamp",
-                    "type",
                     "metric",
-                    "value",
-                    "unit"
+                    "value"
                 ],
-                "title": "MetricEvent"
+                "title": "MetricInResponse"
             },
             "TokenLogProbs": {
                 "type": "object",
@@ -4713,6 +4673,12 @@
             "CompletionResponse": {
                 "type": "object",
                 "properties": {
+                    "metrics": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MetricInResponse"
+                        }
+                    },
                     "content": {
                         "type": "string",
                         "description": "The generated completion text"
@@ -4922,7 +4888,7 @@
                     "metrics": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/MetricEvent"
+                            "$ref": "#/components/schemas/MetricInResponse"
                         }
                     },
                     "event": {
@@ -5080,6 +5046,12 @@
             "CompletionResponseStreamChunk": {
                 "type": "object",
                 "properties": {
+                    "metrics": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MetricInResponse"
+                        }
+                    },
                     "delta": {
                         "type": "string",
                         "description": "New content generated since last chunk. This can be one or more tokens."
@@ -8361,6 +8333,71 @@
                 ],
                 "title": "LogSeverity"
             },
+            "MetricEvent": {
+                "type": "object",
+                "properties": {
+                    "trace_id": {
+                        "type": "string"
+                    },
+                    "span_id": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                },
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "boolean"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        }
+                    },
+                    "type": {
+                        "type": "string",
+                        "const": "metric",
+                        "default": "metric"
+                    },
+                    "metric": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "oneOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "number"
+                            }
+                        ]
+                    },
+                    "unit": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "type",
+                    "metric",
+                    "value"
+                ],
+                "title": "MetricEvent"
+            },
             "SpanEndPayload": {
                 "type": "object",
                 "properties": {
@@ -8448,7 +8485,6 @@
                 },
                 "additionalProperties": false,
                 "required": [
-                    "timestamp",
                     "type",
                     "payload"
                 ],
@@ -8520,7 +8556,6 @@
                 },
                 "additionalProperties": false,
                 "required": [
-                    "timestamp",
                     "type",
                     "message",
                     "severity"

--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -8392,9 +8392,13 @@
                 },
                 "additionalProperties": false,
                 "required": [
+                    "trace_id",
+                    "span_id",
+                    "timestamp",
                     "type",
                     "metric",
-                    "value"
+                    "value",
+                    "unit"
                 ],
                 "title": "MetricEvent"
             },
@@ -8485,6 +8489,9 @@
                 },
                 "additionalProperties": false,
                 "required": [
+                    "trace_id",
+                    "span_id",
+                    "timestamp",
                     "type",
                     "payload"
                 ],
@@ -8556,6 +8563,9 @@
                 },
                 "additionalProperties": false,
                 "required": [
+                    "trace_id",
+                    "span_id",
+                    "timestamp",
                     "type",
                     "message",
                     "severity"

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -3101,7 +3101,7 @@ components:
         metrics:
           type: array
           items:
-            $ref: '#/components/schemas/MetricEvent'
+            $ref: '#/components/schemas/MetricInResponse'
         completion_message:
           $ref: '#/components/schemas/CompletionMessage'
           description: The complete response message
@@ -3116,29 +3116,9 @@ components:
         - completion_message
       title: ChatCompletionResponse
       description: Response from a chat completion request.
-    MetricEvent:
+    MetricInResponse:
       type: object
       properties:
-        trace_id:
-          type: string
-        span_id:
-          type: string
-        timestamp:
-          type: string
-          format: date-time
-        attributes:
-          type: object
-          additionalProperties:
-            oneOf:
-              - type: string
-              - type: integer
-              - type: number
-              - type: boolean
-              - type: 'null'
-        type:
-          type: string
-          const: metric
-          default: metric
         metric:
           type: string
         value:
@@ -3149,12 +3129,9 @@ components:
           type: string
       additionalProperties: false
       required:
-        - timestamp
-        - type
         - metric
         - value
-        - unit
-      title: MetricEvent
+      title: MetricInResponse
     TokenLogProbs:
       type: object
       properties:
@@ -3211,6 +3188,10 @@ components:
     CompletionResponse:
       type: object
       properties:
+        metrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/MetricInResponse'
         content:
           type: string
           description: The generated completion text
@@ -3410,7 +3391,7 @@ components:
         metrics:
           type: array
           items:
-            $ref: '#/components/schemas/MetricEvent'
+            $ref: '#/components/schemas/MetricInResponse'
         event:
           $ref: '#/components/schemas/ChatCompletionResponseEvent'
           description: The event containing the new content
@@ -3529,6 +3510,10 @@ components:
     CompletionResponseStreamChunk:
       type: object
       properties:
+        metrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/MetricInResponse'
         delta:
           type: string
           description: >-
@@ -5701,6 +5686,43 @@ components:
         - error
         - critical
       title: LogSeverity
+    MetricEvent:
+      type: object
+      properties:
+        trace_id:
+          type: string
+        span_id:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        attributes:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: string
+              - type: integer
+              - type: number
+              - type: boolean
+              - type: 'null'
+        type:
+          type: string
+          const: metric
+          default: metric
+        metric:
+          type: string
+        value:
+          oneOf:
+            - type: integer
+            - type: number
+        unit:
+          type: string
+      additionalProperties: false
+      required:
+        - type
+        - metric
+        - value
+      title: MetricEvent
     SpanEndPayload:
       type: object
       properties:
@@ -5758,7 +5780,6 @@ components:
           $ref: '#/components/schemas/StructuredLogPayload'
       additionalProperties: false
       required:
-        - timestamp
         - type
         - payload
       title: StructuredLogEvent
@@ -5800,7 +5821,6 @@ components:
           $ref: '#/components/schemas/LogSeverity'
       additionalProperties: false
       required:
-        - timestamp
         - type
         - message
         - severity

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -3149,8 +3149,6 @@ components:
           type: string
       additionalProperties: false
       required:
-        - trace_id
-        - span_id
         - timestamp
         - type
         - metric
@@ -5760,8 +5758,6 @@ components:
           $ref: '#/components/schemas/StructuredLogPayload'
       additionalProperties: false
       required:
-        - trace_id
-        - span_id
         - timestamp
         - type
         - payload
@@ -5804,8 +5800,6 @@ components:
           $ref: '#/components/schemas/LogSeverity'
       additionalProperties: false
       required:
-        - trace_id
-        - span_id
         - timestamp
         - type
         - message

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -5719,9 +5719,13 @@ components:
           type: string
       additionalProperties: false
       required:
+        - trace_id
+        - span_id
+        - timestamp
         - type
         - metric
         - value
+        - unit
       title: MetricEvent
     SpanEndPayload:
       type: object
@@ -5780,6 +5784,9 @@ components:
           $ref: '#/components/schemas/StructuredLogPayload'
       additionalProperties: false
       required:
+        - trace_id
+        - span_id
+        - timestamp
         - type
         - payload
       title: StructuredLogEvent
@@ -5821,6 +5828,9 @@ components:
           $ref: '#/components/schemas/LogSeverity'
       additionalProperties: false
       required:
+        - trace_id
+        - span_id
+        - timestamp
         - type
         - message
         - severity

--- a/llama_stack/apis/telemetry/telemetry.py
+++ b/llama_stack/apis/telemetry/telemetry.py
@@ -75,9 +75,9 @@ class LogSeverity(Enum):
 
 
 class EventCommon(BaseModel):
-    trace_id: str
-    span_id: str
-    timestamp: datetime
+    trace_id: Optional[str] = None
+    span_id: Optional[str] = None
+    timestamp: Optional[datetime] = None
     attributes: Optional[Dict[str, Primitive]] = Field(default_factory=dict)
 
 
@@ -93,7 +93,14 @@ class MetricEvent(EventCommon):
     type: Literal[EventType.METRIC.value] = EventType.METRIC.value
     metric: str  # this would be an enum
     value: Union[int, float]
-    unit: str
+    unit: Optional[str] = None
+
+
+@json_schema_type
+class MetricInResponse(BaseModel):
+    metric: str
+    value: Union[int, float]
+    unit: Optional[str] = None
 
 
 # This is a short term solution to allow inference API to return metrics
@@ -117,7 +124,7 @@ class MetricEvent(EventCommon):
 
 
 class MetricResponseMixin(BaseModel):
-    metrics: Optional[List[MetricEvent]] = None
+    metrics: Optional[List[MetricInResponse]] = None
 
 
 @json_schema_type

--- a/llama_stack/apis/telemetry/telemetry.py
+++ b/llama_stack/apis/telemetry/telemetry.py
@@ -75,9 +75,9 @@ class LogSeverity(Enum):
 
 
 class EventCommon(BaseModel):
-    trace_id: Optional[str] = None
-    span_id: Optional[str] = None
-    timestamp: Optional[datetime] = None
+    trace_id: str
+    span_id: str
+    timestamp: datetime
     attributes: Optional[Dict[str, Primitive]] = Field(default_factory=dict)
 
 
@@ -93,7 +93,7 @@ class MetricEvent(EventCommon):
     type: Literal[EventType.METRIC.value] = EventType.METRIC.value
     metric: str  # this would be an enum
     value: Union[int, float]
-    unit: Optional[str] = None
+    unit: str
 
 
 @json_schema_type

--- a/llama_stack/distribution/routers/routers.py
+++ b/llama_stack/distribution/routers/routers.py
@@ -48,7 +48,7 @@ from llama_stack.apis.scoring import (
     ScoringFnParams,
 )
 from llama_stack.apis.shields import Shield
-from llama_stack.apis.telemetry import MetricEvent, Telemetry
+from llama_stack.apis.telemetry import MetricEvent, MetricInResponse, Telemetry
 from llama_stack.apis.tools import (
     RAGDocument,
     RAGQueryConfig,
@@ -206,12 +206,12 @@ class InferenceRouter(Inference):
         completion_tokens: int,
         total_tokens: int,
         model: Model,
-    ) -> List[MetricEvent]:
+    ) -> List[MetricInResponse]:
         metrics = self._construct_metrics(prompt_tokens, completion_tokens, total_tokens, model)
         if self.telemetry:
             for metric in metrics:
                 await self.telemetry.log_event(metric)
-        return metrics
+        return [MetricInResponse(metric=metric.metric, value=metric.value) for metric in metrics]
 
     async def _count_tokens(
         self,

--- a/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
@@ -153,20 +153,20 @@ class TelemetryAdapter(TelemetryDatasetMixin, Telemetry):
             else:
                 print(f"Warning: No active span found for span_id {span_id}. Dropping event: {event}")
 
-    def _get_or_create_counter(self, name: str, unit: Optional[str] = None) -> metrics.Counter:
+    def _get_or_create_counter(self, name: str, unit: str) -> metrics.Counter:
         if name not in _GLOBAL_STORAGE["counters"]:
             _GLOBAL_STORAGE["counters"][name] = self.meter.create_counter(
                 name=name,
-                unit=unit or "",
+                unit=unit,
                 description=f"Counter for {name}",
             )
         return _GLOBAL_STORAGE["counters"][name]
 
-    def _get_or_create_gauge(self, name: str, unit: Optional[str] = None) -> metrics.ObservableGauge:
+    def _get_or_create_gauge(self, name: str, unit: str) -> metrics.ObservableGauge:
         if name not in _GLOBAL_STORAGE["gauges"]:
             _GLOBAL_STORAGE["gauges"][name] = self.meter.create_gauge(
                 name=name,
-                unit=unit or "",
+                unit=unit,
                 description=f"Gauge for {name}",
             )
         return _GLOBAL_STORAGE["gauges"][name]
@@ -181,11 +181,11 @@ class TelemetryAdapter(TelemetryDatasetMixin, Telemetry):
             up_down_counter = self._get_or_create_up_down_counter(event.metric, event.unit)
             up_down_counter.add(event.value, attributes=event.attributes)
 
-    def _get_or_create_up_down_counter(self, name: str, unit: Optional[str] = None) -> metrics.UpDownCounter:
+    def _get_or_create_up_down_counter(self, name: str, unit: str) -> metrics.UpDownCounter:
         if name not in _GLOBAL_STORAGE["up_down_counters"]:
             _GLOBAL_STORAGE["up_down_counters"][name] = self.meter.create_up_down_counter(
                 name=name,
-                unit=unit or "",
+                unit=unit,
                 description=f"UpDownCounter for {name}",
             )
         return _GLOBAL_STORAGE["up_down_counters"][name]

--- a/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
@@ -153,20 +153,20 @@ class TelemetryAdapter(TelemetryDatasetMixin, Telemetry):
             else:
                 print(f"Warning: No active span found for span_id {span_id}. Dropping event: {event}")
 
-    def _get_or_create_counter(self, name: str, unit: str) -> metrics.Counter:
+    def _get_or_create_counter(self, name: str, unit: Optional[str] = None) -> metrics.Counter:
         if name not in _GLOBAL_STORAGE["counters"]:
             _GLOBAL_STORAGE["counters"][name] = self.meter.create_counter(
                 name=name,
-                unit=unit,
+                unit=unit or "",
                 description=f"Counter for {name}",
             )
         return _GLOBAL_STORAGE["counters"][name]
 
-    def _get_or_create_gauge(self, name: str, unit: str) -> metrics.ObservableGauge:
+    def _get_or_create_gauge(self, name: str, unit: Optional[str] = None) -> metrics.ObservableGauge:
         if name not in _GLOBAL_STORAGE["gauges"]:
             _GLOBAL_STORAGE["gauges"][name] = self.meter.create_gauge(
                 name=name,
-                unit=unit,
+                unit=unit or "",
                 description=f"Gauge for {name}",
             )
         return _GLOBAL_STORAGE["gauges"][name]
@@ -181,11 +181,11 @@ class TelemetryAdapter(TelemetryDatasetMixin, Telemetry):
             up_down_counter = self._get_or_create_up_down_counter(event.metric, event.unit)
             up_down_counter.add(event.value, attributes=event.attributes)
 
-    def _get_or_create_up_down_counter(self, name: str, unit: str) -> metrics.UpDownCounter:
+    def _get_or_create_up_down_counter(self, name: str, unit: Optional[str] = None) -> metrics.UpDownCounter:
         if name not in _GLOBAL_STORAGE["up_down_counters"]:
             _GLOBAL_STORAGE["up_down_counters"][name] = self.meter.create_up_down_counter(
                 name=name,
-                unit=unit,
+                unit=unit or "",
                 description=f"UpDownCounter for {name}",
             )
         return _GLOBAL_STORAGE["up_down_counters"][name]


### PR DESCRIPTION
# What does this PR do?
This change adds a compact type to include metrics in response as opposed to the full MetricEvent which is relevant for internal logging purposes.

## Test Plan
```
LLAMA_STACK_CONFIG=~/.llama/distributions/fireworks/fireworks-run.yaml pytest -s -v agents/test_agents.py --safety-shield meta-llama/Llama-Guard-3-8B --text-model meta-llama/Llama-3.1-8B-Instruct

 llama stack run ~/.llama/distributions/fireworks/fireworks-run.yaml

curl --request POST \
  --url http://localhost:8321/v1/inference/chat-completion \
  --header 'content-type: application/json' \
  --data '{
  "model_id": "meta-llama/Llama-3.1-70B-Instruct",
  "messages": [
    {
      "role": "user",
      "content": {
        "type": "text",
        "text": "where do humans live"
      }
    }
  ],
  "stream": false
}'

{
  "metrics": [
    {
      "metric": "prompt_tokens",
      "value": 10,
      "unit": null
    },
    {
      "metric": "completion_tokens",
      "value": 522,
      "unit": null
    },
    {
      "metric": "total_tokens",
      "value": 532,
      "unit": null
    }
  ],
  "completion_message": {
    "role": "assistant",
    "content": "Humans live in various parts of the world...............",
    "stop_reason": "out_of_tokens",
    "tool_calls": []
  },
  "logprobs": null
}
```

