### PR TITLE
docs: Add OpenAI, Anthropic, Gemini to API providers table

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Here is a list of the various API providers and available distributions that can
 |        PG Vector         |      Single Node       |            |               |     ✅      |            |               |
 |    PyTorch ExecuTorch    |     On-device iOS      |     ✅      |       ✅       |            |            |               |
 |           vLLM           | Hosted and Single Node |            |       ✅       |            |            |               |
+|          OpenAI          |         Hosted         |            |       ✅       |            |            |               |
+|        Anthropic         |         Hosted         |            |       ✅       |            |            |               |
+|          Gemini          |         Hosted         |            |       ✅       |            |            |               |
+
 
 ### Distributions
 


### PR DESCRIPTION
# What does this PR do?

These are supported via https://github.com/meta-llama/llama-stack/pull/1267.

cc @ashwinb 