### PR TITLE
fix: to issue 1586

### DIFF
--- a/llama_stack/providers/remote/tool_runtime/model_context_protocol/model_context_protocol.py
+++ b/llama_stack/providers/remote/tool_runtime/model_context_protocol/model_context_protocol.py
@@ -36,7 +36,12 @@ class ModelContextProtocolToolRuntimeImpl(ToolsProtocolPrivate, ToolRuntime):
             raise ValueError("mcp_endpoint is required")
 
         tools = []
-        async with sse_client(mcp_endpoint.uri) as streams:
+        if hasattr(mcp_endpoint, "__getitem__"):
+            if mcp_endpoint["uri"] is not None:
+                uri = mcp_endpoint["uri"]
+        else:
+            uri = mcp_endpoint.uri
+        async with sse_client(uri) as streams:
             async with ClientSession(*streams) as session:
                 await session.initialize()
                 tools_result = await session.list_tools()
@@ -56,7 +61,7 @@ class ModelContextProtocolToolRuntimeImpl(ToolsProtocolPrivate, ToolRuntime):
                             description=tool.description,
                             parameters=parameters,
                             metadata={
-                                "endpoint": mcp_endpoint.uri,
+                                "endpoint": uri,
                             },
                         )
                     )


### PR DESCRIPTION
# What does this PR do?

Adds checks when parsing the mcp_endpoint.uri to allow for both mcp_endpoint.uri and mcp_endpoint["uri"]

Closes issue 1586

## Test Plan
I added this to my config yaml:
```
- toolgroup_id: mcp::weather
  provider_id: model-context-protocol
  mcp_endpoint: 
    uri: http://localhost:8000/sse
```

And then started the llama-stack server.  I could then use the llama-stack-client with: ` llama-stack-client toolgroups get mcp::weather ` to get the toolgroup info e.g.:
```
┏━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━┓
┃ descript… ┃ identifi… ┃ metadata  ┃ paramete… ┃ provider… ┃ provider… ┃ tool_host ┃ toolgrou… ┃ type ┃
┡━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━┩
│ Get real  │ getforec… │ {'endpoi… │ [Paramet… │ model-co… │ getforec… │ model_co… │ mcp::wea… │ tool │
│ time      │           │ 'http://… │ of the    │           │           │           │           │      │
│ weather   │           │           │ location… │           │           │           │           │      │
│ forecast  │           │           │ name='la… │           │           │           │           │      │
│ for a     │           │           │ paramete… │           │           │           │           │      │
│ location  │           │           │ required… │           │           │           │           │      │
│           │           │           │ default=… │           │           │           │           │      │
│           │           │           │ Paramete… │           │           │           │           │      │
│           │           │           │ of the    │           │           │           │           │      │
│           │           │           │ location… │           │           │           │           │      │
│           │           │           │ name='lo… │           │           │           │           │      │
│           │           │           │ paramete… │           │           │           │           │      │
│           │           │           │ required… │           │           │           │           │      │
│           │           │           │ default=… │           │           │           │           │      │
└───────────┴───────────┴───────────┴───────────┴───────────┴───────────┴───────────┴───────────┴──────┘```
I then removed the section:
```
- toolgroup_id: mcp::weather
  provider_id: model-context-protocol
  mcp_endpoint: 
    uri: http://localhost:8000/sse
```
From the yaml config and restarted the server.

I was then able to add the toolgroup with:

```
curl -X POST -H "Content-Type: application/json" \
--data \
'{ "provider_id" : "model-context-protocol", "toolgroup_id" : "mcp::weather", "mcp_endpoint" : { "uri" : "http://localhost:8000/sse"}}' \
 localhost:8321/v1/toolgroups 
 ```




[//]: # (## Documentation)
