### PR TITLE
docs: Add OpenAI, Anthropic, Gemini to inference API providers table

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -61,6 +61,10 @@ A number of "adapters" are available for some popular Inference and Vector Store
 |  Groq  |  Hosted  |
 |  SambaNova  |  Hosted  |
 | PyTorch ExecuTorch | On-device iOS, Android |
+|  OpenAI  |  Hosted  |
+|  Anthropic  |  Hosted  |
+|  Gemini  |  Hosted  |
+
 
 **Vector IO API**
 |  **Provider** |  **Environments** |


### PR DESCRIPTION
# What does this PR do?

Forgot to update this page as well as part of https://github.com/meta-llama/llama-stack/pull/1617. 