### PR TITLE
[draft] huggingface-ilab full-precision model fine-tuning

### DIFF
--- a/llama_stack/providers/inline/post_training/huggingface_ilab/__init__.py
+++ b/llama_stack/providers/inline/post_training/huggingface_ilab/__init__.py
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from typing import Any
+
+from llama_stack.distribution.datatypes import Api
+
+from .config import HFilabPostTrainingConfig
+
+
+async def get_provider_impl(
+    config: HFilabPostTrainingConfig,
+    deps: dict[Api, Any],
+):
+    from .post_training import HFilabPostTrainingImpl
+
+    impl = HFilabPostTrainingImpl(
+        config,
+        deps[Api.datasetio],
+        deps[Api.datasets],
+    )
+    return impl

--- a/llama_stack/providers/inline/post_training/huggingface_ilab/config.py
+++ b/llama_stack/providers/inline/post_training/huggingface_ilab/config.py
@@ -1,0 +1,14 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel
+
+
+class HFilabPostTrainingConfig(BaseModel):
+    torch_seed: Optional[int] = None
+    checkpoint_format: Optional[Literal["meta", "huggingface"]] = "meta"

--- a/llama_stack/providers/inline/post_training/huggingface_ilab/post_training.py
+++ b/llama_stack/providers/inline/post_training/huggingface_ilab/post_training.py
@@ -63,8 +63,10 @@ class HFilabPostTrainingImpl:
         if self.current_job is None:
             return True
 
-        finalized_job_states = [JobStatus.completed.value, JobStatus.failed.value]
-        if self.current_job.status in finalized_job_states:
+        finalized_job_states = [JobStatus.completed, JobStatus.failed]
+
+        # check most recent status of job.
+        if self.current_job.status[-1] in finalized_job_states:
             return True
 
         return False
@@ -87,7 +89,8 @@ class HFilabPostTrainingImpl:
         checkpoint_dir: Optional[str],
         algorithm_config: Optional[AlgorithmConfig],
     ) -> JSONResponse:
-        if not self.can_schedule_new_job():
+        if not await self.can_schedule_new_job():
+            # TODO: this status code isn't making its way up to the user. User just getting 500 from SDK.
             raise fastapi.HTTPException(
                 status_code=503,  # service unavailable, try again later.
                 detail="A tuning job is currently running; this could take a while.",

--- a/llama_stack/providers/inline/post_training/huggingface_ilab/post_training.py
+++ b/llama_stack/providers/inline/post_training/huggingface_ilab/post_training.py
@@ -1,0 +1,125 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from llama_stack.apis.datasetio import DatasetIO
+from llama_stack.apis.datasets import Datasets
+from llama_stack.apis.post_training import (
+    AlgorithmConfig,
+    DPOAlignmentConfig,
+    JobStatus,
+    ListPostTrainingJobsResponse,
+    LoraFinetuningConfig,
+    PostTrainingJob,
+    PostTrainingJobArtifactsResponse,
+    PostTrainingJobStatusResponse,
+    TrainingConfig,
+)
+from llama_stack.providers.inline.post_training.huggingface_ilab.config import HFilabPostTrainingConfig
+from llama_stack.schema_utils import webmethod
+
+
+class HFilabPostTrainingImpl:
+    def __init__(
+        self,
+        config: HFilabPostTrainingConfig,
+        datasetio_api: DatasetIO,
+        datasets: Datasets,
+    ) -> None:
+        self.config = config
+        self.datasetio_api = datasetio_api
+        self.datasets_api = datasets
+
+        # TODO: assume sync job, will need jobs API for async scheduling
+        self.jobs = {}
+        self.checkpoints_dict = {}
+
+    async def shutdown(self):
+        pass
+
+    async def supervised_fine_tune(
+        self,
+        job_uuid: str,
+        training_config: TrainingConfig,
+        hyperparam_search_config: Dict[str, Any],
+        logger_config: Dict[str, Any],
+        model: str,
+        checkpoint_dir: Optional[str],
+        algorithm_config: Optional[AlgorithmConfig],
+    ) -> PostTrainingJob:
+        if job_uuid in self.jobs:
+            raise ValueError(f"Job {job_uuid} already exists")
+
+        post_training_job = PostTrainingJob(job_uuid=job_uuid)
+
+        job_status_response = PostTrainingJobStatusResponse(
+            job_uuid=job_uuid,
+            status=JobStatus.scheduled,
+            scheduled_at=datetime.now(),
+        )
+        self.jobs[job_uuid] = job_status_response
+
+        if isinstance(algorithm_config, LoraFinetuningConfig):
+            try:
+                recipe = LoraFinetuningSingleDevice(
+                    self.config,
+                    job_uuid,
+                    training_config,
+                    hyperparam_search_config,
+                    logger_config,
+                    model,
+                    checkpoint_dir,
+                    algorithm_config,
+                    self.datasetio_api,
+                    self.datasets_api,
+                )
+
+                job_status_response.status = JobStatus.in_progress
+                job_status_response.started_at = datetime.now()
+
+                await recipe.setup()
+                resources_allocated, checkpoints = await recipe.train()
+
+                self.checkpoints_dict[job_uuid] = checkpoints
+                job_status_response.resources_allocated = resources_allocated
+                job_status_response.checkpoints = checkpoints
+                job_status_response.status = JobStatus.completed
+                job_status_response.completed_at = datetime.now()
+
+            except Exception:
+                job_status_response.status = JobStatus.failed
+                raise
+        else:
+            raise NotImplementedError()
+
+        return post_training_job
+
+    async def preference_optimize(
+        self,
+        job_uuid: str,
+        finetuned_model: str,
+        algorithm_config: DPOAlignmentConfig,
+        training_config: TrainingConfig,
+        hyperparam_search_config: Dict[str, Any],
+        logger_config: Dict[str, Any],
+    ) -> PostTrainingJob:
+        raise NotImplementedError("preference optimization is not implemented yet")
+
+    async def get_training_jobs(self) -> ListPostTrainingJobsResponse:
+        raise NotImplementedError("'get training jobs' ys not implemented yet")
+
+    @webmethod(route="/post-training/job/status")  # type: ignore
+    async def get_training_job_status(self, job_uuid: str) -> Optional[PostTrainingJobStatusResponse]:
+        raise NotImplementedError("'get training job status' is not implemented yet")
+
+    @webmethod(route="/post-training/job/cancel")  # type: ignore
+    async def cancel_training_job(self, job_uuid: str) -> None:
+        raise NotImplementedError("Job cancel is not implemented yet")
+
+    @webmethod(route="/post-training/job/artifacts")  # type: ignore
+    async def get_training_job_artifacts(self, job_uuid: str) -> Optional[PostTrainingJobArtifactsResponse]:
+        raise NotImplementedError("'get training job artifacts' is not implemented yet")

--- a/llama_stack/providers/inline/post_training/huggingface_ilab/recipes/__init__.py
+++ b/llama_stack/providers/inline/post_training/huggingface_ilab/recipes/__init__.py
@@ -1,0 +1,1 @@
+from .fullprecision_finetuning_multi_device import FullPrecisionFineTuning

--- a/llama_stack/providers/inline/post_training/huggingface_ilab/recipes/fullprecision_finetuning_multi_device.py
+++ b/llama_stack/providers/inline/post_training/huggingface_ilab/recipes/fullprecision_finetuning_multi_device.py
@@ -1,0 +1,173 @@
+import tempfile
+import typing
+from pathlib import Path
+from typing import Callable
+
+import transformers
+from transformers.configuration_utils import PretrainedConfig
+from transformers.tokenization_utils import PreTrainedTokenizer
+from transformers.tokenization_utils_fast import PreTrainedTokenizerFast
+
+from llama_stack.apis.common.job_types import JobStatus
+from llama_stack.apis.datasetio import DatasetIO
+from llama_stack.apis.datasets import Datasets
+from llama_stack.apis.post_training.post_training import AlgorithmConfig, TrainingConfig
+
+STORAGE_SUBDIRS = ["checkpoints", "data", "logs", "hf_cache"]
+VALIDATED_MODEL_ARCHS = ["LlamaForCausalLM", "GraniteForCausalLM"]
+
+SomePretrainedTokenizer: typing.TypeAlias = PreTrainedTokenizer | PreTrainedTokenizerFast
+
+
+class FullPrecisionFineTuning:
+    # TODO: set HF storage in HF utilities to this object's storage so that we can clean it up automatically
+    # TODO: set up logging utils, replace print statements with logging with the right level
+    def __init__(
+        self,
+        model: str,
+        training_config: TrainingConfig,
+        logger_config: dict[str, typing.Any],
+        storage_dir: Path | None,
+        algorithm_config: AlgorithmConfig,  # type: ignore
+        datasets_api: Datasets,
+        datasetsio_api: DatasetIO,
+    ):
+        self.model_name_or_path = model
+        self.training_config = training_config
+        self.logger_config = logger_config
+        if storage_dir:
+            self.storage_dir = storage_dir
+        else:
+            self.storage_dir = Path(tempfile.mkdtemp())
+        self.__setup_storage()
+
+        self.datasets_api = datasets_api
+        self.datasetio_api = datasetsio_api
+        self.loaded_dataset: typing.Any = None  # should be a list of dicts but shape can be weird
+
+    def __setup_storage(self):
+        for subdir in STORAGE_SUBDIRS:
+            new_subdir = self.storage_dir / subdir
+            new_subdir.mkdir(exist_ok=True, parents=True)
+
+    @property
+    def checkpoint_dir(self):
+        return self.storage_dir / "checkpoints"
+
+    @property
+    def data_dir(self):
+        return self.storage_dir / "data"
+
+    @property
+    def logs_dir(self):
+        return self.storage_dir / "logs"
+
+    @staticmethod
+    def check_model_arch_validated(model_config: PretrainedConfig) -> bool:
+        if model_config.architectures is None:
+            return False
+
+        for arch in model_config.architectures:
+            if arch in VALIDATED_MODEL_ARCHS:
+                return True
+
+        return False
+
+    def __try_load_config(self) -> PretrainedConfig:
+        try:
+            model_config: PretrainedConfig = transformers.AutoConfig.from_pretrained(self.model_name_or_path)
+        except OSError:
+            print(
+                f"Attempted to load model config for ({self.model_name_or_path}) but failed. Model config will be loaded by `AutoConfig.from_pretrained()`"
+            )
+            raise
+
+        return model_config
+
+    def __try_load_tokenizer(self) -> SomePretrainedTokenizer:
+        try:
+            tokenizer: SomePretrainedTokenizer = transformers.AutoTokenizer.from_pretrained(
+                self.model_name_or_path, use_fast=True
+            )
+        except OSError:
+            print(
+                f"Attempted to load model tokenizer for ({self.model_name_or_path}) but failed. Model tokenizer will be loaded by `AutoTokenizer.from_pretrained()`"
+            )
+            raise
+
+        return tokenizer
+
+    @staticmethod
+    def check_tokenizer_has_chat_template(tokenizer: SomePretrainedTokenizer) -> bool:
+        if not hasattr(tokenizer, "chat_template"):
+            return False
+
+        if tokenizer.chat_template is None:
+            return False
+
+        return True
+
+    async def load_dataset_from_datasetsio(self):
+        dataset = await self.datasetio_api.get_rows_paginated(
+            dataset_id=self.training_config.data_config.dataset_id, rows_in_page=-1
+        )
+        self.loaded_dataset = dataset.rows
+
+    def preflight(self, set_status_callback: Callable[[JobStatus], None]):
+        """
+        A synchronous "preflight" operation from the recipe runs and does the following checks:
+        1. (future) validates that the host has access to sufficient hardware. For now, assume that an administrator has "cleared" the deployment for any requests it could get. In the future, check:
+            1. Cards exist
+            2. Cards have enough memory
+            3. Cards are idle
+            4. Cards have silicon for functions (bfloat16 tensor cores, support FA)
+            5. Cards are functional
+        2. Validates that model is available from HF.
+        3. Validates that model is a verified architecture (warns user if not).
+        4. Validates that model's tokenizer exists.
+        5. Validates that the model's tokenizer has a chat template.
+        6. Validates that the model's chat template can render a sample from the dataset.
+        """
+
+        model_config = self.__try_load_config()
+        if not self.check_model_arch_validated(model_config=model_config):
+            # could raise Error if we need a strong check against this.
+            print(
+                f"Input model ({self.model_name_or_path}) architecture ({model_config.architectures}) is not among validated architectures."
+            )
+
+        model_tokenizer = self.__try_load_tokenizer()
+        if not self.check_tokenizer_has_chat_template(model_tokenizer):
+            raise RuntimeError(
+                f"Input model ({self.model_name_or_path})'s tokenizer ({model_tokenizer.__name__}) has no chat template from associated `tokenizer_config.json`"
+            )
+
+        try:
+            rendered_sample = model_tokenizer.apply_chat_template(self.loaded_dataset[0]["messages"])
+        except Exception:
+            # catching / raising bare exception because 'apply_chat_template' can raise ValueError or TypeError; want to report the same thing regardless.
+            print(
+                f"Input model ({self.model_name_or_path})'s tokenizer ({model_tokenizer.__name__}) could not tokenize dataset sample. Please make sure that sample is OpenAI 'chat' formatted."
+            )
+            raise
+
+        # Success! Preflight checks haven't caught any immediate problems.
+        set_status_callback(JobStatus.scheduled)
+
+    def setup(self):
+        """
+        A synchronous data preprocessing operation that runs in a kernel-scheduled background thread and does the following:
+        1. Requests all rows of data from datasetsio API
+        2. Ports data into a `huggingface.datasets` object
+        3. Instantiates the model tokenizer
+        4. `dataset.map`'s the input data into chat template format
+        5. generates labels, masks for each sample
+        6. writes dataset to temporary storage
+        """
+        pass
+
+    async def train(self, set_status_callback: Callable[[JobStatus], None]):
+        """
+        An asynchronous instance method that creates and watches a `torchrun` subprocess that's training the input model.
+        """
+        set_status_callback(JobStatus.completed)

--- a/llama_stack/providers/registry/inference.py
+++ b/llama_stack/providers/registry/inference.py
@@ -83,7 +83,7 @@ def available_providers() -> List[ProviderSpec]:
             api=Api.inference,
             adapter=AdapterSpec(
                 adapter_type="ollama",
-                pip_packages=["ollama", "aiohttp"],
+                pip_packages=["ollama", "aiohttp", "openai"],
                 config_class="llama_stack.providers.remote.inference.ollama.OllamaImplConfig",
                 module="llama_stack.providers.remote.inference.ollama",
             ),

--- a/llama_stack/providers/registry/post_training.py
+++ b/llama_stack/providers/registry/post_training.py
@@ -14,7 +14,7 @@ def available_providers() -> List[ProviderSpec]:
         InlineProviderSpec(
             api=Api.post_training,
             provider_type="inline::torchtune",
-            pip_packages=["torch", "torchtune==0.5.0", "torchao==0.8.0", "numpy"],
+            pip_packages=["torch", "torchtune==0.5.0", "torchao==0.8.0", "numpy", "openai"],
             module="llama_stack.providers.inline.post_training.torchtune",
             config_class="llama_stack.providers.inline.post_training.torchtune.TorchtunePostTrainingConfig",
             api_dependencies=[
@@ -25,7 +25,7 @@ def available_providers() -> List[ProviderSpec]:
         InlineProviderSpec(
             api=Api.post_training,
             provider_type="inline::huggingface-ilab",
-            pip_packages=["torch", "transformers", "datasets", "numpy"],
+            pip_packages=["torch", "transformers", "datasets", "numpy", "openai"],
             module="llama_stack.providers.inline.post_training.huggingface_ilab",
             config_class="llama_stack.providers.inline.post_training.huggingface_ilab.HFilabPostTrainingConfig",
             api_dependencies=[

--- a/llama_stack/providers/registry/post_training.py
+++ b/llama_stack/providers/registry/post_training.py
@@ -22,4 +22,15 @@ def available_providers() -> List[ProviderSpec]:
                 Api.datasets,
             ],
         ),
+        InlineProviderSpec(
+            api=Api.post_training,
+            provider_type="inline::huggingface-ilab",
+            pip_packages=["torch", "transformers", "datasets", "numpy"],
+            module="llama_stack.providers.inline.post_training.huggingface_ilab",
+            config_class="llama_stack.providers.inline.post_training.huggingface_ilab.HFilabPostTrainingConfig",
+            api_dependencies=[
+                Api.datasetio,
+                Api.datasets,
+            ],
+        ),
     ]

--- a/llama_stack/providers/utils/datasetio/url_utils.py
+++ b/llama_stack/providers/utils/datasetio/url_utils.py
@@ -20,6 +20,8 @@ def get_dataframe_from_url(url: URL):
         df = pandas.read_csv(url.uri)
     elif url.uri.endswith(".xlsx"):
         df = pandas.read_excel(url.uri)
+    elif url.uri.endswith(".jsonl"):
+        df = pandas.read_json(url.uri, lines=True)
     elif url.uri.startswith("data:"):
         parts = parse_data_url(url.uri)
         data = parts["data"]


### PR DESCRIPTION
# What does this PR do?
Closes #1427

NOTE: This PR description will be updated when the PR moves from DRAFT to OPEN.

Adds `inline::huggingface-ilab` to `/post_training` providers.
This provider makes some (somewhat temporary) assumptions about dataset shape and style and model / tokenizer source (e.g. all calls have to be compliant with huggingface APIs). 
The current impl includes some starlette "hacks" to make synchronous background tasks work correctly. It also does no queuing- new requests are blocked if current request is running.

Next step is to implement the training loop. This will be invoked by subprocessing `torchrun <args> train.py <args>` to implement FSDP training. The parent-most subprocess handle will live in the `current_job` object and will be referenced to get the running status of the job. `psutil` can be used in conjuction with the `Process.pid` to do some more involved monitoring. Training logs will be written to cache rather than std-out.

KNOWN BUGS:
1. If a failure happens when the `current_job` is in a non-finalized state and the background tasks fail, the state doesn't have a TTL to be scheduled over, to the endpoint will effectively be broken until the server is restarted.
2. Lots of fields in incoming user configuration are ignored.
3. Cache may be irrevocably destroyed at the end of a run if 'storage_dir' isn't set (because of tempdirs).
4. PIDs can be recycled so monitoring the training job by PID is an unsustainable pattern.

## Test Plan
(to be implemented)

[//]: # (## Documentation)
