### PR TITLE
fix(test): use a more robust mechanism for detect loop blocking

### DIFF
--- a/tests/unit/providers/inference/test_remote_vllm.py
+++ b/tests/unit/providers/inference/test_remote_vllm.py
@@ -7,7 +7,6 @@
 import asyncio
 import contextlib
 import json
-import logging
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, HTTPServer


### PR DESCRIPTION
As titled. This is somewhat more robust because we detect the stoppage ourselves directly (instead of relying on asyncio's built-in mechanism which is likely to differ across python versions despite the configurable delay).

###  Test Plan
Test passes. If I add a time.sleep(1.0) within chat_completion() inside vLLM, the test fails.