### PR TITLE
feat: [new Open-benchmark] MMMU * , ai2d

### DIFF
--- a/llama_stack/providers/inline/scoring/basic/scoring_fn/fn_defs/regex_parser_multiple_choice_answer.py
+++ b/llama_stack/providers/inline/scoring/basic/scoring_fn/fn_defs/regex_parser_multiple_choice_answer.py
@@ -56,7 +56,7 @@ MULTILINGUAL_ANSWER_REGEXES = [
     r"Àṣàyàn\s*:",
 ]
 
-MULTILINGUAL_ANSWER_PATTERN_TEMPLATE = r"(?i){}\s*([A-D]|[أ-د]|[অ]|[ব]|[ড]|[ঢ]|[Ａ]|[Ｂ]|[Ｃ]|[Ｄ])"
+MULTILINGUAL_ANSWER_PATTERN_TEMPLATE = r"(?i){}\s*([A-J]|[أ-د]|[অ]|[ব]|[ড]|[ঢ]|[Ａ]|[Ｂ]|[Ｃ]|[Ｄ])"
 
 regex_parser_multiple_choice_answer = ScoringFn(
     identifier="basic::regex_parser_multiple_choice_answer",

--- a/llama_stack/templates/open-benchmark/open_benchmark.py
+++ b/llama_stack/templates/open-benchmark/open_benchmark.py
@@ -190,6 +190,20 @@ def get_distribution_template() -> DistributionTemplate:
             ),
         ),
         DatasetInput(
+            dataset_id="gpqa_cot_diamond",
+            purpose=DatasetPurpose.eval_messages_answer,
+            source=URIDataSource(
+                uri="huggingface://datasets/llamastack/gpqa_0shot_cot?split=test&name=gpqa_diamond",
+            ),
+        ),
+        DatasetInput(
+            dataset_id="gpqa",
+            purpose=DatasetPurpose.eval_messages_answer,
+            source=URIDataSource(
+                uri="huggingface://datasets/llamastack/gpqa_0shot?split=test&name=gpqa_main",
+            ),
+        ),
+        DatasetInput(
             dataset_id="math_500",
             purpose=DatasetPurpose.eval_messages_answer,
             source=URIDataSource(
@@ -208,6 +222,34 @@ def get_distribution_template() -> DistributionTemplate:
             purpose=DatasetPurpose.eval_messages_answer,
             source=URIDataSource(
                 uri="huggingface://datasets/llamastack/docvqa?split=val",
+            ),
+        ),
+        DatasetInput(
+            dataset_id="MMMU",
+            purpose=DatasetPurpose.eval_messages_answer,
+            source=URIDataSource(
+                uri="huggingface://datasets/llamastack/mmmu_v3?split=validation",
+            ),
+        ),
+        DatasetInput(
+            dataset_id="MMMU_Pro_standard",
+            purpose=DatasetPurpose.eval_messages_answer,
+            source=URIDataSource(
+                uri="huggingface://datasets/llamastack/MMMU_Pro?name=standard%20(10%20options)&split=test",
+            ),
+        ),
+        DatasetInput(
+            dataset_id="MMMU_Pro_vision",
+            purpose=DatasetPurpose.eval_messages_answer,
+            source=URIDataSource(
+                uri="huggingface://datasets/llamastack/MMMU_Pro?name=vision&split=test",
+            ),
+        ),
+        DatasetInput(
+            dataset_id="ai2d",
+            purpose=DatasetPurpose.eval_messages_answer,
+            source=URIDataSource(
+                uri="huggingface://datasets/llamastack/ai2d?split=test",
             ),
         ),
     ]
@@ -242,6 +284,16 @@ def get_distribution_template() -> DistributionTemplate:
             benchmark_id="meta-reference-docvqa",
             dataset_id="docvqa",
             scoring_functions=["basic::docvqa"],
+        ),
+        BenchmarkInput(
+            benchmark_id="meta-reference-MMMU_Pro_standard",
+            dataset_id="MMMU_Pro_standard",
+            scoring_functions=["basic::regex_parser_multiple_choice_answer"],
+        ),
+        BenchmarkInput(
+            benchmark_id="meta-reference-MMMU_Pro_vision",
+            dataset_id="MMMU_Pro_vision",
+            scoring_functions=["basic::regex_parser_multiple_choice_answer"],
         ),
     ]
     return DistributionTemplate(

--- a/llama_stack/templates/open-benchmark/open_benchmark.py
+++ b/llama_stack/templates/open-benchmark/open_benchmark.py
@@ -271,6 +271,16 @@ def get_distribution_template() -> DistributionTemplate:
             scoring_functions=["basic::regex_parser_multiple_choice_answer"],
         ),
         BenchmarkInput(
+            benchmark_id="meta-reference-gpqa-cot-diamond",
+            dataset_id="gpqa_cot_diamond",
+            scoring_functions=["basic::regex_parser_multiple_choice_answer"],
+        ),
+        BenchmarkInput(
+            benchmark_id="meta-reference-gpqa",
+            dataset_id="gpqa",
+            scoring_functions=["basic::regex_parser_multiple_choice_answer"],
+        ),
+        BenchmarkInput(
             benchmark_id="meta-reference-math-500",
             dataset_id="math_500",
             scoring_functions=["basic::regex_parser_math_response"],
@@ -286,6 +296,11 @@ def get_distribution_template() -> DistributionTemplate:
             scoring_functions=["basic::docvqa"],
         ),
         BenchmarkInput(
+            benchmark_id="meta-reference-MMMU",
+            dataset_id="MMMU",
+            scoring_functions=["basic::regex_parser_multiple_choice_answer"],
+        ),
+        BenchmarkInput(
             benchmark_id="meta-reference-MMMU_Pro_standard",
             dataset_id="MMMU_Pro_standard",
             scoring_functions=["basic::regex_parser_multiple_choice_answer"],
@@ -293,6 +308,11 @@ def get_distribution_template() -> DistributionTemplate:
         BenchmarkInput(
             benchmark_id="meta-reference-MMMU_Pro_vision",
             dataset_id="MMMU_Pro_vision",
+            scoring_functions=["basic::regex_parser_multiple_choice_answer"],
+        ),
+        BenchmarkInput(
+            benchmark_id="meta-reference-ai2d",
+            dataset_id="ai2d",
             scoring_functions=["basic::regex_parser_multiple_choice_answer"],
         ),
     ]

--- a/llama_stack/templates/open-benchmark/run.yaml
+++ b/llama_stack/templates/open-benchmark/run.yaml
@@ -179,6 +179,18 @@ datasets:
 - purpose: eval/messages-answer
   source:
     type: uri
+    uri: huggingface://datasets/llamastack/gpqa_0shot_cot?split=test&name=gpqa_diamond
+  metadata: {}
+  dataset_id: gpqa_cot_diamond
+- purpose: eval/messages-answer
+  source:
+    type: uri
+    uri: huggingface://datasets/llamastack/gpqa_0shot?split=test&name=gpqa_main
+  metadata: {}
+  dataset_id: gpqa
+- purpose: eval/messages-answer
+  source:
+    type: uri
     uri: huggingface://datasets/llamastack/math_500?split=test
   metadata: {}
   dataset_id: math_500
@@ -194,6 +206,30 @@ datasets:
     uri: huggingface://datasets/llamastack/docvqa?split=val
   metadata: {}
   dataset_id: docvqa
+- purpose: eval/messages-answer
+  source:
+    type: uri
+    uri: huggingface://datasets/llamastack/mmmu_v3?split=validation
+  metadata: {}
+  dataset_id: MMMU
+- purpose: eval/messages-answer
+  source:
+    type: uri
+    uri: huggingface://datasets/llamastack/MMMU_Pro?name=standard%20(10%20options)&split=test
+  metadata: {}
+  dataset_id: MMMU_Pro_standard
+- purpose: eval/messages-answer
+  source:
+    type: uri
+    uri: huggingface://datasets/llamastack/MMMU_Pro?name=vision&split=test
+  metadata: {}
+  dataset_id: MMMU_Pro_vision
+- purpose: eval/messages-answer
+  source:
+    type: uri
+    uri: huggingface://datasets/llamastack/ai2d?split=test
+  metadata: {}
+  dataset_id: ai2d
 scoring_fns: []
 benchmarks:
 - dataset_id: simpleqa
@@ -226,6 +262,16 @@ benchmarks:
   - basic::docvqa
   metadata: {}
   benchmark_id: meta-reference-docvqa
+- dataset_id: MMMU_Pro_standard
+  scoring_functions:
+  - basic::regex_parser_multiple_choice_answer
+  metadata: {}
+  benchmark_id: meta-reference-MMMU_Pro_standard
+- dataset_id: MMMU_Pro_vision
+  scoring_functions:
+  - basic::regex_parser_multiple_choice_answer
+  metadata: {}
+  benchmark_id: meta-reference-MMMU_Pro_vision
 tool_groups:
 - toolgroup_id: builtin::websearch
   provider_id: tavily-search

--- a/llama_stack/templates/open-benchmark/run.yaml
+++ b/llama_stack/templates/open-benchmark/run.yaml
@@ -247,6 +247,16 @@ benchmarks:
   - basic::regex_parser_multiple_choice_answer
   metadata: {}
   benchmark_id: meta-reference-gpqa-cot
+- dataset_id: gpqa_cot_diamond
+  scoring_functions:
+  - basic::regex_parser_multiple_choice_answer
+  metadata: {}
+  benchmark_id: meta-reference-gpqa-cot-diamond
+- dataset_id: gpqa
+  scoring_functions:
+  - basic::regex_parser_multiple_choice_answer
+  metadata: {}
+  benchmark_id: meta-reference-gpqa
 - dataset_id: math_500
   scoring_functions:
   - basic::regex_parser_math_response
@@ -262,6 +272,11 @@ benchmarks:
   - basic::docvqa
   metadata: {}
   benchmark_id: meta-reference-docvqa
+- dataset_id: MMMU
+  scoring_functions:
+  - basic::regex_parser_multiple_choice_answer
+  metadata: {}
+  benchmark_id: meta-reference-MMMU
 - dataset_id: MMMU_Pro_standard
   scoring_functions:
   - basic::regex_parser_multiple_choice_answer
@@ -272,6 +287,11 @@ benchmarks:
   - basic::regex_parser_multiple_choice_answer
   metadata: {}
   benchmark_id: meta-reference-MMMU_Pro_vision
+- dataset_id: ai2d
+  scoring_functions:
+  - basic::regex_parser_multiple_choice_answer
+  metadata: {}
+  benchmark_id: meta-reference-ai2d
 tool_groups:
 - toolgroup_id: builtin::websearch
   provider_id: tavily-search


### PR DESCRIPTION
# What does this PR do?
MMMU, MMMU_Pro_vision , MMMU_Pro_standard are all image-based questions. model is shown an image, and asked to answer questions. in MMMU and MMMU_Pro_standard, the question is given in text form, in _Pro_vision, the questions are rendered in the picture. in the _Pro versions, there are 10 choices, in MMMU there are 4 choices.

ai2d are also image based questions. But these focus more on scientific diagrams, instead of real photos.



## Test Plan
setup llama-stack server


```
llama-stack-client eval run-benchmark ai2d    --model-id    meta-llama/Llama-SOME-VERSION    --output-dir /tmp/    --num-examples 10

llama-stack-client eval run-benchmark MMMU_Pro_standard    --model-id    meta-llama/Llama-SOME-VERSION    --output-dir /tmp/    --num-examples 10

llama-stack-client eval run-benchmark MMMU_Pro_vision    --model-id    meta-llama/Llama-SOME-VERSION    --output-dir /tmp/    --num-examples 10
```


## Documentation
https://paperswithcode.com/dataset/ai2d

https://huggingface.co/datasets/MMMU/MMMU_Pro
