### PR TITLE
fix: Correctly set CLI_ARGS using BUILD_PLATFORM env with llama stack…

### DIFF
--- a/llama_stack/distribution/build_container.sh
+++ b/llama_stack/distribution/build_container.sh
@@ -235,7 +235,7 @@ image_tag="$image_name:$version_tag"
 # Detect platform architecture
 ARCH=$(uname -m)
 if [ -n "$BUILD_PLATFORM" ]; then
-  CLI_ARGS+=("--platform $BUILD_PLATFORM")
+  CLI_ARGS+=("--platform" "$BUILD_PLATFORM")
 elif [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then
   CLI_ARGS+=("--platform" "linux/arm64")
 elif [ "$ARCH" = "x86_64" ]; then


### PR DESCRIPTION
# What does this PR do?
This PR updates `build_container.sh` to prevent an "unknown flag" error when using the  `BUILD_PLATFORM` environment variable during `llama stack build`.  


[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

Closes #1699 


## Test Plan

Running the following code with out these changes results in an "unknown flag" error. 

```
CONTAINER_BINARY=podman BUILD_PLATFORM=linux/amd64 llama stack build --template ollama --image-type container 
``` 

With these changes, the same command should build the image correctly. 


