### PR TITLE
fix: telemetry logger

### DIFF
--- a/llama_stack/distribution/server/server.py
+++ b/llama_stack/distribution/server/server.py
@@ -366,7 +366,7 @@ def main():
     if Api.telemetry in impls:
         setup_logger(impls[Api.telemetry])
     else:
-        setup_logger(TelemetryAdapter(TelemetryConfig()))
+        setup_logger(TelemetryAdapter(TelemetryConfig(), {}))
 
     all_endpoints = get_all_api_endpoints()
 


### PR DESCRIPTION
# What does this PR do?

currently if you have a run yaml without temeletry the following error is hit:

TypeError: TelemetryAdapter.__init__() missing 1 required positional argument: 'deps'

this is because the TelemetryAdapter requires a deps arg to be passed. Pass {} to avoid errors.

