### PR TITLE
fix: Add 'accelerate' dependency to 'prompt-guard'

### DIFF
--- a/llama_stack/providers/registry/safety.py
+++ b/llama_stack/providers/registry/safety.py
@@ -21,7 +21,7 @@ def available_providers() -> List[ProviderSpec]:
             api=Api.safety,
             provider_type="inline::prompt-guard",
             pip_packages=[
-                "transformers",
+                "transformers[accelerate]",
                 "torch --index-url https://download.pytorch.org/whl/cpu",
             ],
             module="llama_stack.providers.inline.safety.prompt_guard",


### PR DESCRIPTION
Required to startup a distribution with prompt guard

Closes: #1723

## Test Plan
distribution starts with patch applied