### PR TITLE
fix: missing gcc package for container builds

### DIFF
--- a/llama_stack/distribution/build_container.sh
+++ b/llama_stack/distribution/build_container.sh
@@ -90,6 +90,7 @@ RUN apt-get update && apt-get install -y \
        procps psmisc lsof \
        traceroute \
        bubblewrap \
+       gcc \
        && rm -rf /var/lib/apt/lists/*
 
 ENV UV_SYSTEM_PYTHON=1


### PR DESCRIPTION
# What does this PR do?
adds missing gcc package
Closes #1716 

```
      error: command 'gcc' failed: No such file or directory

      hint: This usually indicates a problem with the package or the build
      environment.
  help: `polyleven` (v0.9.0) was included because `autoevals` (v0.0.124)
        depends on `polyleven`
Error: building at STEP "RUN uv pip install --no-cache scikit-learn nltk sentencepiece tqdm pandas scipy pymilvus emoji requests opentelemetry-sdk aiosqlite autoevals pillow matplotlib chardet mcp transformers pymongo pythainlp datasets chromadb-client langdetect pypdf tree_sitter openai blobfile numpy opentelemetry-exporter-otlp-proto-http faiss-cpu redis psycopg2-binary aiosqlite fastapi fire httpx uvicorn": while running runtime: exit status 1

ERROR    2025-03-20 15:33:31,306 llama_stack.distribution.build:128 uncategorized: Failed to build target
         distribution-remote-vllm with return code 1
Error building stack: Failed to build image distribution-remote-vllm
```

## Test Plan
Merge and perform container build

```
USE_COPY_NOT_MOUNT=true LLAMA_STACK_DIR=. llama stack build --template remote-vllm --image-type container
```

[//]: # (## Documentation)
