### PR TITLE
ci: Enforce concurrency to reduce CI loads

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,6 +14,10 @@ on:
       - 'requirements.txt'
       - '.github/workflows/integration-tests.yml' # This workflow
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/providers-build.yml
+++ b/.github/workflows/providers-build.yml
@@ -18,6 +18,10 @@ on:
       - 'llama_stack/distribution/*.sh'
       - '.github/workflows/providers-build.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   generate-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -8,6 +8,10 @@ on:
       - reopened
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,6 +15,10 @@ on:
       - '.github/workflows/unit-tests.yml' # This workflow
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-readthedocs.yml
+++ b/.github/workflows/update-readthedocs.yml
@@ -22,6 +22,10 @@ on:
       - 'pyproject.toml'
       - '.github/workflows/update-readthedocs.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update-readthedocs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# What does this PR do?

When multiple commits are pushed to a PR, multiple CI builds will be triggered. This PR ensures that we only run one concurrent build for each PR to reduce CI loads.