### PR TITLE
test: make sure integration tests runs against the server

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         # Listing tests manually since some of them currently fail
         # TODO: generate matrix list from tests/integration when fixed
-        test-type: [inference, datasets, inspect, scoring, post_training, providers]
+        test-type: [agents, inference, datasets, inspect, scoring, post_training, providers]
       fail-fast: false # we want to run all tests regardless of failure
 
     steps:
@@ -100,8 +100,14 @@ jobs:
         env:
           INFERENCE_MODEL: "meta-llama/Llama-3.2-3B-Instruct"
         run: |
-          uv run pytest -v tests/integration/${{ matrix.test-type }} --stack-config=ollama --text-model="meta-llama/Llama-3.2-3B-Instruct" --embedding-model=all-MiniLM-L6-v2
+          uv run pytest -v tests/integration/${{ matrix.test-type }} --stack-config=ollama \
+            -k "not(builtin_tool_code or safety_with_image or code_interpreter_for)" \
+            --text-model="meta-llama/Llama-3.2-3B-Instruct" \
+            --embedding-model=all-MiniLM-L6-v2
 
       - name: Run Integration Tests via http client
         run: |
-          uv run pytest -v tests/integration/${{ matrix.test-type }} --stack-config=http://localhost:8321 --text-model="meta-llama/Llama-3.2-3B-Instruct" --embedding-model=all-MiniLM-L6-v2
+          uv run pytest -v tests/integration/${{ matrix.test-type }} --stack-config=http://localhost:8321 \
+            -k "not(builtin_tool_code or safety_with_image or code_interpreter_for)" \
+            --text-model="meta-llama/Llama-3.2-3B-Instruct" \
+            --embedding-model=all-MiniLM-L6-v2

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,7 +26,7 @@ jobs:
         # Listing tests manually since some of them currently fail
         # TODO: generate matrix list from tests/integration when fixed
         test-type: [agents, inference, datasets, inspect, scoring, post_training, providers]
-        stack-config: ["ollama", "http://localhost:8321"]
+        client-type: [library, http]
       fail-fast: false # we want to run all tests regardless of failure
 
     steps:
@@ -77,7 +77,7 @@ jobs:
           exit 1
 
       - name: Start Llama Stack server in background
-        if: matrix.stack-config == "http://localhost:8321"
+        if: matrix.client-type == "http"
         env:
           INFERENCE_MODEL: "meta-llama/Llama-3.2-3B-Instruct"
         run: |
@@ -85,7 +85,7 @@ jobs:
           nohup uv run llama stack run ./llama_stack/templates/ollama/run.yaml --image-type venv > server.log 2>&1 &
 
       - name: Wait for Llama Stack server to be ready
-        if: matrix.stack-config == "http://localhost:8321"
+        if: matrix.client-type == "http"
         run: |
           echo "Waiting for Llama Stack server..."
           for i in {1..30}; do
@@ -103,7 +103,12 @@ jobs:
         env:
           INFERENCE_MODEL: "meta-llama/Llama-3.2-3B-Instruct"
         run: |
-          uv run pytest -v tests/integration/${{ matrix.test-type }} --stack-config=${{ matrix.stack-config }} \
+          if [ "${{ matrix.client-type }}" == "library" ]; then
+            stack_config="ollama"
+          else
+            stack_config="http://localhost:8321"
+          fi
+          uv run pytest -v tests/integration/${{ matrix.test-type }} --stack-config=${stack_config} \
             -k "not(builtin_tool or safety_with_image or code_interpreter or test_rag)" \
             --text-model="meta-llama/Llama-3.2-3B-Instruct" \
             --embedding-model=all-MiniLM-L6-v2

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,7 +26,7 @@ jobs:
         # Listing tests manually since some of them currently fail
         # TODO: generate matrix list from tests/integration when fixed
         test-type: [agents, inference, datasets, inspect, scoring, post_training, providers]
-        stack-config: [ollama, http://localhost:8321]
+        stack-config: ["ollama", "http://localhost:8321"]
       fail-fast: false # we want to run all tests regardless of failure
 
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -77,7 +77,7 @@ jobs:
           exit 1
 
       - name: Start Llama Stack server in background
-        if: matrix.client-type == http
+        if: matrix.client-type == 'http'
         env:
           INFERENCE_MODEL: "meta-llama/Llama-3.2-3B-Instruct"
         run: |
@@ -85,7 +85,7 @@ jobs:
           nohup uv run llama stack run ./llama_stack/templates/ollama/run.yaml --image-type venv > server.log 2>&1 &
 
       - name: Wait for Llama Stack server to be ready
-        if: matrix.client-type == http
+        if: matrix.client-type == 'http'
         run: |
           echo "Waiting for Llama Stack server..."
           for i in {1..30}; do

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -54,6 +54,8 @@ jobs:
           uv sync --extra dev --extra test
           uv pip install ollama faiss-cpu
           # always test against the latest version of the client
+          # TODO: this is not necessarily a good idea. we need to test against both published and latest
+          # to find out backwards compatibility issues.
           uv pip install git+https://github.com/meta-llama/llama-stack-client-python.git@main
           uv pip install -e .
           llama stack build --template ollama --image-type venv
@@ -94,8 +96,12 @@ jobs:
           cat server.log
           exit 1
 
-      - name: Run Integration Tests
+      - name: Run Integration Tests via library client
         env:
           INFERENCE_MODEL: "meta-llama/Llama-3.2-3B-Instruct"
         run: |
           uv run pytest -v tests/integration/${{ matrix.test-type }} --stack-config=ollama --text-model="meta-llama/Llama-3.2-3B-Instruct" --embedding-model=all-MiniLM-L6-v2
+
+      - name: Run Integration Tests via http client
+        run: |
+          uv run pytest -v tests/integration/${{ matrix.test-type }} --stack-config=http://localhost:8321 --text-model="meta-llama/Llama-3.2-3B-Instruct" --embedding-model=all-MiniLM-L6-v2

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,6 +26,7 @@ jobs:
         # Listing tests manually since some of them currently fail
         # TODO: generate matrix list from tests/integration when fixed
         test-type: [agents, inference, datasets, inspect, scoring, post_training, providers]
+        stack-config: [ollama, http://localhost:8321]
       fail-fast: false # we want to run all tests regardless of failure
 
     steps:
@@ -76,6 +77,7 @@ jobs:
           exit 1
 
       - name: Start Llama Stack server in background
+        if: matrix.stack-config == "http://localhost:8321"
         env:
           INFERENCE_MODEL: "meta-llama/Llama-3.2-3B-Instruct"
         run: |
@@ -83,6 +85,7 @@ jobs:
           nohup uv run llama stack run ./llama_stack/templates/ollama/run.yaml --image-type venv > server.log 2>&1 &
 
       - name: Wait for Llama Stack server to be ready
+        if: matrix.stack-config == "http://localhost:8321"
         run: |
           echo "Waiting for Llama Stack server..."
           for i in {1..30}; do
@@ -96,18 +99,11 @@ jobs:
           cat server.log
           exit 1
 
-      - name: Run Integration Tests via library client
+      - name: Run Integration Tests
         env:
           INFERENCE_MODEL: "meta-llama/Llama-3.2-3B-Instruct"
         run: |
-          uv run pytest -v tests/integration/${{ matrix.test-type }} --stack-config=ollama \
-            -k "not(builtin_tool_code or safety_with_image or code_interpreter_for)" \
-            --text-model="meta-llama/Llama-3.2-3B-Instruct" \
-            --embedding-model=all-MiniLM-L6-v2
-
-      - name: Run Integration Tests via http client
-        run: |
-          uv run pytest -v tests/integration/${{ matrix.test-type }} --stack-config=http://localhost:8321 \
-            -k "not(builtin_tool_code or safety_with_image or code_interpreter_for)" \
+          uv run pytest -v tests/integration/${{ matrix.test-type }} --stack-config=${{ matrix.stack-config }} \
+            -k "not(builtin_tool or safety_with_image or code_interpreter or test_rag)" \
             --text-model="meta-llama/Llama-3.2-3B-Instruct" \
             --embedding-model=all-MiniLM-L6-v2

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -77,7 +77,7 @@ jobs:
           exit 1
 
       - name: Start Llama Stack server in background
-        if: matrix.client-type == "http"
+        if: matrix.client-type == http
         env:
           INFERENCE_MODEL: "meta-llama/Llama-3.2-3B-Instruct"
         run: |
@@ -85,7 +85,7 @@ jobs:
           nohup uv run llama stack run ./llama_stack/templates/ollama/run.yaml --image-type venv > server.log 2>&1 &
 
       - name: Wait for Llama Stack server to be ready
-        if: matrix.client-type == "http"
+        if: matrix.client-type == http
         run: |
           echo "Waiting for Llama Stack server..."
           for i in {1..30}; do

--- a/tests/integration/inference/test_text_inference.py
+++ b/tests/integration/inference/test_text_inference.py
@@ -275,6 +275,7 @@ def test_text_chat_completion_first_token_profiling(client_with_models, text_mod
         model_id=text_model_id,
         messages=messages,
         stream=False,
+        timeout=120,  # Increase timeout to 2 minutes for large conversation history
     )
     message_content = response.completion_message.content.lower().strip()
     assert len(message_content) > 0
@@ -301,6 +302,7 @@ def test_text_chat_completion_streaming(client_with_models, text_model_id, test_
         model_id=text_model_id,
         messages=[{"role": "user", "content": question}],
         stream=True,
+        timeout=120,  # Increase timeout to 2 minutes for large conversation history
     )
     streamed_content = [str(chunk.event.delta.text.lower().strip()) for chunk in response]
     assert len(streamed_content) > 0


### PR DESCRIPTION
Previously, the integration tests started the server, but never really used it because `--stack-config=ollama` uses the ollama template and the inline "llama stack as library" client, not the HTTP client.

This PR makes sure we test it both ways.

We also add agents tests to the mix.

## Test Plan 

GitHub
