### PR TITLE
fix: only invoke openapi generator if APIs or API generator changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,6 +93,7 @@ repos:
         language: python
         pass_filenames: false
         require_serial: true
+        files: ^llama_stack/apis/|^docs/openapi_generator/
 
 ci:
     autofix_commit_msg: 🎨 [pre-commit.ci] Auto format from pre-commit.com hooks


### PR DESCRIPTION
As titled
