### PR TITLE
fix: remove image.data temporarily 

### DIFF
--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -3911,11 +3911,6 @@
                             "url": {
                                 "$ref": "#/components/schemas/URL",
                                 "description": "A URL of the image or data URL in the format of data:image/{type};base64,{data}. Note that URL could have length limits."
-                            },
-                            "data": {
-                                "type": "string",
-                                "contentEncoding": "base64",
-                                "description": "base64 encoded image data as string"
                             }
                         },
                         "additionalProperties": false,

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -2702,10 +2702,6 @@ components:
               description: >-
                 A URL of the image or data URL in the format of data:image/{type};base64,{data}.
                 Note that URL could have length limits.
-            data:
-              type: string
-              contentEncoding: base64
-              description: base64 encoded image data as string
           additionalProperties: false
           description: >-
             Image as a base64 encoded string or an URL

--- a/llama_stack/apis/common/content_types.py
+++ b/llama_stack/apis/common/content_types.py
@@ -28,7 +28,7 @@ class _URLOrData(BaseModel):
 
     url: Optional[URL] = None
     # data is a base64 encoded string, hint with contentEncoding=base64
-    data: Optional[str] = Field(contentEncoding="base64", default=None)
+    # data: Optional[str] = Field(contentEncoding="base64", default=None)
 
     @model_validator(mode="before")
     @classmethod

--- a/llama_stack/providers/utils/inference/prompt_adapter.py
+++ b/llama_stack/providers/utils/inference/prompt_adapter.py
@@ -142,9 +142,6 @@ async def interleaved_content_convert_to_raw(
                         data = response.content
                 else:
                     raise ValueError("Unsupported URL type")
-            elif image.data:
-                # data is a base64 encoded string, decode it to bytes for RawMediaItem
-                data = base64.b64decode(image.data)
             else:
                 raise ValueError("No data or URL provided")
 


### PR DESCRIPTION
# What does this PR do?
currently for image requests to passthrough, a bug creates a 
```
{"image": {
 "url": ...
"data":null
}
```
request, which is illegal as far as passthrough sees it.

temporarily disable this . 

the only place image.data is referenced is in the conversion function



## Test Plan
run existing unit tests in pre-commit hooks
