### PR TITLE
chore: enable mypy pydantic plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ ignore = [
 [tool.mypy]
 mypy_path = ["llama_stack"]
 packages = ["llama_stack"]
+plugins = ['pydantic.mypy']
 disable_error_code = []
 warn_return_any = true
 # # honor excludes by not following there through imports
@@ -303,3 +304,8 @@ exclude = [
 # packages that lack typing annotations, do not have stubs, or are unavailable.
 module = ["yaml", "fire"]
 ignore_missing_imports = true
+
+[tool.pydantic-mypy]
+init_forbid_extra = true
+init_typed = true
+warn_required_dynamic_aliases = true


### PR DESCRIPTION
# What does this PR do?

Enable mypy pydantic plugin.

Since the project heavily relies on pydantic models, it's probably wise
to enable the plugin to avoid some potential spurious violation warnings
the further we expand mypy coverage for the code base.

It should be generally risk-free to enable the plugin for the repo.

Some info on what plugin brings to the table:
https://docs.pydantic.dev/latest/integrations/mypy/#mypy-plugin-capabilities
