### PR TITLE
feat: update default tool use prompt

### DIFF
--- a/llama_stack/models/llama/llama3/prompt_templates/system_prompts.py
+++ b/llama_stack/models/llama/llama3/prompt_templates/system_prompts.py
@@ -229,6 +229,11 @@ class PythonListCustomToolGenerator(PromptTemplateGeneratorBase):  # noqa: N801
         You are an expert in composing functions. You are given a question and a set of possible functions.
         Based on the question, you may or may not need to make one function/tool call to achieve the purpose.
 
+        If you decide to invoke any of the function(s), you MUST put it in the format of [func_name1(params_name1=params_value1, params_name2=params_value2...), func_name2(params)]
+        If you decide to invoke a function, you SHOULD NOT include any other text in the response. besides the function call in the above format.
+        For a boolean parameter, be sure to use `True` or `False` (capitalized) for the value.
+
+
         {{ function_description }}
         """.strip("\n")
     )
@@ -243,10 +248,6 @@ class PythonListCustomToolGenerator(PromptTemplateGeneratorBase):  # noqa: N801
     def _gen_function_description(self, custom_tools: List[ToolDefinition]) -> PromptTemplate:
         template_str = textwrap.dedent(
             """
-            If you decide to invoke any of the function(s), you MUST put it in the format of [func_name1(params_name1=params_value1, params_name2=params_value2...), func_name2(params)]
-            For a boolean parameter, be sure to use `True` or `False` (capitalized) for the value.
-            You SHOULD NOT include any other text in the response.
-
             Here is a list of functions in JSON format that you can invoke.
 
             [


### PR DESCRIPTION
# What does this PR do?
User reports in https://github.com/meta-llama/llama-stack/issues/1769#issuecomment-2755564632 that Agent uses tool even on a prompt 'Hello'.

Updated the default prompt. Also move the instruction part out of `function_description` so that user can override it if desired.

## Test Plan
<img width="1344" alt="image" src="https://github.com/user-attachments/assets/c606d65d-071f-4211-a719-b4742676acda" />

Also performance on 100 hotpotqa questions are similar to the current prompt.