### PR TITLE
feat(api): Extend Files API to support registering resources

### DIFF
--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -815,6 +815,56 @@
                     }
                 ]
             },
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FileRegistrationResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest400"
+                    },
+                    "429": {
+                        "$ref": "#/components/responses/TooManyRequests429"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError500"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultError"
+                    }
+                },
+                "tags": [
+                    "Files"
+                ],
+                "description": "Register an existing file with the provider.",
+                "parameters": [
+                    {
+                        "name": "bucket",
+                        "in": "path",
+                        "description": "Storage location",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "key",
+                        "in": "path",
+                        "description": "File path relative to the storage location",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
             "delete": {
                 "responses": {
                     "200": {
@@ -2534,6 +2584,47 @@
                         "name": "bucket",
                         "in": "path",
                         "description": "Bucket name (valid chars: a-zA-Z0-9_-)",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BucketRegistrationResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest400"
+                    },
+                    "429": {
+                        "$ref": "#/components/responses/TooManyRequests429"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError500"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultError"
+                    }
+                },
+                "tags": [
+                    "Files"
+                ],
+                "description": "Register an existing storage location with the provider.",
+                "parameters": [
+                    {
+                        "name": "bucket",
+                        "in": "path",
+                        "description": "Storage location",
                         "required": true,
                         "schema": {
                             "type": "string"
@@ -9384,6 +9475,61 @@
                     "scoring_functions"
                 ],
                 "title": "RegisterBenchmarkRequest"
+            },
+            "BucketRegistrationResponse": {
+                "type": "object",
+                "properties": {
+                    "bucket": {
+                        "type": "string",
+                        "description": "The registered storage location URI (e.g., \"s3://my-bucket\" or \"file:///data\")"
+                    },
+                    "created_at": {
+                        "type": "integer",
+                        "description": "Timestamp of registration"
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "Current status of the storage location"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bucket",
+                    "created_at",
+                    "status"
+                ],
+                "title": "BucketRegistrationResponse",
+                "description": "Response after registering a storage location."
+            },
+            "FileRegistrationResponse": {
+                "type": "object",
+                "properties": {
+                    "bucket": {
+                        "type": "string",
+                        "description": "The storage location URI (e.g., \"s3://my-bucket\" or \"file:///data\")"
+                    },
+                    "key": {
+                        "type": "string",
+                        "description": "The file path relative to the storage location"
+                    },
+                    "created_at": {
+                        "type": "integer",
+                        "description": "Timestamp of registration"
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "Current status of the file"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "bucket",
+                    "key",
+                    "created_at",
+                    "status"
+                ],
+                "title": "FileRegistrationResponse",
+                "description": "Response after registering a file."
             },
             "RegisterDatasetRequest": {
                 "type": "object",

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -553,6 +553,42 @@ paths:
           required: true
           schema:
             type: string
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FileRegistrationResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+        '429':
+          $ref: >-
+            #/components/responses/TooManyRequests429
+        '500':
+          $ref: >-
+            #/components/responses/InternalServerError500
+        default:
+          $ref: '#/components/responses/DefaultError'
+      tags:
+        - Files
+      description: >-
+        Register an existing file with the provider.
+      parameters:
+        - name: bucket
+          in: path
+          description: Storage location
+          required: true
+          schema:
+            type: string
+        - name: key
+          in: path
+          description: >-
+            File path relative to the storage location
+          required: true
+          schema:
+            type: string
     delete:
       responses:
         '200':
@@ -1736,6 +1772,35 @@ paths:
         - name: bucket
           in: path
           description: 'Bucket name (valid chars: a-zA-Z0-9_-)'
+          required: true
+          schema:
+            type: string
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BucketRegistrationResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+        '429':
+          $ref: >-
+            #/components/responses/TooManyRequests429
+        '500':
+          $ref: >-
+            #/components/responses/InternalServerError500
+        default:
+          $ref: '#/components/responses/DefaultError'
+      tags:
+        - Files
+      description: >-
+        Register an existing storage location with the provider.
+      parameters:
+        - name: bucket
+          in: path
+          description: Storage location
           required: true
           schema:
             type: string
@@ -6391,6 +6456,52 @@ components:
         - dataset_id
         - scoring_functions
       title: RegisterBenchmarkRequest
+    BucketRegistrationResponse:
+      type: object
+      properties:
+        bucket:
+          type: string
+          description: >-
+            The registered storage location URI (e.g., "s3://my-bucket" or "file:///data")
+        created_at:
+          type: integer
+          description: Timestamp of registration
+        status:
+          type: string
+          description: Current status of the storage location
+      additionalProperties: false
+      required:
+        - bucket
+        - created_at
+        - status
+      title: BucketRegistrationResponse
+      description: >-
+        Response after registering a storage location.
+    FileRegistrationResponse:
+      type: object
+      properties:
+        bucket:
+          type: string
+          description: >-
+            The storage location URI (e.g., "s3://my-bucket" or "file:///data")
+        key:
+          type: string
+          description: >-
+            The file path relative to the storage location
+        created_at:
+          type: integer
+          description: Timestamp of registration
+        status:
+          type: string
+          description: Current status of the file
+      additionalProperties: false
+      required:
+        - bucket
+        - key
+        - created_at
+        - status
+      title: FileRegistrationResponse
+      description: Response after registering a file.
     RegisterDatasetRequest:
       type: object
       properties:

--- a/llama_stack/apis/files/files.py
+++ b/llama_stack/apis/files/files.py
@@ -77,6 +77,38 @@ class ListFileResponse(BaseModel):
     data: List[FileResponse]
 
 
+@json_schema_type
+class BucketRegistrationResponse(BaseModel):
+    """
+    Response after registering a storage location.
+
+    :param bucket: The registered storage location URI (e.g., "s3://my-bucket" or "file:///data")
+    :param created_at: Timestamp of registration
+    :param status: Current status of the storage location
+    """
+
+    bucket: str
+    created_at: int
+    status: str
+
+
+@json_schema_type
+class FileRegistrationResponse(BaseModel):
+    """
+    Response after registering a file.
+
+    :param bucket: The storage location URI (e.g., "s3://my-bucket" or "file:///data")
+    :param key: The file path relative to the storage location
+    :param created_at: Timestamp of registration
+    :param status: Current status of the file
+    """
+
+    bucket: str
+    key: str
+    created_at: int
+    status: str
+
+
 @runtime_checkable
 @trace_protocol
 class Files(Protocol):
@@ -170,5 +202,33 @@ class Files(Protocol):
 
         :param bucket: Bucket name (valid chars: a-zA-Z0-9_-)
         :param key: Key under which the file is stored (valid chars: a-zA-Z0-9_-/.)
+        """
+        ...
+
+    @webmethod(route="/files/{bucket}", method="PUT")
+    async def register_bucket(
+        self,
+        bucket: str,
+    ) -> BucketRegistrationResponse:
+        """
+        Register an existing storage location with the provider.
+
+        :param bucket: Storage location
+        :raises: ValidationError if URI is invalid or contains invalid characters
+        """
+        ...
+
+    @webmethod(route="/files/{bucket}/{key:path}", method="PUT")
+    async def register_bucket_file(
+        self,
+        bucket: str,
+        key: str,
+    ) -> FileRegistrationResponse:
+        """
+        Register an existing file with the provider.
+
+        :param bucket: Storage location
+        :param key: File path relative to the storage location
+        :raises: ValidationError if URI is invalid or contains invalid characters
         """
         ...


### PR DESCRIPTION
# What does this PR do?

This commit proposes extending the Files API to support registering and unregistering resources. This is particularly useful if you want to point to pre-existing data and let Llama Stack know about them.
