### PR TITLE
fix: Adding chunk_size_in_tokens to playground rag_tool insert

### DIFF
--- a/llama_stack/distribution/ui/page/playground/rag.py
+++ b/llama_stack/distribution/ui/page/playground/rag.py
@@ -58,6 +58,7 @@ def rag_chat_page():
                 llama_stack_api.client.tool_runtime.rag_tool.insert(
                     vector_db_id=vector_db_name,  # Use the user-provided name
                     documents=documents,
+                    chunk_size_in_tokens=512,
                 )
                 st.success("Vector database created successfully!")
 


### PR DESCRIPTION
# What does this PR do?
Adding chunk_size_in_tokens to playground rag_tool insert.

# Closes #1825 

## Test Plan
Tested locally.

[//]: # (## Documentation)
