### PR TITLE
fix(telemetry): root span not yet received

### DIFF
--- a/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
@@ -202,18 +202,6 @@ class TelemetryAdapter(TelemetryDatasetMixin, Telemetry):
                     parent_span_id = int(event.payload.parent_span_id, 16)
                     parent_span = _GLOBAL_STORAGE["active_spans"].get(parent_span_id)
                     context = trace.set_span_in_context(parent_span)
-                else:
-                    context = trace.set_span_in_context(
-                        trace.NonRecordingSpan(
-                            trace.SpanContext(
-                                trace_id=int(event.trace_id, 16),
-                                span_id=span_id,
-                                is_remote=False,
-                                trace_flags=trace.TraceFlags(trace.TraceFlags.SAMPLED),
-                            )
-                        )
-                    )
-                    event.attributes["__root_span__"] = "true"
 
                 span = tracer.start_span(
                     name=event.payload.name,


### PR DESCRIPTION

# What does this PR do?
closes #1725 

In https://github.com/meta-llama/llama-stack/pull/1759's attempt to make trace_id consistent in llama stack and otel exports, it incorrectly sets the span_id in context, which causes the root span to have a parent ID, leading to the issue in #1725. 

This PR reverts #1759's change to set the parent context. We will need to follow up with a proper way to do this.

## Test Plan
<img width="1868" alt="image" src="https://github.com/user-attachments/assets/15e9ac18-8541-461d-b261-c4e124388cc3" />

