### PR TITLE
fix(telemetry): library client does not log span

### DIFF
--- a/llama_stack/distribution/library_client.py
+++ b/llama_stack/distribution/library_client.py
@@ -328,8 +328,9 @@ class AsyncLlamaStackAsLibraryClient(AsyncLlamaStackClient):
 
         body = self._convert_body(path, options.method, body)
 
+        await start_trace(route, {"__location__": "library_client"})
+
         async def gen():
-            await start_trace(route, {"__location__": "library_client"})
             try:
                 async for chunk in await func(**body):
                     data = json.dumps(convert_pydantic_to_json_value(chunk))

--- a/tests/integration/telemetry/test_telemetry.py
+++ b/tests/integration/telemetry/test_telemetry.py
@@ -7,16 +7,10 @@
 import time
 from uuid import uuid4
 
-import pytest
 from llama_stack_client import Agent
-
-from llama_stack.distribution.library_client import LlamaStackAsLibraryClient
 
 
 def test_agent_query_spans(llama_stack_client, text_model_id):
-    if isinstance(llama_stack_client, LlamaStackAsLibraryClient):
-        pytest.mark.xfail(reason="Need to fix LlamaStackAsLibraryClient to log spans")
-
     agent = Agent(llama_stack_client, model=text_model_id, instructions="You are a helpful assistant")
     session_id = agent.create_session(f"test-session-{uuid4()}")
     agent.create_turn(
@@ -41,7 +35,6 @@ def test_agent_query_spans(llama_stack_client, text_model_id):
         ],
         attributes_to_return=["input", "output"],
     ):
-        print(span.attributes)
         if span.attributes["output"] != "no shields":
             agent_logs.append(span.attributes)
 


### PR DESCRIPTION

# What does this PR do?


## Test Plan

 LLAMA_STACK_CONFIG=dev pytest -s -v tests/integration/telemetry --safety-shield meta-llama/Llama-Guard-3-8B --text-model accounts/fireworks/models/llama-v3p3-70b-instruct
