### PR TITLE
docs: Add link to integration tests instructions and minor clarification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ BRAVE_SEARCH_API_KEY=
 
 And then use this dotenv file when running client SDK tests via the following:
 ```bash
-uv run --env-file .env -- pytest -v tests/integration/inference/test_text_inference.py
+uv run --env-file .env -- pytest -v tests/integration/inference/test_text_inference.py --text-model=meta-llama/Llama-3.1-8B-Instruct
 ```
 
 ## Pre-commit Hooks
@@ -125,6 +125,10 @@ If you'd like to run for a non-default version of Python (currently 3.10), pass 
 source .venv/bin/activate
 PYTHON_VERSION=3.13 ./scripts/unit-tests.sh
 ```
+
+## Running integration tests
+
+You can run integration tests following the instructions [here](tests/integration/README.md).
 
 ## Adding a new dependency to the project
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -23,8 +23,8 @@ Model parameters can be influenced by the following options:
 - `--judge-model`: comma-separated list of judge models.
 - `--embedding-dimension`: output dimensionality of the embedding model to use for testing. Default: 384
 
-Each of these are comma-separated lists and can be used to generate multiple parameter combinations.
-
+Each of these are comma-separated lists and can be used to generate multiple parameter combinations. Note that tests will be skipped
+if no model is specified.
 
 Experimental, under development, options:
 - `--record-responses`: record new API responses instead of using cached ones


### PR DESCRIPTION
# What does this PR do?

* Added `--text-model` in example command.
* Added link to integration tests instruction and a note on specifying models.

This is to avoid confusion when all tests are skipped because no model is provided.