### PR TITLE
docs: Updating docs to source from CONTRIBUTING.md

### DIFF
--- a/docs/source/building_applications/rag.md
+++ b/docs/source/building_applications/rag.md
@@ -1,4 +1,4 @@
-## Using Retrieval Augmented Generation (RAG)
+## Retrieval Augmented Generation (RAG)
 
 RAG enables your applications to reference and recall information from previous interactions or external documents.
 
@@ -162,3 +162,8 @@ for vector_db_id in client.vector_dbs.list():
     print(f"Unregistering vector database: {vector_db_id.identifier}")
     client.vector_dbs.unregister(vector_db_id=vector_db_id.identifier)
 ```
+
+### Supported Data Types
+
+You can ingest data into the vector database using `RAGDocument` objects.
+The supported mime types (https://en.wikipedia.org/wiki/Media_type#mime.types) data types are:

--- a/docs/source/building_applications/rag.md
+++ b/docs/source/building_applications/rag.md
@@ -162,8 +162,3 @@ for vector_db_id in client.vector_dbs.list():
     print(f"Unregistering vector database: {vector_db_id.identifier}")
     client.vector_dbs.unregister(vector_db_id=vector_db_id.identifier)
 ```
-
-### Supported Data Types
-
-You can ingest data into the vector database using `RAGDocument` objects.
-The supported mime types (https://en.wikipedia.org/wiki/Media_type#mime.types) data types are:

--- a/docs/source/contributing/index.md
+++ b/docs/source/contributing/index.md
@@ -1,14 +1,14 @@
-# Contributing to Llama Stack
 
-Start with the [Contributing Guide](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md) for some general tips. This section covers a few key topics in more detail.
+```{include} ../../../CONTRIBUTING.md
+```
 
-- [Adding a New API Provider](new_api_provider.md) describes adding new API providers to the Stack.
-- [Testing Llama Stack](testing.md) provides details about the testing framework and how to test providers and distributions.
+See the [Adding a New API Provider](new_api_provider.md) which describes how to add new API providers to the Stack.
+
+
 
 ```{toctree}
 :maxdepth: 1
 :hidden:
 
 new_api_provider
-testing
 ```


### PR DESCRIPTION
# What does this PR do?
Another for https://github.com/meta-llama/llama-stack/issues/1815

This links the `CONTRIBUTING.md` file directly so that we don't have to maintain two different files.

Also I updated the title for RAG under Building AI Applications.

## Changes 
Look of what the Contributing page looks like, proof it sources directly from the markdown file.

![Screenshot 2025-04-01 at 12 43 51 AM](https://github.com/user-attachments/assets/f7021d29-eec3-44ad-a5b3-55c4480ea9ac)
