### PR TITLE
feat: make training config fields optional

### DIFF
--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -8846,13 +8846,16 @@
                         "type": "integer"
                     },
                     "max_steps_per_epoch": {
-                        "type": "integer"
+                        "type": "integer",
+                        "default": 1
                     },
                     "gradient_accumulation_steps": {
-                        "type": "integer"
+                        "type": "integer",
+                        "default": 1
                     },
                     "max_validation_steps": {
-                        "type": "integer"
+                        "type": "integer",
+                        "default": 1
                     },
                     "data_config": {
                         "$ref": "#/components/schemas/DataConfig"
@@ -8872,10 +8875,7 @@
                 "required": [
                     "n_epochs",
                     "max_steps_per_epoch",
-                    "gradient_accumulation_steps",
-                    "max_validation_steps",
-                    "data_config",
-                    "optimizer_config"
+                    "gradient_accumulation_steps"
                 ],
                 "title": "TrainingConfig"
             },
@@ -10051,8 +10051,7 @@
                     "job_uuid",
                     "training_config",
                     "hyperparam_search_config",
-                    "logger_config",
-                    "model"
+                    "logger_config"
                 ],
                 "title": "SupervisedFineTuneRequest"
             },

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -6079,10 +6079,13 @@ components:
           type: integer
         max_steps_per_epoch:
           type: integer
+          default: 1
         gradient_accumulation_steps:
           type: integer
+          default: 1
         max_validation_steps:
           type: integer
+          default: 1
         data_config:
           $ref: '#/components/schemas/DataConfig'
         optimizer_config:
@@ -6097,9 +6100,6 @@ components:
         - n_epochs
         - max_steps_per_epoch
         - gradient_accumulation_steps
-        - max_validation_steps
-        - data_config
-        - optimizer_config
       title: TrainingConfig
     PreferenceOptimizeRequest:
       type: object
@@ -6833,7 +6833,6 @@ components:
         - training_config
         - hyperparam_search_config
         - logger_config
-        - model
       title: SupervisedFineTuneRequest
     SyntheticDataGenerateRequest:
       type: object

--- a/llama_stack/apis/post_training/post_training.py
+++ b/llama_stack/apis/post_training/post_training.py
@@ -60,11 +60,11 @@ class EfficiencyConfig(BaseModel):
 @json_schema_type
 class TrainingConfig(BaseModel):
     n_epochs: int
-    max_steps_per_epoch: int
-    gradient_accumulation_steps: int
-    max_validation_steps: int
-    data_config: DataConfig
-    optimizer_config: OptimizerConfig
+    max_steps_per_epoch: int = 1
+    gradient_accumulation_steps: int = 1
+    max_validation_steps: Optional[int] = 1
+    data_config: Optional[DataConfig] = None
+    optimizer_config: Optional[OptimizerConfig] = None
     efficiency_config: Optional[EfficiencyConfig] = None
     dtype: Optional[str] = "bf16"
 
@@ -177,9 +177,9 @@ class PostTraining(Protocol):
         training_config: TrainingConfig,
         hyperparam_search_config: Dict[str, Any],
         logger_config: Dict[str, Any],
-        model: str = Field(
-            default="Llama3.2-3B-Instruct",
-            description="Model descriptor from `llama model list`",
+        model: Optional[str] = Field(
+            default=None,
+            description="Model descriptor for training if not in provider config`",
         ),
         checkpoint_dir: Optional[str] = None,
         algorithm_config: Optional[AlgorithmConfig] = None,


### PR DESCRIPTION
# What does this PR do?

Today, supervised_fine_tune itself and the `TrainingConfig` class have a bunch of required fields that a provider implementation might not need. 

for example, if a provider wants to handle hyperparameters in its configuration as well as any type of dataset retrieval, optimizer or LoRA config, a user will still need to pass in a virtually empty `DataConfig`, `OptimizerConfig` and `AlgorithmConfig` in some cases.

Many of these fields are intended to work specifically with llama models and knobs intended for customizing inline. 

Adding remote post_training providers will require loosening these arguments, or forcing users to pass in empty objects to satisfy the pydantic models. 
