### PR TITLE
fix(telemetry): unstructured log event warning

### DIFF
--- a/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
@@ -126,7 +126,7 @@ class TelemetryAdapter(TelemetryDatasetMixin, Telemetry):
     def _log_unstructured(self, event: UnstructuredLogEvent, ttl_seconds: int) -> None:
         with self._lock:
             # Use global storage instead of instance storage
-            span_id = event.span_id
+            span_id = int(event.span_id, 16)
             span = _GLOBAL_STORAGE["active_spans"].get(span_id)
 
             if span:


### PR DESCRIPTION
# What does this PR do?
Removes warnings like this: 'Warning: No active span found for span_id ...'

## Test Plan
Run agent example. No more warnings.


 LLAMA_STACK_CONFIG=dev pytest -s -v tests/integration/telemetry --safety-shield meta-llama/Llama-Guard-3-8B --text-model accounts/fireworks/models/llama-v3p3-70b-instruct