### PR TITLE
test: add multi-turn tool call to test_text_inference

### DIFF
--- a/tests/integration/inference/test_text_inference.py
+++ b/tests/integration/inference/test_text_inference.py
@@ -566,4 +566,3 @@ def test_multi_turn_chat_completion(client_with_models, text_model_id):
     )
 
     assert "rain" in response.completion_message.content.lower()
-

--- a/tests/integration/inference/test_text_inference.py
+++ b/tests/integration/inference/test_text_inference.py
@@ -565,6 +565,5 @@ def test_multi_turn_chat_completion(client_with_models, text_model_id):
         messages=messages,
     )
 
-    print(response.completion_message.tool_calls)
-    print(response)
-    assert response.completion_message.content == "raining"
+    assert "rain" in response.completion_message.content.lower()
+


### PR DESCRIPTION
# What does this PR do?
- as title

## Test Plan
```
pytest --stack-config="http://localhost:8321" -v tests/integration/inference/test_text_inference.py --text-model meta-llama/Llama-3.3-70B-Instruct -k test_multi_turn_chat_completion
```

[//]: # (## Documentation)
