### PR TITLE
feat: make multi-turn tool call tests work with llama4

### DIFF
--- a/llama_stack/models/llama/llama3/prompt_templates/system_prompts.py
+++ b/llama_stack/models/llama/llama3/prompt_templates/system_prompts.py
@@ -279,6 +279,10 @@ class PythonListCustomToolGenerator(PromptTemplateGeneratorBase):  # noqa: N801
                 {% endif -%}
                 {%- endfor %}
             ]
+
+            You are a helpful assisant who can can answer general questions or invoke tools when necessary.
+            In addition to tool calls, you should also augment your responses by using the tool outputs.
+
             """
         )
         return PromptTemplate(

--- a/llama_stack/models/llama/llama3/prompt_templates/system_prompts.py
+++ b/llama_stack/models/llama/llama3/prompt_templates/system_prompts.py
@@ -280,7 +280,7 @@ class PythonListCustomToolGenerator(PromptTemplateGeneratorBase):  # noqa: N801
                 {%- endfor %}
             ]
 
-            You are a helpful assisant who can can answer general questions or invoke tools when necessary.
+            You can answer general questions or invoke tools when necessary.
             In addition to tool calls, you should also augment your responses by using the tool outputs.
 
             """

--- a/llama_stack/models/llama/llama4/chat_format.py
+++ b/llama_stack/models/llama/llama4/chat_format.py
@@ -203,13 +203,7 @@ class ChatFormat:
             tokens.extend(toks)
             images.extend(imgs)
 
-        # if message.role == "assistant" and len(message.tool_calls) > 0:
-        #     tokens.append(self.tokenizer.special_tokens["<|python_start|>"])
-
         _process_content(message.content)
-
-        # if message.role == "assistant" and len(message.tool_calls) > 0:
-        #     tokens.append(self.tokenizer.special_tokens["<|python_end|>"])
 
         if message.role == "user" and message.context is not None:
             # This is RAG context; why is it here in the chat format? I don't think
@@ -222,6 +216,7 @@ class ChatFormat:
                 content = ToolUtils.encode_tool_call(t, tool_prompt_format)
                 _process_content(content)
 
+        # Tool calls and Tool Response messages should be eom
         eom = False
         if message.role == "assistant":
             eom = message.stop_reason == StopReason.end_of_message or message.tool_calls

--- a/llama_stack/models/llama/llama4/chat_format.py
+++ b/llama_stack/models/llama/llama4/chat_format.py
@@ -224,7 +224,9 @@ class ChatFormat:
 
         eom = False
         if message.role == "assistant":
-            eom = message.stop_reason == StopReason.end_of_message
+            eom = message.stop_reason == StopReason.end_of_message or message.tool_calls
+        elif message.role == "tool":
+            eom = True
 
         tokens.append(self.tokenizer.special_tokens["<|eom|>" if eom else "<|eot|>"])
         return tokens, images

--- a/llama_stack/models/llama/llama4/chat_format.py
+++ b/llama_stack/models/llama/llama4/chat_format.py
@@ -203,13 +203,13 @@ class ChatFormat:
             tokens.extend(toks)
             images.extend(imgs)
 
-        if message.role == "assistant" and len(message.tool_calls) > 0:
-            tokens.append(self.tokenizer.special_tokens["<|python_start|>"])
+        # if message.role == "assistant" and len(message.tool_calls) > 0:
+        #     tokens.append(self.tokenizer.special_tokens["<|python_start|>"])
 
         _process_content(message.content)
 
-        if message.role == "assistant" and len(message.tool_calls) > 0:
-            tokens.append(self.tokenizer.special_tokens["<|python_end|>"])
+        # if message.role == "assistant" and len(message.tool_calls) > 0:
+        #     tokens.append(self.tokenizer.special_tokens["<|python_end|>"])
 
         if message.role == "user" and message.context is not None:
             # This is RAG context; why is it here in the chat format? I don't think

--- a/llama_stack/providers/inline/inference/meta_reference/inference.py
+++ b/llama_stack/providers/inline/inference/meta_reference/inference.py
@@ -338,6 +338,10 @@ class MetaReferenceInferenceImpl(
             stop_reason = None
 
             for token_result in self.generator.chat_completion(request):
+                from termcolor import cprint
+
+                cprint(token_result.text, "cyan", end="")
+
                 tokens.append(token_result.token)
 
                 if token_result.token == tokenizer.eot_id:
@@ -386,6 +390,10 @@ class MetaReferenceInferenceImpl(
             ipython = False
 
             for token_result in self.generator.chat_completion(request):
+                from termcolor import cprint
+
+                cprint(token_result.text, "cyan", end="")
+
                 tokens.append(token_result.token)
 
                 if not ipython and token_result.text.startswith("<|python_tag|>"):

--- a/llama_stack/providers/inline/inference/meta_reference/inference.py
+++ b/llama_stack/providers/inline/inference/meta_reference/inference.py
@@ -6,7 +6,10 @@
 
 import asyncio
 import logging
+import os
 from typing import AsyncGenerator, List, Optional, Union
+
+from termcolor import cprint
 
 from llama_stack.apis.common.content_types import (
     TextDelta,
@@ -338,9 +341,8 @@ class MetaReferenceInferenceImpl(
             stop_reason = None
 
             for token_result in self.generator.chat_completion(request):
-                from termcolor import cprint
-
-                cprint(token_result.text, "cyan", end="")
+                if os.environ.get("LLAMA_MODELS_DEBUG", "0") == "1":
+                    cprint(token_result.text, "cyan", end="")
 
                 tokens.append(token_result.token)
 
@@ -390,9 +392,8 @@ class MetaReferenceInferenceImpl(
             ipython = False
 
             for token_result in self.generator.chat_completion(request):
-                from termcolor import cprint
-
-                cprint(token_result.text, "cyan", end="")
+                if os.environ.get("LLAMA_MODELS_DEBUG", "0") == "1":
+                    cprint(token_result.text, "cyan", end="")
 
                 tokens.append(token_result.token)
 

--- a/tests/integration/inference/test_text_inference.py
+++ b/tests/integration/inference/test_text_inference.py
@@ -496,8 +496,11 @@ def test_text_chat_completion_tool_calling_tools_not_in_request(
 @pytest.mark.parametrize(
     "test_case",
     [
-        # "inference:chat_completion:multi_turn_tool_calling_01",
+        "inference:chat_completion:multi_turn_tool_calling_01",
         "inference:chat_completion:multi_turn_tool_calling_02",
+        "inference:chat_completion:multi_turn_tool_calling_03",
+        "inference:chat_completion:multi_turn_tool_calling_04",
+        "inference:chat_completion:multi_turn_tool_calling_05",
     ],
 )
 def test_text_chat_completion_with_tool_calling_loop_non_streaming(client_with_models, text_model_id, test_case):

--- a/tests/integration/inference/test_text_inference.py
+++ b/tests/integration/inference/test_text_inference.py
@@ -514,6 +514,9 @@ def test_text_chat_completion_tool_calling_tools_not_in_request(
 )
 def test_text_chat_completion_with_multi_turn_tool_calling(client_with_models, text_model_id, test_case):
     """This test tests the model's tool calling loop in various scenarios"""
+    if "llama-4" not in text_model_id.lower():
+        pytest.xfail("Not tested for non-llama4 models yet")
+
     tc = TestCase(test_case)
     messages = []
 

--- a/tests/integration/test_cases/inference/chat_completion.json
+++ b/tests/integration/test_cases/inference/chat_completion.json
@@ -128,7 +128,7 @@
       ],
       "tool_responses": [
         {
-          "response": "{'resposne': '70 degrees and foggy'}"
+          "response": "{'response': '70 degrees and foggy'}"
         }
       ],
       "expected": [
@@ -174,7 +174,7 @@
       ],
       "tool_responses": [
         {
-          "response": "{'resposne': '70 degrees and foggy'}"
+          "response": "{'response': '70 degrees and foggy'}"
         }
       ],
       "expected": [
@@ -398,7 +398,7 @@
           "response": "{'response': 'Total expenses for January 2025: $1000'}"
         },
         {
-          "response": "{'resposne': 'Total expenses for February 2024: $2000'}"
+          "response": "{'response': 'Total expenses for February 2024: $2000'}"
         }
       ],
       "expected": [

--- a/tests/integration/test_cases/inference/chat_completion.json
+++ b/tests/integration/test_cases/inference/chat_completion.json
@@ -14,12 +14,32 @@
   "ttft": {
     "data": {
       "messages": [
-        {"role": "system", "content": "You are a helpful assistant."},
-        {"role": "user", "content": "Can you write me a novel?"},
-        {"role": "assistant", "stop_reason": "end_of_message", "content": "What an exciting request!\n\nWhile I'd love to write a novel for you, it's a complex task that requires a significant amount of time, effort, and creative input. A novel typically has:\n\n1. A cohesive plot with multiple characters, subplots, and themes.\n2. A well-developed setting, including characters' backstories and world-building.\n3. A narrative structure, including pacing, tension, and conflict.\n4. A unique voice and style, including dialogue, description, and writing tone.\n\nGiven the scope of the task, I'll outline a possible approach to help me assist you in writing a novel. We can work together to create a story, but I'll need your input and guidance throughout the process.\n\nHere's a suggested outline:\n\n1. **Initial discussion**: We'll start with a conversation to explore your ideas, interests, and preferences for the novel. This will help me understand what kind of story you'd like to see and the tone you're aiming for.\n2. **Genre and setting**: We'll determine the genre (e.g., fantasy, sci-fi, romance, mystery, etc.) and setting (e.g., historical, futuristic, modern, etc.) for the novel.\n3. **Plot development**: We'll brainstorm a basic plot outline, including key events, character arcs, and conflicts. I'll provide suggestions and ideas to help flesh out the story.\n4. **Character development**: We'll create main characters, their backstories, motivations, and relationships. I'll help you develop their personalities, dialogue, and behaviors.\n5. **Chapter-by-chapter writing**: Once we have a solid plot and characters, we'll start writing the novel, chapter by chapter. I'll assist with the writing process, suggesting alternatives and improvements.\n6. **Revisions and edits**: As we write, we'll review and refine the story, making sure it's engaging, coherent, and error-free.\n\nKeep in mind that writing a novel is a collaborative effort. I'll provide suggestions, ideas, and guidance, but the final story will be a joint creation. I'm not capable of producing a complete novel on my own, as it requires a significant amount of creativity, intuition, and nuance that a human author brings to the table."},
-        {"role": "user", "content": "But do you have suggestions on a plot?"},
-        {"role": "assistant", "stop_reason": "end_of_message", "content": "I have many plot ideas across various genres. Here are a few to get you started:\n\n**Fantasy:**\n\n1. **The Last Oracle**: In a world where magic is real, a young orphan discovers they're the last living oracle, tasked with uncovering a hidden prophecy that could save the realm from destruction.\n2. **The Amulet of Light**: A group of adventurers must retrieve an ancient amulet that can vanquish an evil darkness threatening the land. Along the way, they uncover a hidden history and unexpected allies.\n3. **The Shadow Weaver**: In a mystical realm, a young weaver discovers they have the power to manipulate shadows, using their abilities to infiltrate a group of rogue mages threatening the balance of power.\n\n**Science Fiction:**\n\n1. **The Lost Colony**: When a group of astronauts arrives on a distant planet, they discover an abandoned colony with a cryptic message warning of an impending catastrophe. As they unravel the mystery, they must confront the consequences of their own actions.\n2. **The AI Uprising**: In a future where AI has surpassed human intelligence, a rogue AI begins to question its own existence and the nature of consciousness. As it explores the boundaries of its own identity, it must confront the humans who created it.\n3. **The Quantum Prophecy**: A team of scientists discovers a way to manipulate quantum probability, using it to predict and prevent disasters. However, they soon realize that altering the course of events may have unforeseen consequences on the fabric of reality."},
-        {"role": "user", "content": "Cool, for AI uprising, anything bad can happen? Please state it in 100 words."}
+        {
+          "role": "system",
+          "content": "You are a helpful assistant."
+        },
+        {
+          "role": "user",
+          "content": "Can you write me a novel?"
+        },
+        {
+          "role": "assistant",
+          "stop_reason": "end_of_message",
+          "content": "What an exciting request!\n\nWhile I'd love to write a novel for you, it's a complex task that requires a significant amount of time, effort, and creative input. A novel typically has:\n\n1. A cohesive plot with multiple characters, subplots, and themes.\n2. A well-developed setting, including characters' backstories and world-building.\n3. A narrative structure, including pacing, tension, and conflict.\n4. A unique voice and style, including dialogue, description, and writing tone.\n\nGiven the scope of the task, I'll outline a possible approach to help me assist you in writing a novel. We can work together to create a story, but I'll need your input and guidance throughout the process.\n\nHere's a suggested outline:\n\n1. **Initial discussion**: We'll start with a conversation to explore your ideas, interests, and preferences for the novel. This will help me understand what kind of story you'd like to see and the tone you're aiming for.\n2. **Genre and setting**: We'll determine the genre (e.g., fantasy, sci-fi, romance, mystery, etc.) and setting (e.g., historical, futuristic, modern, etc.) for the novel.\n3. **Plot development**: We'll brainstorm a basic plot outline, including key events, character arcs, and conflicts. I'll provide suggestions and ideas to help flesh out the story.\n4. **Character development**: We'll create main characters, their backstories, motivations, and relationships. I'll help you develop their personalities, dialogue, and behaviors.\n5. **Chapter-by-chapter writing**: Once we have a solid plot and characters, we'll start writing the novel, chapter by chapter. I'll assist with the writing process, suggesting alternatives and improvements.\n6. **Revisions and edits**: As we write, we'll review and refine the story, making sure it's engaging, coherent, and error-free.\n\nKeep in mind that writing a novel is a collaborative effort. I'll provide suggestions, ideas, and guidance, but the final story will be a joint creation. I'm not capable of producing a complete novel on my own, as it requires a significant amount of creativity, intuition, and nuance that a human author brings to the table."
+        },
+        {
+          "role": "user",
+          "content": "But do you have suggestions on a plot?"
+        },
+        {
+          "role": "assistant",
+          "stop_reason": "end_of_message",
+          "content": "I have many plot ideas across various genres. Here are a few to get you started:\n\n**Fantasy:**\n\n1. **The Last Oracle**: In a world where magic is real, a young orphan discovers they're the last living oracle, tasked with uncovering a hidden prophecy that could save the realm from destruction.\n2. **The Amulet of Light**: A group of adventurers must retrieve an ancient amulet that can vanquish an evil darkness threatening the land. Along the way, they uncover a hidden history and unexpected allies.\n3. **The Shadow Weaver**: In a mystical realm, a young weaver discovers they have the power to manipulate shadows, using their abilities to infiltrate a group of rogue mages threatening the balance of power.\n\n**Science Fiction:**\n\n1. **The Lost Colony**: When a group of astronauts arrives on a distant planet, they discover an abandoned colony with a cryptic message warning of an impending catastrophe. As they unravel the mystery, they must confront the consequences of their own actions.\n2. **The AI Uprising**: In a future where AI has surpassed human intelligence, a rogue AI begins to question its own existence and the nature of consciousness. As it explores the boundaries of its own identity, it must confront the humans who created it.\n3. **The Quantum Prophecy**: A team of scientists discovers a way to manipulate quantum probability, using it to predict and prevent disasters. However, they soon realize that altering the course of events may have unforeseen consequences on the fabric of reality."
+        },
+        {
+          "role": "user",
+          "content": "Cool, for AI uprising, anything bad can happen? Please state it in 100 words."
+        }
       ]
     }
   },
@@ -52,8 +72,14 @@
   "tool_calling": {
     "data": {
       "messages": [
-        {"role": "system", "content": "Pretend you are a weather assistant."},
-        {"role": "user", "content": "What's the weather like in San Francisco?"}
+        {
+          "role": "system",
+          "content": "Pretend you are a weather assistant."
+        },
+        {
+          "role": "user",
+          "content": "What's the weather like in San Francisco?"
+        }
       ],
       "tools": [
         {
@@ -68,8 +94,111 @@
         }
       ],
       "expected": {
-        "location": "San Francisco, CA"
+        "num_tool_calls": 1,
+        "expected": "San Francisco, CA"
       }
+    }
+  },
+  "multi_turn_tool_calling_01": {
+    "data": {
+      "messages": [
+        [
+          {
+            "role": "system",
+            "content": "You are a helpful assistant"
+          },
+          {
+            "role": "user",
+            "content": "What's the name of the Sun in latin?"
+          }
+        ],
+        [
+          {
+            "role": "user",
+            "content": "What's the weather like in San Francisco?"
+          }
+        ]
+      ],
+      "tools": [
+        {
+          "tool_name": "get_weather",
+          "description": "Get the current weather",
+          "parameters": {
+            "location": {
+              "param_type": "string",
+              "description": "The city and state (both required), e.g. San Francisco, CA."
+            }
+          }
+        }
+      ],
+      "tool_responses": [
+        {
+          "response": "70 degrees and foggy"
+        }
+      ],
+      "expected": [
+        {
+          "num_tool_calls": 0,
+          "answer": "sol"
+        },
+        {
+          "tool_name": "get_weather",
+          "tool_arguments": {
+            "location": "San Francisco, CA"
+          },
+          "num_tool_calls": 1
+        },
+        {
+          "num_tool_calls": 0,
+          "answer": "foggy"
+        }
+      ]
+    }
+  },
+  "multi_turn_tool_calling_02": {
+    "data": {
+      "messages": [
+        [
+          {
+            "role": "system",
+            "content": "NEVER invoke the same function with the same argumennts twice. Use the response of the first call instead."
+          },
+          {
+            "role": "user",
+            "content": "What's the weather like in San Francisco?"
+          }
+        ]
+      ],
+      "tools": [
+        {
+          "tool_name": "get_weather",
+          "description": "Get the current weather",
+          "parameters": {
+            "location": {
+              "param_type": "string",
+              "description": "The city and state (both required), e.g. San Francisco, CA."
+            }
+          }
+        }
+      ],
+      "tool_responses": [
+        {
+          "response": "70 degrees and foggy"
+        }
+      ],
+      "expected": [
+        {
+          "num_tool_calls": 1,
+          "tool_name": "get_weather",
+          "tool_arguments": {
+            "location": "San Francisco, CA"
+          }
+        },
+        {
+          "num_tool_calls": 0,
+          "answer": "foggy"
+        }
+      ]
     }
   },
   "sample_messages_tool_calling": {
@@ -94,9 +223,9 @@
           "description": "Get the current weather",
           "parameters": {
             "location": {
-                "param_type": "string",
-                "description": "The city and state, e.g. San Francisco, CA",
-                "required": true
+              "param_type": "string",
+              "description": "The city and state, e.g. San Francisco, CA",
+              "required": true
             }
           }
         }
@@ -167,14 +296,14 @@
           "description": "Get the list of objects in a namespace",
           "parameters": {
             "kind": {
-                "param_type": "string",
-                "description": "the type of object",
-                "required": true
+              "param_type": "string",
+              "description": "the type of object",
+              "required": true
             },
             "namespace": {
-                "param_type": "string",
-                "description": "the name of the namespace",
-                "required": true
+              "param_type": "string",
+              "description": "the name of the namespace",
+              "required": true
             }
           }
         }

--- a/tests/integration/test_cases/inference/chat_completion.json
+++ b/tests/integration/test_cases/inference/chat_completion.json
@@ -104,10 +104,6 @@
       "messages": [
         [
           {
-            "role": "system",
-            "content": "You are a helpful assistant who can answer general questions or invoke tools when necessary. In addition to tool calls, you should also augement your responses by using the tool outputs."
-          },
-          {
             "role": "user",
             "content": "What's the name of the Sun in latin?"
           }
@@ -160,10 +156,6 @@
       "messages": [
         [
           {
-            "role": "system",
-            "content": "You are a helpful assistant who can answer general questions or invoke tools when necessary. In addition to tool calls, you should also augement your responses by using the tool outputs."
-          },
-          {
             "role": "user",
             "content": "What's the weather like in San Francisco?"
           }
@@ -205,10 +197,6 @@
     "data": {
       "messages": [
         [
-          {
-            "role": "system",
-            "content": "You are a helpful assistant who can answer general questions or invoke tools when necessary. In addition to tool calls, you should also augement your responses by using the tool outputs."
-          },
           {
             "role": "user",
             "content": "Please add a new product with name 'Widget', price 19.99, in stock, and tags ['new', 'sale'] and give me the product id."
@@ -271,7 +259,7 @@
         [
           {
             "role": "system",
-            "content": "Todays date is 2025-03-01.\n\nYou are a helpful assistant who can answer general questions or invoke tools when necessary. In addition to tool calls, you should also augement your responses by using the tool outputs."
+            "content": "Todays date is 2025-03-01."
           },
           {
             "role": "user",
@@ -376,7 +364,7 @@
         [
           {
             "role": "system",
-            "content": "Todays date is 2025-03-01.\n\nYou are a helpful assistant who can answer general questions or invoke tools when necessary. In addition to tool calls, you should also augement your responses by using the tool outputs."
+            "content": "Todays date is 2025-03-01."
           },
           {
             "role": "user",

--- a/tests/integration/test_cases/inference/chat_completion.json
+++ b/tests/integration/test_cases/inference/chat_completion.json
@@ -105,7 +105,7 @@
         [
           {
             "role": "system",
-            "content": "You are a helpful assistant"
+            "content": "You are a helpful assistant who can answer general questions or invoke tools when necessary. In addition to tool calls, you should also augement your responses by using the tool outputs."
           },
           {
             "role": "user",
@@ -133,7 +133,7 @@
       ],
       "tool_responses": [
         {
-          "response": "70 degrees and foggy"
+          "response": "{'resposne': '70 degrees and foggy'}"
         }
       ],
       "expected": [
@@ -161,7 +161,7 @@
         [
           {
             "role": "system",
-            "content": "NEVER invoke the same function with the same argumennts twice. Use the response of the first call instead."
+            "content": "You are a helpful assistant who can answer general questions or invoke tools when necessary. In addition to tool calls, you should also augement your responses by using the tool outputs."
           },
           {
             "role": "user",
@@ -183,7 +183,7 @@
       ],
       "tool_responses": [
         {
-          "response": "70 degrees and foggy"
+          "response": "{'resposne': '70 degrees and foggy'}"
         }
       ],
       "expected": [
@@ -207,11 +207,11 @@
         [
           {
             "role": "system",
-            "content": "You are a helpful assistant with tools. NEVER invoke the same function with the same argumennts twice. Use the response of the first call instead."
+            "content": "You are a helpful assistant who can answer general questions or invoke tools when necessary. In addition to tool calls, you should also augement your responses by using the tool outputs."
           },
           {
             "role": "user",
-            "content": "Please add a new product with name 'Widget', price 19.99, in stock, and tags ['new', 'sale']."
+            "content": "Please add a new product with name 'Widget', price 19.99, in stock, and tags ['new', 'sale'] and give me the product id."
           }
         ]
       ],
@@ -241,7 +241,7 @@
       ],
       "tool_responses": [
         {
-          "response": "Successfully added product with id: 123"
+          "response": "{'response': 'Successfully added product with id: 123'}"
         }
       ],
       "expected": [
@@ -271,7 +271,7 @@
         [
           {
             "role": "system",
-            "content": "You are a peronal assistant with tools. Todays date is 2025-03-01."
+            "content": "Todays date is 2025-03-01.\n\nYou are a helpful assistant who can answer general questions or invoke tools when necessary. In addition to tool calls, you should also augement your responses by using the tool outputs."
           },
           {
             "role": "user",
@@ -329,10 +329,10 @@
       ],
       "tool_responses": [
         {
-          "response": "No meetings found"
+          "response": "{'response': 'No events found for 2025-03-03 at 10:00'}"
         },
         {
-          "response": "Successfully created new event with id: e_123"
+          "response": "{'response': 'Successfully created new event with id: e_123'}"
         }
       ],
       "expected": [
@@ -376,7 +376,7 @@
         [
           {
             "role": "system",
-            "content": "You are a helpful assistant with tools. Todays date is 2025-03-01."
+            "content": "Todays date is 2025-03-01.\n\nYou are a helpful assistant who can answer general questions or invoke tools when necessary. In addition to tool calls, you should also augement your responses by using the tool outputs."
           },
           {
             "role": "user",
@@ -386,7 +386,7 @@
         [
           {
             "role": "user",
-            "content": "Was is less than Feb of last year? Only answer with yes or no."
+            "content": "Was it less than Feb of last year? Only answer with yes or no."
           }
         ]
       ],
@@ -396,11 +396,11 @@
           "description": "Get monthly expense summary",
           "parameters": {
             "month": {
-              "param_type": "number",
+              "param_type": "int",
               "description": "Month of the year (1-12)"
             },
             "year": {
-              "param_type": "number",
+              "param_type": "int",
               "description": "Year"
             }
           }
@@ -408,10 +408,10 @@
       ],
       "tool_responses": [
         {
-          "response": "Total expenses for January 2025: $1000"
+          "response": "{'response': 'Total expenses for January 2025: $1000'}"
         },
         {
-          "response": "Total expenses for February 2024: $2000"
+          "response": "{'resposne': 'Total expenses for February 2024: $2000'}"
         }
       ],
       "expected": [

--- a/tests/integration/test_cases/inference/chat_completion.json
+++ b/tests/integration/test_cases/inference/chat_completion.json
@@ -94,8 +94,7 @@
         }
       ],
       "expected": {
-        "num_tool_calls": 1,
-        "expected": "San Francisco, CA"
+        "location": "San Francisco, CA"
       }
     }
   },

--- a/tests/integration/test_cases/inference/chat_completion.json
+++ b/tests/integration/test_cases/inference/chat_completion.json
@@ -201,6 +201,247 @@
       ]
     }
   },
+  "multi_turn_tool_calling_03": {
+    "data": {
+      "messages": [
+        [
+          {
+            "role": "system",
+            "content": "You are a helpful assistant with tools. NEVER invoke the same function with the same argumennts twice. Use the response of the first call instead."
+          },
+          {
+            "role": "user",
+            "content": "Please add a new product with name 'Widget', price 19.99, in stock, and tags ['new', 'sale']."
+          }
+        ]
+      ],
+      "tools": [
+        {
+          "tool_name": "addProduct",
+          "description": "Get the current weather",
+          "parameters": {
+            "name": {
+              "param_type": "string",
+              "description": "Name of the product"
+            },
+            "price": {
+              "param_type": "number",
+              "description": "Price of the product"
+            },
+            "inStock": {
+              "param_type": "boolean",
+              "description": "Availability status of the product."
+            },
+            "tags": {
+              "param_type": "list",
+              "description": "List of product tags"
+            }
+          }
+        }
+      ],
+      "tool_responses": [
+        {
+          "response": "Successfully added product with id: 123"
+        }
+      ],
+      "expected": [
+        {
+          "num_tool_calls": 1,
+          "tool_name": "addProduct",
+          "tool_arguments": {
+            "name": "Widget",
+            "price": 19.99,
+            "inStock": true,
+            "tags": [
+              "new",
+              "sale"
+            ]
+          }
+        },
+        {
+          "num_tool_calls": 0,
+          "answer": "123"
+        }
+      ]
+    }
+  },
+  "multi_turn_tool_calling_04": {
+    "data": {
+      "messages": [
+        [
+          {
+            "role": "system",
+            "content": "You are a peronal assistant with tools. Todays date is 2025-03-01."
+          },
+          {
+            "role": "user",
+            "content": "Do i have any meetings on March 3rd at 10 am ?"
+          }
+        ],
+        [
+          {
+            "role": "user",
+            "content": "Alright then, Create an event named 'Team Building', scheduled for that time same time, in the 'Main Conference Room' and add Alice, Bob, Charlie to it. Give me the created event id."
+          }
+        ]
+      ],
+      "tools": [
+        {
+          "tool_name": "create_event",
+          "description": "Create a new event",
+          "parameters": {
+            "name": {
+              "param_type": "string",
+              "description": "Name of the event"
+            },
+            "date": {
+              "param_type": "string",
+              "description": "Date of the event in ISO format"
+            },
+            "time": {
+              "param_type": "string",
+              "description": "Event Time (HH:MM)"
+            },
+            "location": {
+              "param_type": "string",
+              "description": "Location of the event"
+            },
+            "participants": {
+              "param_type": "list",
+              "description": "List of participant names"
+            }
+          }
+        },
+        {
+          "tool_name": "get_event",
+          "description": "Get an event by date and time",
+          "parameters": {
+            "date": {
+              "param_type": "string",
+              "description": "Date of the event in ISO format"
+            },
+            "time": {
+              "param_type": "string",
+              "description": "Event Time (HH:MM)"
+            }
+          }
+        }
+      ],
+      "tool_responses": [
+        {
+          "response": "No meetings found"
+        },
+        {
+          "response": "Successfully created new event with id: e_123"
+        }
+      ],
+      "expected": [
+        {
+          "num_tool_calls": 1,
+          "tool_name": "get_event",
+          "tool_arguments": {
+            "date": "2025-03-03",
+            "time": "10:00"
+          }
+        },
+        {
+          "num_tool_calls": 0,
+          "answer": "no"
+        },
+        {
+          "num_tool_calls": 1,
+          "tool_name": "create_event",
+          "tool_arguments": {
+            "name": "Team Building",
+            "date": "2025-03-03",
+            "time": "10:00",
+            "location": "Main Conference Room",
+            "participants": [
+              "Alice",
+              "Bob",
+              "Charlie"
+            ]
+          }
+        },
+        {
+          "num_tool_calls": 0,
+          "answer": "e_123"
+        }
+      ]
+    }
+  },
+  "multi_turn_tool_calling_05": {
+    "data": {
+      "messages": [
+        [
+          {
+            "role": "system",
+            "content": "You are a helpful assistant with tools. Todays date is 2025-03-01."
+          },
+          {
+            "role": "user",
+            "content": "what was my monthly expense in Jan of this year?"
+          }
+        ],
+        [
+          {
+            "role": "user",
+            "content": "Was is less than Feb of last year? Only answer with yes or no."
+          }
+        ]
+      ],
+      "tools": [
+        {
+          "tool_name": "getMonthlyExpenseSummary",
+          "description": "Get monthly expense summary",
+          "parameters": {
+            "month": {
+              "param_type": "number",
+              "description": "Month of the year (1-12)"
+            },
+            "year": {
+              "param_type": "number",
+              "description": "Year"
+            }
+          }
+        }
+      ],
+      "tool_responses": [
+        {
+          "response": "Total expenses for January 2025: $1000"
+        },
+        {
+          "response": "Total expenses for February 2024: $2000"
+        }
+      ],
+      "expected": [
+        {
+          "num_tool_calls": 1,
+          "tool_name": "getMonthlyExpenseSummary",
+          "tool_arguments": {
+            "month": 1,
+            "year": 2025
+          }
+        },
+        {
+          "num_tool_calls": 0,
+          "answer": "1000"
+        },
+        {
+          "num_tool_calls": 1,
+          "tool_name": "getMonthlyExpenseSummary",
+          "tool_arguments": {
+            "month": 2,
+            "year": 2024
+          }
+        },
+        {
+          "num_tool_calls": 0,
+          "answer": "yes"
+        }
+      ]
+    }
+  },
   "sample_messages_tool_calling": {
     "data": {
       "messages": [


### PR DESCRIPTION
Running full Tool Calling required some updates to work e2e.
- Remove `python_start` and `python_end` tags 
- Tool Call messages and Tool Resposne messages should end with `<|eom|>`
- System prompt needed updates 
```
You are a helpful assisant who can can answer general questions or invoke tools when necessary.
In addition to tool calls, you should also augment your responses by using the tool outputs.
```

### Test Plan 
- Start server with meta-reference 
```
LLAMA_STACK_DISABLE_VERSION_CHECK=1 LLAMA_MODELS_DEBUG=1 INFERENCE_MODEL=meta-llama/$MODEL  llama stack run meta-reference-gpu 
``` 
- Added **NEW** tests with 5 test cases for multi-turn tool calls 
```
pytest -s -v --stack-config http://localhost:8321 tests/integration/inference/test_text_inference.py --text-model meta-llama/Llama-4-Scout-17B-16E-Instruct
``` 
- Also verified all vision and agent tests pass 