### PR TITLE
ci: introduce Mergify bot to notify on PR conflicts

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,23 @@
+pull_request_rules:
+- name: ping author on conflicts and add 'needs-rebase' label
+  conditions:
+      - conflict
+      - -closed
+  actions:
+    label:
+      add:
+        - needs-rebase
+    comment:
+      message: >
+       This pull request has merge conflicts that must be resolved before it
+       can be merged. @{{author}} please rebase it.
+       https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
+
+- name: remove 'needs-rebase' label when conflict is resolved
+  conditions:
+      - -conflict
+      - -closed
+  actions:
+    label:
+      remove:
+        - needs-rebase


### PR DESCRIPTION
This commit introduces Mergify, a powerful bot designed to assist with automated merging and other CI-related tasks. As an initial step, we enable a basic feature: automatically notifying users when a pull request has merge conflicts.

When a conflict is detected, Mergify will add a label to the PR. This label will be removed once the conflict is resolved.

In the future, we plan to expand Mergify’s role to include auto-merging, as discussed in #1667, once the project is ready.