### PR TITLE
fix: add tavily_search option to playground api

### DIFF
--- a/llama_stack/distribution/ui/modules/api.py
+++ b/llama_stack/distribution/ui/modules/api.py
@@ -19,6 +19,7 @@ class LlamaStackApi:
                 "together_api_key": os.environ.get("TOGETHER_API_KEY", ""),
                 "sambanova_api_key": os.environ.get("SAMBANOVA_API_KEY", ""),
                 "openai_api_key": os.environ.get("OPENAI_API_KEY", ""),
+                "tavily_search_api_key": os.environ.get("TAVILY_SEARCH_API_KEY", ""),
             },
         )
 


### PR DESCRIPTION
# What does this PR do?
This PR adds the "TAVILY_SEARCH_API_KEY" option to the playground to enable the use of the websearch tool.

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan

```
export TAVILY_SEARCH_API_KEY=***
streamlit run  llama_stack/distribution/ui/app.py      
```
Without this change the builtin websearch tool will fail due to missing API key. 


[//]: # (## Documentation)
Related to #1902 