### PR TITLE
chore: Detect browser setting for dark/light mode and set default to light mode

### DIFF
--- a/docs/_static/js/detect_theme.js
+++ b/docs/_static/js/detect_theme.js
@@ -1,0 +1,9 @@
+document.addEventListener("DOMContentLoaded", function () {
+  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  const htmlElement = document.documentElement;
+  if (prefersDark) {
+    htmlElement.setAttribute("data-theme", "dark");
+  } else {
+    htmlElement.setAttribute("data-theme", "light");
+  }
+});

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -121,6 +121,7 @@ html_static_path = ["../_static"]
 
 def setup(app):
     app.add_css_file("css/my_theme.css")
+    app.add_js_file("js/detect_theme.js")
 
     def dockerhub_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
         url = f"https://hub.docker.com/r/llamastack/{text}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -111,6 +111,9 @@ html_theme_options = {
     "collapse_navigation": False,
     # "style_nav_header_background": "#c3c9d4",
 }
+html_context = {
+    "default_mode": "auto"
+}
 
 html_static_path = ["../_static"]
 # html_logo = "../_static/llama-stack-logo.png"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -111,9 +111,8 @@ html_theme_options = {
     "collapse_navigation": False,
     # "style_nav_header_background": "#c3c9d4",
 }
-html_context = {
-    "default_mode": "auto"
-}
+
+default_dark_mode = False
 
 html_static_path = ["../_static"]
 # html_logo = "../_static/llama-stack-logo.png"


### PR DESCRIPTION
# What does this PR do?

1. Adding some lightweight JS to detect the default browser setting for dark/light mode
3. Setting default screen setting to light mode as to not change default behavior. 

From the docs: https://github.com/MrDogeBro/sphinx_rtd_dark_mode

>This lets you choose which theme the user sees when they load the docs for the first time ever. After the first time however, this setting has no effect as the users preference is stored in local storage within their browser. This option accepts a boolean for the value. If this option is true (the default option), users will start in dark mode when first visiting the site. If this option is false, users will start in light mode when they first visit the site.

# Closes #1915 

## Test Plan
Tested locally on my Mac on Safari and Chrome.