### PR TITLE
fix: use torchao 0.8.0 for inference

### DIFF
--- a/llama_stack/providers/registry/inference.py
+++ b/llama_stack/providers/registry/inference.py
@@ -24,7 +24,7 @@ META_REFERENCE_DEPS = [
     "zmq",
     "lm-format-enforcer",
     "sentence-transformers",
-    "torchao==0.5.0",
+    "torchao==0.8.0",
     "fbgemm-gpu-genai==1.1.2",
 ]
 

--- a/llama_stack/templates/dependencies.json
+++ b/llama_stack/templates/dependencies.json
@@ -381,7 +381,7 @@
     "sentence-transformers",
     "sentencepiece",
     "torch",
-    "torchao==0.5.0",
+    "torchao==0.8.0",
     "torchvision",
     "tqdm",
     "transformers",


### PR DESCRIPTION
# What does this PR do?

While building the "experimental-post-training" distribution, we encountered a version conflict between torchao with inference requiring version 0.5.0 and training currently depending on version 0.8.0.

Resolves this error:

```
  × No solution found when resolving dependencies:
  ╰─▶ Because you require torchao==0.5.0 and torchao==0.8.0, we can conclude that your requirements are unsatisfiable.
ERROR    2025-04-10 10:41:22,597 llama_stack.distribution.build:128 uncategorized: Failed to build target test with
         return code 1
```