### PR TITLE
doc: Updating background color for code in darkmode

### DIFF
--- a/docs/_static/css/my_theme.css
+++ b/docs/_static/css/my_theme.css
@@ -16,3 +16,7 @@
 .hide-title h1 {
     display: none;
 }
+
+html[data-theme="dark"] .rst-content div[class^="highlight"] {
+  background-color: #0b0b0b;
+}


### PR DESCRIPTION
# What does this PR do?
A small quality of life adjustment to make the code background for darkmode black. Makes it much easier to differentiate between code and non-code text.

From:
<img width="1250" alt="Screenshot 2025-04-10 at 9 22 23 AM" src="https://github.com/user-attachments/assets/3a3aea8b-e540-4e76-a7db-6c276e389cc2" />
To:
<img width="1273" alt="Screenshot 2025-04-10 at 9 22 43 AM" src="https://github.com/user-attachments/assets/6ada2cb1-2c33-4a95-be88-7b4c65d4ba93" />