### PR TITLE
docs: Updated docs to show minimal RAG example and some other minor changes

### DIFF
--- a/docs/_static/css/my_theme.css
+++ b/docs/_static/css/my_theme.css
@@ -17,9 +17,13 @@
     display: none;
 }
 
-h3 {
+h2, h3, h4 {
     font-weight: normal;
 }
 html[data-theme="dark"] .rst-content div[class^="highlight"] {
   background-color: #0b0b0b;
+}
+pre {
+    white-space: pre-wrap !important;
+    word-break: break-all;
 }

--- a/docs/source/getting_started/detailed_tutorial.md
+++ b/docs/source/getting_started/detailed_tutorial.md
@@ -220,7 +220,7 @@ Other SDKs are also available, please refer to the [Client SDK](../index.md#clie
 ::::{tab-set}
 
 :::{tab-item} Basic Inference
-Alternatively, you can run inference using the Llama Stack client SDK.
+Now you can run inference using the Llama Stack client SDK.
 
 ### i. Create the Script
 Create a file `inference.py` and add the following code:
@@ -265,7 +265,7 @@ Beauty in the bits
 :::
 
 :::{tab-item} Build a Simple Agent
-Now we can move beyond simple inference and build an agent that can perform tasks using the Llama Stack server.
+Next we can move beyond simple inference and build an agent that can perform tasks using the Llama Stack server.
 ### i. Create the Script
 Create a file `agent.py` and add the following code:
 

--- a/docs/source/getting_started/detailed_tutorial.md
+++ b/docs/source/getting_started/detailed_tutorial.md
@@ -173,9 +173,8 @@ You will see the below:
 Done! You can now use the Llama Stack Client CLI with endpoint http://localhost:8321
 ```
 
-#### iii. List Available Models
 List the models
-```
+```bash
 llama-stack-client models list
 Available Models
 
@@ -190,15 +189,6 @@ Available Models
 Total models: 2
 
 ```
-
-## Step 4: Run the Demos
-
-Note that these demos show the [Python Client SDK](../references/python_sdk_reference/index.md).
-Other SDKs are also available, please refer to the [Client SDK](../index.md#client-sdks) list for the complete options.
-
-::::{tab-set}
-
-:::{tab-item} Basic Inference with the CLI
 You can test basic Llama inference completion using the CLI.
 
 ```bash
@@ -221,9 +211,15 @@ ChatCompletionResponse(
     ],
 )
 ```
-:::
 
-:::{tab-item} Basic Inference with a Script
+## Step 4: Run the Demos
+
+Note that these demos show the [Python Client SDK](../references/python_sdk_reference/index.md).
+Other SDKs are also available, please refer to the [Client SDK](../index.md#client-sdks) list for the complete options.
+
+::::{tab-set}
+
+:::{tab-item} Basic Inference
 Alternatively, you can run inference using the Llama Stack client SDK.
 
 ### i. Create the Script


### PR DESCRIPTION
# What does this PR do?
Incorporating some feedback into the docs.

- **`docs/source/getting_started/index.md`:**
    - Demo actually does RAG now
    - Simplified the installation command for dependencies.
    - Updated demo script examples to align with the latest API changes.
    - Replaced manual document manipulation with `RAGDocument` for clarity and maintainability.
    - Introduced new logic for model and embedding selection using the Llama Stack Client SDK.
    - Enhanced examples to showcase proper agent initialization and logging.
- **`docs/source/getting_started/detailed_tutorial.md`:**
    - Updated the section for listing models to include proper code formatting with `bash`.
    - Removed and reorganized the "Run the Demos" section for clarity.
    - Adjusted tab-item structures and added new instructions for demo scripts.
- **`docs/_static/css/my_theme.css`:**
    - Updated heading styles to include `h2`, `h3`, and `h4` for consistent font weight.
    - Added a new style for `pre` tags to wrap text and break long words, this is particularly useful for rendering long output from generation.

    
## Test Plan
Tested locally. Screenshot for reference:

<img width="1250" alt="Screenshot 2025-04-10 at 10 12 12 PM" src="https://github.com/user-attachments/assets/ce1c8986-e072-4c6f-a697-ed0d8fb75b34" />
