### PR TITLE
docs: Move Llama 4 instructions in a collapsed section

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
 
 [**Quick Start**](https://llama-stack.readthedocs.io/en/latest/getting_started/index.html) | [**Documentation**](https://llama-stack.readthedocs.io/en/latest/index.html) | [**Colab Notebook**](./docs/getting_started.ipynb)
 
-
 ### ✨🎉 Llama 4 Support  🎉✨
 We released [Version 0.2.0](https://github.com/meta-llama/llama-stack/releases/tag/v0.2.0) with support for the Llama 4 herd of models released by Meta.
 
-You can now run Llama 4 models on Llama Stack.
+<details>
+
+<summary>You can now run Llama 4 models on Llama Stack (click for details)</summary>
 
 *Note you need 8xH100 GPU-host to run these models*
-
 
 ```bash
 pip install -U llama_stack
@@ -65,6 +65,9 @@ response = client.inference.chat_completion(
 print(f"Assistant> {response.completion_message.content}")
 ```
 As more providers start supporting Llama 4, you can use them in Llama Stack as well. We are adding to the list. Stay tuned!
+
+
+</details>
 
 
 ### Overview


### PR DESCRIPTION
# What does this PR do?

Currently the instructions for Llama 4 are lengthy before people can see the overview and other sections about Llama Stack. Moving this to a collapsed section would make it less verbose.
