### PR TITLE
fix: add max_tokens slider to playground tools page

### DIFF
--- a/llama_stack/distribution/ui/page/playground/tools.py
+++ b/llama_stack/distribution/ui/page/playground/tools.py
@@ -56,6 +56,17 @@ def tool_chat_page():
         st.subheader(f"Active Tools: 🛠 {len(active_tool_list)}")
         st.json(active_tool_list)
 
+        st.subheader("Chat Configurations")
+        max_tokens = st.slider(
+            "Max Tokens",
+            min_value=0,
+            max_value=4096,
+            value=512,
+            step=1,
+            help="The maximum number of tokens to generate",
+            on_change=reset_agent,
+        )
+
     @st.cache_resource
     def create_agent():
         return Agent(
@@ -63,9 +74,7 @@ def tool_chat_page():
             model=model,
             instructions="You are a helpful assistant. When you use a tool always respond with a summary of the result.",
             tools=toolgroup_selection,
-            sampling_params={
-                "strategy": {"type": "greedy"},
-            },
+            sampling_params={"strategy": {"type": "greedy"}, "max_tokens": max_tokens},
         )
 
     agent = create_agent()


### PR DESCRIPTION
# What does this PR do?

This PR adds a `max_tokens` slider to playground tools page. I have found that in some instances the llama stack server throws a 500 error if the max_tokens value is not explicitly set in the agent's `sampling_params`. This PR, uses the same implementation of the `max_tokens` slider from the chat page, and includes it on the tools page.  


## Test Plan
1. Attempting to call a tool without these changes results in a `500: Internal server error: An unexpected error occurred`.  
2. Attempting to call a tool with these changes results in the expected output.   
