### PR TITLE
fix: print traceback on build failure

### DIFF
--- a/llama_stack/cli/stack/_build.py
+++ b/llama_stack/cli/stack/_build.py
@@ -235,10 +235,14 @@ def run_stack_build_command(args: argparse.Namespace) -> None:
         )
 
     except (Exception, RuntimeError) as exc:
+        import traceback
+
         cprint(
             f"Error building stack: {exc}",
             color="red",
         )
+        cprint("Stack trace:", color="red")
+        traceback.print_exc()
         sys.exit(1)
     if run_config is None:
         cprint(


### PR DESCRIPTION
# What does this PR do?

Build failures are hard to read, sometimes we get errors like:

```
Error building stack: 'key'
```

Which are difficult to debug without a proper trace.

## Test Plan

If `llama stack build` fails you get a traceback now.
