### PR TITLE
fix: update ref to raw_errors due to new version of pydantic

### DIFF
--- a/llama_stack/distribution/server/server.py
+++ b/llama_stack/distribution/server/server.py
@@ -92,7 +92,7 @@ async def global_exception_handler(request: Request, exc: Exception):
 
 def translate_exception(exc: Exception) -> Union[HTTPException, RequestValidationError]:
     if isinstance(exc, ValidationError):
-        exc = RequestValidationError(exc.raw_errors)
+        exc = RequestValidationError(exc.errors())
 
     if isinstance(exc, RequestValidationError):
         return HTTPException(


### PR DESCRIPTION
https://github.com/meta-llama/llama-stack/commit/37da47ef8ee9234f370b3105d006ef20fb3cacab#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552 Pydantic was updated from v1 to v2 in this commit which caused this breaking change

# What does this PR do?
Part of #1857 

This won't fix the Validation error with the example, but it will correctly supply user with a proper error rather than a 5xx code.