### PR TITLE
feat: add tool name to chat output in playground

### DIFF
--- a/llama_stack/distribution/ui/page/playground/tools.py
+++ b/llama_stack/distribution/ui/page/playground/tools.py
@@ -133,7 +133,11 @@ def tool_chat_page():
                             yield response.event.payload.delta.text
                     if response.event.payload.event_type == "step_complete":
                         if response.event.payload.step_details.step_type == "tool_execution":
-                            yield " 🛠 "
+                            if response.event.payload.step_details.tool_calls:
+                                tool_name = str(response.event.payload.step_details.tool_calls[0].tool_name)
+                                yield f'\n\n🛠 :grey[_Using "{tool_name}" tool:_]\n\n'
+                            else:
+                                yield "No tool_calls present in step_details"
                 else:
                     yield f"Error occurred in the Llama Stack Cluster: {response}"
 


### PR DESCRIPTION
# What does this PR do?
This PR adds the name of the tool that is used by the agent on the "tools" page of the playground. See image below for an example. 

![Screenshot 2025-04-18 at 3 14 18 PM](https://github.com/user-attachments/assets/04e97783-4003-4121-9446-9e0ad7209256)

## Test Plan

Run the playground and navigate to the tools page. There users can see that this additional text is present when tools are invoked and absent when they are not. 
```
streamlit run llama_stack/distribution/ui/app.py
```


