### PR TITLE
feat: cleanup sidebar formatting on tools playground

### DIFF
--- a/llama_stack/distribution/ui/page/playground/tools.py
+++ b/llama_stack/distribution/ui/page/playground/tools.py
@@ -29,12 +29,19 @@ def tool_chat_page():
         st.cache_resource.clear()
 
     with st.sidebar:
+        st.title("Configuration")
         st.subheader("Model")
-        model = st.selectbox(label="models", options=model_list, on_change=reset_agent)
+        model = st.selectbox(label="Model", options=model_list, on_change=reset_agent, label_visibility="collapsed")
 
-        st.subheader("Builtin Tools")
+        st.subheader("Available ToolGroups")
+
         toolgroup_selection = st.pills(
-            label="Available ToolGroups", options=builtin_tools_list, selection_mode="multi", on_change=reset_agent
+            label="Built-in tools",
+            options=builtin_tools_list,
+            selection_mode="multi",
+            on_change=reset_agent,
+            format_func=lambda tool: "".join(tool.split("::")[1:]),
+            help="List of built-in tools from your llama stack server.",
         )
 
         if "builtin::rag" in toolgroup_selection:
@@ -48,9 +55,13 @@ def tool_chat_page():
                 on_change=reset_agent,
             )
 
-        st.subheader("MCP Servers")
         mcp_selection = st.pills(
-            label="Available MCP Servers", options=mcp_tools_list, selection_mode="multi", on_change=reset_agent
+            label="MCP Servers",
+            options=mcp_tools_list,
+            selection_mode="multi",
+            on_change=reset_agent,
+            format_func=lambda tool: "".join(tool.split("::")[1:]),
+            help="List of MCP servers registered to your llama stack server.",
         )
 
         toolgroup_selection.extend(mcp_selection)
@@ -64,10 +75,10 @@ def tool_chat_page():
                 ]
             )
 
-        st.subheader(f"Active Tools: 🛠 {len(active_tool_list)}")
+        st.markdown(f"Active Tools: 🛠 {len(active_tool_list)}", help="List of currently active tools.")
         st.json(active_tool_list)
 
-        st.subheader("Chat Configurations")
+        st.subheader("Agent Configurations")
         max_tokens = st.slider(
             "Max Tokens",
             min_value=0,


### PR DESCRIPTION
# What does this PR do?

This PR cleans up the sidebar on the tools page of the playground in the following ways:
* created a clearer hierarchy of configuration options and tool selections.
* Removed the `mcp::` or `builtin::` prefixes from the tool selection buttons.  

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan

Run the playground and see the updated sidebar does not cause any new errors.
```
streamlit run llama_stack/distribution/ui/app.py  
```
[//]: # (## Documentation)
