### PR TITLE
fix: do not override the entrypoint when running container

### DIFF
--- a/llama_stack/distribution/start_stack.sh
+++ b/llama_stack/distribution/start_stack.sh
@@ -152,12 +152,8 @@ elif [[ "$env_type" == "container" ]]; then
     $CONTAINER_BINARY run $CONTAINER_OPTS -it \
     -p $port:$port \
     $env_vars \
-    -v "$yaml_config:/app/config.yaml" \
     $mounts \
     --env LLAMA_STACK_PORT=$port \
-    --entrypoint python \
     $container_image:$version_tag \
-    -m llama_stack.distribution.server.server \
-    --yaml-config /app/config.yaml \
     $other_args
 fi


### PR DESCRIPTION
# What does this PR do?

Since https://github.com/meta-llama/llama-stack/pull/2005 the run configuration is embedded into the container image itself and the entrypoint is correctly configured during the container image build process. We don't need to override the container image entrypoint anymore.

## Test Plan

Run a container that was built after https://github.com/meta-llama/llama-stack/pull/2005:

```
CONTAINER_BINARY=podman llama stack run --image-type container /Users/leseb/.llama/distributions/leseb-test/leseb-test-run.yaml --
env OLLAMA_URL=http://host.containers.internal:11434
INFO     2025-04-24 13:55:29,821 llama_stack.cli.stack.run:125 server: Using run configuration:                         
         /Users/leseb/.llama/distributions/leseb-test/leseb-test-run.yaml                                               
+ is_command_available podman
+ command -v podman
+ is_command_available selinuxenabled
+ mounts=
+ '[' -n '' ']'
+ '[' -n '' ']'
+ '[' -n '' ']'
+ '[' -n '' ']'
+ '[' -n '' ']'
+ is_command_available jq
+ command -v jq
+ URL=https://pypi.org/pypi/llama-stack/json
++ curl -s https://pypi.org/pypi/llama-stack/json
++ jq -r .info.version
+ version_tag=0.2.2
+ podman run -it -p 8321:8321 --env OLLAMA_URL=http://host.containers.internal:11434 --env LLAMA_STACK_PORT=8321 localhost/leseb-test:0.2.2
INFO     2025-04-24 11:55:31,408 __main__:404 server: Using config file: /app/run.yaml                                  
INFO     2025-04-24 11:55:31,409 __main__:406 server: Run configuration:                                                
INFO     2025-04-24 11:55:31,412 __main__:408 server: apis:                                                             
         - inference                                                                                                    
         - vector_io                                                                                                    
         - safety                                                                                                       
         - agents                                                                                                       
         - telemetry                                                                                                    
         - eval                                                                                                         
         - datasetio                                                                                                    
         - scoring                                                                                                      
         - tool_runtime                                                                                                 
         - post_training                                                                                                
         benchmarks: []                                                                                                 
         container_image: leseb-test                                                                                    
         datasets: []                                                                                                   
         external_providers_dir: /app/providers.d                                                                       
         image_name: leseb-test                                                                                         
         logging: null                                                                                                  
         metadata_store: null                                                                                           
         models: []                                                                                                     
         providers:                                                                                                     
           agents:                                                                                                      
           - config:                                                                                                    
               persistence_store:                                                                                       
                 db_path: /root/.llama/distributions/leseb-test/agents_store.db                                         
                 namespace: null                                                                                        
                 type: sqlite                                                                                           
             provider_id: meta-reference                                                                                
             provider_type: inline::meta-reference                                                                      
           datasetio:                                                                                                   
           - config:                                                                                                    
               kvstore:                                                                                                 
                 db_path: /root/.llama/distributions/leseb-test/huggingface_datasetio.db                                
                 namespace: null                                                                                        
                 type: sqlite                                                                                           
             provider_id: huggingface-0                                                                                 
             provider_type: remote::huggingface                                                                         
           - config:                                                                                                    
               kvstore:                                                                                                 
                 db_path: /root/.llama/distributions/leseb-test/localfs_datasetio.db                                    
                 namespace: null                                                                                        
                 type: sqlite                                                                                           
             provider_id: localfs-1                                                                                     
             provider_type: inline::localfs                                                                             
           eval:                                                                                                        
           - config:                                                                                                    
               kvstore:                                                                                                 
                 db_path: /root/.llama/distributions/leseb-test/meta_reference_eval.db                                  
                 namespace: null                                                                                        
                 type: sqlite                                                                                           
             provider_id: meta-reference                                                                                
             provider_type: inline::meta-reference                                                                      
           inference:                                                                                                   
           - config:                                                                                                    
               url: http://host.containers.internal:11434                                                               
             provider_id: ollama                                                                                        
             provider_type: remote::ollama                                                                              
           post_training:                                                                                               
           - config: {}                                                                                                 
             provider_id: instructlab_kft                                                                               
             provider_type: remote::instructlab_kft                                                                     
           safety:                                                                                                      
           - config:                                                                                                    
               excluded_categories: []                                                                                  
             provider_id: llama-guard                                                                                   
             provider_type: inline::llama-guard                                                                         
           scoring:                                                                                                     
           - config: {}                                                                                                 
             provider_id: basic-0                                                                                       
             provider_type: inline::basic                                                                               
           - config: {}                                                                                                 
             provider_id: llm-as-judge-1                                                                                
             provider_type: inline::llm-as-judge                                                                        
           - config:                                                                                                    
               openai_api_key: '********'                                                                               
             provider_id: braintrust-2                                                                                  
             provider_type: inline::braintrust                                                                          
           telemetry:                                                                                                   
           - config:                                                                                                    
               service_name: "\u200B"                                                                                   
               sinks: console,sqlite                                                                                    
               sqlite_db_path: /root/.llama/distributions/leseb-test/trace_store.db                                     
             provider_id: meta-reference                                                                                
             provider_type: inline::meta-reference                                                                      
           tool_runtime:                                                                                                
           - config:                                                                                                    
               api_key: '********'                                                                                      
               max_results: 3                                                                                           
             provider_id: brave-search-0                                                                                
             provider_type: remote::brave-search                                                                        
           - config:                                                                                                    
               api_key: '********'                                                                                      
               max_results: 3                                                                                           
             provider_id: tavily-search-1                                                                               
             provider_type: remote::tavily-search                                                                       
           - config: {}                                                                                                 
             provider_id: code-interpreter-2                                                                            
             provider_type: inline::code-interpreter                                                                    
           - config: {}                                                                                                 
             provider_id: rag-runtime-3                                                                                 
             provider_type: inline::rag-runtime                                                                         
           - config: {}                                                                                                 
             provider_id: model-context-protocol-4                                                                      
             provider_type: remote::model-context-protocol                                                              
           - config:                                                                                                    
               api_key: '********'                                                                                      
             provider_id: wolfram-alpha-5                                                                               
             provider_type: remote::wolfram-alpha                                                                       
           vector_io:                                                                                                   
           - config:                                                                                                    
               kvstore:                                                                                                 
                 db_path: /root/.llama/distributions/leseb-test/faiss_store.db                                          
                 namespace: null                                                                                        
                 type: sqlite                                                                                           
             provider_id: faiss                                                                                         
             provider_type: inline::faiss                                                                               
         scoring_fns: []                                                                                                
         server:                                                                                                        
           auth: null                                                                                                   
           port: 8321                                                                                                   
           tls_certfile: null                                                                                           
           tls_keyfile: null                                                                                            
         shields: []                                                                                                    
         tool_groups: []                                                                                                
         vector_dbs: []                                                                                                 
         version: '2'                                                                                                   
                                                                                                                        
INFO     2025-04-24 11:55:31,426 llama_stack.distribution.distribution:151 core: Loading external providers from        
         /app/providers.d                                                                                               
INFO     2025-04-24 11:55:31,427 llama_stack.distribution.distribution:166 core: Loading remote provider spec from      
         /app/providers.d/remote/post_training/instructlab_kft.yaml                                                     
INFO     2025-04-24 11:55:31,428 llama_stack.distribution.distribution:179 core: Loaded remote provider spec for        
         remote::instructlab_kft from /app/providers.d/remote/post_training/instructlab_kft.yaml                        
INFO     2025-04-24 11:55:31,564 llama_stack.providers.remote.inference.ollama.ollama:99 inference: checking            
         connectivity to Ollama at `http://host.containers.internal:11434`...                                           
WARNING  2025-04-24 11:55:33,239 root:72 uncategorized: Warning: `bwrap` is not available. Code interpreter tool will  
```