### PR TITLE
feat: allow the interface on which the server will listen to be configured

### DIFF
--- a/docs/source/distributions/building_distro.md
+++ b/docs/source/distributions/building_distro.md
@@ -271,7 +271,7 @@ Now, let's start the Llama Stack Distribution Server. You will need the YAML con
 
 ```
 llama stack run -h
-usage: llama stack run [-h] [--port PORT] [--image-name IMAGE_NAME] [--disable-ipv6] [--env KEY=VALUE] [--tls-keyfile TLS_KEYFILE] [--tls-certfile TLS_CERTFILE]
+usage: llama stack run [-h] [--port PORT] [--image-name IMAGE_NAME] [--env KEY=VALUE] [--tls-keyfile TLS_KEYFILE] [--tls-certfile TLS_CERTFILE]
                        [--image-type {conda,container,venv}]
                        config
 
@@ -285,7 +285,6 @@ options:
   --port PORT           Port to run the server on. It can also be passed via the env var LLAMA_STACK_PORT. (default: 8321)
   --image-name IMAGE_NAME
                         Name of the image to run. Defaults to the current environment (default: None)
-  --disable-ipv6        Disable IPv6 support (default: False)
   --env KEY=VALUE       Environment variables to pass to the server in KEY=VALUE format. Can be specified multiple times. (default: [])
   --tls-keyfile TLS_KEYFILE
                         Path to TLS key file for HTTPS (default: None)

--- a/llama_stack/distribution/datatypes.py
+++ b/llama_stack/distribution/datatypes.py
@@ -258,9 +258,9 @@ class ServerConfig(BaseModel):
         default=None,
         description="Authentication configuration for the server",
     )
-    disable_ipv6: bool = Field(
-        default=False,
-        description="Disable IPv6 support",
+    host: str | None = Field(
+        default=None,
+        description="The host the server should listen on",
     )
 
 

--- a/llama_stack/distribution/server/server.py
+++ b/llama_stack/distribution/server/server.py
@@ -358,7 +358,6 @@ def main(args: argparse.Namespace | None = None):
         default=int(os.getenv("LLAMA_STACK_PORT", 8321)),
         help="Port to listen on",
     )
-    parser.add_argument("--disable-ipv6", action="store_true", help="Whether to disable IPv6 support")
     parser.add_argument(
         "--env",
         action="append",
@@ -514,7 +513,7 @@ def main(args: argparse.Namespace | None = None):
         else:
             logger.info(f"HTTPS enabled with certificates:\n  Key: {keyfile}\n  Cert: {certfile}")
 
-    listen_host = ["::", "0.0.0.0"] if not config.server.disable_ipv6 else "0.0.0.0"
+    listen_host = config.server.host or ["::", "0.0.0.0"]
     logger.info(f"Listening on {listen_host}:{port}")
 
     uvicorn_config = {

--- a/llama_stack/templates/bedrock/run.yaml
+++ b/llama_stack/templates/bedrock/run.yaml
@@ -139,4 +139,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/cerebras/run.yaml
+++ b/llama_stack/templates/cerebras/run.yaml
@@ -137,4 +137,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/ci-tests/run.yaml
+++ b/llama_stack/templates/ci-tests/run.yaml
@@ -235,4 +235,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/dell/run-with-safety.yaml
+++ b/llama_stack/templates/dell/run-with-safety.yaml
@@ -126,4 +126,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/dell/run.yaml
+++ b/llama_stack/templates/dell/run.yaml
@@ -117,4 +117,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/fireworks/run-with-safety.yaml
+++ b/llama_stack/templates/fireworks/run-with-safety.yaml
@@ -254,4 +254,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/fireworks/run.yaml
+++ b/llama_stack/templates/fireworks/run.yaml
@@ -244,4 +244,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/groq/run.yaml
+++ b/llama_stack/templates/groq/run.yaml
@@ -202,4 +202,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/hf-endpoint/run-with-safety.yaml
+++ b/llama_stack/templates/hf-endpoint/run-with-safety.yaml
@@ -134,4 +134,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/hf-endpoint/run.yaml
+++ b/llama_stack/templates/hf-endpoint/run.yaml
@@ -124,4 +124,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/hf-serverless/run-with-safety.yaml
+++ b/llama_stack/templates/hf-serverless/run-with-safety.yaml
@@ -134,4 +134,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/hf-serverless/run.yaml
+++ b/llama_stack/templates/hf-serverless/run.yaml
@@ -124,4 +124,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/llama_api/run.yaml
+++ b/llama_stack/templates/llama_api/run.yaml
@@ -160,4 +160,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/meta-reference-gpu/run-with-safety.yaml
+++ b/llama_stack/templates/meta-reference-gpu/run-with-safety.yaml
@@ -144,4 +144,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/meta-reference-gpu/run.yaml
+++ b/llama_stack/templates/meta-reference-gpu/run.yaml
@@ -129,4 +129,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/nvidia/run-with-safety.yaml
+++ b/llama_stack/templates/nvidia/run-with-safety.yaml
@@ -113,4 +113,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/nvidia/run.yaml
+++ b/llama_stack/templates/nvidia/run.yaml
@@ -219,4 +219,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/ollama/run-with-safety.yaml
+++ b/llama_stack/templates/ollama/run-with-safety.yaml
@@ -137,4 +137,3 @@ tool_groups:
   provider_id: wolfram-alpha
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/ollama/run.yaml
+++ b/llama_stack/templates/ollama/run.yaml
@@ -127,4 +127,3 @@ tool_groups:
   provider_id: wolfram-alpha
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/open-benchmark/run.yaml
+++ b/llama_stack/templates/open-benchmark/run.yaml
@@ -241,4 +241,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/passthrough/run-with-safety.yaml
+++ b/llama_stack/templates/passthrough/run-with-safety.yaml
@@ -147,4 +147,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/passthrough/run.yaml
+++ b/llama_stack/templates/passthrough/run.yaml
@@ -137,4 +137,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/remote-vllm/run-with-safety.yaml
+++ b/llama_stack/templates/remote-vllm/run-with-safety.yaml
@@ -144,4 +144,3 @@ tool_groups:
   provider_id: wolfram-alpha
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/remote-vllm/run.yaml
+++ b/llama_stack/templates/remote-vllm/run.yaml
@@ -132,4 +132,3 @@ tool_groups:
   provider_id: wolfram-alpha
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/sambanova/run.yaml
+++ b/llama_stack/templates/sambanova/run.yaml
@@ -202,4 +202,3 @@ tool_groups:
   provider_id: wolfram-alpha
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/starter/run.yaml
+++ b/llama_stack/templates/starter/run.yaml
@@ -620,4 +620,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/tgi/run-with-safety.yaml
+++ b/llama_stack/templates/tgi/run-with-safety.yaml
@@ -124,4 +124,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/tgi/run.yaml
+++ b/llama_stack/templates/tgi/run.yaml
@@ -123,4 +123,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/together/run-with-safety.yaml
+++ b/llama_stack/templates/together/run-with-safety.yaml
@@ -271,4 +271,3 @@ tool_groups:
   provider_id: wolfram-alpha
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/together/run.yaml
+++ b/llama_stack/templates/together/run.yaml
@@ -261,4 +261,3 @@ tool_groups:
   provider_id: wolfram-alpha
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/verification/run.yaml
+++ b/llama_stack/templates/verification/run.yaml
@@ -723,4 +723,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/vllm-gpu/run.yaml
+++ b/llama_stack/templates/vllm-gpu/run.yaml
@@ -128,4 +128,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false

--- a/llama_stack/templates/watsonx/run.yaml
+++ b/llama_stack/templates/watsonx/run.yaml
@@ -211,4 +211,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-  disable_ipv6: false


### PR DESCRIPTION

# What does this PR do?

It may not always be desirable to listen on all interfaces, which is the default. As an example, by listening instead only on a loopback interface, the server cannot be reached except from within the host it is run on. This PR makes this configurable, through a CLI option, an env var or an entry on the config file.

## Test Plan

I ran a server with and without the added CLI argument to verify that the argument is used if provided, but the default is as it was before if not.
