### PR TITLE
docs: Add TrustyAI LM-Eval to list of known external providers

### DIFF
--- a/docs/source/providers/external.md
+++ b/docs/source/providers/external.md
@@ -54,6 +54,7 @@ Here's a list of known external providers that you can use with Llama Stack:
 |------|-------------|-----|------|------------|
 | KubeFlow Training | Train models with KubeFlow | Post Training | Remote | [llama-stack-provider-kft](https://github.com/opendatahub-io/llama-stack-provider-kft) |
 | RamaLama | Inference models with RamaLama | Inference | Remote | [ramalama-stack](https://github.com/containers/ramalama-stack) |
+| TrustyAI LM-Eval | Evaluate models with TrustyAI LM-Eval | Eval | Remote | [llama-stack-provider-lmeval](https://github.com/trustyai-explainability/llama-stack-provider-lmeval) |
 
 ### Remote Provider Specification
 


### PR DESCRIPTION
# What does this PR do?
Adds documentation for the remote [TrustyAI LM-Eval Eval Provider](https://github.com/trustyai-explainability/llama-stack-provider-lmeval). LM-Eval is a service for large language model evaluation based on the open source project [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) and is integrated into the [TrustyAI Kubernetes Operator](https://trustyai-explainability.github.io/trustyai-site/main/trustyai-operator.html).
