### PR TITLE
chore: exclude test, provider, and template directories from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+omit =
+    */tests/*
+    */llama_stack/providers/*
+    */llama_stack/templates/*
+    .venv/*


### PR DESCRIPTION
# What does this PR do?

Introduce a `.coveragerc` file to omit:

- test files (*/tests/*)
- provider code (*/llama_stack/providers/*)
- template files (*/llama_stack/templates/*)
- virtual environment (.venv/*)

This ensures coverage reports focus on core application logic (API and CLI).

Note: I'm opening this for discussing as well - we might decide to ignore more and or re-add some directories!
