### PR TITLE
ci: add UBI 9 container-build gate

### DIFF
--- a/.github/workflows/providers-build.yml
+++ b/.github/workflows/providers-build.yml
@@ -145,3 +145,50 @@ jobs:
             echo "Entrypoint is not correct"
             exit 1
           fi
+
+  build-ubi9-container-distribution:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+        with:
+          python-version: '3.10'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+        with:
+          python-version: "3.10"
+
+      - name: Install LlamaStack
+        run: |
+          uv venv
+          source .venv/bin/activate
+          uv pip install -e .
+
+      - name: Pin template to UBI9 base
+        run: |
+          yq -i '
+            .image_type    = "container" |
+            .image_name    = "ubi9-test" |
+            .container_base = "registry.access.redhat.com/ubi9/ubi-minimal:latest"
+          ' llama_stack/templates/dev/build.yaml
+
+      - name: Build dev → container (UBI9)
+        env:
+          USE_COPY_NOT_MOUNT: "true"
+          LLAMA_STACK_DIR:   "."
+        run: |
+          uv run llama stack build --config llama_stack/templates/dev/build.yaml
+
+      - name: Inspect the container image entrypoint
+        run: |
+          IMAGE_ID=$(docker images --format "{{.Repository}}:{{.Tag}}" | head -n 1)
+          entrypoint=$(docker inspect --format '{{ .Config.Entrypoint }}' $IMAGE_ID)
+          echo "Entrypoint: $entrypoint"
+          if [ "$entrypoint" != "[python -m llama_stack.distribution.server.server --config /app/run.yaml]" ]; then
+            echo "Entrypoint is not correct"
+            exit 1
+          fi


### PR DESCRIPTION
# What does this PR do?
* new workflow job **build-ubi9-container-distribution**
  * runs on the default `ubuntu-latest` runner
  * uses the existing `dev` template
  * invokes `uv run llama stack build` with `.container_base = "registry.access.redhat.com/ubi9/ubi-minimal:latest"`
  * inspects the resulting image to verify its entrypoint

# (Closes #1994)

## Test Plan
- CI now includes the `build-ubi9-container-distribution` job and will turn green when that job passes on changes to build files