### PR TITLE
fix: tools page on playground resets agent after every interaction

### DIFF
--- a/llama_stack/distribution/ui/page/playground/tools.py
+++ b/llama_stack/distribution/ui/page/playground/tools.py
@@ -94,11 +94,15 @@ def tool_chat_page():
         st.subheader("Agent Configurations")
         st.subheader("Agent Type")
         agent_type = st.radio(
-            "Select Agent Type",
-            [AgentType.REGULAR, AgentType.REACT],
-            format_func=lambda x: x.value,
+            label="Select Agent Type",
+            options=["Regular", "ReAct"],
             on_change=reset_agent,
         )
+
+        if agent_type == "ReAct":
+            agent_type = AgentType.REACT
+        else:
+            agent_type = AgentType.REGULAR
 
         max_tokens = st.slider(
             "Max Tokens",


### PR DESCRIPTION
# What does this PR do?

This PR updates how the `AgentType` gets set using the radio button on the tools page of the playground. This change is needed due to the fact with its current implementation, the chat interface will resets after every input, preventing users from having a multi-turn conversation with the agent.

## Test Plan

Run the Playground without these changes:
```bash
streamlit run llama_stack/distribution/ui/app.py
```
Navigate to the tools page and attempt to have a multi-turn conversation. You should see the conversation reset after asking a second question. 

Repeat the steps above with these changes and you will see that it works as expected when asking the agent multiple questions. 
