### PR TITLE
docs: update prompt in quickstart guide to reflect output

### DIFF
--- a/docs/source/getting_started/index.md
+++ b/docs/source/getting_started/index.md
@@ -68,7 +68,7 @@ agent = Agent(
     ],
 )
 
-prompt = "How do you do great work?"
+prompt = "What is the key to doing great work"
 print("prompt>", prompt)
 
 response = agent.create_turn(
@@ -88,11 +88,11 @@ And you should see output like below.
 ```
 rag_tool> Ingesting document: https://www.paulgraham.com/greatwork.html
 
-prompt> How do you do great work?
+prompt> What is the key to doing great work
 
-inference> [knowledge_search(query="What is the key to doing great work")]
+inference> [knowledge_search(query="key to doing great work")]
 
-tool_execution> Tool:knowledge_search Args:{'query': 'What is the key to doing great work'}
+tool_execution> Tool:knowledge_search Args:{'query': 'key to doing great work'}
 
 tool_execution> Tool:knowledge_search Response:[TextContentItem(text='knowledge_search tool found 5 chunks:\nBEGIN of knowledge_search tool results.\n', type='text'), TextContentItem(text="Result 1:\nDocument_id:docum\nContent:  work. Doing great work means doing something important\nso well that you expand people's ideas of what's possible. But\nthere's no threshold for importance. It's a matter of degree, and\noften hard to judge at the time anyway.\n", type='text'), TextContentItem(text="Result 2:\nDocument_id:docum\nContent:  work. Doing great work means doing something important\nso well that you expand people's ideas of what's possible. But\nthere's no threshold for importance. It's a matter of degree, and\noften hard to judge at the time anyway.\n", type='text'), TextContentItem(text="Result 3:\nDocument_id:docum\nContent:  work. Doing great work means doing something important\nso well that you expand people's ideas of what's possible. But\nthere's no threshold for importance. It's a matter of degree, and\noften hard to judge at the time anyway.\n", type='text'), TextContentItem(text="Result 4:\nDocument_id:docum\nContent:  work. Doing great work means doing something important\nso well that you expand people's ideas of what's possible. But\nthere's no threshold for importance. It's a matter of degree, and\noften hard to judge at the time anyway.\n", type='text'), TextContentItem(text="Result 5:\nDocument_id:docum\nContent:  work. Doing great work means doing something important\nso well that you expand people's ideas of what's possible. But\nthere's no threshold for importance. It's a matter of degree, and\noften hard to judge at the time anyway.\n", type='text'), TextContentItem(text='END of knowledge_search tool results.\n', type='text')]
 


### PR DESCRIPTION
# What does this PR do?
[Provide a short summary of what this PR does and why. Link to relevant issues if applicable.]
Update Quickstart demo prompt to reflect output. 

I noticed while running the quickstart that the prompt does not match the intended outcome e.g.
With the given prompt "How do you do great work?"
The following is outputted:
```
rag_tool> Ingesting document: https://www.paulgraham.com/greatwork.html
prompt> How do you do great work?
inference> I don't have personal experiences or emotions, but I was trained on a large corpus of text data and use various techniques such as natural language processing (NLP) and machine learning algorithms to generate human-like responses.
```

But with the correct prompt "What is the key to doing great work" the appropriate response similar to the example is given.


## Test Plan
[Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.*]
N/A

[//]: # (## Documentation)
