### PR TITLE
chore: Add fixtures to conftest.py

### DIFF
--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+# We need to import the fixtures here so that pytest can find them
+# but ruff doesn't think they are used and removes the import. "noqa: F401" prevents them from being removed
+from .fixtures import cached_disk_dist_registry, disk_dist_registry, sqlite_kvstore  # noqa: F401

--- a/tests/unit/distribution/routers/test_routing_tables.py
+++ b/tests/unit/distribution/routers/test_routing_tables.py
@@ -26,20 +26,6 @@ from llama_stack.distribution.routers.routing_tables import (
     ToolGroupsRoutingTable,
     VectorDBsRoutingTable,
 )
-from llama_stack.distribution.store.registry import CachedDiskDistributionRegistry
-from llama_stack.providers.utils.kvstore.config import SqliteKVStoreConfig
-from llama_stack.providers.utils.kvstore.sqlite import SqliteKVStoreImpl
-
-
-@pytest.fixture
-async def dist_registry(tmp_path):
-    db_path = tmp_path / "test_kv.db"
-    kvstore_config = SqliteKVStoreConfig(db_path=db_path.as_posix())
-    kvstore = SqliteKVStoreImpl(kvstore_config)
-    await kvstore.initialize()
-    registry = CachedDiskDistributionRegistry(kvstore)
-    await registry.initialize()
-    yield registry
 
 
 class Impl:
@@ -136,8 +122,8 @@ class ToolGroupsImpl(Impl):
 
 
 @pytest.mark.asyncio
-async def test_models_routing_table(dist_registry):
-    table = ModelsRoutingTable({"test_provider": InferenceImpl()}, dist_registry)
+async def test_models_routing_table(cached_disk_dist_registry):
+    table = ModelsRoutingTable({"test_provider": InferenceImpl()}, cached_disk_dist_registry)
     await table.initialize()
 
     # Register multiple models and verify listing
@@ -178,8 +164,8 @@ async def test_models_routing_table(dist_registry):
 
 
 @pytest.mark.asyncio
-async def test_shields_routing_table(dist_registry):
-    table = ShieldsRoutingTable({"test_provider": SafetyImpl()}, dist_registry)
+async def test_shields_routing_table(cached_disk_dist_registry):
+    table = ShieldsRoutingTable({"test_provider": SafetyImpl()}, cached_disk_dist_registry)
     await table.initialize()
 
     # Register multiple shields and verify listing
@@ -194,11 +180,11 @@ async def test_shields_routing_table(dist_registry):
 
 
 @pytest.mark.asyncio
-async def test_vectordbs_routing_table(dist_registry):
-    table = VectorDBsRoutingTable({"test_provider": VectorDBImpl()}, dist_registry)
+async def test_vectordbs_routing_table(cached_disk_dist_registry):
+    table = VectorDBsRoutingTable({"test_provider": VectorDBImpl()}, cached_disk_dist_registry)
     await table.initialize()
 
-    m_table = ModelsRoutingTable({"test_providere": InferenceImpl()}, dist_registry)
+    m_table = ModelsRoutingTable({"test_providere": InferenceImpl()}, cached_disk_dist_registry)
     await m_table.initialize()
     await m_table.register_model(
         model_id="test-model",
@@ -224,8 +210,8 @@ async def test_vectordbs_routing_table(dist_registry):
     assert len(vector_dbs.data) == 0
 
 
-async def test_datasets_routing_table(dist_registry):
-    table = DatasetsRoutingTable({"localfs": DatasetsImpl()}, dist_registry)
+async def test_datasets_routing_table(cached_disk_dist_registry):
+    table = DatasetsRoutingTable({"localfs": DatasetsImpl()}, cached_disk_dist_registry)
     await table.initialize()
 
     # Register multiple datasets and verify listing
@@ -250,8 +236,8 @@ async def test_datasets_routing_table(dist_registry):
 
 
 @pytest.mark.asyncio
-async def test_scoring_functions_routing_table(dist_registry):
-    table = ScoringFunctionsRoutingTable({"test_provider": ScoringFunctionsImpl()}, dist_registry)
+async def test_scoring_functions_routing_table(cached_disk_dist_registry):
+    table = ScoringFunctionsRoutingTable({"test_provider": ScoringFunctionsImpl()}, cached_disk_dist_registry)
     await table.initialize()
 
     # Register multiple scoring functions and verify listing
@@ -276,8 +262,8 @@ async def test_scoring_functions_routing_table(dist_registry):
 
 
 @pytest.mark.asyncio
-async def test_benchmarks_routing_table(dist_registry):
-    table = BenchmarksRoutingTable({"test_provider": BenchmarksImpl()}, dist_registry)
+async def test_benchmarks_routing_table(cached_disk_dist_registry):
+    table = BenchmarksRoutingTable({"test_provider": BenchmarksImpl()}, cached_disk_dist_registry)
     await table.initialize()
 
     # Register multiple benchmarks and verify listing
@@ -294,8 +280,8 @@ async def test_benchmarks_routing_table(dist_registry):
 
 
 @pytest.mark.asyncio
-async def test_tool_groups_routing_table(dist_registry):
-    table = ToolGroupsRoutingTable({"test_provider": ToolGroupsImpl()}, dist_registry)
+async def test_tool_groups_routing_table(cached_disk_dist_registry):
+    table = ToolGroupsRoutingTable({"test_provider": ToolGroupsImpl()}, cached_disk_dist_registry)
     await table.initialize()
 
     # Register multiple tool groups and verify listing

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -1,0 +1,34 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import pytest
+
+from llama_stack.distribution.store.registry import CachedDiskDistributionRegistry, DiskDistributionRegistry
+from llama_stack.providers.utils.kvstore.config import SqliteKVStoreConfig
+from llama_stack.providers.utils.kvstore.sqlite import SqliteKVStoreImpl
+
+
+@pytest.fixture(scope="function")
+async def sqlite_kvstore(tmp_path):
+    db_path = tmp_path / "test_kv.db"
+    kvstore_config = SqliteKVStoreConfig(db_path=db_path.as_posix())
+    kvstore = SqliteKVStoreImpl(kvstore_config)
+    await kvstore.initialize()
+    yield kvstore
+
+
+@pytest.fixture(scope="function")
+async def disk_dist_registry(sqlite_kvstore):
+    registry = DiskDistributionRegistry(sqlite_kvstore)
+    await registry.initialize()
+    yield registry
+
+
+@pytest.fixture(scope="function")
+async def cached_disk_dist_registry(sqlite_kvstore):
+    registry = CachedDiskDistributionRegistry(sqlite_kvstore)
+    await registry.initialize()
+    yield registry

--- a/tests/unit/providers/agents/test_persistence_access_control.py
+++ b/tests/unit/providers/agents/test_persistence_access_control.py
@@ -4,9 +4,6 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-import os
-import shutil
-import tempfile
 import uuid
 from datetime import datetime
 from unittest.mock import patch
@@ -17,20 +14,12 @@ from llama_stack.apis.agents import Turn
 from llama_stack.apis.inference import CompletionMessage, StopReason
 from llama_stack.distribution.datatypes import AccessAttributes
 from llama_stack.providers.inline.agents.meta_reference.persistence import AgentPersistence, AgentSessionInfo
-from llama_stack.providers.utils.kvstore.config import SqliteKVStoreConfig
-from llama_stack.providers.utils.kvstore.sqlite import SqliteKVStoreImpl
 
 
 @pytest.fixture
-async def test_setup():
-    temp_dir = tempfile.mkdtemp()
-    db_path = os.path.join(temp_dir, "test_persistence_access_control.db")
-    kvstore_config = SqliteKVStoreConfig(db_path=db_path)
-    kvstore = SqliteKVStoreImpl(kvstore_config)
-    await kvstore.initialize()
-    agent_persistence = AgentPersistence(agent_id="test_agent", kvstore=kvstore)
+async def test_setup(sqlite_kvstore):
+    agent_persistence = AgentPersistence(agent_id="test_agent", kvstore=sqlite_kvstore)
     yield agent_persistence
-    shutil.rmtree(temp_dir)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Add fixtures for SqliteKVStore, DiskDistributionRegistry and CachedDiskDistributionRegistry. And use them in tests that had all been duplicating similar setups.

## Test Plan
unit tests continue to run