### PR TITLE
fix: Responses API previous_response input items

### DIFF
--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -6283,54 +6283,15 @@
                 ],
                 "title": "AgentTurnResponseTurnStartPayload"
             },
-            "OpenAIResponseInputMessage": {
-                "type": "object",
-                "properties": {
-                    "content": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/OpenAIResponseInputMessageContent"
-                                }
-                            }
-                        ]
+            "OpenAIResponseInput": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/OpenAIResponseOutputMessageWebSearchToolCall"
                     },
-                    "role": {
-                        "oneOf": [
-                            {
-                                "type": "string",
-                                "const": "system"
-                            },
-                            {
-                                "type": "string",
-                                "const": "developer"
-                            },
-                            {
-                                "type": "string",
-                                "const": "user"
-                            },
-                            {
-                                "type": "string",
-                                "const": "assistant"
-                            }
-                        ]
-                    },
-                    "type": {
-                        "type": "string",
-                        "const": "message",
-                        "default": "message"
+                    {
+                        "$ref": "#/components/schemas/OpenAIResponseMessage"
                     }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "content",
-                    "role"
-                ],
-                "title": "OpenAIResponseInputMessage"
+                ]
             },
             "OpenAIResponseInputMessageContent": {
                 "oneOf": [
@@ -6431,6 +6392,111 @@
                 ],
                 "title": "OpenAIResponseInputToolWebSearch"
             },
+            "OpenAIResponseMessage": {
+                "type": "object",
+                "properties": {
+                    "content": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/OpenAIResponseInputMessageContent"
+                                }
+                            },
+                            {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/OpenAIResponseOutputMessageContent"
+                                }
+                            }
+                        ]
+                    },
+                    "role": {
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "const": "system"
+                            },
+                            {
+                                "type": "string",
+                                "const": "developer"
+                            },
+                            {
+                                "type": "string",
+                                "const": "user"
+                            },
+                            {
+                                "type": "string",
+                                "const": "assistant"
+                            }
+                        ]
+                    },
+                    "type": {
+                        "type": "string",
+                        "const": "message",
+                        "default": "message"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "content",
+                    "role",
+                    "type"
+                ],
+                "title": "OpenAIResponseMessage",
+                "description": "Corresponds to the various Message types in the Responses API. They are all under one type because the Responses API gives them all the same \"type\" value, and there is no way to tell them apart in certain scenarios."
+            },
+            "OpenAIResponseOutputMessageContent": {
+                "type": "object",
+                "properties": {
+                    "text": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string",
+                        "const": "output_text",
+                        "default": "output_text"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "text",
+                    "type"
+                ],
+                "title": "OpenAIResponseOutputMessageContentOutputText"
+            },
+            "OpenAIResponseOutputMessageWebSearchToolCall": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string",
+                        "const": "web_search_call",
+                        "default": "web_search_call"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "id",
+                    "status",
+                    "type"
+                ],
+                "title": "OpenAIResponseOutputMessageWebSearchToolCall"
+            },
             "CreateOpenaiResponseRequest": {
                 "type": "object",
                 "properties": {
@@ -6442,7 +6508,7 @@
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/components/schemas/OpenAIResponseInputMessage"
+                                    "$ref": "#/components/schemas/OpenAIResponseInput"
                                 }
                             }
                         ],
@@ -6560,7 +6626,7 @@
             "OpenAIResponseOutput": {
                 "oneOf": [
                     {
-                        "$ref": "#/components/schemas/OpenAIResponseOutputMessage"
+                        "$ref": "#/components/schemas/OpenAIResponseMessage"
                     },
                     {
                         "$ref": "#/components/schemas/OpenAIResponseOutputMessageWebSearchToolCall"
@@ -6569,88 +6635,10 @@
                 "discriminator": {
                     "propertyName": "type",
                     "mapping": {
-                        "message": "#/components/schemas/OpenAIResponseOutputMessage",
+                        "message": "#/components/schemas/OpenAIResponseMessage",
                         "web_search_call": "#/components/schemas/OpenAIResponseOutputMessageWebSearchToolCall"
                     }
                 }
-            },
-            "OpenAIResponseOutputMessage": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "content": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/OpenAIResponseOutputMessageContent"
-                        }
-                    },
-                    "role": {
-                        "type": "string",
-                        "const": "assistant",
-                        "default": "assistant"
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "type": "string",
-                        "const": "message",
-                        "default": "message"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "id",
-                    "content",
-                    "role",
-                    "status",
-                    "type"
-                ],
-                "title": "OpenAIResponseOutputMessage"
-            },
-            "OpenAIResponseOutputMessageContent": {
-                "type": "object",
-                "properties": {
-                    "text": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "type": "string",
-                        "const": "output_text",
-                        "default": "output_text"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "text",
-                    "type"
-                ],
-                "title": "OpenAIResponseOutputMessageContentOutputText"
-            },
-            "OpenAIResponseOutputMessageWebSearchToolCall": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "type": "string",
-                        "const": "web_search_call",
-                        "default": "web_search_call"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "id",
-                    "status",
-                    "type"
-                ],
-                "title": "OpenAIResponseOutputMessageWebSearchToolCall"
             },
             "OpenAIResponseObjectStream": {
                 "oneOf": [

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -4392,34 +4392,10 @@ components:
         - event_type
         - turn_id
       title: AgentTurnResponseTurnStartPayload
-    OpenAIResponseInputMessage:
-      type: object
-      properties:
-        content:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAIResponseInputMessageContent'
-        role:
-          oneOf:
-            - type: string
-              const: system
-            - type: string
-              const: developer
-            - type: string
-              const: user
-            - type: string
-              const: assistant
-        type:
-          type: string
-          const: message
-          default: message
-      additionalProperties: false
-      required:
-        - content
-        - role
-      title: OpenAIResponseInputMessage
+    OpenAIResponseInput:
+      oneOf:
+        - $ref: '#/components/schemas/OpenAIResponseOutputMessageWebSearchToolCall'
+        - $ref: '#/components/schemas/OpenAIResponseMessage'
     OpenAIResponseInputMessageContent:
       oneOf:
         - $ref: '#/components/schemas/OpenAIResponseInputMessageContentText'
@@ -4483,6 +4459,79 @@ components:
       required:
         - type
       title: OpenAIResponseInputToolWebSearch
+    OpenAIResponseMessage:
+      type: object
+      properties:
+        content:
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                $ref: '#/components/schemas/OpenAIResponseInputMessageContent'
+            - type: array
+              items:
+                $ref: '#/components/schemas/OpenAIResponseOutputMessageContent'
+        role:
+          oneOf:
+            - type: string
+              const: system
+            - type: string
+              const: developer
+            - type: string
+              const: user
+            - type: string
+              const: assistant
+        type:
+          type: string
+          const: message
+          default: message
+        id:
+          type: string
+        status:
+          type: string
+      additionalProperties: false
+      required:
+        - content
+        - role
+        - type
+      title: OpenAIResponseMessage
+      description: >-
+        Corresponds to the various Message types in the Responses API. They are all
+        under one type because the Responses API gives them all the same "type" value,
+        and there is no way to tell them apart in certain scenarios.
+    OpenAIResponseOutputMessageContent:
+      type: object
+      properties:
+        text:
+          type: string
+        type:
+          type: string
+          const: output_text
+          default: output_text
+      additionalProperties: false
+      required:
+        - text
+        - type
+      title: >-
+        OpenAIResponseOutputMessageContentOutputText
+    "OpenAIResponseOutputMessageWebSearchToolCall":
+      type: object
+      properties:
+        id:
+          type: string
+        status:
+          type: string
+        type:
+          type: string
+          const: web_search_call
+          default: web_search_call
+      additionalProperties: false
+      required:
+        - id
+        - status
+        - type
+      title: >-
+        OpenAIResponseOutputMessageWebSearchToolCall
     CreateOpenaiResponseRequest:
       type: object
       properties:
@@ -4491,7 +4540,7 @@ components:
             - type: string
             - type: array
               items:
-                $ref: '#/components/schemas/OpenAIResponseInputMessage'
+                $ref: '#/components/schemas/OpenAIResponseInput'
           description: Input message(s) to create the response.
         model:
           type: string
@@ -4575,73 +4624,13 @@ components:
       title: OpenAIResponseObject
     OpenAIResponseOutput:
       oneOf:
-        - $ref: '#/components/schemas/OpenAIResponseOutputMessage'
+        - $ref: '#/components/schemas/OpenAIResponseMessage'
         - $ref: '#/components/schemas/OpenAIResponseOutputMessageWebSearchToolCall'
       discriminator:
         propertyName: type
         mapping:
-          message: '#/components/schemas/OpenAIResponseOutputMessage'
+          message: '#/components/schemas/OpenAIResponseMessage'
           web_search_call: '#/components/schemas/OpenAIResponseOutputMessageWebSearchToolCall'
-    OpenAIResponseOutputMessage:
-      type: object
-      properties:
-        id:
-          type: string
-        content:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAIResponseOutputMessageContent'
-        role:
-          type: string
-          const: assistant
-          default: assistant
-        status:
-          type: string
-        type:
-          type: string
-          const: message
-          default: message
-      additionalProperties: false
-      required:
-        - id
-        - content
-        - role
-        - status
-        - type
-      title: OpenAIResponseOutputMessage
-    OpenAIResponseOutputMessageContent:
-      type: object
-      properties:
-        text:
-          type: string
-        type:
-          type: string
-          const: output_text
-          default: output_text
-      additionalProperties: false
-      required:
-        - text
-        - type
-      title: >-
-        OpenAIResponseOutputMessageContentOutputText
-    "OpenAIResponseOutputMessageWebSearchToolCall":
-      type: object
-      properties:
-        id:
-          type: string
-        status:
-          type: string
-        type:
-          type: string
-          const: web_search_call
-          default: web_search_call
-      additionalProperties: false
-      required:
-        - id
-        - status
-        - type
-      title: >-
-        OpenAIResponseOutputMessageWebSearchToolCall
     OpenAIResponseObjectStream:
       oneOf:
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseCreated'

--- a/llama_stack/apis/agents/agents.py
+++ b/llama_stack/apis/agents/agents.py
@@ -29,7 +29,7 @@ from llama_stack.apis.tools import ToolDef
 from llama_stack.schema_utils import json_schema_type, register_schema, webmethod
 
 from .openai_responses import (
-    OpenAIResponseInputMessage,
+    OpenAIResponseInput,
     OpenAIResponseInputTool,
     OpenAIResponseObject,
     OpenAIResponseObjectStream,
@@ -588,7 +588,7 @@ class Agents(Protocol):
     @webmethod(route="/openai/v1/responses", method="POST")
     async def create_openai_response(
         self,
-        input: str | list[OpenAIResponseInputMessage],
+        input: str | list[OpenAIResponseInput],
         model: str,
         previous_response_id: str | None = None,
         store: bool | None = True,

--- a/llama_stack/apis/agents/openai_responses.py
+++ b/llama_stack/apis/agents/openai_responses.py
@@ -131,3 +131,20 @@ OpenAIResponseInputTool = Annotated[
     Field(discriminator="type"),
 ]
 register_schema(OpenAIResponseInputTool, name="OpenAIResponseInputTool")
+
+
+@json_schema_type
+class OpenAIResponseInputItemMessage(OpenAIResponseInputMessage):
+    id: str
+
+
+@json_schema_type
+class OpenAIResponseInputItemList(BaseModel):
+    data: list[OpenAIResponseInputItemMessage]
+    object: Literal["list"] = "list"
+
+
+@json_schema_type
+class OpenAIResponsePreviousResponseWithInputItems(BaseModel):
+    input_items: OpenAIResponseInputItemList
+    response: OpenAIResponseObject

--- a/llama_stack/providers/inline/agents/meta_reference/agents.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agents.py
@@ -22,7 +22,7 @@ from llama_stack.apis.agents import (
     Document,
     ListAgentSessionsResponse,
     ListAgentsResponse,
-    OpenAIResponseInputMessage,
+    OpenAIResponseInput,
     OpenAIResponseInputTool,
     OpenAIResponseObject,
     Session,
@@ -255,7 +255,7 @@ class MetaReferenceAgentsImpl(Agents):
 
     async def create_openai_response(
         self,
-        input: str | list[OpenAIResponseInputMessage],
+        input: str | list[OpenAIResponseInput],
         model: str,
         previous_response_id: str | None = None,
         store: bool | None = True,

--- a/llama_stack/providers/inline/agents/meta_reference/openai_responses.py
+++ b/llama_stack/providers/inline/agents/meta_reference/openai_responses.py
@@ -12,7 +12,10 @@ from typing import cast
 from openai.types.chat import ChatCompletionToolParam
 
 from llama_stack.apis.agents.openai_responses import (
+    OpenAIResponseInputItemList,
+    OpenAIResponseInputItemMessage,
     OpenAIResponseInputMessage,
+    OpenAIResponseInputMessageContent,
     OpenAIResponseInputMessageContentImage,
     OpenAIResponseInputMessageContentText,
     OpenAIResponseInputTool,
@@ -24,6 +27,7 @@ from llama_stack.apis.agents.openai_responses import (
     OpenAIResponseOutputMessage,
     OpenAIResponseOutputMessageContentOutputText,
     OpenAIResponseOutputMessageWebSearchToolCall,
+    OpenAIResponsePreviousResponseWithInputItems,
 )
 from llama_stack.apis.inference.inference import (
     Inference,
@@ -50,9 +54,56 @@ logger = get_logger(name=__name__, category="openai_responses")
 OPENAI_RESPONSES_PREFIX = "openai_responses:"
 
 
-async def _previous_response_to_messages(previous_response: OpenAIResponseObject) -> list[OpenAIMessageParam]:
+async def _convert_response_input_content_to_chat_content_parts(
+    input_content: list[OpenAIResponseInputMessageContent],
+) -> list[OpenAIChatCompletionContentPartParam]:
+    """
+    Convert a list of input content items to a list of chat completion content parts
+    """
+    content_parts = []
+    for input_content_part in input_content:
+        if isinstance(input_content_part, OpenAIResponseInputMessageContentText):
+            content_parts.append(OpenAIChatCompletionContentPartTextParam(text=input_content_part.text))
+        elif isinstance(input_content_part, OpenAIResponseInputMessageContentImage):
+            if input_content_part.image_url:
+                image_url = OpenAIImageURL(url=input_content_part.image_url, detail=input_content_part.detail)
+                content_parts.append(OpenAIChatCompletionContentPartImageParam(image_url=image_url))
+    return content_parts
+
+
+async def _convert_response_input_to_chat_user_content(
+    input: str | list[OpenAIResponseInputMessage],
+) -> str | list[OpenAIChatCompletionContentPartParam]:
+    user_content: str | list[OpenAIChatCompletionContentPartParam] = ""
+    if isinstance(input, list):
+        user_content = []
+        for user_input in input:
+            if isinstance(user_input.content, list):
+                user_content.extend(await _convert_response_input_content_to_chat_content_parts(user_input.content))
+            else:
+                user_content.append(OpenAIChatCompletionContentPartTextParam(text=user_input.content))
+    else:
+        user_content = input
+    return user_content
+
+
+async def _previous_response_to_messages(
+    previous_response: OpenAIResponsePreviousResponseWithInputItems,
+) -> list[OpenAIMessageParam]:
     messages: list[OpenAIMessageParam] = []
-    for output_message in previous_response.output:
+    for previous_message in previous_response.input_items.data:
+        previous_content = await _convert_response_input_content_to_chat_content_parts(previous_message.content)
+        if previous_message.role == "user":
+            converted_message = OpenAIUserMessageParam(content=previous_content)
+        elif previous_message.role == "assistant":
+            converted_message = OpenAIAssistantMessageParam(content=previous_content)
+        else:
+            # TODO: handle other message roles? unclear if system/developer roles are
+            # used in previous responses
+            continue
+        messages.append(converted_message)
+
+    for output_message in previous_response.response.output:
         if isinstance(output_message, OpenAIResponseOutputMessage):
             messages.append(OpenAIAssistantMessageParam(content=output_message.content[0].text))
     return messages
@@ -90,15 +141,19 @@ class OpenAIResponsesImpl:
         self.tool_groups_api = tool_groups_api
         self.tool_runtime_api = tool_runtime_api
 
-    async def get_openai_response(
-        self,
-        id: str,
-    ) -> OpenAIResponseObject:
+    async def _get_previous_response_with_input(self, id: str) -> OpenAIResponsePreviousResponseWithInputItems:
         key = f"{OPENAI_RESPONSES_PREFIX}{id}"
         response_json = await self.persistence_store.get(key=key)
         if response_json is None:
             raise ValueError(f"OpenAI response with id '{id}' not found")
-        return OpenAIResponseObject.model_validate_json(response_json)
+        return OpenAIResponsePreviousResponseWithInputItems.model_validate_json(response_json)
+
+    async def get_openai_response(
+        self,
+        id: str,
+    ) -> OpenAIResponseObject:
+        response_with_input = await self._get_previous_response_with_input(id)
+        return response_with_input.response
 
     async def create_openai_response(
         self,
@@ -114,27 +169,10 @@ class OpenAIResponsesImpl:
 
         messages: list[OpenAIMessageParam] = []
         if previous_response_id:
-            previous_response = await self.get_openai_response(previous_response_id)
-            messages.extend(await _previous_response_to_messages(previous_response))
-        # TODO: refactor this user_content parsing out into a separate method
-        user_content: str | list[OpenAIChatCompletionContentPartParam] = ""
-        if isinstance(input, list):
-            user_content = []
-            for user_input in input:
-                if isinstance(user_input.content, list):
-                    for user_input_content in user_input.content:
-                        if isinstance(user_input_content, OpenAIResponseInputMessageContentText):
-                            user_content.append(OpenAIChatCompletionContentPartTextParam(text=user_input_content.text))
-                        elif isinstance(user_input_content, OpenAIResponseInputMessageContentImage):
-                            if user_input_content.image_url:
-                                image_url = OpenAIImageURL(
-                                    url=user_input_content.image_url, detail=user_input_content.detail
-                                )
-                                user_content.append(OpenAIChatCompletionContentPartImageParam(image_url=image_url))
-                else:
-                    user_content.append(OpenAIChatCompletionContentPartTextParam(text=user_input.content))
-        else:
-            user_content = input
+            previous_response_with_input = await self._get_previous_response_with_input(previous_response_id)
+            messages.extend(await _previous_response_to_messages(previous_response_with_input))
+
+        user_content = await _convert_response_input_to_chat_user_content(input)
         messages.append(OpenAIUserMessageParam(content=user_content))
 
         chat_tools = await self._convert_response_tools_to_chat_tools(tools) if tools else None
@@ -198,10 +236,32 @@ class OpenAIResponsesImpl:
 
         if store:
             # Store in kvstore
+
+            if isinstance(input, str):
+                # synthesize a message from the input string
+                input_content = OpenAIResponseInputMessageContentText(text=input)
+                input_content_item = OpenAIResponseInputItemMessage(
+                    role="user",
+                    content=[input_content],
+                    id=f"msg_{uuid.uuid4()}",
+                )
+                input_items_data = [input_content_item]
+            else:
+                # we already have a list of messages
+                input_items_data = []
+                for input_item in input:
+                    input_items_data.append(
+                        OpenAIResponseInputItemMessage(id=f"msg_{uuid.uuid4()}", **input_item.model_dump())
+                    )
+            input_items = OpenAIResponseInputItemList(data=input_items_data)
+            prev_response = OpenAIResponsePreviousResponseWithInputItems(
+                input_items=input_items,
+                response=response,
+            )
             key = f"{OPENAI_RESPONSES_PREFIX}{response.id}"
             await self.persistence_store.set(
                 key=key,
-                value=response.model_dump_json(),
+                value=prev_response.model_dump_json(),
             )
 
         if stream:


### PR DESCRIPTION
# What does this PR do?

This adds storing of input items with previous responses and then restores those input items to prepend to the user's messages list when using conversation state.

I missed this in the initial implementation, but it makes sense that we have to store the input items from previous responses so that we can reconstruct the proper messages stack for multi-turn conversations - just the output from previous responses isn't enough context for the models to follow the turns and the original instructions.

Closes #2074

## Test Plan

This is to get `tests/verifications/openai_api/test_responses.py` green against a local Llama 4 Scout running on vLLM - `test_response_non_streaming_multi_turn_image` currently fails there with the model complaining in the 2nd turn that this is the start of its conversation with the user, which is what led me to realize I was missing the previous input items.
