### PR TITLE
build: Remove no-commit-to-branch check from pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,6 @@ repos:
         args: ['--maxkb=1000']
     -   id: end-of-file-fixer
         exclude: '^(.*\.svg)$'
-    -   id: no-commit-to-branch
     -   id: check-yaml
         args: ["--unsafe"]
     -   id: detect-private-key


### PR DESCRIPTION
# What does this PR do?

This does not seem to work correctly. Example https://github.com/meta-llama/llama-stack/commit/6378c2a2f3aae6fface3438d319df417f01ad108 which was merged through PR but failed this check.