### PR TITLE
feat(openai-responses): Support multiple message roles in API inputs

### DIFF
--- a/tests/unit/providers/agents/meta_reference/fixtures/__init__.py
+++ b/tests/unit/providers/agents/meta_reference/fixtures/__init__.py
@@ -1,0 +1,74 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import os
+
+import yaml
+
+from llama_stack.apis.inference.inference import (
+    OpenAIAssistantMessageParam,
+    OpenAIChatCompletion,
+    OpenAIChatCompletionToolCall,
+    OpenAIChatCompletionToolCallFunction,
+    OpenAIChoice,
+)
+
+
+def load_chat_completion_fixture(filename: str) -> OpenAIChatCompletion:
+    """
+    Load a YAML fixture file and convert it to an OpenAIChatCompletion object.
+
+    Args:
+        filename: Name of the YAML file (without path)
+
+    Returns:
+        OpenAIChatCompletion object
+    """
+    fixtures_dir = os.path.dirname(os.path.abspath(__file__))
+    fixture_path = os.path.join(fixtures_dir, filename)
+
+    with open(fixture_path) as f:
+        data = yaml.safe_load(f)
+
+    choices = []
+    for choice_data in data.get("choices", []):
+        message_data = choice_data.get("message", {})
+
+        # Handle tool calls if present
+        tool_calls = None
+        if "tool_calls" in message_data:
+            tool_calls = []
+            for tool_call_data in message_data.get("tool_calls", []):
+                function_data = tool_call_data.get("function", {})
+                function = OpenAIChatCompletionToolCallFunction(
+                    name=function_data.get("name"),
+                    arguments=function_data.get("arguments"),
+                )
+                tool_call = OpenAIChatCompletionToolCall(
+                    id=tool_call_data.get("id"),
+                    type=tool_call_data.get("type"),
+                    function=function,
+                )
+                tool_calls.append(tool_call)
+
+        message = OpenAIAssistantMessageParam(
+            content=message_data.get("content"),
+            tool_calls=tool_calls,
+        )
+
+        choice = OpenAIChoice(
+            message=message,
+            finish_reason=choice_data.get("finish_reason"),
+            index=choice_data.get("index", 0),
+        )
+        choices.append(choice)
+
+    return OpenAIChatCompletion(
+        id=data.get("id"),
+        choices=choices,
+        created=data.get("created"),
+        model=data.get("model"),
+    )

--- a/tests/unit/providers/agents/meta_reference/fixtures/simple_chat_completion.yaml
+++ b/tests/unit/providers/agents/meta_reference/fixtures/simple_chat_completion.yaml
@@ -1,0 +1,8 @@
+id: chat-completion-123
+choices:
+  - message:
+      content: "Dublin"
+    finish_reason: stop
+    index: 0
+created: 1234567890
+model: meta-llama/Llama-3.1-8B-Instruct

--- a/tests/unit/providers/agents/meta_reference/fixtures/tool_call_completion.yaml
+++ b/tests/unit/providers/agents/meta_reference/fixtures/tool_call_completion.yaml
@@ -1,0 +1,13 @@
+id: chat-completion-123
+choices:
+  - message:
+      tool_calls:
+        - id: tool_call_123
+          type: function
+          function:
+            name: web_search
+            arguments: '{"query":"What is the capital of Ireland?"}'
+    finish_reason: stop
+    index: 0
+created: 1234567890
+model: meta-llama/Llama-3.1-8B-Instruct


### PR DESCRIPTION
Also update the nesting to add multiple messages(where appropriate) rather then a single message with multiple content parts.



Using this example 

```
messages = [
  {"role": "developer", "content": "You are a helpful assistant."},
  {"role": "user", "content": "Tell me a single sentence about a unicorn.",},
  {"role": "assistant","content": "Once upon a time, there was a unicorn name bob.",},
  {"role": "user", "content": "what was the unicorn's name? (just the name, no other text)",},
]
response = client.responses.create(model="meta-llama/Llama-3.1-8B-Instruct", input=messages)
```

With the patch and the above code the message sent from LLS to VLLM change from 
```
  "messages": [         
    {"role": "user","content": [
    	{"type": "text", "text": "You are a helpful assistant."},                    
    	{"type": "text", "text": "Tell me a single sentence about a unicorn."},                    
        {"type": "text", "text": "Once upon a time, there was a unicorn name bob."},                       
        {"type": "text", "text": "what was the unicorn's name? (just the name, no other text)"}                        
      ]}],
```
To
```
  "messages": [
    {"role": "developer", "content": "You are a helpful assistant."},        
    {"role": "user", "content": "Tell me a single sentence about a unicorn."},
    {"role": "assistant", "content": "Once upon a time, there was a unicorn name bob."},
    {"role": "user", "content": "what was the unicorn's name? (just the name, no other text)"}   
  ],                                                      

```

Leaving in draft until https://github.com/meta-llama/llama-stack/pull/2065 merges (so I can add to the unit tests added there) 