### PR TITLE
ci: Disable no-commit-to-branch

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -27,6 +27,8 @@ jobs:
             .pre-commit-config.yaml
 
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        env:
+          SKIP: no-commit-to-branch
 
       - name: Verify if there are any diff files after pre-commit
         run: |


### PR DESCRIPTION
All merges produced by github are pushes to main, which makes the check
fail. The check is local by design, not meant for CI.

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
