### PR TITLE
fix: improve Mermaid diagram visibility in dark mode

### DIFF
--- a/docs/_static/css/my_theme.css
+++ b/docs/_static/css/my_theme.css
@@ -27,3 +27,9 @@ pre {
     white-space: pre-wrap !important;
     word-break: break-all;
 }
+
+[data-theme="dark"] .mermaid {
+    background-color: #f4f4f6 !important;
+    border-radius: 6px;
+    padding: 0.5em;
+  }


### PR DESCRIPTION
# What does this PR do?
Closes #2078 

Previously, the Agent Execution Loop diagram was barely visible in dark mode:

![image](https://github.com/user-attachments/assets/78567334-c57f-4cd0-ba93-290b20ed3aba)

I experimented with styling individual classes, but ultimately found that adding an off-white background provides the best visibility in both dark and light modes:

![image](https://github.com/user-attachments/assets/419d153a-d870-410b-b635-02b95da67a3d)

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan

The documentation can be built locally by following the docs: https://llama-stack.readthedocs.io/en/latest/contributing/index.html#building-the-documentation 

[//]: # (## Documentation)
