### PR TITLE
docs: contrib add a note about unicode in code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,6 +153,8 @@ uv sync
   justification for bypassing the check.
 * When using `# type: ignore` to suppress a mypy warning, include a comment explaining the
   justification for bypassing the check.
+* Don't use unicode characters in the codebase. ASCII-only is preferred for compatibility or
+  readability reasons.
 
 ## Common Tasks
 


### PR DESCRIPTION
# What does this PR do?

Don't use unicode characters in the codebase. ASCII-only is preferred for compatibility or readability reasons
