### PR TITLE
feat: enable mutual tls

### DIFF
--- a/llama_stack/distribution/datatypes.py
+++ b/llama_stack/distribution/datatypes.py
@@ -249,6 +249,10 @@ class ServerConfig(BaseModel):
         default=None,
         description="Path to TLS key file for HTTPS",
     )
+    tls_cafile: str | None = Field(
+        default=None,
+        description="Path to TLS CA file for HTTPS with mutual TLS authentication",
+    )
     auth: AuthenticationConfig | None = Field(
         default=None,
         description="Authentication configuration for the server",

--- a/llama_stack/distribution/server/server.py
+++ b/llama_stack/distribution/server/server.py
@@ -9,6 +9,7 @@ import asyncio
 import inspect
 import json
 import os
+import ssl
 import sys
 import traceback
 import warnings
@@ -484,7 +485,14 @@ def main(args: argparse.Namespace | None = None):
             "ssl_keyfile": keyfile,
             "ssl_certfile": certfile,
         }
-        logger.info(f"HTTPS enabled with certificates:\n  Key: {keyfile}\n  Cert: {certfile}")
+        if config.server.tls_cafile:
+            ssl_config["ssl_ca_certs"] = config.server.tls_cafile
+            ssl_config["ssl_cert_reqs"] = ssl.CERT_REQUIRED
+            logger.info(
+                f"HTTPS enabled with certificates:\n  Key: {keyfile}\n  Cert: {certfile}\n  CA: {config.server.tls_cafile}"
+            )
+        else:
+            logger.info(f"HTTPS enabled with certificates:\n  Key: {keyfile}\n  Cert: {certfile}")
 
     listen_host = ["::", "0.0.0.0"] if not config.server.disable_ipv6 else "0.0.0.0"
     logger.info(f"Listening on {listen_host}:{port}")


### PR DESCRIPTION
# What does this PR do?
This adds a config option for a CA to be specified with which client certs are verified. If specified client certs are required. This offers a simple way of securing access to the server.

(Note: at present it is not possible to access the details of the client certificate using uvicorn (unless it was monkey patched). Though there is a defined TLS extension for ASGI, this is not implemented in uvicorn pending a review and likely change to the specification. See https://github.com/encode/uvicorn/pull/1119 and https://github.com/django/asgiref/issues/466. Without access to the DN it isn't possible to set user access attributes for a mutually authentication tls connection, so more fine grained access control is not yet possible). 

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan
Used proposed config option to specify a CA and verified that the server can only be accessed with a valid client certificate.

[//]: # (## Documentation)
