### PR TITLE
fix(cli): fix behavior of --image-type in llama stack build

### DIFF
--- a/.github/workflows/providers-build.yml
+++ b/.github/workflows/providers-build.yml
@@ -132,9 +132,8 @@ jobs:
 
       - name: Build a single provider
         run: |
-          yq -i '.image_type = "container"' llama_stack/templates/dev/build.yaml
           yq -i '.image_name = "test"' llama_stack/templates/dev/build.yaml
-          USE_COPY_NOT_MOUNT=true LLAMA_STACK_DIR=. uv run llama stack build --config llama_stack/templates/dev/build.yaml
+          USE_COPY_NOT_MOUNT=true LLAMA_STACK_DIR=. uv run llama stack build --image-type=container --config llama_stack/templates/dev/build.yaml
 
       - name: Inspect the container image entrypoint
         run: |

--- a/llama_stack/cli/stack/_build.py
+++ b/llama_stack/cli/stack/_build.py
@@ -209,6 +209,8 @@ def run_stack_build_command(args: argparse.Namespace) -> None:
                     color="red",
                 )
                 sys.exit(1)
+        if args.image_type:
+            build_config.image_type = args.image_type
 
     if args.print_deps_only:
         print(f"# Dependencies for {args.template or args.config or image_name}")


### PR DESCRIPTION
# What does this PR do?
[Provide a short summary of what this PR does and why. Link to relevant issues if applicable.]

This PR is fixing the behavior of the `llama stack build --image-type=... --config=mybuild.yaml` as described in the issue below. 

[//]: # (If resolving an issue, uncomment and update the line below)
Closes #2162

## Test Plan
[Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.*]

[//]: # (## Documentation)
