### PR TITLE
feat: start ui server in `llama stack run`

### DIFF
--- a/llama_stack/ui/package.json
+++ b/llama_stack/ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack --port 8322",
+    "dev": "next dev --turbopack --port ${LLAMA_STACK_UI_PORT:-8322}",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
# What does this PR do?
TSIA
`--enable-ui` to enable


## Test Plan
`llama stack run dev --image-type conda --enable-ui`
`localhost:8322` shows UI


llama stack run dev --image-type conda
`localhost:8322` does not work