### PR TITLE
fix: ReadTheDocs should display all versions

### DIFF
--- a/.github/workflows/update-readthedocs.yml
+++ b/.github/workflows/update-readthedocs.yml
@@ -59,9 +59,15 @@ jobs:
             exit 1
           fi
 
+          # Get the version from the GitHub ref
+          VERSION=${GITHUB_REF#refs/*/}
+
           response=$(curl -X POST \
             -H "Content-Type: application/json" \
-            -d "{\"token\": \"$TOKEN\"}" \
+            -d "{
+              \"token\": \"$TOKEN\",
+              \"version\": \"$VERSION\"
+            }" \
             https://readthedocs.org/api/v2/webhook/llama-stack/289768/)
 
           echo "Response: $response"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -110,6 +110,8 @@ html_theme_options = {
     "canonical_url": "https://github.com/meta-llama/llama-stack",
     "collapse_navigation": False,
     # "style_nav_header_background": "#c3c9d4",
+    'display_version': True,
+    'version_selector': True,
 }
 
 default_dark_mode = False


### PR DESCRIPTION
# What does this PR do?

Currently the website only displays the "latest" version. This is because our config and workflow do not include version information. This PR adds missing version info.