### PR TITLE
wip: experiment running the UI from fastapi

### DIFF
--- a/llama_stack/ui/README.md
+++ b/llama_stack/ui/README.md
@@ -2,7 +2,13 @@
 
 ## Getting Started
 
-First, run the development server:
+First, install dependencies:
+
+```bash
+npm install next react react-dom
+```
+
+Then, run the development server:
 
 ```bash
 npm run dev

--- a/llama_stack/ui/app/layout.tsx
+++ b/llama_stack/ui/app/layout.tsx
@@ -22,16 +22,16 @@ import { AppSidebar } from "@/components/app-sidebar"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-<html lang="en">
-<body>
-<SidebarProvider>
-      <AppSidebar />
-      <main>
-        <SidebarTrigger />
-        {children}
-      </main>
-    </SidebarProvider>
-  </body>
-</html>
+    <html lang="en" className={`${geistSans.variable} ${geistMono.variable}`}>
+      <body>
+        <SidebarProvider>
+          <AppSidebar />
+          <main>
+            <SidebarTrigger />
+            {children}
+          </main>
+        </SidebarProvider>
+      </body>
+    </html>
   )
 }

--- a/llama_stack/ui/components/app-sidebar.tsx
+++ b/llama_stack/ui/components/app-sidebar.tsx
@@ -1,4 +1,5 @@
 import { MessageSquareText, MessagesSquare } from "lucide-react"
+import Link from "next/link"
 
 import {
   Sidebar,
@@ -29,9 +30,9 @@ const logItems = [
 export function AppSidebar() {
   return (
     <Sidebar>
-        <SidebarHeader>
-            <a href="/">Llama Stack</a>
-        </SidebarHeader>
+      <SidebarHeader>
+        <Link href="/">Llama Stack</Link>
+      </SidebarHeader>
       <SidebarContent>
         <SidebarGroup>
           <SidebarGroupLabel>Logs</SidebarGroupLabel>
@@ -40,10 +41,10 @@ export function AppSidebar() {
               {logItems.map((item) => (
                 <SidebarMenuItem key={item.title}>
                   <SidebarMenuButton asChild>
-                    <a href={item.url}>
+                    <Link href={item.url}>
                       <item.icon />
                       <span>{item.title}</span>
-                    </a>
+                    </Link>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
               ))}

--- a/llama_stack/ui/package-lock.json
+++ b/llama_stack/ui/package-lock.json
@@ -15,9 +15,9 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.510.0",
-        "next": "15.3.2",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
+        "next": "^15.3.2",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
         "tailwind-merge": "^3.3.0"
       },
       "devDependencies": {

--- a/llama_stack/ui/package.json
+++ b/llama_stack/ui/package.json
@@ -16,9 +16,9 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.510.0",
-    "next": "15.3.2",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "next": "^15.3.2",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {

--- a/llama_stack/ui/server.py
+++ b/llama_stack/ui/server.py
@@ -1,0 +1,81 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+# /// script
+# dependencies = [
+#     "fastapi",
+#     "fastapi-cors",
+#     "fastapi-staticfiles",
+#     "fastapi-responses",
+#     "fastapi-middleware",
+#     "fastapi-middleware-cors",
+#     "fastapi-middleware-staticfiles",
+#     "fastapi-middleware-responses",
+#     "uvicorn",
+# ]
+# ///
+#
+#
+# Before running the script, build the Next.js app:
+# cd llama_stack/ui
+# npm run build
+#
+# Run the script like:
+# uv run uvicorn server:app --reload
+
+import os
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+
+app = FastAPI()
+
+# Add CORS middleware
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # In production, replace with your actual domain
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Get the absolute paths
+current_dir = os.path.dirname(os.path.abspath(__file__))
+static_dir = os.path.join(current_dir, ".next", "static")
+server_dir = os.path.join(current_dir, ".next", "server")
+app_dir = os.path.join(server_dir, "app")
+
+# Mount the static files directory at the Next.js path
+app.mount("/_next/static", StaticFiles(directory=static_dir), name="static")
+
+
+# Serve HTML files for each route
+@app.get("/{path:path}")
+async def serve_page(path: str):
+    # Handle root path
+    if path == "" or path == "/":
+        return FileResponse(os.path.join(app_dir, "index.html"))
+
+    # Handle logs routes
+    if path.startswith("logs/"):
+        log_name = path.replace("logs/", "")
+        log_html = os.path.join(app_dir, "logs", f"{log_name}.html")
+        if os.path.exists(log_html):
+            return FileResponse(log_html)
+
+    # If no specific route is found, return 404 page
+    not_found_path = os.path.join(app_dir, "_not-found.html")
+    if os.path.exists(not_found_path):
+        return FileResponse(not_found_path)
+
+    raise HTTPException(status_code=404, detail="Page not found")
+
+
+@app.get("/api/health")
+async def health_check():
+    return {"status": "healthy", "message": "Static file server is running"}


### PR DESCRIPTION
@ashwinb this is a followup on our previous conversation. By using the script attached in f9095ce3df265ee76991685133821b71347dd6b7, I could run a static version of the file. This eliminates the need to call `npm` to run the UI. We can include the static content in a new route on the distro server.

I've run both the static version and the one with `npm dev run`, and I get two identical pages—except the dev tool debug thingy.

Am I missing something? If not, I feel we still have a case where we build the static version of the site (from `.next`, we would need to track that directory) and package it along with our current package. Then users can decide to activate the UI or not through a server spec config.

Thanks for considering this!
