### PR TITLE
fix: update llama stack build --run to use new start_stack.sh signature

### DIFF
--- a/llama_stack/cli/stack/_build.py
+++ b/llama_stack/cli/stack/_build.py
@@ -254,7 +254,7 @@ def run_stack_build_command(args: argparse.Namespace) -> None:
         if not os.path.exists(str(config.external_providers_dir)):
             os.makedirs(str(config.external_providers_dir), exist_ok=True)
         run_args = formulate_run_args(args.image_type, args.image_name, config, args.template)
-        run_args.extend([run_config, str(os.getenv("LLAMA_STACK_PORT", 8321))])
+        run_args.extend([str(os.getenv("LLAMA_STACK_PORT", 8321)), "--config", run_config])
         run_command(run_args)
 
 


### PR DESCRIPTION
# What does this PR do?
fixes #2188

## Test Plan
`INFERENCE_MODEL=meta-llama/Llama-3.3-70B-Instruct llama stack build --image-name ollama --image-type conda --template ollama --run` without error
