### PR TITLE
feat: add cpu/cuda config for prompt guard

### DIFF
--- a/llama_stack/providers/inline/safety/prompt_guard/config.py
+++ b/llama_stack/providers/inline/safety/prompt_guard/config.py
@@ -15,8 +15,14 @@ class PromptGuardType(Enum):
     jailbreak = "jailbreak"
 
 
+class PromptGuardExecutionType(Enum):
+    cpu = "cpu"
+    cuda = "cuda"
+
+
 class PromptGuardConfig(BaseModel):
     guard_type: str = PromptGuardType.injection.value
+    guard_execution_type: str = PromptGuardExecutionType.cuda.value
 
     @classmethod
     @field_validator("guard_type")
@@ -26,7 +32,15 @@ class PromptGuardConfig(BaseModel):
         return v
 
     @classmethod
+    @field_validator("guard_execution_type")
+    def validate_guard_execution_type(cls, v):
+        if v not in [t.value for t in PromptGuardExecutionType]:
+            raise ValueError(f"Unknown prompt guard execution type: {v}")
+        return v
+
+    @classmethod
     def sample_run_config(cls, __distro_dir__: str, **kwargs: Any) -> dict[str, Any]:
         return {
             "guard_type": "injection",
+            "guard_execution_type": "cuda",
         }

--- a/llama_stack/providers/inline/safety/prompt_guard/config.py
+++ b/llama_stack/providers/inline/safety/prompt_guard/config.py
@@ -15,14 +15,8 @@ class PromptGuardType(Enum):
     jailbreak = "jailbreak"
 
 
-class PromptGuardExecutionType(Enum):
-    cpu = "cpu"
-    cuda = "cuda"
-
-
 class PromptGuardConfig(BaseModel):
     guard_type: str = PromptGuardType.injection.value
-    guard_execution_type: str = PromptGuardExecutionType.cuda.value
 
     @classmethod
     @field_validator("guard_type")
@@ -32,15 +26,7 @@ class PromptGuardConfig(BaseModel):
         return v
 
     @classmethod
-    @field_validator("guard_execution_type")
-    def validate_guard_execution_type(cls, v):
-        if v not in [t.value for t in PromptGuardExecutionType]:
-            raise ValueError(f"Unknown prompt guard execution type: {v}")
-        return v
-
-    @classmethod
     def sample_run_config(cls, __distro_dir__: str, **kwargs: Any) -> dict[str, Any]:
         return {
             "guard_type": "injection",
-            "guard_execution_type": "cuda",
         }

--- a/llama_stack/providers/inline/safety/prompt_guard/prompt_guard.py
+++ b/llama_stack/providers/inline/safety/prompt_guard/prompt_guard.py
@@ -75,7 +75,7 @@ class PromptGuardShield:
         self.temperature = temperature
         self.threshold = threshold
 
-        self.device = "cuda"
+        self.device = self.config.guard_execution_type
 
         # load model and tokenizer
         self.tokenizer = AutoTokenizer.from_pretrained(model_dir)

--- a/llama_stack/providers/inline/safety/prompt_guard/prompt_guard.py
+++ b/llama_stack/providers/inline/safety/prompt_guard/prompt_guard.py
@@ -75,7 +75,9 @@ class PromptGuardShield:
         self.temperature = temperature
         self.threshold = threshold
 
-        self.device = self.config.guard_execution_type
+        self.device = "cpu"
+        if torch.cuda.is_available():
+            self.device = "cuda"
 
         # load model and tokenizer
         self.tokenizer = AutoTokenizer.from_pretrained(model_dir)


### PR DESCRIPTION
# What does this PR do?
Previously prompt guard was hard coded to require cuda which prevented it from being used on an instance without a cuda support.

This PR allows prompt guard to be configured to use either cpu or cuda.

[//]: # (If resolving an issue, uncomment and update the line below)
Closes [#2133](https://github.com/meta-llama/llama-stack/issues/2133)

## Test Plan (Edited after incorporating suggestion)
1) started stack configured with prompt guard  as follows on a system without a GPU
and validated prompt guard could be used through the APIs

2) validated on a system with a gpu (but without llama stack) that the python selecting between cpu and cuda support returned the right value when a cuda device was available.

3) ran the unit tests as per - https://github.com/meta-llama/llama-stack/blob/main/tests/unit/README.md

[//]: # (## Documentation)
