### PR TITLE
feat: Add "instructions" support to responses API

### DIFF
--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -7027,6 +7027,9 @@
                         "type": "string",
                         "description": "The underlying LLM used for completions."
                     },
+                    "instructions": {
+                        "type": "string"
+                    },
                     "previous_response_id": {
                         "type": "string",
                         "description": "(Optional) if specified, the new response will be a continuation of the previous response. This can be used to easily fork-off new responses from existing responses."

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -4952,6 +4952,8 @@ components:
         model:
           type: string
           description: The underlying LLM used for completions.
+        instructions:
+          type: string
         previous_response_id:
           type: string
           description: >-

--- a/llama_stack/apis/agents/agents.py
+++ b/llama_stack/apis/agents/agents.py
@@ -596,6 +596,7 @@ class Agents(Protocol):
         self,
         input: str | list[OpenAIResponseInput],
         model: str,
+        instructions: str | None = None,
         previous_response_id: str | None = None,
         store: bool | None = True,
         stream: bool | None = False,

--- a/llama_stack/providers/inline/agents/meta_reference/agents.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agents.py
@@ -313,6 +313,7 @@ class MetaReferenceAgentsImpl(Agents):
         self,
         input: str | list[OpenAIResponseInput],
         model: str,
+        instructions: str | None = None,
         previous_response_id: str | None = None,
         store: bool | None = True,
         stream: bool | None = False,
@@ -320,5 +321,5 @@ class MetaReferenceAgentsImpl(Agents):
         tools: list[OpenAIResponseInputTool] | None = None,
     ) -> OpenAIResponseObject:
         return await self.openai_responses_impl.create_openai_response(
-            input, model, previous_response_id, store, stream, temperature, tools
+            input, model, instructions, previous_response_id, store, stream, temperature, tools
         )

--- a/llama_stack/providers/inline/agents/meta_reference/openai_responses.py
+++ b/llama_stack/providers/inline/agents/meta_reference/openai_responses.py
@@ -208,6 +208,10 @@ class OpenAIResponsesImpl:
 
         return input
 
+    async def _prepend_instructions(self, messages, instructions):
+        if instructions:
+            messages.insert(0, OpenAISystemMessageParam(content=instructions))
+
     async def get_openai_response(
         self,
         id: str,
@@ -219,6 +223,7 @@ class OpenAIResponsesImpl:
         self,
         input: str | list[OpenAIResponseInput],
         model: str,
+        instructions: str | None = None,
         previous_response_id: str | None = None,
         store: bool | None = True,
         stream: bool | None = False,
@@ -229,7 +234,9 @@ class OpenAIResponsesImpl:
 
         input = await self._prepend_previous_response(input, previous_response_id)
         messages = await _convert_response_input_to_chat_messages(input)
+        await self._prepend_instructions(messages, instructions)
         chat_tools = await self._convert_response_tools_to_chat_tools(tools) if tools else None
+
         chat_response = await self.inference_api.openai_chat_completion(
             model=model,
             messages=messages,


### PR DESCRIPTION
# What does this PR do?
Add support for "instructions" to the responses API. Instructions provide a way to swap out system (or developer) messages in new responses.


## Test Plan
unit tests added

