### PR TITLE
chore: clarify cache_ttl to be key_recheck_period

### DIFF
--- a/docs/source/distributions/configuration.md
+++ b/docs/source/distributions/configuration.md
@@ -183,7 +183,7 @@ server:
     config:
       jwks:
         uri: "https://kubernetes.default.svc"
-        cache_ttl: 3600
+        key_recheck_period: 3600
       tls_cafile: "/path/to/ca.crt"
       issuer: "https://kubernetes.default.svc"
       audience: "https://kubernetes.default.svc"

--- a/tests/unit/server/test_auth.py
+++ b/tests/unit/server/test_auth.py
@@ -293,7 +293,7 @@ def oauth2_app():
         config={
             "jwks": {
                 "uri": "http://mock-authz-service/token/introspect",
-                "cache_ttl": "3600",
+                "key_recheck_period": "3600",
             },
             "audience": "llama-stack",
         },


### PR DESCRIPTION
# What does this PR do?

The cache_ttl config value is not in fact tied to the lifetime of any of
the keys, it represents the time interval between for our key cache
refresher.