### PR TITLE
feat: allow using llama-stack-library-client from verifications

### DIFF
--- a/tests/verifications/conftest.py
+++ b/tests/verifications/conftest.py
@@ -25,6 +25,11 @@ def pytest_addoption(parser):
         action="store",
         help="Provider to use for testing",
     )
+    parser.addoption(
+        "--model",
+        action="store",
+        help="Model to use for testing",
+    )
 
 
 pytest_plugins = [

--- a/tests/verifications/openai_api/conftest.py
+++ b/tests/verifications/openai_api/conftest.py
@@ -16,6 +16,11 @@ def pytest_generate_tests(metafunc):
             metafunc.parametrize("model", [])
             return
 
+        model = metafunc.config.getoption("model")
+        if model:
+            metafunc.parametrize("model", [model])
+            return
+
         try:
             config_data = _load_all_verification_configs()
         except (OSError, FileNotFoundError) as e:


### PR DESCRIPTION
Having to run (and re-run) a server while running verifications can be annoying while you are iterating on code. This makes it so you can use the library client -- and because it is OpenAI client compatible, it all works.

## Test Plan

```
pytest -s -v tests/verifications/openai_api/test_responses.py \
   --provider=stack:together \
   --model meta-llama/Llama-4-Scout-17B-16E-Instruct
```