### PR TITLE
fix(security): Upgrade setuptools to v80.8.0. Fixes CVE-2025-47273

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ requests==2.32.3
 rich==13.9.4
 rpds-py==0.22.3
 rsa==4.9
-setuptools==75.8.0
+setuptools==80.8.0
 six==1.17.0
 sniffio==1.3.1
 termcolor==2.5.0

--- a/uv.lock
+++ b/uv.lock
@@ -3504,11 +3504,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "75.8.0"
+version = "80.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/92/ec/089608b791d210aec4e7f97488e67ab0d33add3efccb83a056cbafe3a2a6/setuptools-75.8.0.tar.gz", hash = "sha256:c5afc8f407c626b8313a86e10311dd3f661c6cd9c09d4bf8c15c0e11f9f2b0e6", size = 1343222 }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/d2/ec1acaaff45caed5c2dedb33b67055ba9d4e96b091094df90762e60135fe/setuptools-80.8.0.tar.gz", hash = "sha256:49f7af965996f26d43c8ae34539c8d99c5042fbff34302ea151eaa9c207cd257", size = 1319720 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/8a/b9dc7678803429e4a3bc9ba462fa3dd9066824d3c607490235c6a796be5a/setuptools-75.8.0-py3-none-any.whl", hash = "sha256:e3982f444617239225d675215d51f6ba05f845d4eec313da4418fdbb56fb27e3", size = 1228782 },
+    { url = "https://files.pythonhosted.org/packages/58/29/93c53c098d301132196c3238c312825324740851d77a8500a2462c0fd888/setuptools-80.8.0-py3-none-any.whl", hash = "sha256:95a60484590d24103af13b686121328cc2736bee85de8936383111e421b9edc0", size = 1201470 },
 ]
 
 [[package]]


### PR DESCRIPTION
# What does this PR do?

This fixes a high vulnerable CVE in `setuptools`: https://github.com/advisories/GHSA-5rjg-fvgr-3xxf 
