### PR TITLE
fix: disable test_responses_store

### DIFF
--- a/tests/integration/agents/test_openai_responses.py
+++ b/tests/integration/agents/test_openai_responses.py
@@ -41,6 +41,7 @@ def openai_client(client_with_models):
         ],
     ],
 )
+@pytest.mark.skip(reason="Very flaky, sometimes there is a message not a function call, standard tool calling issues")
 def test_responses_store(openai_client, client_with_models, text_model_id, stream, tools):
     if isinstance(client_with_models, LlamaStackAsLibraryClient):
         pytest.skip("OpenAI responses are not supported when testing with library client yet.")

--- a/tests/integration/inference/test_openai_completion.py
+++ b/tests/integration/inference/test_openai_completion.py
@@ -274,6 +274,7 @@ def test_inference_store(openai_client, client_with_models, text_model_id, strea
         False,
     ],
 )
+@pytest.mark.skip(reason="Very flaky, tool calling really wacky on CI")
 def test_inference_store_tool_calls(openai_client, client_with_models, text_model_id, stream):
     skip_if_model_doesnt_support_openai_chat_completion(client_with_models, text_model_id)
     client = openai_client


### PR DESCRIPTION
The test depends on llama's tool calling ability. In the CI, we run with a small ollama model. 

The fix might be to check for either message or function_call because the model is flaky and we aren't really testing that behavior?