### PR TITLE
fix(telemetry): get rid of annoying sqlite span export error

### DIFF
--- a/llama_stack/providers/inline/telemetry/meta_reference/sqlite_span_processor.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/sqlite_span_processor.py
@@ -9,7 +9,6 @@ import os
 import sqlite3
 import threading
 from datetime import datetime, timezone
-from enum import Enum
 
 from opentelemetry.sdk.trace import SpanProcessor
 from opentelemetry.trace import Span
@@ -154,9 +153,6 @@ class SQLiteSpanProcessor(SpanProcessor):
             )
 
             for event in span.events:
-                name = event.name
-                if isinstance(name, Enum):
-                    name = name.value
                 cursor.execute(
                     """
                     INSERT INTO span_events (
@@ -165,7 +161,7 @@ class SQLiteSpanProcessor(SpanProcessor):
                 """,
                     (
                         span_id,
-                        name,
+                        event.name,
                         datetime.fromtimestamp(event.timestamp / 1e9, timezone.utc).isoformat(),
                         json.dumps(dict(event.attributes)),
                     ),

--- a/llama_stack/providers/inline/telemetry/meta_reference/sqlite_span_processor.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/sqlite_span_processor.py
@@ -9,6 +9,7 @@ import os
 import sqlite3
 import threading
 from datetime import datetime, timezone
+from enum import Enum
 
 from opentelemetry.sdk.trace import SpanProcessor
 from opentelemetry.trace import Span
@@ -153,6 +154,9 @@ class SQLiteSpanProcessor(SpanProcessor):
             )
 
             for event in span.events:
+                name = event.name
+                if isinstance(name, Enum):
+                    name = name.value
                 cursor.execute(
                     """
                     INSERT INTO span_events (
@@ -161,7 +165,7 @@ class SQLiteSpanProcessor(SpanProcessor):
                 """,
                     (
                         span_id,
-                        event.name,
+                        name,
                         datetime.fromtimestamp(event.timestamp / 1e9, timezone.utc).isoformat(),
                         json.dumps(dict(event.attributes)),
                     ),

--- a/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
@@ -148,7 +148,7 @@ class TelemetryAdapter(TelemetryDatasetMixin, Telemetry):
             if span:
                 timestamp_ns = int(event.timestamp.timestamp() * 1e9)
                 span.add_event(
-                    name=event.type,
+                    name=event.type.value,
                     attributes={
                         "message": event.message,
                         "severity": event.severity.value,


### PR DESCRIPTION
Run 

```
SQLITE_STORE_DIR=$(mktemp -d) \
  pytest -s -v integration/tool_runtime/test_mcp.py --stack-config fireworks
```

no more annoying errors