### PR TITLE
fix: handle None external_providers_dir in build with run arg

### DIFF
--- a/llama_stack/cli/stack/_build.py
+++ b/llama_stack/cli/stack/_build.py
@@ -266,8 +266,8 @@ def run_stack_build_command(args: argparse.Namespace) -> None:
     if args.run:
         config_dict = yaml.safe_load(run_config.read_text())
         config = parse_and_maybe_upgrade_config(config_dict)
-        if not os.path.exists(config.external_providers_dir):
-            os.makedirs(config.external_providers_dir, exist_ok=True)
+        if config.external_providers_dir and not config.external_providers_dir.exists():
+            config.external_providers_dir.mkdir(exist_ok=True)
         run_args = formulate_run_args(args.image_type, args.image_name, config, args.template)
         run_args.extend([str(os.getenv("LLAMA_STACK_PORT", 8321)), "--config", run_config])
         run_command(run_args)


### PR DESCRIPTION
# What does this PR do?
Fixes an issue where running `llama stack build --template ollama --image-type venv --run` fails with a TypeError when validating external providers directory paths.

The error occurs because `os.path.exists()` is called with `Path(None)` instead of converting it to a string first. This change ensures consistent handling of `None` values for `external_providers_dir` across both build and [run](https://github.com/meta-llama/llama-stack/blob/main/llama_stack/cli/stack/run.py#L134) commands by using `str()` conversion before path validation.  

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan
```bash
INFERENCE_MODEL=llama3.2:3b uv run --with llama-stack llama stack build --template ollama --image-type venv --run
```
Command completes successfully without TypeError

[//]: # (## Documentation)
