### PR TITLE
docs: Remove unused import.

### DIFF
--- a/docs/source/building_applications/tools.md
+++ b/docs/source/building_applications/tools.md
@@ -177,7 +177,6 @@ export TAVILY_SEARCH_API_KEY="your key"
 3. Run the following script.
 ```python
 from llama_stack_client.lib.agents.agent import Agent
-from llama_stack_client.types.agent_create_params import AgentConfig
 from llama_stack_client.lib.agents.event_logger import EventLogger
 from llama_stack_client import LlamaStackClient
 


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
This PR removes an unused import from the `building_applications/tools` documentation page.

Specifically, the import:
```python
from llama_stack_client.types.agent_create_params import AgentConfig
```
 is not used in the documented example and, further, `AgentConfig` is not exported from `agent_create_params`.

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->
N/A - single line removed from documentation.

To sanity check, I tested the example locally and the example runs without this import.
