### PR TITLE
chore: use groups when running commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,10 +168,10 @@ If you are making changes to the documentation at [https://llama-stack.readthedo
 
 ```bash
 # This rebuilds the documentation pages.
-uv run --with ".[docs]" make -C docs/ html
+uv run --group docs make -C docs/ html
 
 # This will start a local server (usually at http://127.0.0.1:8000) that automatically rebuilds and refreshes when you make changes to the documentation.
-uv run --with ".[docs]" sphinx-autobuild docs/source docs/build/html --write-all
+uv run --group docs sphinx-autobuild docs/source docs/build/html --write-all
 ```
 
 ### Update API Documentation
@@ -179,7 +179,7 @@ uv run --with ".[docs]" sphinx-autobuild docs/source docs/build/html --write-all
 If you modify or add new API endpoints, update the API documentation accordingly. You can do this by running the following command:
 
 ```bash
-uv run --with ".[dev]" ./docs/openapi_generator/run_openapi_generator.sh
+uv run ./docs/openapi_generator/run_openapi_generator.sh
 ```
 
 The generated API documentation will be available in `docs/_static/`. Make sure to review the changes before committing.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -6,7 +6,7 @@ Here's a collection of comprehensive guides, examples, and resources for buildin
 
 From the llama-stack root directory, run the following command to render the docs locally:
 ```bash
-uv run --with ".[docs]" sphinx-autobuild docs/source docs/build/html --write-all
+uv run --group docs sphinx-autobuild docs/source docs/build/html --write-all
 ```
 You can open up the docs in your browser at http://localhost:8000
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ unit = [
 ]
 # These are the core dependencies required for running integration tests. They are shared across all
 # providers. If a provider requires additional dependencies, please add them to your environment
-# separately. If you are using "uv" to execute your tests, you can use the "--with" flag to specify extra
+# separately. If you are using "uv" to execute your tests, you can use the "--group" flag to specify extra
 # dependencies.
 test = [
     "openai",

--- a/tests/verifications/README.md
+++ b/tests/verifications/README.md
@@ -27,7 +27,7 @@ export TOGETHER_API_KEY=<your_together_api_key>
 ```
 then run
 ```bash
-uv run --with-editable ".[dev]" python tests/verifications/generate_report.py --run-tests
+uv run python tests/verifications/generate_report.py --run-tests
 ```
 
 ## Running Tests


### PR DESCRIPTION
# What does this PR do?

Followup of https://github.com/meta-llama/llama-stack/pull/2287. We must use `--group` when running commands with uv.

<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->
