### PR TITLE
docs: Add OpenAI API compatibility page

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -103,6 +103,7 @@ getting_started/index
 getting_started/detailed_tutorial
 introduction/index
 concepts/index
+openai/index
 providers/index
 distributions/index
 building_applications/index

--- a/docs/source/openai/index.md
+++ b/docs/source/openai/index.md
@@ -2,7 +2,7 @@
 
 ## Server path
 
-Llama Stack exposes an OpenAI-compatible API endpoint at `/v1/openai/v1`. So, for a Llama Stack server running on locally on port 8321, the full url to the OpenAI-compatible API endpoint is `http://localhost:8321/v1/openai/v1`.
+Llama Stack exposes an OpenAI-compatible API endpoint at `/v1/openai/v1`. So, for a Llama Stack server running locally on port `8321`, the full url to the OpenAI-compatible API endpoint is `http://localhost:8321/v1/openai/v1`.
 
 ## Clients
 
@@ -119,7 +119,7 @@ Example output:
 
 ```text
 Lines of code unfold
- Logic flows like a river
+Logic flows like a river
 Code's gentle beauty
 ```
 

--- a/docs/source/openai/index.md
+++ b/docs/source/openai/index.md
@@ -32,11 +32,19 @@ Regardless of the client you choose, the following code examples should all work
 
 ## APIs implemented
 
+### Models
+
+Many of the APIs require you to pass in a model parameter. To see the list of models available in your Llama Stack server:
+
+```python
+models = client.models.list()
+```
+
 ### Responses
 
-```{note}
+:::{note}
 The Responses API implementation is still in active development. While it is quite usable, there are still unimplemented parts of the API. We'd love feedback on any use-cases you try that do not work to help prioritize the pieces left to implement. Please open issues in the [meta-llama/llama-stack](https://github.com/meta-llama/llama-stack) GitHub repository with details of anything that does not work.
-```
+:::
 
 #### Simple inference
 
@@ -59,10 +67,6 @@ Code's gentle silence
 ```
 
 #### Structured Output
-
-```{warning}
-Structured outputs are not yet implemented for the Responses API as of Llama Stack 0.2.8. Below is an example of how this should work, once it is implemented.
-```
 
 Request:
 
@@ -98,7 +102,9 @@ print(response.output_text)
 
 Example output:
 
-Omitted - see warning above.
+```text
+{ "participants": ["Alice", "Bob"] }
+```
 
 ### Chat Completions
 
@@ -184,10 +190,4 @@ Example output:
 Lines of code unfurl
 Logic whispers in the dark
 Art in hidden form
-```
-
-### Models
-
-```python
-models = client.models.list()
 ```

--- a/docs/source/openai/index.md
+++ b/docs/source/openai/index.md
@@ -14,6 +14,7 @@ When using the Llama Stack client, set the `base_url` to the root of your Llama 
 
 ```python
 from llama_stack_client import LlamaStackClient
+
 client = LlamaStackClient(base_url="http://localhost:8321")
 ```
 
@@ -23,6 +24,7 @@ When using an OpenAI client, set the `base_url` to the `/v1/openai/v1` path on y
 
 ```python
 from openai import OpenAI
+
 client = OpenAI(base_url="http://localhost:8321/v1/openai/v1", api_key="none")
 ```
 
@@ -70,12 +72,12 @@ response = client.responses.create(
     input=[
         {
             "role": "system",
-            "content": "Extract the participants from the event information."
+            "content": "Extract the participants from the event information.",
         },
         {
             "role": "user",
-            "content": "Alice and Bob are going to a science fair on Friday."
-        }
+            "content": "Alice and Bob are going to a science fair on Friday.",
+        },
     ],
     text={
         "format": {
@@ -84,19 +86,12 @@ response = client.responses.create(
             "schema": {
                 "type": "object",
                 "properties": {
-                    "participants": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
+                    "participants": {"type": "array", "items": {"type": "string"}}
                 },
-                "required": [
-                    "participants"
-                ],
-            }
+                "required": ["participants"],
+            },
         }
-    }
+    },
 )
 print(response.output_text)
 ```
@@ -114,12 +109,7 @@ Request:
 ```python
 chat_completion = client.chat.completions.create(
     model="meta-llama/Llama-3.2-3B-Instruct",
-    messages=[
-        {
-            "role": "user",
-            "content": "Write a haiku about coding."
-        }
-    ]
+    messages=[{"role": "user", "content": "Write a haiku about coding."}],
 )
 
 print(chat_completion.choices[0].message.content)
@@ -143,12 +133,12 @@ chat_completion = client.chat.completions.create(
     messages=[
         {
             "role": "system",
-            "content": "Extract the participants from the event information."
+            "content": "Extract the participants from the event information.",
         },
         {
             "role": "user",
-            "content": "Alice and Bob are going to a science fair on Friday."
-        }
+            "content": "Alice and Bob are going to a science fair on Friday.",
+        },
     ],
     response_format={
         "type": "json_schema",
@@ -157,19 +147,12 @@ chat_completion = client.chat.completions.create(
             "schema": {
                 "type": "object",
                 "properties": {
-                    "participants": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
+                    "participants": {"type": "array", "items": {"type": "string"}}
                 },
-                "required": [
-                    "participants"
-                ],
-            }
-        }
-    }
+                "required": ["participants"],
+            },
+        },
+    },
 )
 
 print(chat_completion.choices[0].message.content)
@@ -189,8 +172,7 @@ Request:
 
 ```python
 completion = client.completions.create(
-    model="meta-llama/Llama-3.2-3B-Instruct",
-    prompt="Write a haiku about coding."
+    model="meta-llama/Llama-3.2-3B-Instruct", prompt="Write a haiku about coding."
 )
 
 print(completion.choices[0].text)

--- a/docs/source/openai/index.md
+++ b/docs/source/openai/index.md
@@ -1,0 +1,211 @@
+# OpenAI API Compatibility
+
+## Server path
+
+Llama Stack exposes an OpenAI-compatible API endpoint at `/v1/openai/v1`. So, for a Llama Stack server running on locally on port 8321, the full url to the OpenAI-compatible API endpoint is `http://localhost:8321/v1/openai/v1`.
+
+## Clients
+
+You should be able to use any client that speaks OpenAI APIs with Llama Stack. We regularly test with the official Llama Stack clients as well as OpenAI's official Python client.
+
+### Llama Stack Client
+
+When using the Llama Stack client, set the `base_url` to the root of your Llama Stack server. It will automatically route OpenAI-compatible requests to the right server endpoint for you.
+
+```python
+from llama_stack_client import LlamaStackClient
+client = LlamaStackClient(base_url="http://localhost:8321")
+```
+
+### OpenAI Client
+
+When using an OpenAI client, set the `base_url` to the `/v1/openai/v1` path on your Llama Stack server.
+
+```python
+from openai import OpenAI
+client = OpenAI(base_url="http://localhost:8321/v1/openai/v1", api_key="none")
+```
+
+Regardless of the client you choose, the following code examples should all work the same.
+
+## APIs implemented
+
+### Responses
+
+```{note}
+The Responses API implementation is still in active development. While it is quite usable, there are still unimplemented parts of the API. We'd love feedback on any use-cases you try that do not work to help prioritize the pieces left to implement. Please open issues in the [meta-llama/llama-stack](https://github.com/meta-llama/llama-stack) GitHub repository with details of anything that does not work.
+```
+
+#### Simple inference
+
+Request:
+
+```
+response = client.responses.create(
+    model="meta-llama/Llama-3.2-3B-Instruct",
+    input="Write a haiku about coding."
+)
+
+print(response.output_text)
+```
+Example output:
+
+```text
+Pixels dancing slow
+Syntax whispers secrets sweet
+Code's gentle silence
+```
+
+#### Structured Output
+
+```{warning}
+Structured outputs are not yet implemented for the Responses API as of Llama Stack 0.2.8. Below is an example of how this should work, once it is implemented.
+```
+
+Request:
+
+```python
+response = client.responses.create(
+    model="meta-llama/Llama-3.2-3B-Instruct",
+    input=[
+        {
+            "role": "system",
+            "content": "Extract the participants from the event information."
+        },
+        {
+            "role": "user",
+            "content": "Alice and Bob are going to a science fair on Friday."
+        }
+    ],
+    text={
+        "format": {
+            "type": "json_schema",
+            "name": "participants",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "participants": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "participants"
+                ],
+            }
+        }
+    }
+)
+print(response.output_text)
+```
+
+Example output:
+
+Omitted - see warning above.
+
+### Chat Completions
+
+#### Simple inference
+
+Request:
+
+```python
+chat_completion = client.chat.completions.create(
+    model="meta-llama/Llama-3.2-3B-Instruct",
+    messages=[
+        {
+            "role": "user",
+            "content": "Write a haiku about coding."
+        }
+    ]
+)
+
+print(chat_completion.choices[0].message.content)
+```
+
+Example output:
+
+```text
+Lines of code unfold
+ Logic flows like a river
+Code's gentle beauty
+```
+
+#### Structured Output
+
+Request:
+
+```python
+chat_completion = client.chat.completions.create(
+    model="meta-llama/Llama-3.2-3B-Instruct",
+    messages=[
+        {
+            "role": "system",
+            "content": "Extract the participants from the event information."
+        },
+        {
+            "role": "user",
+            "content": "Alice and Bob are going to a science fair on Friday."
+        }
+    ],
+    response_format={
+        "type": "json_schema",
+        "json_schema": {
+            "name": "participants",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "participants": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "participants"
+                ],
+            }
+        }
+    }
+)
+
+print(chat_completion.choices[0].message.content)
+```
+
+Example output:
+
+```text
+{ "participants": ["Alice", "Bob"] }
+```
+
+### Completions
+
+#### Simple inference
+
+Request:
+
+```python
+completion = client.completions.create(
+    model="meta-llama/Llama-3.2-3B-Instruct",
+    prompt="Write a haiku about coding."
+)
+
+print(completion.choices[0].text)
+```
+
+Example output:
+
+```text
+Lines of code unfurl
+Logic whispers in the dark
+Art in hidden form
+```
+
+### Models
+
+```python
+models = client.models.list()
+```


### PR DESCRIPTION
# What does this PR do?

This adds some initial content documenting our OpenAI compatible APIs
- Responses, Chat Completions, Completions, and Models - along with instructions on how to use them via OpenAI or Llama Stack clients and some simple examples for each.

It's not a lot of content, but it's a start so that users have some idea how to get going as we continue to work on these APIs.


## Test Plan

I generated the docs site locally and verified things render properly. I also ran each code example to ensure it works as expected. And, I asked my AI code assistant to do a quick spell-check and review of the docs and it didn't flag any obvious errors.
