### PR TITLE
fix: Ensure use of string representation of event.name

### DIFF
--- a/llama_stack/providers/inline/telemetry/meta_reference/sqlite_span_processor.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/sqlite_span_processor.py
@@ -161,7 +161,7 @@ class SQLiteSpanProcessor(SpanProcessor):
                 """,
                     (
                         span_id,
-                        event.name,
+                        str(event.name),
                         datetime.fromtimestamp(event.timestamp / 1e9, timezone.utc).isoformat(),
                         json.dumps(dict(event.attributes)),
                     ),


### PR DESCRIPTION
# What does this PR do?

The `event.name` can be a `EventType.UNSTRUCTURED_LOG` object.

This PR ensures the string representation of the event's name is used when writing the span event data.

This prevents the following exception from appearing in the logs (and presumably event data being dropped).

```
Error exporting span to SQLite: Error binding parameter 1 - probably unsupported type.
```

## Test Plan

I observed the exception being thrown (in my case when registering a `tool_group`).

With this fix the events are correctly persisted.