### PR TITLE
chore: remove torch dep from sentence-transformers

### DIFF
--- a/llama_stack/providers/registry/inference.py
+++ b/llama_stack/providers/registry/inference.py
@@ -48,10 +48,7 @@ def available_providers() -> list[ProviderSpec]:
         InlineProviderSpec(
             api=Api.inference,
             provider_type="inline::sentence-transformers",
-            pip_packages=[
-                "torch torchvision --index-url https://download.pytorch.org/whl/cpu",
-                "sentence-transformers --no-deps",
-            ],
+            pip_packages=[],
             module="llama_stack.providers.inline.inference.sentence_transformers",
             config_class="llama_stack.providers.inline.inference.sentence_transformers.config.SentenceTransformersInferenceConfig",
         ),


### PR DESCRIPTION
# What does this PR do?

Since the capability moved to the inference provider backends we don't need to do the transformation locally. Thus no deps are needed.

Note to reviewers: not 100% sure about this one :)
