### PR TITLE
fix(server): Add missing OpenTelemetry dependencies to resolve telemetry import errors

### DIFF
--- a/llama_stack/distribution/build.py
+++ b/llama_stack/distribution/build.py
@@ -29,6 +29,8 @@ SERVER_DEPENDENCIES = [
     "fire",
     "httpx",
     "uvicorn",
+    "opentelemetry-sdk",
+    "opentelemetry-exporter-otlp-proto-http",
 ]
 
 


### PR DESCRIPTION
This PR fixes a runtime import error caused by missing OpenTelemetry dependencies during `llama stack run`.

Specifically, the following imports fail if `opentelemetry-sdk` and `opentelemetry-exporter-otlp-proto-http` are not present in the environment:

```python
from opentelemetry import metrics, trace
from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
```

See [llama\_stack/providers/inline/telemetry/meta\_reference/telemetry.py#L10-L19](https://github.com/meta-llama/llama-stack/blob/main/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py#L10-L19)

This PR resolves the issue by adding both packages to the `SERVER_DEPENDENCIES` list:

```python
"opentelemetry-sdk",
"opentelemetry-exporter-otlp-proto-http",
```

### Reproduction Steps

```bash
llama stack build --config llama.yaml --image-type venv --image-name fun-with-lamas
llama stack run ~/.llama/distributions/fun-with-lamas/fun-with-lamas-run.yaml
```

Results in:

```
ModuleNotFoundError: No module named 'opentelemetry'
```

or

```
ModuleNotFoundError: No module named 'opentelemetry.exporter'
```