### PR TITLE
fix: Fix session handling in NVIDIA post_training request handler

### DIFF
--- a/llama_stack/providers/remote/post_training/nvidia/post_training.py
+++ b/llama_stack/providers/remote/post_training/nvidia/post_training.py
@@ -170,7 +170,6 @@ class NvidiaPostTrainingAdapter(ModelRegistryHelper):
             - metrics: Optional[Dict] - Additional training metrics
             - status_logs: Optional[List] - Detailed logs of status changes
         """
-        print("Using local Llama Stack Customizer API")
         response = await self._make_request(
             "GET",
             f"/v1/customization/jobs/{job_uuid}/status",


### PR DESCRIPTION
# What does this PR do?
**Context:** We run a llama-stack notebook as part of our e2e test suite. After [0.2.10](https://github.com/meta-llama/llama-stack/releases/tag/v0.2.10), I noticed that calls after the first call to our `post_training` adapter fail. For example:
```
from llama_stack.distribution.library_client import LlamaStackAsLibraryClient

client = LlamaStackAsLibraryClient("nvidia")
client.initialize()
...
# First call succeeds
response = client.post_training.supervised_fine_tune(...)
# Second call fails
status = client.post_training.job.status(job_uuid="job-1234")
```
fails due to:
```
RuntimeError: Event loop is closed
```

I believe this is due to an issue with our session handling that is coming to the surface after [this change](https://github.com/meta-llama/llama-stack/commit/3251b44d8a4387a40b260eaf18d3cad82873f338) to request handling in `LlamaStackAsLibraryClient`.

## Test Plan
The notebook code above succeeds with this change.
