### PR TITLE
chore: Add OpenAI compatibility for Ollama embeddings

### DIFF
--- a/llama_stack/providers/remote/inference/ollama/ollama.py
+++ b/llama_stack/providers/remote/inference/ollama/ollama.py
@@ -71,7 +71,6 @@ from llama_stack.providers.utils.inference.openai_compat import (
     process_chat_completion_stream_response,
     process_completion_response,
     process_completion_stream_response,
-    process_embedding_b64_encoded_input,
 )
 from llama_stack.providers.utils.inference.prompt_adapter import (
     chat_completion_request_to_prompt,
@@ -397,6 +396,7 @@ class OllamaInferenceAdapter(
         if model_obj.provider_resource_id is None:
             raise ValueError(f"Model {model} has no provider_resource_id set")
 
+        # Note, at the moment Ollama does not support encoding_format, dimensions, and user parameters
         params = prepare_openai_embeddings_params(
             model=model_obj.provider_resource_id,
             input=input,
@@ -404,9 +404,6 @@ class OllamaInferenceAdapter(
             dimensions=dimensions,
             user=user,
         )
-        # Note, at the moment Ollama does not support encoding_format, dimensions, and user parameters
-        # but we implement the encoding here
-        params = process_embedding_b64_encoded_input(params)
 
         response = await self.openai_client.embeddings.create(**params)
         data = b64_encode_openai_embeddings_response(response.data, encoding_format)

--- a/llama_stack/providers/remote/inference/ollama/ollama.py
+++ b/llama_stack/providers/remote/inference/ollama/ollama.py
@@ -419,9 +419,10 @@ class OllamaInferenceAdapter(
             prompt_tokens=response.usage.prompt_tokens,
             total_tokens=response.usage.total_tokens,
         )
+        # TODO: Investigate why model_obj.identifier is used instead of response.model
         return OpenAIEmbeddingsResponse(
             data=data,
-            model=response.model,
+            model=model_obj.identifier,
             usage=usage,
         )
 

--- a/llama_stack/providers/remote/inference/ollama/ollama.py
+++ b/llama_stack/providers/remote/inference/ollama/ollama.py
@@ -392,7 +392,7 @@ class OllamaInferenceAdapter(
         if model_obj.model_type != ModelType.embedding:
             raise ValueError(f"Model {model} is not an embedding model")
 
-        params = {
+        params: dict[str, Any] = {
             "model": model_obj.provider_resource_id,
             "input": input,
         }
@@ -401,7 +401,7 @@ class OllamaInferenceAdapter(
         if encoding_format is not None:
             params["encoding_format"] = encoding_format
         if dimensions is not None:
-            params["dimensions"] = str(dimensions)
+            params["dimensions"] = dimensions
         if user is not None:
             params["user"] = user
 

--- a/llama_stack/providers/utils/inference/litellm_openai_mixin.py
+++ b/llama_stack/providers/utils/inference/litellm_openai_mixin.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-import base64
-import struct
 from collections.abc import AsyncGenerator, AsyncIterator
 from typing import Any
 
@@ -37,7 +35,6 @@ from llama_stack.apis.inference.inference import (
     OpenAIChatCompletion,
     OpenAIChatCompletionChunk,
     OpenAICompletion,
-    OpenAIEmbeddingData,
     OpenAIEmbeddingsResponse,
     OpenAIEmbeddingUsage,
     OpenAIMessageParam,
@@ -48,6 +45,7 @@ from llama_stack.distribution.request_headers import NeedsRequestProviderData
 from llama_stack.log import get_logger
 from llama_stack.providers.utils.inference.model_registry import ModelRegistryHelper
 from llama_stack.providers.utils.inference.openai_compat import (
+    b64_encode_openai_embeddings_response,
     convert_message_to_openai_dict_new,
     convert_openai_chat_completion_choice,
     convert_openai_chat_completion_stream,
@@ -293,16 +291,7 @@ class LiteLLMOpenAIMixin(
         )
 
         # Convert response to OpenAI format
-        data = []
-        for i, embedding_data in enumerate(response["data"]):
-            # we encode to base64 if the encoding format is base64 in the request
-            if encoding_format == "base64":
-                byte_data = b"".join(struct.pack("f", f) for f in embedding_data["embedding"])
-                embedding = base64.b64encode(byte_data).decode("utf-8")
-            else:
-                embedding = embedding_data["embedding"]
-
-            data.append(OpenAIEmbeddingData(embedding=embedding, index=i))
+        data = b64_encode_openai_embeddings_response(response.data, encoding_format)
 
         usage = OpenAIEmbeddingUsage(
             prompt_tokens=response["usage"]["prompt_tokens"],

--- a/llama_stack/providers/utils/inference/openai_compat.py
+++ b/llama_stack/providers/utils/inference/openai_compat.py
@@ -3,8 +3,10 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
+import base64
 import json
 import logging
+import struct
 import time
 import uuid
 import warnings
@@ -108,6 +110,7 @@ from llama_stack.apis.inference.inference import (
     OpenAIChatCompletion,
     OpenAICompletion,
     OpenAICompletionChoice,
+    OpenAIEmbeddingData,
     OpenAIMessageParam,
     OpenAIResponseFormatParam,
     ToolConfig,
@@ -1483,3 +1486,73 @@ class OpenAIChatCompletionToLlamaStackMixin:
             model=model,
             object="chat.completion",
         )
+
+
+def prepare_openai_embeddings_params(
+    model: str,
+    input: str | list[str],
+    encoding_format: str | None = "float",
+    dimensions: int | None = None,
+    user: str | None = None,
+):
+    if model is None:
+        raise ValueError("Model must be provided for embeddings")
+
+    input_list = [input] if isinstance(input, str) else input
+
+    params: dict[str, Any] = {
+        "model": model,
+        "input": input_list,
+    }
+
+    if encoding_format is not None:
+        params["encoding_format"] = encoding_format
+    if dimensions is not None:
+        params["dimensions"] = dimensions
+    if user is not None:
+        params["user"] = user
+
+    return params
+
+
+def process_embedding_b64_encoded_input(params: dict[str, Any]) -> dict[str, Any]:
+    """
+    Process the embeddings parameters to encode the input in base64 format if specified.
+        Currently implemented for ollama as base64 is not yet supported by their compatible API.
+    """
+    if params.get("encoding_format") == "base64":
+        processed_params = params.copy()
+        input = params.get("input")
+        if isinstance(input, str):
+            processed_params["input"] = base64.b64encode(input.encode()).decode()
+        elif isinstance(input, list):
+            processed_params["input"] = [base64.b64encode(i.encode()).decode() for i in input]
+    else:
+        return params
+
+    return processed_params
+
+
+def b64_encode_openai_embeddings_response(
+    response_data: dict, encoding_format: str | None = "float"
+) -> list[OpenAIEmbeddingData]:
+    """
+    Process the OpenAI embeddings response to encode the embeddings in base64 format if specified.
+    """
+    data = []
+    for i, embedding_data in enumerate(response_data):
+        if encoding_format == "base64":
+            byte_array = bytearray()
+            for embedding_value in embedding_data.embedding:
+                byte_array.extend(struct.pack("f", float(embedding_value)))
+
+            response_embedding = base64.b64encode(byte_array).decode("utf-8")
+        else:
+            response_embedding = embedding_data.embedding
+        data.append(
+            OpenAIEmbeddingData(
+                embedding=response_embedding,
+                index=i,
+            )
+        )
+    return data

--- a/llama_stack/providers/utils/inference/openai_compat.py
+++ b/llama_stack/providers/utils/inference/openai_compat.py
@@ -1515,24 +1515,6 @@ def prepare_openai_embeddings_params(
     return params
 
 
-def process_embedding_b64_encoded_input(params: dict[str, Any]) -> dict[str, Any]:
-    """
-    Process the embeddings parameters to encode the input in base64 format if specified.
-        Currently implemented for ollama as base64 is not yet supported by their compatible API.
-    """
-    if params.get("encoding_format") == "base64":
-        processed_params = params.copy()
-        input = params.get("input")
-        if isinstance(input, str):
-            processed_params["input"] = base64.b64encode(input.encode()).decode()
-        elif isinstance(input, list):
-            processed_params["input"] = [base64.b64encode(i.encode()).decode() for i in input]
-    else:
-        return params
-
-    return processed_params
-
-
 def b64_encode_openai_embeddings_response(
     response_data: dict, encoding_format: str | None = "float"
 ) -> list[OpenAIEmbeddingData]:

--- a/tests/integration/inference/test_openai_embeddings.py
+++ b/tests/integration/inference/test_openai_embeddings.py
@@ -34,11 +34,7 @@ def skip_if_model_doesnt_support_variable_dimensions(model_id):
         pytest.skip("{model_id} does not support variable output embedding dimensions")
 
 
-@pytest.fixture(
-    params=[
-        "openai_client",
-    ]
-)
+@pytest.fixture(params=["openai_client", "llama_stack_client"])
 def compat_client(request, client_with_models):
     if request.param == "openai_client" and isinstance(client_with_models, LlamaStackAsLibraryClient):
         pytest.skip("OpenAI client tests not supported with library client")

--- a/tests/integration/inference/test_openai_embeddings.py
+++ b/tests/integration/inference/test_openai_embeddings.py
@@ -55,6 +55,12 @@ def skip_if_model_doesnt_support_openai_embeddings(client, model_id):
         pytest.skip(f"Model {model_id} hosted by {provider.provider_type} doesn't support OpenAI embeddings.")
 
 
+def skip_if_client_doesnt_support_base64_encoding(client, model_id):
+    provider = provider_from_model(client, model_id)
+    if provider.provider_type in ("remote::ollama",):
+        pytest.skip(f"Client {client} doesn't support base64 encoding for embeddings.")
+
+
 @pytest.fixture
 def openai_client(client_with_models):
     base_url = f"{client_with_models.base_url}/v1/openai/v1"
@@ -247,6 +253,7 @@ def test_openai_embeddings_with_encoding_format_base64(compat_client, client_wit
 def test_openai_embeddings_base64_batch_processing(compat_client, client_with_models, embedding_model_id):
     """Test OpenAI embeddings endpoint with base64 encoding for batch processing."""
     skip_if_model_doesnt_support_openai_embeddings(client_with_models, embedding_model_id)
+    skip_if_client_doesnt_support_base64_encoding(client_with_models, embedding_model_id)
 
     input_texts = ["First text for base64", "Second text for base64", "Third text for base64"]
 

--- a/tests/integration/inference/test_openai_embeddings.py
+++ b/tests/integration/inference/test_openai_embeddings.py
@@ -34,7 +34,11 @@ def skip_if_model_doesnt_support_variable_dimensions(model_id):
         pytest.skip("{model_id} does not support variable output embedding dimensions")
 
 
-@pytest.fixture(params=["openai_client", "llama_stack_client"])
+@pytest.fixture(
+    params=[
+        "openai_client",
+    ]
+)
 def compat_client(request, client_with_models):
     if request.param == "openai_client" and isinstance(client_with_models, LlamaStackAsLibraryClient):
         pytest.skip("OpenAI client tests not supported with library client")
@@ -53,12 +57,6 @@ def skip_if_model_doesnt_support_openai_embeddings(client, model_id):
         "remote::tgi",
     ):
         pytest.skip(f"Model {model_id} hosted by {provider.provider_type} doesn't support OpenAI embeddings.")
-
-
-def skip_if_client_doesnt_support_base64_encoding(client, model_id):
-    provider = provider_from_model(client, model_id)
-    if provider.provider_type in ("remote::ollama",):
-        pytest.skip(f"Client {client} doesn't support base64 encoding for embeddings.")
 
 
 @pytest.fixture
@@ -253,7 +251,6 @@ def test_openai_embeddings_with_encoding_format_base64(compat_client, client_wit
 def test_openai_embeddings_base64_batch_processing(compat_client, client_with_models, embedding_model_id):
     """Test OpenAI embeddings endpoint with base64 encoding for batch processing."""
     skip_if_model_doesnt_support_openai_embeddings(client_with_models, embedding_model_id)
-    skip_if_client_doesnt_support_base64_encoding(client_with_models, embedding_model_id)
 
     input_texts = ["First text for base64", "Second text for base64", "Third text for base64"]
 

--- a/tests/integration/inference/test_openai_embeddings.py
+++ b/tests/integration/inference/test_openai_embeddings.py
@@ -51,7 +51,6 @@ def skip_if_model_doesnt_support_openai_embeddings(client, model_id):
         "remote::runpod",
         "remote::sambanova",
         "remote::tgi",
-        "remote::ollama",
     ):
         pytest.skip(f"Model {model_id} hosted by {provider.provider_type} doesn't support OpenAI embeddings.")
 


### PR DESCRIPTION
# What does this PR do?
This PR adds OpenAI compatibility for Ollama embeddings. Closes https://github.com/meta-llama/llama-stack/issues/2428

Summary of changes:
- `llama_stack/providers/remote/inference/ollama/ollama.py`
   - Implements the OpenAI embeddings endpoint for Ollama, replacing the NotImplementedError with a full function that validates the model, prepares parameters, calls the client, encodes embedding data (optionally in base64), and returns a correctly structured response.
   - Updates import statements to include the new embedding response utilities.

- `llama_stack/providers/utils/inference/litellm_openai_mixin.py`
   - Refactors the embedding data encoding logic to use a new shared utility (`b64_encode_openai_embeddings_response`) instead of inline base64 encoding and packing logic.
   - Cleans up imports accordingly.

- `llama_stack/providers/utils/inference/openai_compat.py`
   - Adds `b64_encode_openai_embeddings_response` to handle encoding OpenAI embedding outputs (including base64 support) in a reusable way.
   - Adds `prepare_openai_embeddings_params` utility for standardizing embedding parameter preparation.
   - Updates imports to include the new embedding data class.

- `tests/integration/inference/test_openai_embeddings.py`
   - Removes `"remote::ollama"` from the list of providers that skip OpenAI embeddings tests, since support is now implemented.

## Note

There was one minor issue, which required me to override the `OpenAIEmbeddingsResponse.model` name with `self._get_model(model).identifier` name, which is very unsatisfying.

## Test Plan
Unit Tests and integration tests