### PR TITLE
fix: clarify bash requirement in install flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ As more providers start supporting Llama 4, you can use them in Llama Stack as w
 To try Llama Stack locally, run:
 
 ```bash
-curl -LsSf https://github.com/meta-llama/llama-stack/raw/main/install.sh | sh
+curl -LsSf https://github.com/meta-llama/llama-stack/raw/main/install.sh | bash
 ```
 
 ### Overview

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,11 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+[ -z "$BASH_VERSION" ] && {
+  echo "This script must be run with bash" >&2
+  exit 1
+}
+
 set -Eeuo pipefail
 
 PORT=8321


### PR DESCRIPTION
# What does this PR do?
Our "run this line to get started" pipes into `sh`, but the default shell on Ubuntu (a common setup) is `dash`, which doesn't support `pipefail`:

```
dalton@ollama-test:~$ ls -l /usr/bin/sh
lrwxrwxrwx 1 root root 4 Mar 31  2024 /usr/bin/sh -> dash
```

```
$ curl -LsSf https://github.com/meta-llama/llama-stack/raw/main/install.sh | sh
sh: 8: set: Illegal option -o pipefail
``` 

Let's be explicit with `bash`? It covers Linux, WSL, macOS and I doubt anyone's trying to run Llama Stack on embedded systems :)


## Test Plan

```
dalton@ollama-test:~/llama-stack$ cat install.sh | sh
This script must be run with bash
dalton@ollama-test:~/llama-stack$ cat install.sh | bash
❌ Docker or Podman is required. Install Docker: https://docs.docker.com/get-docker/ or Podman: https://podman.io/getting-started/installation
```