### PR TITLE
fix: Do not throw when listing vector stores

### DIFF
--- a/llama_stack/distribution/routers/vector_io.py
+++ b/llama_stack/distribution/routers/vector_io.py
@@ -163,10 +163,14 @@ class VectorIORouter(VectorIO):
         vector_dbs = await self.routing_table.get_all_with_type("vector_db")
         all_stores = []
         for vector_db in vector_dbs:
-            vector_store = await self.routing_table.get_provider_impl(
-                vector_db.identifier
-            ).openai_retrieve_vector_store(vector_db.identifier)
-            all_stores.append(vector_store)
+            try:
+                vector_store = await self.routing_table.get_provider_impl(
+                    vector_db.identifier
+                ).openai_retrieve_vector_store(vector_db.identifier)
+                all_stores.append(vector_store)
+            except Exception as e:
+                logger.error(f"Error retrieving vector store {vector_db.identifier}: {e}")
+                continue
 
         # Sort by created_at
         reverse_order = order == "desc"


### PR DESCRIPTION
When trying to `list` vector_stores , if we cannot retrieve one, log an error and return all the ones that are valid. 

### Test Plan 
```
pytest -sv --stack-config=http://localhost:8321 tests/integration/vector_io/test_openai_vector_stores.py  --embedding-model all-MiniLM-L6-v2
```
Also tested for `--stack-config fireworks`