### PR TITLE
feat: Add missing Vector Store Files API surface

### DIFF
--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -13756,6 +13756,24 @@
                 "type": "object",
                 "title": "Response"
             },
+            "VectorStoreContent": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "const": "text"
+                    },
+                    "text": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "type",
+                    "text"
+                ],
+                "title": "VectorStoreContent"
+            },
             "VectorStoreFileContentsResponse": {
                 "type": "object",
                 "properties": {
@@ -13793,7 +13811,7 @@
                     "content": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/InterleavedContentItem"
+                            "$ref": "#/components/schemas/VectorStoreContent"
                         }
                     }
                 },
@@ -13878,24 +13896,6 @@
                     "query"
                 ],
                 "title": "OpenaiSearchVectorStoreRequest"
-            },
-            "VectorStoreContent": {
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "const": "text"
-                    },
-                    "text": {
-                        "type": "string"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "type",
-                    "text"
-                ],
-                "title": "VectorStoreContent"
             },
             "VectorStoreSearchResponse": {
                 "type": "object",

--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -3241,6 +3241,47 @@
             }
         },
         "/v1/openai/v1/vector_stores/{vector_store_id}/files": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "A VectorStoreListFilesResponse containing the list of files.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VectorStoreListFilesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest400"
+                    },
+                    "429": {
+                        "$ref": "#/components/responses/TooManyRequests429"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError500"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultError"
+                    }
+                },
+                "tags": [
+                    "VectorIO"
+                ],
+                "description": "List files in a vector store.",
+                "parameters": [
+                    {
+                        "name": "vector_store_id",
+                        "in": "path",
+                        "description": "The ID of the vector store to list files from.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
             "post": {
                 "responses": {
                     "200": {
@@ -3658,6 +3699,168 @@
                         "name": "vector_store_id",
                         "in": "path",
                         "description": "The ID of the vector store to delete.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/v1/openai/v1/vector_stores/{vector_store_id}/files/{file_id}": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "A VectorStoreFileObject representing the file.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VectorStoreFileObject"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest400"
+                    },
+                    "429": {
+                        "$ref": "#/components/responses/TooManyRequests429"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError500"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultError"
+                    }
+                },
+                "tags": [
+                    "VectorIO"
+                ],
+                "description": "Retrieves a vector store file.",
+                "parameters": [
+                    {
+                        "name": "vector_store_id",
+                        "in": "path",
+                        "description": "The ID of the vector store containing the file to retrieve.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "file_id",
+                        "in": "path",
+                        "description": "The ID of the file to retrieve.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "A VectorStoreFileObject representing the updated file.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VectorStoreFileObject"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest400"
+                    },
+                    "429": {
+                        "$ref": "#/components/responses/TooManyRequests429"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError500"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultError"
+                    }
+                },
+                "tags": [
+                    "VectorIO"
+                ],
+                "description": "Updates a vector store file.",
+                "parameters": [
+                    {
+                        "name": "vector_store_id",
+                        "in": "path",
+                        "description": "The ID of the vector store containing the file to update.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "file_id",
+                        "in": "path",
+                        "description": "The ID of the file to update.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OpenaiUpdateVectorStoreFileRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                }
+            },
+            "delete": {
+                "responses": {
+                    "200": {
+                        "description": "A VectorStoreFileDeleteResponse indicating the deletion status.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VectorStoreFileDeleteResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest400"
+                    },
+                    "429": {
+                        "$ref": "#/components/responses/TooManyRequests429"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError500"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultError"
+                    }
+                },
+                "tags": [
+                    "VectorIO"
+                ],
+                "description": "Delete a vector store file.",
+                "parameters": [
+                    {
+                        "name": "vector_store_id",
+                        "in": "path",
+                        "description": "The ID of the vector store containing the file to delete.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "file_id",
+                        "in": "path",
+                        "description": "The ID of the file to delete.",
                         "required": true,
                         "schema": {
                             "type": "string"
@@ -12969,6 +13172,35 @@
                 ],
                 "title": "OpenaiCreateVectorStoreRequest"
             },
+            "VectorStoreFileCounts": {
+                "type": "object",
+                "properties": {
+                    "completed": {
+                        "type": "integer"
+                    },
+                    "cancelled": {
+                        "type": "integer"
+                    },
+                    "failed": {
+                        "type": "integer"
+                    },
+                    "in_progress": {
+                        "type": "integer"
+                    },
+                    "total": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "completed",
+                    "cancelled",
+                    "failed",
+                    "in_progress",
+                    "total"
+                ],
+                "title": "VectorStoreFileCounts"
+            },
             "VectorStoreObject": {
                 "type": "object",
                 "properties": {
@@ -12990,10 +13222,7 @@
                         "default": 0
                     },
                     "file_counts": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "integer"
-                        }
+                        "$ref": "#/components/schemas/VectorStoreFileCounts"
                     },
                     "status": {
                         "type": "string",
@@ -13119,6 +13348,30 @@
                 ],
                 "title": "VectorStoreDeleteResponse",
                 "description": "Response from deleting a vector store."
+            },
+            "VectorStoreFileDeleteResponse": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "object": {
+                        "type": "string",
+                        "default": "vector_store.file.deleted"
+                    },
+                    "deleted": {
+                        "type": "boolean",
+                        "default": true
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "id",
+                    "object",
+                    "deleted"
+                ],
+                "title": "VectorStoreFileDeleteResponse",
+                "description": "Response from deleting a vector store file."
             },
             "OpenaiEmbeddingsRequest": {
                 "type": "object",
@@ -13347,6 +13600,28 @@
                 ],
                 "title": "OpenAIFileObject",
                 "description": "OpenAI File object as defined in the OpenAI Files API."
+            },
+            "VectorStoreListFilesResponse": {
+                "type": "object",
+                "properties": {
+                    "object": {
+                        "type": "string",
+                        "default": "list"
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/VectorStoreFileObject"
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "object",
+                    "data"
+                ],
+                "title": "VectorStoreListFilesResponse",
+                "description": "Response from listing vector stores."
             },
             "OpenAIModel": {
                 "type": "object",
@@ -13660,6 +13935,42 @@
                 },
                 "additionalProperties": false,
                 "title": "OpenaiUpdateVectorStoreRequest"
+            },
+            "OpenaiUpdateVectorStoreFileRequest": {
+                "type": "object",
+                "properties": {
+                    "attributes": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "type": "boolean"
+                                },
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        },
+                        "description": "The updated key-value attributes to store with the file."
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "attributes"
+                ],
+                "title": "OpenaiUpdateVectorStoreFileRequest"
             },
             "DPOAlignmentConfig": {
                 "type": "object",

--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -4112,6 +4112,58 @@
                 ]
             }
         },
+        "/v1/openai/v1/vector_stores/{vector_store_id}/files/{file_id}/content": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "A list of InterleavedContent representing the file contents.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VectorStoreFileContentsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest400"
+                    },
+                    "429": {
+                        "$ref": "#/components/responses/TooManyRequests429"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError500"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultError"
+                    }
+                },
+                "tags": [
+                    "VectorIO"
+                ],
+                "description": "Retrieves the contents of a vector store file.",
+                "parameters": [
+                    {
+                        "name": "vector_store_id",
+                        "in": "path",
+                        "description": "The ID of the vector store containing the file to retrieve.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "file_id",
+                        "in": "path",
+                        "description": "The ID of the file to retrieve.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
         "/v1/openai/v1/vector_stores/{vector_store_id}/search": {
             "post": {
                 "responses": {
@@ -13703,6 +13755,57 @@
             "Response": {
                 "type": "object",
                 "title": "Response"
+            },
+            "VectorStoreFileContentsResponse": {
+                "type": "object",
+                "properties": {
+                    "file_id": {
+                        "type": "string"
+                    },
+                    "filename": {
+                        "type": "string"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "type": "boolean"
+                                },
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    },
+                    "content": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/InterleavedContentItem"
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "file_id",
+                    "filename",
+                    "attributes",
+                    "content"
+                ],
+                "title": "VectorStoreFileContentsResponse",
+                "description": "Response from retrieving the contents of a vector store file."
             },
             "OpenaiSearchVectorStoreRequest": {
                 "type": "object",

--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -3279,6 +3279,46 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "order",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "after",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "before",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/VectorStoreFileStatus"
+                        }
                     }
                 ]
             },
@@ -12357,24 +12397,7 @@
                         "$ref": "#/components/schemas/VectorStoreFileLastError"
                     },
                     "status": {
-                        "oneOf": [
-                            {
-                                "type": "string",
-                                "const": "completed"
-                            },
-                            {
-                                "type": "string",
-                                "const": "in_progress"
-                            },
-                            {
-                                "type": "string",
-                                "const": "cancelled"
-                            },
-                            {
-                                "type": "string",
-                                "const": "failed"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/VectorStoreFileStatus"
                     },
                     "usage_bytes": {
                         "type": "integer",
@@ -12397,6 +12420,26 @@
                 ],
                 "title": "VectorStoreFileObject",
                 "description": "OpenAI Vector Store File object."
+            },
+            "VectorStoreFileStatus": {
+                "oneOf": [
+                    {
+                        "type": "string",
+                        "const": "completed"
+                    },
+                    {
+                        "type": "string",
+                        "const": "in_progress"
+                    },
+                    {
+                        "type": "string",
+                        "const": "cancelled"
+                    },
+                    {
+                        "type": "string",
+                        "const": "failed"
+                    }
+                ]
             },
             "OpenAIJSONSchema": {
                 "type": "object",
@@ -13665,12 +13708,23 @@
                         "items": {
                             "$ref": "#/components/schemas/VectorStoreFileObject"
                         }
+                    },
+                    "first_id": {
+                        "type": "string"
+                    },
+                    "last_id": {
+                        "type": "string"
+                    },
+                    "has_more": {
+                        "type": "boolean",
+                        "default": false
                     }
                 },
                 "additionalProperties": false,
                 "required": [
                     "object",
-                    "data"
+                    "data",
+                    "has_more"
                 ],
                 "title": "VectorStoreListFilesResponse",
                 "description": "Response from listing vector stores."

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -2264,6 +2264,36 @@ paths:
               $ref: '#/components/schemas/LogEventRequest'
         required: true
   /v1/openai/v1/vector_stores/{vector_store_id}/files:
+    get:
+      responses:
+        '200':
+          description: >-
+            A VectorStoreListFilesResponse containing the list of files.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VectorStoreListFilesResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+        '429':
+          $ref: >-
+            #/components/responses/TooManyRequests429
+        '500':
+          $ref: >-
+            #/components/responses/InternalServerError500
+        default:
+          $ref: '#/components/responses/DefaultError'
+      tags:
+        - VectorIO
+      description: List files in a vector store.
+      parameters:
+        - name: vector_store_id
+          in: path
+          description: >-
+            The ID of the vector store to list files from.
+          required: true
+          schema:
+            type: string
     post:
       responses:
         '200':
@@ -2569,6 +2599,121 @@ paths:
         - name: vector_store_id
           in: path
           description: The ID of the vector store to delete.
+          required: true
+          schema:
+            type: string
+  /v1/openai/v1/vector_stores/{vector_store_id}/files/{file_id}:
+    get:
+      responses:
+        '200':
+          description: >-
+            A VectorStoreFileObject representing the file.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VectorStoreFileObject'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+        '429':
+          $ref: >-
+            #/components/responses/TooManyRequests429
+        '500':
+          $ref: >-
+            #/components/responses/InternalServerError500
+        default:
+          $ref: '#/components/responses/DefaultError'
+      tags:
+        - VectorIO
+      description: Retrieves a vector store file.
+      parameters:
+        - name: vector_store_id
+          in: path
+          description: >-
+            The ID of the vector store containing the file to retrieve.
+          required: true
+          schema:
+            type: string
+        - name: file_id
+          in: path
+          description: The ID of the file to retrieve.
+          required: true
+          schema:
+            type: string
+    post:
+      responses:
+        '200':
+          description: >-
+            A VectorStoreFileObject representing the updated file.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VectorStoreFileObject'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+        '429':
+          $ref: >-
+            #/components/responses/TooManyRequests429
+        '500':
+          $ref: >-
+            #/components/responses/InternalServerError500
+        default:
+          $ref: '#/components/responses/DefaultError'
+      tags:
+        - VectorIO
+      description: Updates a vector store file.
+      parameters:
+        - name: vector_store_id
+          in: path
+          description: >-
+            The ID of the vector store containing the file to update.
+          required: true
+          schema:
+            type: string
+        - name: file_id
+          in: path
+          description: The ID of the file to update.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OpenaiUpdateVectorStoreFileRequest'
+        required: true
+    delete:
+      responses:
+        '200':
+          description: >-
+            A VectorStoreFileDeleteResponse indicating the deletion status.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VectorStoreFileDeleteResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+        '429':
+          $ref: >-
+            #/components/responses/TooManyRequests429
+        '500':
+          $ref: >-
+            #/components/responses/InternalServerError500
+        default:
+          $ref: '#/components/responses/DefaultError'
+      tags:
+        - VectorIO
+      description: Delete a vector store file.
+      parameters:
+        - name: vector_store_id
+          in: path
+          description: >-
+            The ID of the vector store containing the file to delete.
+          required: true
+          schema:
+            type: string
+        - name: file_id
+          in: path
+          description: The ID of the file to delete.
           required: true
           schema:
             type: string
@@ -9031,6 +9176,27 @@ components:
       required:
         - name
       title: OpenaiCreateVectorStoreRequest
+    VectorStoreFileCounts:
+      type: object
+      properties:
+        completed:
+          type: integer
+        cancelled:
+          type: integer
+        failed:
+          type: integer
+        in_progress:
+          type: integer
+        total:
+          type: integer
+      additionalProperties: false
+      required:
+        - completed
+        - cancelled
+        - failed
+        - in_progress
+        - total
+      title: VectorStoreFileCounts
     VectorStoreObject:
       type: object
       properties:
@@ -9047,9 +9213,7 @@ components:
           type: integer
           default: 0
         file_counts:
-          type: object
-          additionalProperties:
-            type: integer
+          $ref: '#/components/schemas/VectorStoreFileCounts'
         status:
           type: string
           default: completed
@@ -9129,6 +9293,25 @@ components:
         - deleted
       title: VectorStoreDeleteResponse
       description: Response from deleting a vector store.
+    VectorStoreFileDeleteResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        object:
+          type: string
+          default: vector_store.file.deleted
+        deleted:
+          type: boolean
+          default: true
+      additionalProperties: false
+      required:
+        - id
+        - object
+        - deleted
+      title: VectorStoreFileDeleteResponse
+      description: >-
+        Response from deleting a vector store file.
     OpenaiEmbeddingsRequest:
       type: object
       properties:
@@ -9320,6 +9503,22 @@ components:
       title: OpenAIFileObject
       description: >-
         OpenAI File object as defined in the OpenAI Files API.
+    VectorStoreListFilesResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          default: list
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/VectorStoreFileObject'
+      additionalProperties: false
+      required:
+        - object
+        - data
+      title: VectorStoreListFilesResponse
+      description: Response from listing vector stores.
     OpenAIModel:
       type: object
       properties:
@@ -9524,6 +9723,25 @@ components:
             Set of 16 key-value pairs that can be attached to an object.
       additionalProperties: false
       title: OpenaiUpdateVectorStoreRequest
+    OpenaiUpdateVectorStoreFileRequest:
+      type: object
+      properties:
+        attributes:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+          description: >-
+            The updated key-value attributes to store with the file.
+      additionalProperties: false
+      required:
+        - attributes
+      title: OpenaiUpdateVectorStoreFileRequest
     DPOAlignmentConfig:
       type: object
       properties:

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -2294,6 +2294,31 @@ paths:
           required: true
           schema:
             type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: order
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: after
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: before
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: filter
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/VectorStoreFileStatus'
     post:
       responses:
         '200':
@@ -8641,15 +8666,7 @@ components:
         last_error:
           $ref: '#/components/schemas/VectorStoreFileLastError'
         status:
-          oneOf:
-            - type: string
-              const: completed
-            - type: string
-              const: in_progress
-            - type: string
-              const: cancelled
-            - type: string
-              const: failed
+          $ref: '#/components/schemas/VectorStoreFileStatus'
         usage_bytes:
           type: integer
           default: 0
@@ -8667,6 +8684,16 @@ components:
         - vector_store_id
       title: VectorStoreFileObject
       description: OpenAI Vector Store File object.
+    VectorStoreFileStatus:
+      oneOf:
+        - type: string
+          const: completed
+        - type: string
+          const: in_progress
+        - type: string
+          const: cancelled
+        - type: string
+          const: failed
     OpenAIJSONSchema:
       type: object
       properties:
@@ -9551,10 +9578,18 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/VectorStoreFileObject'
+        first_id:
+          type: string
+        last_id:
+          type: string
+        has_more:
+          type: boolean
+          default: false
       additionalProperties: false
       required:
         - object
         - data
+        - has_more
       title: VectorStoreListFilesResponse
       description: Response from listing vector stores.
     OpenAIModel:

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -2907,6 +2907,44 @@ paths:
           required: true
           schema:
             type: string
+  /v1/openai/v1/vector_stores/{vector_store_id}/files/{file_id}/content:
+    get:
+      responses:
+        '200':
+          description: >-
+            A list of InterleavedContent representing the file contents.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VectorStoreFileContentsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+        '429':
+          $ref: >-
+            #/components/responses/TooManyRequests429
+        '500':
+          $ref: >-
+            #/components/responses/InternalServerError500
+        default:
+          $ref: '#/components/responses/DefaultError'
+      tags:
+        - VectorIO
+      description: >-
+        Retrieves the contents of a vector store file.
+      parameters:
+        - name: vector_store_id
+          in: path
+          description: >-
+            The ID of the vector store containing the file to retrieve.
+          required: true
+          schema:
+            type: string
+        - name: file_id
+          in: path
+          description: The ID of the file to retrieve.
+          required: true
+          schema:
+            type: string
   /v1/openai/v1/vector_stores/{vector_store_id}/search:
     post:
       responses:
@@ -9578,6 +9616,36 @@ components:
     Response:
       type: object
       title: Response
+    VectorStoreFileContentsResponse:
+      type: object
+      properties:
+        file_id:
+          type: string
+        filename:
+          type: string
+        attributes:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: 'null'
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/InterleavedContentItem'
+      additionalProperties: false
+      required:
+        - file_id
+        - filename
+        - attributes
+        - content
+      title: VectorStoreFileContentsResponse
+      description: >-
+        Response from retrieving the contents of a vector store file.
     OpenaiSearchVectorStoreRequest:
       type: object
       properties:

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -9616,6 +9616,19 @@ components:
     Response:
       type: object
       title: Response
+    VectorStoreContent:
+      type: object
+      properties:
+        type:
+          type: string
+          const: text
+        text:
+          type: string
+      additionalProperties: false
+      required:
+        - type
+        - text
+      title: VectorStoreContent
     VectorStoreFileContentsResponse:
       type: object
       properties:
@@ -9636,7 +9649,7 @@ components:
         content:
           type: array
           items:
-            $ref: '#/components/schemas/InterleavedContentItem'
+            $ref: '#/components/schemas/VectorStoreContent'
       additionalProperties: false
       required:
         - file_id
@@ -9693,19 +9706,6 @@ components:
       required:
         - query
       title: OpenaiSearchVectorStoreRequest
-    VectorStoreContent:
-      type: object
-      properties:
-        type:
-          type: string
-          const: text
-        text:
-          type: string
-      additionalProperties: false
-      required:
-        - type
-        - text
-      title: VectorStoreContent
     VectorStoreSearchResponse:
       type: object
       properties:

--- a/llama_stack/apis/vector_io/vector_io.py
+++ b/llama_stack/apis/vector_io/vector_io.py
@@ -12,6 +12,7 @@ from typing import Annotated, Any, Literal, Protocol, runtime_checkable
 
 from pydantic import BaseModel, Field
 
+from llama_stack.apis.common.content_types import InterleavedContentItem
 from llama_stack.apis.inference import InterleavedContent
 from llama_stack.apis.vector_dbs import VectorDB
 from llama_stack.providers.utils.telemetry.trace_protocol import trace_protocol
@@ -198,6 +199,16 @@ class VectorStoreListFilesResponse(BaseModel):
 
     object: str = "list"
     data: list[VectorStoreFileObject]
+
+
+@json_schema_type
+class VectorStoreFileContentsResponse(BaseModel):
+    """Response from retrieving the contents of a vector store file."""
+
+    file_id: str
+    filename: str
+    attributes: dict[str, Any]
+    content: list[InterleavedContentItem]
 
 
 @json_schema_type
@@ -408,6 +419,20 @@ class VectorIO(Protocol):
         :param vector_store_id: The ID of the vector store containing the file to retrieve.
         :param file_id: The ID of the file to retrieve.
         :returns: A VectorStoreFileObject representing the file.
+        """
+        ...
+
+    @webmethod(route="/openai/v1/vector_stores/{vector_store_id}/files/{file_id}/content", method="GET")
+    async def openai_retrieve_vector_store_file_contents(
+        self,
+        vector_store_id: str,
+        file_id: str,
+    ) -> VectorStoreFileContentsResponse:
+        """Retrieves the contents of a vector store file.
+
+        :param vector_store_id: The ID of the vector store containing the file to retrieve.
+        :param file_id: The ID of the file to retrieve.
+        :returns: A list of InterleavedContent representing the file contents.
         """
         ...
 

--- a/llama_stack/apis/vector_io/vector_io.py
+++ b/llama_stack/apis/vector_io/vector_io.py
@@ -12,7 +12,6 @@ from typing import Annotated, Any, Literal, Protocol, runtime_checkable
 
 from pydantic import BaseModel, Field
 
-from llama_stack.apis.common.content_types import InterleavedContentItem
 from llama_stack.apis.inference import InterleavedContent
 from llama_stack.apis.vector_dbs import VectorDB
 from llama_stack.providers.utils.telemetry.trace_protocol import trace_protocol
@@ -208,7 +207,7 @@ class VectorStoreFileContentsResponse(BaseModel):
     file_id: str
     filename: str
     attributes: dict[str, Any]
-    content: list[InterleavedContentItem]
+    content: list[VectorStoreContent]
 
 
 @json_schema_type

--- a/llama_stack/apis/vector_io/vector_io.py
+++ b/llama_stack/apis/vector_io/vector_io.py
@@ -177,6 +177,10 @@ class VectorStoreFileLastError(BaseModel):
     message: str
 
 
+VectorStoreFileStatus = Literal["completed"] | Literal["in_progress"] | Literal["cancelled"] | Literal["failed"]
+register_schema(VectorStoreFileStatus, name="VectorStoreFileStatus")
+
+
 @json_schema_type
 class VectorStoreFileObject(BaseModel):
     """OpenAI Vector Store File object."""
@@ -187,7 +191,7 @@ class VectorStoreFileObject(BaseModel):
     chunking_strategy: VectorStoreChunkingStrategy
     created_at: int
     last_error: VectorStoreFileLastError | None = None
-    status: Literal["completed"] | Literal["in_progress"] | Literal["cancelled"] | Literal["failed"]
+    status: VectorStoreFileStatus
     usage_bytes: int = 0
     vector_store_id: str
 
@@ -198,6 +202,9 @@ class VectorStoreListFilesResponse(BaseModel):
 
     object: str = "list"
     data: list[VectorStoreFileObject]
+    first_id: str | None = None
+    last_id: str | None = None
+    has_more: bool = False
 
 
 @json_schema_type
@@ -399,6 +406,11 @@ class VectorIO(Protocol):
     async def openai_list_files_in_vector_store(
         self,
         vector_store_id: str,
+        limit: int | None = 20,
+        order: str | None = "desc",
+        after: str | None = None,
+        before: str | None = None,
+        filter: VectorStoreFileStatus | None = None,
     ) -> VectorStoreListFilesResponse:
         """List files in a vector store.
 

--- a/llama_stack/distribution/routers/vector_io.py
+++ b/llama_stack/distribution/routers/vector_io.py
@@ -21,7 +21,11 @@ from llama_stack.apis.vector_io import (
     VectorStoreObject,
     VectorStoreSearchResponsePage,
 )
-from llama_stack.apis.vector_io.vector_io import VectorStoreChunkingStrategy, VectorStoreFileObject
+from llama_stack.apis.vector_io.vector_io import (
+    VectorStoreChunkingStrategy,
+    VectorStoreFileDeleteResponse,
+    VectorStoreFileObject,
+)
 from llama_stack.log import get_logger
 from llama_stack.providers.datatypes import HealthResponse, HealthStatus, RoutingTable
 
@@ -277,6 +281,58 @@ class VectorIORouter(VectorIO):
             file_id=file_id,
             attributes=attributes,
             chunking_strategy=chunking_strategy,
+        )
+
+    async def openai_list_files_in_vector_store(
+        self,
+        vector_store_id: str,
+    ) -> list[VectorStoreFileObject]:
+        logger.debug(f"VectorIORouter.openai_list_files_in_vector_store: {vector_store_id}")
+        # Route based on vector store ID
+        provider = self.routing_table.get_provider_impl(vector_store_id)
+        return await provider.openai_list_files_in_vector_store(
+            vector_store_id=vector_store_id,
+        )
+
+    async def openai_retrieve_vector_store_file(
+        self,
+        vector_store_id: str,
+        file_id: str,
+    ) -> VectorStoreFileObject:
+        logger.debug(f"VectorIORouter.openai_retrieve_vector_store_file: {vector_store_id}, {file_id}")
+        # Route based on vector store ID
+        provider = self.routing_table.get_provider_impl(vector_store_id)
+        return await provider.openai_retrieve_vector_store_file(
+            vector_store_id=vector_store_id,
+            file_id=file_id,
+        )
+
+    async def openai_update_vector_store_file(
+        self,
+        vector_store_id: str,
+        file_id: str,
+        attributes: dict[str, Any],
+    ) -> VectorStoreFileObject:
+        logger.debug(f"VectorIORouter.openai_update_vector_store_file: {vector_store_id}, {file_id}")
+        # Route based on vector store ID
+        provider = self.routing_table.get_provider_impl(vector_store_id)
+        return await provider.openai_update_vector_store_file(
+            vector_store_id=vector_store_id,
+            file_id=file_id,
+            attributes=attributes,
+        )
+
+    async def openai_delete_vector_store_file(
+        self,
+        vector_store_id: str,
+        file_id: str,
+    ) -> VectorStoreFileDeleteResponse:
+        logger.debug(f"VectorIORouter.openai_delete_vector_store_file: {vector_store_id}, {file_id}")
+        # Route based on vector store ID
+        provider = self.routing_table.get_provider_impl(vector_store_id)
+        return await provider.openai_delete_vector_store_file(
+            vector_store_id=vector_store_id,
+            file_id=file_id,
         )
 
     async def health(self) -> dict[str, HealthResponse]:

--- a/llama_stack/distribution/routers/vector_io.py
+++ b/llama_stack/distribution/routers/vector_io.py
@@ -26,6 +26,7 @@ from llama_stack.apis.vector_io.vector_io import (
     VectorStoreFileContentsResponse,
     VectorStoreFileDeleteResponse,
     VectorStoreFileObject,
+    VectorStoreFileStatus,
 )
 from llama_stack.log import get_logger
 from llama_stack.providers.datatypes import HealthResponse, HealthStatus, RoutingTable
@@ -287,12 +288,22 @@ class VectorIORouter(VectorIO):
     async def openai_list_files_in_vector_store(
         self,
         vector_store_id: str,
+        limit: int | None = 20,
+        order: str | None = "desc",
+        after: str | None = None,
+        before: str | None = None,
+        filter: VectorStoreFileStatus | None = None,
     ) -> list[VectorStoreFileObject]:
         logger.debug(f"VectorIORouter.openai_list_files_in_vector_store: {vector_store_id}")
         # Route based on vector store ID
         provider = self.routing_table.get_provider_impl(vector_store_id)
         return await provider.openai_list_files_in_vector_store(
             vector_store_id=vector_store_id,
+            limit=limit,
+            order=order,
+            after=after,
+            before=before,
+            filter=filter,
         )
 
     async def openai_retrieve_vector_store_file(

--- a/llama_stack/distribution/routers/vector_io.py
+++ b/llama_stack/distribution/routers/vector_io.py
@@ -23,6 +23,7 @@ from llama_stack.apis.vector_io import (
 )
 from llama_stack.apis.vector_io.vector_io import (
     VectorStoreChunkingStrategy,
+    VectorStoreFileContentsResponse,
     VectorStoreFileDeleteResponse,
     VectorStoreFileObject,
 )
@@ -303,6 +304,19 @@ class VectorIORouter(VectorIO):
         # Route based on vector store ID
         provider = self.routing_table.get_provider_impl(vector_store_id)
         return await provider.openai_retrieve_vector_store_file(
+            vector_store_id=vector_store_id,
+            file_id=file_id,
+        )
+
+    async def openai_retrieve_vector_store_file_contents(
+        self,
+        vector_store_id: str,
+        file_id: str,
+    ) -> VectorStoreFileContentsResponse:
+        logger.debug(f"VectorIORouter.openai_retrieve_vector_store_file_contents: {vector_store_id}, {file_id}")
+        # Route based on vector store ID
+        provider = self.routing_table.get_provider_impl(vector_store_id)
+        return await provider.openai_retrieve_vector_store_file_contents(
             vector_store_id=vector_store_id,
             file_id=file_id,
         )

--- a/llama_stack/providers/inline/vector_io/faiss/faiss.py
+++ b/llama_stack/providers/inline/vector_io/faiss/faiss.py
@@ -45,6 +45,7 @@ VERSION = "v3"
 VECTOR_DBS_PREFIX = f"vector_dbs:{VERSION}::"
 FAISS_INDEX_PREFIX = f"faiss_index:{VERSION}::"
 OPENAI_VECTOR_STORES_PREFIX = f"openai_vector_stores:{VERSION}::"
+OPENAI_VECTOR_STORES_FILES_PREFIX = f"openai_vector_stores_files:{VERSION}::"
 
 
 class FaissIndex(EmbeddingIndex):
@@ -282,4 +283,29 @@ class FaissVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorDBsProtocolPr
         """Delete vector store metadata from kvstore."""
         assert self.kvstore is not None
         key = f"{OPENAI_VECTOR_STORES_PREFIX}{store_id}"
+        await self.kvstore.delete(key)
+
+    async def _save_openai_vector_store_file(self, store_id: str, file_id: str, file_info: dict[str, Any]) -> None:
+        """Save vector store file metadata to kvstore."""
+        assert self.kvstore is not None
+        key = f"{OPENAI_VECTOR_STORES_FILES_PREFIX}{store_id}:{file_id}"
+        await self.kvstore.set(key=key, value=json.dumps(file_info))
+
+    async def _load_openai_vector_store_file(self, store_id: str, file_id: str) -> dict[str, Any]:
+        """Load vector store file metadata from kvstore."""
+        assert self.kvstore is not None
+        key = f"{OPENAI_VECTOR_STORES_FILES_PREFIX}{store_id}:{file_id}"
+        stored_data = await self.kvstore.get(key)
+        return json.loads(stored_data) if stored_data else {}
+
+    async def _update_openai_vector_store_file(self, store_id: str, file_id: str, file_info: dict[str, Any]) -> None:
+        """Update vector store file metadata in kvstore."""
+        assert self.kvstore is not None
+        key = f"{OPENAI_VECTOR_STORES_FILES_PREFIX}{store_id}:{file_id}"
+        await self.kvstore.set(key=key, value=json.dumps(file_info))
+
+    async def _delete_openai_vector_store_file_from_storage(self, store_id: str, file_id: str) -> None:
+        """Delete vector store file metadata from kvstore."""
+        assert self.kvstore is not None
+        key = f"{OPENAI_VECTOR_STORES_FILES_PREFIX}{store_id}:{file_id}"
         await self.kvstore.delete(key)

--- a/llama_stack/providers/inline/vector_io/sqlite_vec/sqlite_vec.py
+++ b/llama_stack/providers/inline/vector_io/sqlite_vec/sqlite_vec.py
@@ -660,7 +660,6 @@ class SQLiteVecVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorDBsProtoc
                     (store_id, file_id),
                 )
                 row = cur.fetchone()
-                print(f"!!! row is {row}")
                 if row is None:
                     return None
                 (metadata,) = row

--- a/llama_stack/providers/remote/vector_io/chroma/chroma.py
+++ b/llama_stack/providers/remote/vector_io/chroma/chroma.py
@@ -24,7 +24,11 @@ from llama_stack.apis.vector_io import (
     VectorStoreObject,
     VectorStoreSearchResponsePage,
 )
-from llama_stack.apis.vector_io.vector_io import VectorStoreChunkingStrategy, VectorStoreFileObject
+from llama_stack.apis.vector_io.vector_io import (
+    VectorStoreChunkingStrategy,
+    VectorStoreFileObject,
+    VectorStoreListFilesResponse,
+)
 from llama_stack.providers.datatypes import Api, VectorDBsProtocolPrivate
 from llama_stack.providers.inline.vector_io.chroma import ChromaVectorIOConfig as InlineChromaVectorIOConfig
 from llama_stack.providers.utils.memory.vector_store import (
@@ -261,5 +265,33 @@ class ChromaVectorIOAdapter(VectorIO, VectorDBsProtocolPrivate):
         file_id: str,
         attributes: dict[str, Any] | None = None,
         chunking_strategy: VectorStoreChunkingStrategy | None = None,
+    ) -> VectorStoreFileObject:
+        raise NotImplementedError("OpenAI Vector Stores API is not supported in Chroma")
+
+    async def openai_list_files_in_vector_store(
+        self,
+        vector_store_id: str,
+    ) -> VectorStoreListFilesResponse:
+        raise NotImplementedError("OpenAI Vector Stores API is not supported in Chroma")
+
+    async def openai_retrieve_vector_store_file(
+        self,
+        vector_store_id: str,
+        file_id: str,
+    ) -> VectorStoreFileObject:
+        raise NotImplementedError("OpenAI Vector Stores API is not supported in Chroma")
+
+    async def openai_update_vector_store_file(
+        self,
+        vector_store_id: str,
+        file_id: str,
+        attributes: dict[str, Any] | None = None,
+    ) -> VectorStoreFileObject:
+        raise NotImplementedError("OpenAI Vector Stores API is not supported in Chroma")
+
+    async def openai_delete_vector_store_file(
+        self,
+        vector_store_id: str,
+        file_id: str,
     ) -> VectorStoreFileObject:
         raise NotImplementedError("OpenAI Vector Stores API is not supported in Chroma")

--- a/llama_stack/providers/remote/vector_io/chroma/chroma.py
+++ b/llama_stack/providers/remote/vector_io/chroma/chroma.py
@@ -26,6 +26,7 @@ from llama_stack.apis.vector_io import (
 )
 from llama_stack.apis.vector_io.vector_io import (
     VectorStoreChunkingStrategy,
+    VectorStoreFileContentsResponse,
     VectorStoreFileObject,
     VectorStoreListFilesResponse,
 )
@@ -279,6 +280,13 @@ class ChromaVectorIOAdapter(VectorIO, VectorDBsProtocolPrivate):
         vector_store_id: str,
         file_id: str,
     ) -> VectorStoreFileObject:
+        raise NotImplementedError("OpenAI Vector Stores API is not supported in Chroma")
+
+    async def openai_retrieve_vector_store_file_contents(
+        self,
+        vector_store_id: str,
+        file_id: str,
+    ) -> VectorStoreFileContentsResponse:
         raise NotImplementedError("OpenAI Vector Stores API is not supported in Chroma")
 
     async def openai_update_vector_store_file(

--- a/llama_stack/providers/remote/vector_io/milvus/milvus.py
+++ b/llama_stack/providers/remote/vector_io/milvus/milvus.py
@@ -26,7 +26,11 @@ from llama_stack.apis.vector_io import (
     VectorStoreObject,
     VectorStoreSearchResponsePage,
 )
-from llama_stack.apis.vector_io.vector_io import VectorStoreChunkingStrategy, VectorStoreFileObject
+from llama_stack.apis.vector_io.vector_io import (
+    VectorStoreChunkingStrategy,
+    VectorStoreFileObject,
+    VectorStoreListFilesResponse,
+)
 from llama_stack.providers.datatypes import Api, VectorDBsProtocolPrivate
 from llama_stack.providers.inline.vector_io.milvus import MilvusVectorIOConfig as InlineMilvusVectorIOConfig
 from llama_stack.providers.utils.memory.vector_store import (
@@ -259,6 +263,34 @@ class MilvusVectorIOAdapter(VectorIO, VectorDBsProtocolPrivate):
         file_id: str,
         attributes: dict[str, Any] | None = None,
         chunking_strategy: VectorStoreChunkingStrategy | None = None,
+    ) -> VectorStoreFileObject:
+        raise NotImplementedError("OpenAI Vector Stores API is not supported in Milvus")
+
+    async def openai_list_files_in_vector_store(
+        self,
+        vector_store_id: str,
+    ) -> VectorStoreListFilesResponse:
+        raise NotImplementedError("OpenAI Vector Stores API is not supported in Milvus")
+
+    async def openai_retrieve_vector_store_file(
+        self,
+        vector_store_id: str,
+        file_id: str,
+    ) -> VectorStoreFileObject:
+        raise NotImplementedError("OpenAI Vector Stores API is not supported in Milvus")
+
+    async def openai_update_vector_store_file(
+        self,
+        vector_store_id: str,
+        file_id: str,
+        attributes: dict[str, Any] | None = None,
+    ) -> VectorStoreFileObject:
+        raise NotImplementedError("OpenAI Vector Stores API is not supported in Milvus")
+
+    async def openai_delete_vector_store_file(
+        self,
+        vector_store_id: str,
+        file_id: str,
     ) -> VectorStoreFileObject:
         raise NotImplementedError("OpenAI Vector Stores API is not supported in Milvus")
 

--- a/llama_stack/providers/remote/vector_io/milvus/milvus.py
+++ b/llama_stack/providers/remote/vector_io/milvus/milvus.py
@@ -28,6 +28,7 @@ from llama_stack.apis.vector_io import (
 )
 from llama_stack.apis.vector_io.vector_io import (
     VectorStoreChunkingStrategy,
+    VectorStoreFileContentsResponse,
     VectorStoreFileObject,
     VectorStoreListFilesResponse,
 )
@@ -277,6 +278,13 @@ class MilvusVectorIOAdapter(VectorIO, VectorDBsProtocolPrivate):
         vector_store_id: str,
         file_id: str,
     ) -> VectorStoreFileObject:
+        raise NotImplementedError("OpenAI Vector Stores API is not supported in Milvus")
+
+    async def openai_retrieve_vector_store_file_contents(
+        self,
+        vector_store_id: str,
+        file_id: str,
+    ) -> VectorStoreFileContentsResponse:
         raise NotImplementedError("OpenAI Vector Stores API is not supported in Milvus")
 
     async def openai_update_vector_store_file(

--- a/llama_stack/providers/remote/vector_io/qdrant/qdrant.py
+++ b/llama_stack/providers/remote/vector_io/qdrant/qdrant.py
@@ -24,7 +24,11 @@ from llama_stack.apis.vector_io import (
     VectorStoreObject,
     VectorStoreSearchResponsePage,
 )
-from llama_stack.apis.vector_io.vector_io import VectorStoreChunkingStrategy, VectorStoreFileObject
+from llama_stack.apis.vector_io.vector_io import (
+    VectorStoreChunkingStrategy,
+    VectorStoreFileObject,
+    VectorStoreListFilesResponse,
+)
 from llama_stack.providers.datatypes import Api, VectorDBsProtocolPrivate
 from llama_stack.providers.inline.vector_io.qdrant import QdrantVectorIOConfig as InlineQdrantVectorIOConfig
 from llama_stack.providers.utils.memory.vector_store import (
@@ -261,5 +265,33 @@ class QdrantVectorIOAdapter(VectorIO, VectorDBsProtocolPrivate):
         file_id: str,
         attributes: dict[str, Any] | None = None,
         chunking_strategy: VectorStoreChunkingStrategy | None = None,
+    ) -> VectorStoreFileObject:
+        raise NotImplementedError("OpenAI Vector Stores API is not supported in Qdrant")
+
+    async def openai_list_files_in_vector_store(
+        self,
+        vector_store_id: str,
+    ) -> VectorStoreListFilesResponse:
+        raise NotImplementedError("OpenAI Vector Stores API is not supported in Qdrant")
+
+    async def openai_retrieve_vector_store_file(
+        self,
+        vector_store_id: str,
+        file_id: str,
+    ) -> VectorStoreFileObject:
+        raise NotImplementedError("OpenAI Vector Stores API is not supported in Qdrant")
+
+    async def openai_update_vector_store_file(
+        self,
+        vector_store_id: str,
+        file_id: str,
+        attributes: dict[str, Any] | None = None,
+    ) -> VectorStoreFileObject:
+        raise NotImplementedError("OpenAI Vector Stores API is not supported in Qdrant")
+
+    async def openai_delete_vector_store_file(
+        self,
+        vector_store_id: str,
+        file_id: str,
     ) -> VectorStoreFileObject:
         raise NotImplementedError("OpenAI Vector Stores API is not supported in Qdrant")

--- a/llama_stack/providers/remote/vector_io/qdrant/qdrant.py
+++ b/llama_stack/providers/remote/vector_io/qdrant/qdrant.py
@@ -26,6 +26,7 @@ from llama_stack.apis.vector_io import (
 )
 from llama_stack.apis.vector_io.vector_io import (
     VectorStoreChunkingStrategy,
+    VectorStoreFileContentsResponse,
     VectorStoreFileObject,
     VectorStoreListFilesResponse,
 )
@@ -279,6 +280,13 @@ class QdrantVectorIOAdapter(VectorIO, VectorDBsProtocolPrivate):
         vector_store_id: str,
         file_id: str,
     ) -> VectorStoreFileObject:
+        raise NotImplementedError("OpenAI Vector Stores API is not supported in Qdrant")
+
+    async def openai_retrieve_vector_store_file_contents(
+        self,
+        vector_store_id: str,
+        file_id: str,
+    ) -> VectorStoreFileContentsResponse:
         raise NotImplementedError("OpenAI Vector Stores API is not supported in Qdrant")
 
     async def openai_update_vector_store_file(

--- a/tests/integration/vector_io/test_openai_vector_stores.py
+++ b/tests/integration/vector_io/test_openai_vector_stores.py
@@ -6,8 +6,11 @@
 
 import logging
 import time
+from io import BytesIO
 
 import pytest
+from llama_stack_client import BadRequestError, LlamaStackClient
+from openai import BadRequestError as OpenAIBadRequestError
 from openai import OpenAI
 
 from llama_stack.apis.vector_io import Chunk
@@ -73,11 +76,23 @@ def compat_client_with_empty_stores(compat_client):
             logger.warning("Failed to clear vector stores")
             pass
 
+    def clear_files():
+        try:
+            response = compat_client.files.list()
+            for file in response.data:
+                compat_client.files.delete(file_id=file.id)
+        except Exception:
+            # If the API is not available or fails, just continue
+            logger.warning("Failed to clear files")
+            pass
+
     clear_vector_stores()
+    clear_files()
     yield compat_client
 
     # Clean up after the test
     clear_vector_stores()
+    clear_files()
 
 
 def test_openai_create_vector_store(compat_client_with_empty_stores, client_with_models):
@@ -423,3 +438,204 @@ def test_openai_vector_store_search_with_max_num_results(
 
     assert search_response is not None
     assert len(search_response.data) == 2
+
+
+def test_openai_vector_store_attach_file_response_attributes(compat_client_with_empty_stores, client_with_models):
+    """Test OpenAI vector store attach file."""
+    skip_if_provider_doesnt_support_openai_vector_stores(client_with_models)
+
+    if isinstance(compat_client_with_empty_stores, LlamaStackClient):
+        pytest.skip("Vector Store Files attach is not yet supported with LlamaStackClient")
+
+    compat_client = compat_client_with_empty_stores
+
+    # Create a vector store
+    vector_store = compat_client.vector_stores.create(name="test_store")
+
+    # Create a file
+    test_content = b"This is a test file"
+    with BytesIO(test_content) as file_buffer:
+        file_buffer.name = "openai_test.txt"
+        file = compat_client.files.create(file=file_buffer, purpose="assistants")
+
+    # Attach the file to the vector store
+    file_attach_response = compat_client.vector_stores.files.create(
+        vector_store_id=vector_store.id,
+        file_id=file.id,
+    )
+
+    assert file_attach_response
+    assert file_attach_response.object == "vector_store.file"
+    assert file_attach_response.id == file.id
+    assert file_attach_response.vector_store_id == vector_store.id
+    assert file_attach_response.status == "completed"
+    assert file_attach_response.chunking_strategy.type == "auto"
+    assert file_attach_response.created_at > 0
+    assert not file_attach_response.last_error
+
+    updated_vector_store = compat_client.vector_stores.retrieve(vector_store_id=vector_store.id)
+    assert updated_vector_store.file_counts.completed == 1
+    assert updated_vector_store.file_counts.total == 1
+    assert updated_vector_store.file_counts.cancelled == 0
+    assert updated_vector_store.file_counts.failed == 0
+    assert updated_vector_store.file_counts.in_progress == 0
+
+
+def test_openai_vector_store_list_files(compat_client_with_empty_stores, client_with_models):
+    """Test OpenAI vector store list files."""
+    skip_if_provider_doesnt_support_openai_vector_stores(client_with_models)
+
+    if isinstance(compat_client_with_empty_stores, LlamaStackClient):
+        pytest.skip("Vector Store Files list is not yet supported with LlamaStackClient")
+
+    compat_client = compat_client_with_empty_stores
+
+    # Create a vector store
+    vector_store = compat_client.vector_stores.create(name="test_store")
+
+    # Create some files and attach them to the vector store
+    file_ids = []
+    for i in range(3):
+        with BytesIO(f"This is a test file {i}".encode()) as file_buffer:
+            file_buffer.name = f"openai_test_{i}.txt"
+            file = compat_client.files.create(file=file_buffer, purpose="assistants")
+
+        compat_client.vector_stores.files.create(
+            vector_store_id=vector_store.id,
+            file_id=file.id,
+        )
+        file_ids.append(file.id)
+
+    files_list = compat_client.vector_stores.files.list(vector_store_id=vector_store.id)
+    assert files_list
+    assert files_list.object == "list"
+    assert files_list.data
+    assert len(files_list.data) == 3
+    assert file_ids == [file.id for file in files_list.data]
+    assert files_list.data[0].object == "vector_store.file"
+    assert files_list.data[0].vector_store_id == vector_store.id
+    assert files_list.data[0].status == "completed"
+    assert files_list.data[0].chunking_strategy.type == "auto"
+    assert files_list.data[0].created_at > 0
+    assert not files_list.data[0].last_error
+
+    updated_vector_store = compat_client.vector_stores.retrieve(vector_store_id=vector_store.id)
+    assert updated_vector_store.file_counts.completed == 3
+    assert updated_vector_store.file_counts.total == 3
+    assert updated_vector_store.file_counts.cancelled == 0
+    assert updated_vector_store.file_counts.failed == 0
+    assert updated_vector_store.file_counts.in_progress == 0
+
+
+def test_openai_vector_store_list_files_invalid_vector_store(compat_client_with_empty_stores, client_with_models):
+    """Test OpenAI vector store list files with invalid vector store ID."""
+    skip_if_provider_doesnt_support_openai_vector_stores(client_with_models)
+
+    if isinstance(compat_client_with_empty_stores, LlamaStackClient):
+        pytest.skip("Vector Store Files list is not yet supported with LlamaStackClient")
+
+    compat_client = compat_client_with_empty_stores
+
+    with pytest.raises((BadRequestError, OpenAIBadRequestError)):
+        compat_client.vector_stores.files.list(vector_store_id="abc123")
+
+
+def test_openai_vector_store_delete_file(compat_client_with_empty_stores, client_with_models):
+    """Test OpenAI vector store delete file."""
+    skip_if_provider_doesnt_support_openai_vector_stores(client_with_models)
+
+    if isinstance(compat_client_with_empty_stores, LlamaStackClient):
+        pytest.skip("Vector Store Files list is not yet supported with LlamaStackClient")
+
+    compat_client = compat_client_with_empty_stores
+
+    # Create a vector store
+    vector_store = compat_client.vector_stores.create(name="test_store")
+
+    # Create some files and attach them to the vector store
+    file_ids = []
+    for i in range(3):
+        with BytesIO(f"This is a test file {i}".encode()) as file_buffer:
+            file_buffer.name = f"openai_test_{i}.txt"
+            file = compat_client.files.create(file=file_buffer, purpose="assistants")
+
+        compat_client.vector_stores.files.create(
+            vector_store_id=vector_store.id,
+            file_id=file.id,
+        )
+        file_ids.append(file.id)
+
+    files_list = compat_client.vector_stores.files.list(vector_store_id=vector_store.id)
+    assert len(files_list.data) == 3
+
+    # Delete the first file
+    delete_response = compat_client.vector_stores.files.delete(vector_store_id=vector_store.id, file_id=file_ids[0])
+    assert delete_response
+    assert delete_response.id == file_ids[0]
+    assert delete_response.deleted is True
+    assert delete_response.object == "vector_store.file.deleted"
+
+    updated_vector_store = compat_client.vector_stores.retrieve(vector_store_id=vector_store.id)
+    assert updated_vector_store.file_counts.completed == 2
+    assert updated_vector_store.file_counts.total == 2
+    assert updated_vector_store.file_counts.cancelled == 0
+    assert updated_vector_store.file_counts.failed == 0
+    assert updated_vector_store.file_counts.in_progress == 0
+
+    # Delete the second file
+    delete_response = compat_client.vector_stores.files.delete(vector_store_id=vector_store.id, file_id=file_ids[1])
+    assert delete_response
+    assert delete_response.id == file_ids[1]
+
+    updated_vector_store = compat_client.vector_stores.retrieve(vector_store_id=vector_store.id)
+    assert updated_vector_store.file_counts.completed == 1
+    assert updated_vector_store.file_counts.total == 1
+    assert updated_vector_store.file_counts.cancelled == 0
+    assert updated_vector_store.file_counts.failed == 0
+    assert updated_vector_store.file_counts.in_progress == 0
+
+
+def test_openai_vector_store_update_file(compat_client_with_empty_stores, client_with_models):
+    """Test OpenAI vector store update file."""
+    skip_if_provider_doesnt_support_openai_vector_stores(client_with_models)
+
+    if isinstance(compat_client_with_empty_stores, LlamaStackClient):
+        pytest.skip("Vector Store Files update is not yet supported with LlamaStackClient")
+
+    compat_client = compat_client_with_empty_stores
+
+    # Create a vector store
+    vector_store = compat_client.vector_stores.create(name="test_store")
+
+    # Create a file
+    test_content = b"This is a test file"
+    with BytesIO(test_content) as file_buffer:
+        file_buffer.name = "openai_test.txt"
+        file = compat_client.files.create(file=file_buffer, purpose="assistants")
+
+    # Attach the file to the vector store
+    file_attach_response = compat_client.vector_stores.files.create(
+        vector_store_id=vector_store.id,
+        file_id=file.id,
+        attributes={"foo": "bar"},
+    )
+
+    assert file_attach_response.status == "completed"
+    assert file_attach_response.attributes["foo"] == "bar"
+
+    # Update the file's attributes
+    updated_response = compat_client.vector_stores.files.update(
+        vector_store_id=vector_store.id,
+        file_id=file.id,
+        attributes={"foo": "baz"},
+    )
+
+    assert updated_response.status == "completed"
+    assert updated_response.attributes["foo"] == "baz"
+
+    # Ensure we can retrieve the file and see the updated attributes
+    retrieved_file = compat_client.vector_stores.files.retrieve(
+        vector_store_id=vector_store.id,
+        file_id=file.id,
+    )
+    assert retrieved_file.attributes["foo"] == "baz"


### PR DESCRIPTION
# What does this PR do?

This adds the ability to list, retrieve, update, and delete Vector Store Files. It implements these new APIs for the faiss and sqlite-vec providers, since those are the two that also have the rest of the vector store files implementation.

Closes #2445 

## Test Plan

### test_openai_vector_stores Integration Tests

There are a number of new integration tests added, which I ran for each provider as outlined below.

faiss (from ollama distro):

```
INFERENCE_MODEL="meta-llama/Llama-3.2-3B-Instruct" \
llama stack run llama_stack/templates/ollama/run.yaml

LLAMA_STACK_CONFIG=http://localhost:8321 \
pytest -sv tests/integration/vector_io/test_openai_vector_stores.py \
  --embedding-model=all-MiniLM-L6-v2
```

sqlite-vec (from starter distro):

```
llama stack run llama_stack/templates/starter/run.yaml

LLAMA_STACK_CONFIG=http://localhost:8321 \
pytest -sv tests/integration/vector_io/test_openai_vector_stores.py \
  --embedding-model=all-MiniLM-L6-v2
```

### file_search verification tests

I also ensured the file_search verification tests continue to work, both for faiss and sqlite-vec.

faiss (ollama distro):

```
INFERENCE_MODEL="meta-llama/Llama-3.2-3B-Instruct" \
llama stack run llama_stack/templates/ollama/run.yaml

pytest -sv tests/verifications/openai_api/test_responses.py \
  -k'file_search' \
  --base-url=http://localhost:8321/v1/openai/v1 \
  --model=meta-llama/Llama-3.2-3B-Instruct
```


sqlite-vec (starter distro):

```
llama stack run llama_stack/templates/starter/run.yaml

pytest -sv tests/verifications/openai_api/test_responses.py \
  -k'file_search' \
  --base-url=http://localhost:8321/v1/openai/v1 \
  --model=together/meta-llama/Llama-3.2-3B-Instruct-Turbo
```