### PR TITLE
fix: remove asyncio.TimeoutError since Python update

### DIFF
--- a/llama_stack/distribution/routers/vector_io.py
+++ b/llama_stack/distribution/routers/vector_io.py
@@ -289,7 +289,7 @@ class VectorIORouter(VectorIO):
                     continue
                 health = await asyncio.wait_for(impl.health(), timeout=timeout)
                 health_statuses[provider_id] = health
-            except (asyncio.TimeoutError, TimeoutError):
+            except TimeoutError:
                 health_statuses[provider_id] = HealthResponse(
                     status=HealthStatus.ERROR,
                     message=f"Health check timed out after {timeout} seconds",


### PR DESCRIPTION
# What does this PR do?

Since we now support Pythong starting from 3.11, this is not needed anymore.

