### PR TITLE
feat: remove score_threshold constraint

### DIFF
--- a/llama_stack/apis/vector_io/vector_io.py
+++ b/llama_stack/apis/vector_io/vector_io.py
@@ -168,7 +168,10 @@ register_schema(VectorStoreChunkingStrategy, name="VectorStoreChunkingStrategy")
 
 class SearchRankingOptions(BaseModel):
     ranker: str | None = None
-    score_threshold: float | None = Field(default=0.0, ge=0.0, le=1.0)
+    # NOTE: OpenAI File Search Tool requires threshold to be between 0 and 1, however
+    # we don't guarantee that the score is between 0 and 1, so will leave this unconstrained
+    # and let the provider handle it
+    score_threshold: float | None = Field(default=0.0)
 
 
 @json_schema_type


### PR DESCRIPTION
# What does this PR do?
See inline comment.


fixes test

_ test_openai_vector_store_search_with_high_score_filter[llama_stack_client-meta-llama/Llama-3.3-70B-Instruct-meta-llama/Llama-4-Scout-17B-16E-Instruct-all-MiniLM-L6-v2-None-None] _
llama-stack/llama_stack/distribution/library_client.py:98: in convert_to_pydantic
    return TypeAdapter(annotation).validate_python(value)
.venv/lib/python3.10/site-packages/pydantic/type_adapter.py:421: in validate_python
    return self.validator.validate_python(
E   pydantic_core._pydantic_core.ValidationError: 1 validation error for nullable[SearchRankingOptions]
E   score_threshold
E     Input should be less than or equal to 1 [type=less_than_equal, input_value=1.3458905661753127, input_type=float]
E       For further information visit https://errors.pydantic.dev/2.11/v/less_than_equal

The above exception was the direct cause of the following exception:
llama-stack/tests/integration/vector_io/test_openai_vector_stores.py:376: in test_openai_vector_store_search_with_high_score_filter
    search_response = compat_client.vector_stores.search(
.venv/lib/python3.10/site-packages/llama_stack_client/resources/vector_stores/vector_stores.py:356: in search
    return self._post(
.venv/lib/python3.10/site-packages/llama_stack_client/_base_client.py:1232: in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
llama-stack/llama_stack/distribution/library_client.py:177: in request
    result = loop.run_until_complete(self.async_client.request(*args, **kwargs))
/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/asyncio/base_events.py:649: in run_until_complete
    return future.result()
llama-stack/llama_stack/distribution/library_client.py:292: in request
    response = await self._call_non_streaming(
llama-stack/llama_stack/distribution/library_client.py:313: in _call_non_streaming
    body = self._convert_body(path, options.method, body)
llama-stack/llama_stack/distribution/library_client.py:425: in _convert_body
    converted_body[param_name] = convert_to_pydantic(param.annotation, value)
llama-stack/llama_stack/distribution/library_client.py:112: in convert_to_pydantic
    raise ValueError(f"Failed to convert parameter {value} into {annotation}: {e}") from e
E   ValueError: Failed to convert parameter {'score_threshold': 1.3458905661753127} into llama_stack.apis.vector_io.vector_io.SearchRankingOptions | None: 1 validation error for nullable[SearchRankingOptions]
E   score_threshold
E     Input should be less than or equal to 1 [type=less_than_equal, input_value=1.3458905661753127, input_type=float]
E       For further information visit https://errors.pydantic.dev/2.11/v/less_than_equal

## Test Plan

