### PR TITLE
fix(ui): ensure initial data fetch only happens once

### DIFF
--- a/llama_stack/ui/hooks/usePagination.ts
+++ b/llama_stack/ui/hooks/usePagination.ts
@@ -55,6 +55,9 @@ export function usePagination<T>({
   // Use refs to avoid stale closures
   const stateRef = useRef(state);
   stateRef.current = state;
+  
+  // Track if initial data has been fetched
+  const hasFetchedInitialData = useRef(false);
 
   /**
    * Fetches data from the API with cursor-based pagination
@@ -119,8 +122,12 @@ export function usePagination<T>({
 
   // Auto-load initial data on mount
   useEffect(() => {
-    fetchData();
-  }, []);
+    if (!hasFetchedInitialData.current) {
+      hasFetchedInitialData.current = true;
+      fetchData();
+    }
+  }, [fetchData]);
+  
 
   return {
     data: state.data,


### PR DESCRIPTION
# What does this PR do?
Bug:
1. go to responses chat logs in UI
2. go to chat completions logs page
3. observe that same data appears in the table twice

This is because `fetchData` is called multiple times when multiple renders occur.

## Test Plan
manual testing of above bug repro steps
