### PR TITLE
fix: stack build

### DIFF
--- a/llama_stack/cli/stack/_build.py
+++ b/llama_stack/cli/stack/_build.py
@@ -408,10 +408,10 @@ def _run_stack_build_command_from_build_config(
             shutil.copy(path, run_config_file)
 
         cprint("Build Successful!", color="green", file=sys.stderr)
-        cprint(f"You can find the newly-built template here: {template_path}", color="light_blue", file=sys.stderr)
+        cprint(f"You can find the newly-built template here: {template_path}", color="blue", file=sys.stderr)
         cprint(
             "You can run the new Llama Stack distro via: "
-            + colored(f"llama stack run {template_path} --image-type {build_config.image_type}", "light_blue"),
+            + colored(f"llama stack run {template_path} --image-type {build_config.image_type}", "blue"),
             color="green",
             file=sys.stderr,
         )


### PR DESCRIPTION

# What does this PR do?

probably related to 3.11 upgrade

^^^^
  File "/opt/homebrew/Caskroom/miniconda/base/envs/myenv/lib/python3.11/site-packages/termcolor/termcolor.py", line 147, in colored
    text = fmt_str % (COLORS[color], text)
                      ~~~~~~^^^^^^^
KeyError: 'light_blue'

## Test Plan

