### PR TITLE
fix: dataset metadata without provider_id

### DIFF
--- a/llama_stack/distribution/routing_tables/datasets.py
+++ b/llama_stack/distribution/routing_tables/datasets.py
@@ -57,9 +57,8 @@ class DatasetsRoutingTable(CommonRoutingTableImpl, Datasets):
         provider_dataset_id = dataset_id
 
         # infer provider from source
-        if metadata:
-            if metadata.get("provider_id"):
-                provider_id = metadata.get("provider_id")  # pass through from nvidia datasetio
+        if metadata and metadata.get("provider_id"):
+            provider_id = metadata.get("provider_id")  # pass through from nvidia datasetio
         elif source.type == DatasetType.rows.value:
             provider_id = "localfs"
         elif source.type == DatasetType.uri.value:


### PR DESCRIPTION
# What does this PR do?
Fixes an error when inferring dataset provider_id with metadata

Closes #[2506](https://github.com/meta-llama/llama-stack/issues/2506)
