### PR TITLE
fix: Gracefully handle errors when listing MCP tools

### DIFF
--- a/llama_stack/distribution/routing_tables/toolgroups.py
+++ b/llama_stack/distribution/routing_tables/toolgroups.py
@@ -52,9 +52,14 @@ class ToolGroupsRoutingTable(CommonRoutingTableImpl, ToolGroups):
 
         all_tools = []
         for toolgroup in toolgroups:
-            if toolgroup.identifier not in self.toolgroups_to_tools:
-                await self._index_tools(toolgroup)
-            all_tools.extend(self.toolgroups_to_tools[toolgroup.identifier])
+            try:
+                if toolgroup.identifier not in self.toolgroups_to_tools:
+                    await self._index_tools(toolgroup)
+                all_tools.extend(self.toolgroups_to_tools[toolgroup.identifier])
+            except Exception as e:
+                logger.warning(f"Error listing tools for toolgroup {toolgroup.identifier}: {e}")
+                logger.debug(e, exc_info=True)
+                continue
 
         return ListToolsResponse(data=all_tools)
 


### PR DESCRIPTION
# What does this PR do?

When listing (and lazily indexing) tools, it's possible for an error to get thrown by individual toolgroups if for example an MCP toolgroup is unable to connect to its `mcp_endpoint`.

This logs a warning in the server when that happens, logs a full stack trace of the error if debug logging is enabled, and just returns the list of tools from all working toolgroups instead of throwing an error to the client when a single toolgroup is temporarily or permanently misbehaving.

Closes #2540

## Test Plan

A new unit test was added to test this exception handling, which is run as part of our regular test suite but also manually run to specifically verify this fix via:

```
uv run pytest -sv --asyncio-mode=auto \
tests/unit/distribution/routers/test_routing_tables.py
```

To verify the additional debug logging is printing properly:

```
LLAMA_STACK_LOGGING=core=debug \
uv run pytest -sv --asyncio-mode=auto \
tests/unit/distribution/routers/test_routing_tables.py
```