### PR TITLE
default api_key from env must be a SecretStr

### DIFF
--- a/llama_stack/providers/remote/inference/nvidia/config.py
+++ b/llama_stack/providers/remote/inference/nvidia/config.py
@@ -40,7 +40,7 @@ class NVIDIAConfig(BaseModel):
         description="A base url for accessing the NVIDIA NIM",
     )
     api_key: SecretStr | None = Field(
-        default_factory=lambda: os.getenv("NVIDIA_API_KEY"),
+        default_factory=lambda: SecretStr(os.getenv("NVIDIA_API_KEY")),
         description="The NVIDIA API key, only needed of using the hosted service",
     )
     timeout: int = Field(


### PR DESCRIPTION
# What does this PR do?

fixes the api_key type when read from env

## Test Plan

run nvidia template w/o api_key in run.yaml and perform inference

before change the inference will fail w/ -

```
  File ".../llama-stack/llama_stack/providers/remote/inference/nvidia/nvidia.py", line 118, in _get_client_for_base_url
    api_key=(self._config.api_key.get_secret_value() if self._config.api_key else "NO KEY"),
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'get_secret_value'
```