### PR TITLE
docs: fixed incorrect API list item

### DIFF
--- a/docs/source/distributions/configuration.md
+++ b/docs/source/distributions/configuration.md
@@ -67,7 +67,7 @@ Let's break this down into the different sections. The first section specifies t
 apis:
 - agents
 - inference
-- memory
+- vector_io
 - safety
 - telemetry
 ```


### PR DESCRIPTION
Current text did not match section in example Ollama distro: https://llama-stack.readthedocs.io/en/latest/distributions/configuration.html