### PR TITLE
docs: update external provider guide and navigation

### DIFF
--- a/docs/source/providers/external.md
+++ b/docs/source/providers/external.md
@@ -1,4 +1,4 @@
-# External Providers
+# External Providers Guide
 
 Llama Stack supports external providers that live outside of the main codebase. This allows you to:
 - Create and maintain your own providers independently

--- a/docs/source/providers/index.md
+++ b/docs/source/providers/index.md
@@ -13,7 +13,13 @@ Importantly, Llama Stack always strives to provide at least one fully inline pro
 
 ## External Providers
 
-Llama Stack supports external providers that live outside of the main codebase. This allows you to create and maintain your own providers independently. See the [External Providers Guide](external) for details.
+Llama Stack supports external providers that live outside of the main codebase. This allows you to create and maintain your own providers independently.
+
+```{toctree}
+:maxdepth: 1
+
+external
+```
 
 ## Agents
 Run multi-step agentic workflows with LLMs with tool usage, memory (RAG), etc.


### PR DESCRIPTION
# What does this PR do?
The external providers guide can now be accessed directly from the sidebar

## Test Plan
Build locally to test the changes
