### PR TITLE
fix: Fixing Milvus sample config and updating documentation

### DIFF
--- a/docs/source/providers/vector_io/inline_milvus.md
+++ b/docs/source/providers/vector_io/inline_milvus.md
@@ -16,11 +16,11 @@ Please refer to the remote provider documentation.
 ## Sample Configuration
 
 ```yaml
-db_path: ${env.MILVUS_DB_PATH:=~/.llama/dummy/milvus.db}
+db_path: ${env.MILVUS_DB_PATH:=~/.llama/dummy}/milvus.db
 kvstore:
   type: sqlite
   namespace: null
-  db_path: ${env.SQLITE_STORE_DIR:=~/.llama/dummy}/${env.MILVUS_KVSTORE_DB_PATH:=~/.llama/dummy/milvus_registry.db}
+  db_path: ${env.SQLITE_STORE_DIR:=~/.llama/dummy}/milvus_registry.db
 
 ```
 

--- a/llama_stack/providers/inline/vector_io/milvus/config.py
+++ b/llama_stack/providers/inline/vector_io/milvus/config.py
@@ -23,9 +23,9 @@ class MilvusVectorIOConfig(BaseModel):
     @classmethod
     def sample_run_config(cls, __distro_dir__: str, **kwargs: Any) -> dict[str, Any]:
         return {
-            "db_path": f"${{env.MILVUS_DB_PATH:={__distro_dir__}/milvus.db}}",
+            "db_path": "${env.MILVUS_DB_PATH:=" + __distro_dir__ + "}/" + "milvus.db",
             "kvstore": SqliteKVStoreConfig.sample_run_config(
                 __distro_dir__=__distro_dir__,
-                db_name=f"${{env.MILVUS_KVSTORE_DB_PATH:={__distro_dir__}/milvus_registry.db}}",
+                db_name="milvus_registry.db",
             ),
         }

--- a/llama_stack/templates/starter/run.yaml
+++ b/llama_stack/templates/starter/run.yaml
@@ -75,11 +75,11 @@ providers:
   - provider_id: ${env.ENABLE_MILVUS:+milvus}
     provider_type: inline::milvus
     config:
-      db_path: ${env.MILVUS_DB_PATH:=~/.llama/distributions/starter/milvus.db}
+      db_path: ${env.MILVUS_DB_PATH:=~/.llama/distributions/starter}/milvus.db
       kvstore:
         type: sqlite
         namespace: null
-        db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/starter}/${env.MILVUS_KVSTORE_DB_PATH:=~/.llama/distributions/starter/milvus_registry.db}
+        db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/starter}/milvus_registry.db
   - provider_id: ${env.ENABLE_CHROMADB:+chromadb}
     provider_type: remote::chromadb
     config:


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/meta-llama/llama-stack/issues/2560 and https://github.com/meta-llama/llama-stack/issues/2561

## Test Plan
CI and tested locally with

```bash
 ENABLE_MILVUS=true llama stack run ./llama_stack/templates/starter/run.yaml --image-type venv --env OLLAMA_URL="http://0.0.0.0:11434"
```

```bash
ENABLE_MILVUS=true pytest -sv --stack-config=http://localhost:8321 tests/integration/vector_io/test_openai_vector_stores.py  --embedding-model all-MiniLM-L6-v2      
```
All tests passed. Also the config path is generated correctly.