### PR TITLE
docs: specify the ability to train non-Llama models

### DIFF
--- a/docs/source/concepts/apis.md
+++ b/docs/source/concepts/apis.md
@@ -14,5 +14,5 @@ A Llama Stack API is described as a collection of REST endpoints. We currently s
 We are working on adding a few more APIs to complete the application lifecycle. These will include:
 - **Batch Inference**: run inference on a dataset of inputs
 - **Batch Agents**: run agents on a dataset of inputs
-- **Post Training**: fine-tune a Llama model
+- **Post Training**: fine-tune a model
 - **Synthetic Data Generation**: generate synthetic data for model development


### PR DESCRIPTION
# What does this PR do?
Clarifies that non-Llama models can be trained via the Post Training API

## Test Plan
Build docs locally