### PR TITLE
ci: error when a pipefails

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -53,10 +53,13 @@ jobs:
 
       - name: Run Integration Tests
         env:
-          INFERENCE_MODEL: "meta-llama/Llama-3.2-3B-Instruct"
-          OLLAMA_INFERENCE_MODEL: "meta-llama/Llama-3.2-3B-Instruct" # for library tests
-          ENABLE_OLLAMA: "ollama" # for library tests
+          OLLAMA_INFERENCE_MODEL: "meta-llama/Llama-3.2-3B-Instruct" # for server tests
+          ENABLE_OLLAMA: "ollama" # for server tests
           OLLAMA_URL: "http://0.0.0.0:11434"
+        # Use 'shell' to get pipefail behavior
+        # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+        # TODO: write a precommit hook to detect if a test contains a pipe but does not use 'shell: bash'
+        shell: bash
         run: |
           if [ "${{ matrix.client-type }}" == "library" ]; then
             stack_config="starter"

--- a/tests/integration/fixtures/common.py
+++ b/tests/integration/fixtures/common.py
@@ -42,7 +42,7 @@ def start_llama_stack_server(config_name: str) -> subprocess.Popen:
     process = subprocess.Popen(
         cmd,
         stdout=devnull,  # redirect stdout to devnull to prevent deadlock
-        stderr=devnull,  # redirect stderr to devnull to prevent deadlock
+        stderr=subprocess.PIPE,  # keep stderr to see errors
         text=True,
         env={**os.environ, "LLAMA_STACK_LOG_FILE": "server.log"},
     )
@@ -57,6 +57,7 @@ def wait_for_server_ready(base_url: str, timeout: int = 30, process: subprocess.
     while time.time() - start_time < timeout:
         if process and process.poll() is not None:
             print(f"Server process terminated with return code: {process.returncode}")
+            print(f"Server stderr: {process.stderr.read()}")
             return False
 
         try:


### PR DESCRIPTION
# What does this PR do?

The CI was failing but the error was eaten by the pipe. Now we run the
task with pipefail.
