### PR TITLE
fix: use `--template` flag for server

### DIFF
--- a/llama_stack/cli/stack/run.py
+++ b/llama_stack/cli/stack/run.py
@@ -155,8 +155,12 @@ class StackRun(Subcommand):
                 # func=<bound method StackRun._run_stack_run_cmd of <llama_stack.cli.stack.run.StackRun object at 0x10484b010>>
                 if callable(getattr(args, arg)):
                     continue
-                if arg == "config" and template_name:
-                    server_args.config = str(config_file)
+                if arg == "config":
+                    if template_name:
+                        server_args.template = str(template_name)
+                    else:
+                        # Set the config file path
+                        server_args.config = str(config_file)
                 else:
                     setattr(server_args, arg, getattr(args, arg))
 
@@ -168,7 +172,10 @@ class StackRun(Subcommand):
             run_args.extend([str(args.port)])
 
             if config_file:
-                run_args.extend(["--config", str(config_file)])
+                if template_name:
+                    run_args.extend(["--template", str(template_name)])
+                else:
+                    run_args.extend(["--config", str(config_file)])
 
             if args.env:
                 for env_var in args.env:

--- a/llama_stack/distribution/server/server.py
+++ b/llama_stack/distribution/server/server.py
@@ -405,13 +405,13 @@ def main(args: argparse.Namespace | None = None):
         args = parser.parse_args()
 
     log_line = ""
-    if args.config:
+    if hasattr(args, "config") and args.config:
         # if the user provided a config file, use it, even if template was specified
         config_file = Path(args.config)
         if not config_file.exists():
             raise ValueError(f"Config file {config_file} does not exist")
         log_line = f"Using config file: {config_file}"
-    elif args.template:
+    elif hasattr(args, "template") and args.template:
         config_file = Path(REPO_ROOT) / "llama_stack" / "templates" / args.template / "run.yaml"
         if not config_file.exists():
             raise ValueError(f"Template {args.template} does not exist")


### PR DESCRIPTION
# What does this PR do?

currently when a template is used, we still use `--config`.

`server.py` has a dedicated `--template` flag and logic, use that instead

