### PR TITLE
fix: properly represent paths in server logs

### DIFF
--- a/llama_stack/distribution/server/server.py
+++ b/llama_stack/distribution/server/server.py
@@ -445,7 +445,7 @@ def main(args: argparse.Namespace | None = None):
     logger.info(log_line)
 
     logger.info("Run configuration:")
-    safe_config = redact_sensitive_fields(config.model_dump())
+    safe_config = redact_sensitive_fields(config.model_dump(mode="json"))
     logger.info(yaml.dump(safe_config, indent=2))
 
     app = FastAPI(


### PR DESCRIPTION
# What does this PR do?

currently when logging the run yaml, if there are path objects in the object they are represented as:

```
         external_providers_dir: !!python/object/apply:pathlib.PosixPath
         - '~'
         - .llama
         - providers.d
```

now, with a config.model_dump(mode="json"), it works properly

```
         external_providers_dir: ~/.llama/providers.d
```

