### PR TITLE
ci: add config for pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -133,3 +133,8 @@ repos:
 ci:
     autofix_commit_msg: 🎨 [pre-commit.ci] Auto format from pre-commit.com hooks
     autoupdate_commit_msg: ⬆ [pre-commit.ci] pre-commit autoupdate
+    autofix_prs: true
+    autoupdate_branch: ''
+    autoupdate_schedule: weekly
+    skip: []
+    submodules: false


### PR DESCRIPTION
# What does this PR do?
the project already had some config setup for https://pre-commit.ci/

this commit adds additional explicit fields

Closes #2711

**IMPORTANT:** A project maintainer must add `pre-commit.ci` to this repo for this to work - this can be done via https://pre-commit.ci/


