### PR TITLE
fix: add missing extra_body to client.chat.completions.create() call

### DIFF
--- a/llama_stack/providers/remote/inference/vllm/vllm.py
+++ b/llama_stack/providers/remote/inference/vllm/vllm.py
@@ -654,6 +654,7 @@ class VLLMInferenceAdapter(Inference, ModelsProtocolPrivate):
         top_logprobs: int | None = None,
         top_p: float | None = None,
         user: str | None = None,
+        extra_body: dict[str, Any] | None = None,
     ) -> OpenAIChatCompletion | AsyncIterator[OpenAIChatCompletionChunk]:
         self._lazy_initialize_client()
         model_obj = await self._get_model(model)
@@ -681,6 +682,7 @@ class VLLMInferenceAdapter(Inference, ModelsProtocolPrivate):
             top_logprobs=top_logprobs,
             top_p=top_p,
             user=user,
+            extra_body=extra_body,
         )
         return await self.client.chat.completions.create(**params)  # type: ignore
 


### PR DESCRIPTION

# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->

<!-- If resolving an issue, uncomment and update the line below -->
Closes #2720 

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->
- test requires vLLM as provider, currently is skipped in GH Action, local test:
```
>export VLLM_URL="http://localhost:8000"
>pytest tests/integration/inference/test_openai_completion.py::test_openai_chat_completion_extra_body -v --stack-config="inference=remote::vllm"
```
