### PR TITLE
chore: remove posttraining from starter

### DIFF
--- a/llama_stack/templates/starter/build.yaml
+++ b/llama_stack/templates/starter/build.yaml
@@ -42,8 +42,6 @@ distribution_spec:
     - inline::meta-reference
     telemetry:
     - inline::meta-reference
-    post_training:
-    - inline::huggingface
     eval:
     - inline::meta-reference
     datasetio:

--- a/llama_stack/templates/starter/run.yaml
+++ b/llama_stack/templates/starter/run.yaml
@@ -6,7 +6,6 @@ apis:
 - eval
 - files
 - inference
-- post_training
 - safety
 - scoring
 - telemetry
@@ -200,13 +199,6 @@ providers:
       sinks: ${env.TELEMETRY_SINKS:=console,sqlite}
       sqlite_db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/starter}/trace_store.db
       otel_exporter_otlp_endpoint: ${env.OTEL_EXPORTER_OTLP_ENDPOINT:=}
-  post_training:
-  - provider_id: huggingface
-    provider_type: inline::huggingface
-    config:
-      checkpoint_format: huggingface
-      distributed_backend: null
-      device: cpu
   eval:
   - provider_id: meta-reference
     provider_type: inline::meta-reference

--- a/llama_stack/templates/starter/starter.py
+++ b/llama_stack/templates/starter/starter.py
@@ -19,7 +19,6 @@ from llama_stack.providers.inline.files.localfs.config import LocalfsFilesImplCo
 from llama_stack.providers.inline.inference.sentence_transformers import (
     SentenceTransformersInferenceConfig,
 )
-from llama_stack.providers.inline.post_training.huggingface import HuggingFacePostTrainingConfig
 from llama_stack.providers.inline.vector_io.faiss.config import FaissVectorIOConfig
 from llama_stack.providers.inline.vector_io.milvus.config import (
     MilvusVectorIOConfig,
@@ -256,7 +255,6 @@ def get_distribution_template() -> DistributionTemplate:
         "safety": ["inline::llama-guard"],
         "agents": ["inline::meta-reference"],
         "telemetry": ["inline::meta-reference"],
-        "post_training": ["inline::huggingface"],
         "eval": ["inline::meta-reference"],
         "datasetio": ["remote::huggingface", "inline::localfs"],
         "scoring": ["inline::basic", "inline::llm-as-judge", "inline::braintrust"],
@@ -276,11 +274,6 @@ def get_distribution_template() -> DistributionTemplate:
         provider_id="${env.ENABLE_SENTENCE_TRANSFORMERS:=sentence-transformers}",
         provider_type="inline::sentence-transformers",
         config=SentenceTransformersInferenceConfig.sample_run_config(),
-    )
-    post_training_provider = Provider(
-        provider_id="huggingface",
-        provider_type="inline::huggingface",
-        config=HuggingFacePostTrainingConfig.sample_run_config(f"~/.llama/distributions/{name}"),
     )
     default_tool_groups = [
         ToolGroupInput(
@@ -321,7 +314,6 @@ def get_distribution_template() -> DistributionTemplate:
                     "inference": remote_inference_providers + [embedding_provider],
                     "vector_io": vector_io_providers,
                     "files": [files_provider],
-                    "post_training": [post_training_provider],
                 },
                 default_models=default_models + [embedding_model],
                 default_tool_groups=default_tool_groups,


### PR DESCRIPTION

# What does this PR do?
post_training makes start-up really slow: >1min vs 10sec. Removing as `starter` distro shouldn't need this.

## Test Plan
