### PR TITLE
fix(vectordb): VectorDBInput has no provider_id

### DIFF
--- a/llama_stack/apis/vector_dbs/vector_dbs.py
+++ b/llama_stack/apis/vector_dbs/vector_dbs.py
@@ -34,6 +34,7 @@ class VectorDBInput(BaseModel):
     vector_db_id: str
     embedding_model: str
     embedding_dimension: int
+    provider_id: str | None = None
     provider_vector_db_id: str | None = None
 
 


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
This PR add `provider_id` field to `VectorDBInput` class.

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

fixes https://github.com/meta-llama/llama-stack/issues/2819

