### PR TITLE
fix: Add permissions for pull request creation in coverage-badge workflow

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -15,6 +15,9 @@ on:
 
 jobs:
   unit-tests:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
# What does this PR do?
The workflow that automatically creates a PR to update the Coverage Badge fails as the `GITHUB_TOKEN` doesn't have write permissions.

As opposed to providing write permissions to the token, we can provide the permissions for just this workflow with this PR.