### PR TITLE
fix: uvicorn respect log_config

### DIFF
--- a/llama_stack/distribution/server/server.py
+++ b/llama_stack/distribution/server/server.py
@@ -592,6 +592,7 @@ def main(args: argparse.Namespace | None = None):
         "port": port,
         "lifespan": "on",
         "log_level": logger.getEffectiveLevel(),
+        "log_config": logger_config,
     }
     if ssl_config:
         uvicorn_config.update(ssl_config)


### PR DESCRIPTION
# What does this PR do?
currently if a user does something like `LLAMA_STACK_LOG_FILE=foobar.log` the uvicorn logs do not end up in that file

meaning during testing, it looks like a server gets no requests. This is problematic as it can lead users to believe they have misconfigured their server

when in reality the logging config is just incorrect.


## Test Plan

before: 

```
2025-07-21 15:06:02,767 llama_stack.providers.remote.inference.ollama.ollama:117 inference: checking connectivity to Ollama at `http://localhost:11434`...
2025-07-21 15:06:05,025 opentelemetry.trace:537 uncategorized: Overriding of current TracerProvider is not allowed
2025-07-21 15:06:05,272 __main__:587 server: Listening on ['::', '0.0.0.0']:8321
2025-07-21 15:06:05,279 __main__:163 server: Starting up
```


after:

```
2025-07-21 15:05:20,556 llama_stack.providers.remote.inference.ollama.ollama:117 inference: checking connectivity to Ollama at `http://localhost:11434`...
2025-07-21 15:05:22,824 opentelemetry.trace:537 uncategorized: Overriding of current TracerProvider is not allowed
2025-07-21 15:05:23,075 __main__:587 server: Listening on ['::', '0.0.0.0']:8321
2025-07-21 15:05:23,082 uvicorn.error:84 uncategorized: Started server process [64496]
2025-07-21 15:05:23,083 uvicorn.error:48 uncategorized: Waiting for application startup.
2025-07-21 15:05:23,083 __main__:163 server: Starting up
2025-07-21 15:05:23,084 uvicorn.error:62 uncategorized: Application startup complete.
2025-07-21 15:05:23,084 uvicorn.error:216 uncategorized: Uvicorn running on http://['::', '0.0.0.0']:8321 (Press CTRL+C to quit)
2025-07-21 15:05:29,149 uvicorn.access:473 uncategorized: 127.0.0.1:52084 - "POST /v1/openai/v1/chat/completions HTTP/1.1" 200
```
