### PR TITLE
fix: honour deprecation of --config and --template

### DIFF
--- a/llama_stack/cli/utils.py
+++ b/llama_stack/cli/utils.py
@@ -6,6 +6,10 @@
 
 import argparse
 
+from llama_stack.log import get_logger
+
+logger = get_logger(name=__name__, category="cli")
+
 
 def add_config_template_args(parser: argparse.ArgumentParser):
     """Add unified config/template arguments with backward compatibility."""
@@ -20,12 +24,25 @@ def add_config_template_args(parser: argparse.ArgumentParser):
     # Backward compatibility arguments (deprecated)
     group.add_argument(
         "--config",
-        dest="config",
+        dest="config_deprecated",
         help="(DEPRECATED) Use positional argument [config] instead. Configuration file path",
     )
 
     group.add_argument(
         "--template",
-        dest="config",
+        dest="template_deprecated",
         help="(DEPRECATED) Use positional argument [config] instead. Template name",
     )
+
+
+def get_config_from_args(args: argparse.Namespace) -> str | None:
+    """Extract config value from parsed arguments, handling both new and deprecated forms."""
+    if args.config is not None:
+        return str(args.config)
+    elif hasattr(args, "config_deprecated") and args.config_deprecated is not None:
+        logger.warning("Using deprecated --config argument. Use positional argument [config] instead.")
+        return str(args.config_deprecated)
+    elif hasattr(args, "template_deprecated") and args.template_deprecated is not None:
+        logger.warning("Using deprecated --template argument. Use positional argument [config] instead.")
+        return str(args.template_deprecated)
+    return None

--- a/llama_stack/distribution/server/server.py
+++ b/llama_stack/distribution/server/server.py
@@ -32,7 +32,7 @@ from openai import BadRequestError
 from pydantic import BaseModel, ValidationError
 
 from llama_stack.apis.common.responses import PaginatedResponse
-from llama_stack.cli.utils import add_config_template_args
+from llama_stack.cli.utils import add_config_template_args, get_config_from_args
 from llama_stack.distribution.access_control.access_control import AccessDeniedError
 from llama_stack.distribution.datatypes import (
     AuthenticationRequiredError,
@@ -399,7 +399,8 @@ def main(args: argparse.Namespace | None = None):
     if args is None:
         args = parser.parse_args()
 
-    config_file = resolve_config_or_template(args.config, Mode.RUN)
+    config_or_template = get_config_from_args(args)
+    config_file = resolve_config_or_template(config_or_template, Mode.RUN)
 
     logger_config = None
     with open(config_file) as fp:


### PR DESCRIPTION
# What does this PR do?

https://github.com/meta-llama/llama-stack/pull/2716/ broke commands like:

```
 python -m llama_stack.distribution.server.server --config
 llama_stack/templates/starter/run.yaml
 ```

 And will fail with:

 ```
 Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/leseb/Documents/AI/llama-stack/llama_stack/distribution/server/server.py", line 626, in <module>
    main()
  File "/Users/leseb/Documents/AI/llama-stack/llama_stack/distribution/server/server.py", line 402, in main
    config_file = resolve_config_or_template(args.config, Mode.RUN)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/leseb/Documents/AI/llama-stack/llama_stack/distribution/utils/config_resolution.py", line 43, in resolve_config_or_template
    config_path = Path(config_or_template)
                  ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.8/Frameworks/Python.framework/Versions/3.12/lib/python3.12/pathlib.py", line 1162, in __init__
    super().__init__(*args)
  File "/opt/homebrew/Cellar/python@3.12/3.12.8/Frameworks/Python.framework/Versions/3.12/lib/python3.12/pathlib.py", line 373, in __init__
    raise TypeError(
TypeError: argument should be a str or an os.PathLike object where __fspath__ returns a str, not 'NoneType'
```

Complaining that no positional arguments are present. We now honour the deprecation until --config and --template are removed completely.

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->

Both ` python -m llama_stack.distribution.server.server --config llama_stack/templates/starter/run.yaml` and ` python -m llama_stack.distribution.server.server llama_stack/templates/starter/run.yaml` should run the server. Same for `--template starter`. 
