### PR TITLE
chore: Making name optional in openai_create_vector_store

### DIFF
--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -13596,9 +13596,6 @@
                     }
                 },
                 "additionalProperties": false,
-                "required": [
-                    "name"
-                ],
                 "title": "OpenaiCreateVectorStoreRequest"
             },
             "VectorStoreFileCounts": {

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -9497,8 +9497,6 @@ components:
           description: >-
             The ID of the provider to use for this vector store.
       additionalProperties: false
-      required:
-        - name
       title: OpenaiCreateVectorStoreRequest
     VectorStoreFileCounts:
       type: object

--- a/llama_stack/apis/vector_io/vector_io.py
+++ b/llama_stack/apis/vector_io/vector_io.py
@@ -338,7 +338,7 @@ class VectorIO(Protocol):
     @webmethod(route="/openai/v1/vector_stores", method="POST")
     async def openai_create_vector_store(
         self,
-        name: str,
+        name: str | None = None,
         file_ids: list[str] | None = None,
         expires_after: dict[str, Any] | None = None,
         chunking_strategy: dict[str, Any] | None = None,

--- a/llama_stack/providers/utils/memory/openai_vector_store_mixin.py
+++ b/llama_stack/providers/utils/memory/openai_vector_store_mixin.py
@@ -161,7 +161,7 @@ class OpenAIVectorStoreMixin(ABC):
 
     async def openai_create_vector_store(
         self,
-        name: str,
+        name: str | None = None,
         file_ids: list[str] | None = None,
         expires_after: dict[str, Any] | None = None,
         chunking_strategy: dict[str, Any] | None = None,


### PR DESCRIPTION
# What does this PR do?
chore: Making name optional in openai_create_vector_store


# Closes https://github.com/meta-llama/llama-stack/issues/2706

## Test Plan
CI and unit tests