### PR TITLE
fix: cleanup after build_container.sh

### DIFF
--- a/llama_stack/distribution/build_container.sh
+++ b/llama_stack/distribution/build_container.sh
@@ -336,7 +336,7 @@ $CONTAINER_BINARY build \
   "$BUILD_CONTEXT_DIR"
 
 # clean up tmp/configs
-rm -f "$BUILD_CONTEXT_DIR/run.yaml"
+rm -rf "$BUILD_CONTEXT_DIR/run.yaml" "$TEMP_DIR"
 set +x
 
 echo "Success!"


### PR DESCRIPTION
- rm TEMP_DIR when build_container.sh succeeds
- prevents multiple temp directories with Containerfile being left in /tmp
