### PR TITLE
fix: starter template and litellm backward compat conflict for openai

### DIFF
--- a/llama_stack/providers/remote/inference/openai/models.py
+++ b/llama_stack/providers/remote/inference/openai/models.py
@@ -12,11 +12,6 @@ from llama_stack.providers.utils.inference.model_registry import (
 )
 
 LLM_MODEL_IDS = [
-    # the models w/ "openai/" prefix are the litellm specific model names.
-    # they should be deprecated in favor of the canonical openai model names.
-    "openai/gpt-4o",
-    "openai/gpt-4o-mini",
-    "openai/chatgpt-4o-latest",
     "gpt-3.5-turbo-0125",
     "gpt-3.5-turbo",
     "gpt-3.5-turbo-instruct",
@@ -43,8 +38,6 @@ class EmbeddingModelInfo:
 
 
 EMBEDDING_MODEL_IDS: dict[str, EmbeddingModelInfo] = {
-    "openai/text-embedding-3-small": EmbeddingModelInfo(1536, 8192),
-    "openai/text-embedding-3-large": EmbeddingModelInfo(3072, 8192),
     "text-embedding-3-small": EmbeddingModelInfo(1536, 8192),
     "text-embedding-3-large": EmbeddingModelInfo(3072, 8192),
 }

--- a/llama_stack/templates/ci-tests/run.yaml
+++ b/llama_stack/templates/ci-tests/run.yaml
@@ -786,21 +786,6 @@ models:
   provider_model_id: Llama3.2-3B
   model_type: llm
 - metadata: {}
-  model_id: ${env.ENABLE_OPENAI:=__disabled__}/openai/gpt-4o
-  provider_id: ${env.ENABLE_OPENAI:=__disabled__}
-  provider_model_id: openai/gpt-4o
-  model_type: llm
-- metadata: {}
-  model_id: ${env.ENABLE_OPENAI:=__disabled__}/openai/gpt-4o-mini
-  provider_id: ${env.ENABLE_OPENAI:=__disabled__}
-  provider_model_id: openai/gpt-4o-mini
-  model_type: llm
-- metadata: {}
-  model_id: ${env.ENABLE_OPENAI:=__disabled__}/openai/chatgpt-4o-latest
-  provider_id: ${env.ENABLE_OPENAI:=__disabled__}
-  provider_model_id: openai/chatgpt-4o-latest
-  model_type: llm
-- metadata: {}
   model_id: ${env.ENABLE_OPENAI:=__disabled__}/gpt-3.5-turbo-0125
   provider_id: ${env.ENABLE_OPENAI:=__disabled__}
   provider_model_id: gpt-3.5-turbo-0125
@@ -870,20 +855,6 @@ models:
   provider_id: ${env.ENABLE_OPENAI:=__disabled__}
   provider_model_id: o4-mini
   model_type: llm
-- metadata:
-    embedding_dimension: 1536
-    context_length: 8192
-  model_id: ${env.ENABLE_OPENAI:=__disabled__}/openai/text-embedding-3-small
-  provider_id: ${env.ENABLE_OPENAI:=__disabled__}
-  provider_model_id: openai/text-embedding-3-small
-  model_type: embedding
-- metadata:
-    embedding_dimension: 3072
-    context_length: 8192
-  model_id: ${env.ENABLE_OPENAI:=__disabled__}/openai/text-embedding-3-large
-  provider_id: ${env.ENABLE_OPENAI:=__disabled__}
-  provider_model_id: openai/text-embedding-3-large
-  model_type: embedding
 - metadata:
     embedding_dimension: 1536
     context_length: 8192

--- a/llama_stack/templates/starter/run.yaml
+++ b/llama_stack/templates/starter/run.yaml
@@ -786,21 +786,6 @@ models:
   provider_model_id: Llama3.2-3B
   model_type: llm
 - metadata: {}
-  model_id: ${env.ENABLE_OPENAI:=__disabled__}/openai/gpt-4o
-  provider_id: ${env.ENABLE_OPENAI:=__disabled__}
-  provider_model_id: openai/gpt-4o
-  model_type: llm
-- metadata: {}
-  model_id: ${env.ENABLE_OPENAI:=__disabled__}/openai/gpt-4o-mini
-  provider_id: ${env.ENABLE_OPENAI:=__disabled__}
-  provider_model_id: openai/gpt-4o-mini
-  model_type: llm
-- metadata: {}
-  model_id: ${env.ENABLE_OPENAI:=__disabled__}/openai/chatgpt-4o-latest
-  provider_id: ${env.ENABLE_OPENAI:=__disabled__}
-  provider_model_id: openai/chatgpt-4o-latest
-  model_type: llm
-- metadata: {}
   model_id: ${env.ENABLE_OPENAI:=__disabled__}/gpt-3.5-turbo-0125
   provider_id: ${env.ENABLE_OPENAI:=__disabled__}
   provider_model_id: gpt-3.5-turbo-0125
@@ -870,20 +855,6 @@ models:
   provider_id: ${env.ENABLE_OPENAI:=__disabled__}
   provider_model_id: o4-mini
   model_type: llm
-- metadata:
-    embedding_dimension: 1536
-    context_length: 8192
-  model_id: ${env.ENABLE_OPENAI:=__disabled__}/openai/text-embedding-3-small
-  provider_id: ${env.ENABLE_OPENAI:=__disabled__}
-  provider_model_id: openai/text-embedding-3-small
-  model_type: embedding
-- metadata:
-    embedding_dimension: 3072
-    context_length: 8192
-  model_id: ${env.ENABLE_OPENAI:=__disabled__}/openai/text-embedding-3-large
-  provider_id: ${env.ENABLE_OPENAI:=__disabled__}
-  provider_model_id: openai/text-embedding-3-large
-  model_type: embedding
 - metadata:
     embedding_dimension: 1536
     context_length: 8192


### PR DESCRIPTION
# What does this PR do?

openai/models.py has backward compat entries for litellm model names. the starter template includes these in the list of registered models. the inclusion results in duplicate model registrations.

the backward compat is no longer necessary.

## Test Plan

ci