### PR TITLE
test: upload logs for external provider tests

### DIFF
--- a/.github/workflows/test-external-provider-module.yml
+++ b/.github/workflows/test-external-provider-module.yml
@@ -13,7 +13,7 @@ on:
       - 'uv.lock'
       - 'pyproject.toml'
       - 'requirements.txt'
-      - '.github/workflows/test-external-providers-module.yml' # This workflow
+      - '.github/workflows/test-external-provider-module.yml' # This workflow
 
 jobs:
   test-external-providers-from-module:
@@ -52,6 +52,7 @@ jobs:
         if: ${{ matrix.image-type }} == 'venv'
         env:
           INFERENCE_MODEL: "llama3.2:3b-instruct-fp16"
+          LLAMA_STACK_LOG_FILE: "server.log"
         run: |
           # Use the virtual environment created by the build step (name comes from build config)
           source ramalama-stack-test/bin/activate
@@ -72,3 +73,12 @@ jobs:
           echo "Provider failed to load"
           cat server.log
           exit 1
+
+      - name: Upload all logs to artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: logs-${{ github.run_id }}-${{ github.run_attempt }}-external-provider-module-test
+          path: |
+            *.log
+          retention-days: 1

--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -52,6 +52,7 @@ jobs:
         if: ${{ matrix.image-type }} == 'venv'
         env:
           INFERENCE_MODEL: "meta-llama/Llama-3.2-3B-Instruct"
+          LLAMA_STACK_LOG_FILE: "server.log"
         run: |
           # Use the virtual environment created by the build step (name comes from build config)
           source ci-test/bin/activate
@@ -75,3 +76,12 @@ jobs:
       - name: Test external API
         run: |
           curl -sSf http://localhost:8321/v1/weather/locations
+
+      - name: Upload all logs to artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: logs-${{ github.run_id }}-${{ github.run_attempt }}-external-test
+          path: |
+            *.log
+          retention-days: 1


### PR DESCRIPTION
# What does this PR do?

currently the external provider tests don't upload log files as artifacts nor do they use LLAMA_STACK_LOG_FILE. align with the other integration tests

## Test Plan

logs should be present in the two tests on this PR
