### PR TITLE
fix: adjust provider type used in external provider test

### DIFF
--- a/.github/workflows/test-external-provider-module.yml
+++ b/.github/workflows/test-external-provider-module.yml
@@ -13,6 +13,7 @@ on:
       - 'uv.lock'
       - 'pyproject.toml'
       - 'requirements.txt'
+      - 'tests/external/*'
       - '.github/workflows/test-external-provider-module.yml' # This workflow
 
 jobs:

--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -13,6 +13,7 @@ on:
       - 'uv.lock'
       - 'pyproject.toml'
       - 'requirements.txt'
+      - 'tests/external/*'
       - '.github/workflows/test-external.yml' # This workflow
 
 jobs:

--- a/tests/external/build.yaml
+++ b/tests/external/build.yaml
@@ -3,8 +3,7 @@ distribution_spec:
   description: Custom distro for CI tests
   providers:
     weather:
-    - provider_id: kaze
-      provider_type: remote::kaze
+    - provider_type: remote::kaze
 image_type: venv
 image_name: ci-test
 external_providers_dir: ~/.llama/providers.d

--- a/tests/external/ramalama-stack/build.yaml
+++ b/tests/external/ramalama-stack/build.yaml
@@ -4,8 +4,7 @@ distribution_spec:
   container_image: null
   providers:
     inference:
-    - provider_id: ramalama
-      provider_type: remote::ramalama
+    - provider_type: remote::ramalama
       module: ramalama_stack==0.3.0a0
 image_type: venv
 image_name: ramalama-stack-test


### PR DESCRIPTION

# What does this PR do?

provider_id is no longer valid in a build.yaml, remove it in the external provider test


