### PR TITLE
fix: switch refresh to debug log

### DIFF
--- a/llama_stack/distribution/stack.py
+++ b/llama_stack/distribution/stack.py
@@ -358,7 +358,7 @@ async def shutdown_stack(impls: dict[Api, Any]):
 
 
 async def refresh_registry_once(impls: dict[Api, Any]):
-    logger.info("refreshing registry")
+    logger.debug("refreshing registry")
     routing_tables = [v for v in impls.values() if isinstance(v, CommonRoutingTableImpl)]
     for routing_table in routing_tables:
         await routing_table.refresh()


### PR DESCRIPTION
# What does this PR do?
the server logs have a persistent `core: refreshing registry` log that clogs up the output. Switch it to debug

this is what it looked like:

<img width="1126" height="1028" alt="Screenshot 2025-07-28 at 9 56 44 AM" src="https://github.com/user-attachments/assets/a1880fd3-7fc7-4a97-bfb8-89a62e4c5c19" />
