### PR TITLE
fix: use same image_name logic for build & run config

### DIFF
--- a/llama_stack/cli/stack/_build.py
+++ b/llama_stack/cli/stack/_build.py
@@ -279,7 +279,7 @@ def run_stack_build_command(args: argparse.Namespace) -> None:
         config = parse_and_maybe_upgrade_config(config_dict)
         if config.external_providers_dir and not config.external_providers_dir.exists():
             config.external_providers_dir.mkdir(exist_ok=True)
-        run_args = formulate_run_args(args.image_type, args.image_name)
+        run_args = formulate_run_args(args.image_type, image_name or config.image_name)
         run_args.extend([str(os.getenv("LLAMA_STACK_PORT", 8321)), "--config", str(run_config)])
         run_command(run_args)
 


### PR DESCRIPTION
# What does this PR do?

when --image-name is not provided the build script default to the image_name in the config, this makes sure the same is done for the run script

## Test Plan

llama stack build w/o --image-name
