### PR TITLE
chore(ci): disable post training tests

### DIFF
--- a/tests/integration/post_training/test_post_training.py
+++ b/tests/integration/post_training/test_post_training.py
@@ -22,6 +22,15 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(
 logger = logging.getLogger(__name__)
 
 
+skip_because_resource_intensive = pytest.mark.skip(
+    reason="""
+       Post training tests are extremely resource intensive. They download large models and partly as a result,
+       are very slow to run. We cannot run them on every single PR update. CI should be considered
+       a scarce resource and properly utilitized.
+    """
+)
+
+
 @pytest.fixture(autouse=True)
 def capture_output(capsys):
     """Fixture to capture and display output during test execution."""
@@ -57,6 +66,7 @@ class TestPostTraining:
         ],
     )
     @pytest.mark.timeout(360)  # 6 minutes timeout
+    @skip_because_resource_intensive
     def test_supervised_fine_tune(self, llama_stack_client, purpose, source):
         logger.info("Starting supervised fine-tuning test")
 


### PR DESCRIPTION
Post training tests need _much_ better thinking before we can re-enable them to be run on every single PR. Running periodically should be approached only when it is shown that the tests are reliable and as light-weight as can be; otherwise, it is just kicking the can down the road.
