### PR TITLE
fix: remove redundant code from unregister_dataset

### DIFF
--- a/llama_stack/distribution/routing_tables/datasets.py
+++ b/llama_stack/distribution/routing_tables/datasets.py
@@ -88,6 +88,4 @@ class DatasetsRoutingTable(CommonRoutingTableImpl, Datasets):
 
     async def unregister_dataset(self, dataset_id: str) -> None:
         dataset = await self.get_dataset(dataset_id)
-        if dataset is None:
-            raise DatasetNotFoundError(dataset_id)
         await self.unregister_object(dataset)


### PR DESCRIPTION
get_dataset() will raise an exception if a dataset won't be returned

client handling is redundant