### PR TITLE
fix(ci): more correct concurrency key for workflows

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,7 +33,19 @@ on:
         default: 'ollama'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ contains(github.event.pull_request.labels.*.name, 're-record-tests') && 'rerecord' || 'replay' }}
+  # This creates three concurrency groups:
+  #   ${{ github.workflow }}-${{ github.ref }}-rerecord (for valid triggers with re-record-tests label)
+  #   ${{ github.workflow }}-${{ github.ref }}-replay (for valid triggers without re-record-tests label)
+  #   ${{ github.workflow }}-${{ github.ref }}-no-run (for invalid triggers that will be skipped)
+  # The "no-run" group ensures that irrelevant label events don't interfere with the real workflows.
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}-${{
+    (github.event.action == 'opened' ||
+     github.event.action == 'synchronize' ||
+     (github.event.action == 'labeled' && contains(github.event.pull_request.labels.*.name, 're-record-tests'))) &&
+    (contains(github.event.pull_request.labels.*.name, 're-record-tests') && 'rerecord' || 'replay') ||
+    'no-run'
+    }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
See comment inline. We don't want a random label to pre-empt an existing workflow which had gone ahead.
