### PR TITLE
fix: remove redundant code from unregister_vector_db

### DIFF
--- a/llama_stack/core/routing_tables/vector_dbs.py
+++ b/llama_stack/core/routing_tables/vector_dbs.py
@@ -84,8 +84,6 @@ class VectorDBsRoutingTable(CommonRoutingTableImpl, VectorDBs):
 
     async def unregister_vector_db(self, vector_db_id: str) -> None:
         existing_vector_db = await self.get_vector_db(vector_db_id)
-        if existing_vector_db is None:
-            raise VectorStoreNotFoundError(vector_db_id)
         await self.unregister_object(existing_vector_db)
 
     async def openai_retrieve_vector_store(


### PR DESCRIPTION
get_vector_db() will raise an exception if a vector store won't be returned

client handling is redundant
