### PR TITLE
fix: integration tests not triggering on PR open

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -40,9 +40,9 @@ concurrency:
   # The "no-run" group ensures that irrelevant label events don't interfere with the real workflows.
   group: >-
     ${{ github.workflow }}-${{ github.ref }}-${{
-    (github.event.action == 'opened' || github.event.action == 'synchronize') && 'replay' ||
-    (github.event.action == 'labeled' && contains(github.event.pull_request.labels.*.name, 're-record-tests')) && 'rerecord' ||
-    'no-run'
+    ((github.event.action == 'opened' || github.event.action == 'synchronize') && 'replay') ||
+    ((github.event.action == 'labeled' && contains(github.event.pull_request.labels.*.name, 're-record-tests')) && 'rerecord' ||
+    'no-run')
     }}
   cancel-in-progress: true
 


### PR DESCRIPTION
# What does this PR do?

I realized that when a new PR is opened, the integration tests aren't triggering (or aren't always?) since the replay logic was introduced

amend the concurrency logic a bit to trigger  on opened PRs

