### PR TITLE
fix: Post Training Model change in Tests in order to make it less intensive

### DIFF
--- a/tests/integration/post_training/test_post_training.py
+++ b/tests/integration/post_training/test_post_training.py
@@ -110,7 +110,7 @@ class TestPostTraining:
         # train with HF trl SFTTrainer as the default
         _ = llama_stack_client.post_training.supervised_fine_tune(
             job_uuid=job_uuid,
-            model="HuggingFaceTB/SmolLM2-135M-Instruct",  # a smaller model that supports the current sft recipe
+            model="HuggingFaceTB/SmolLM2-135M-Instruct",  # smaller model that supports the current sft recipe
             algorithm_config=algorithm_config,
             training_config=training_config,
             hyperparam_search_config={},


### PR DESCRIPTION
# What does this PR do?

Changed from` ibm-granite/granite-3.3-2b-instruct` to` HuggingFaceTB/SmolLM2-135M-Instruct` so it as not resource intensive in CI

Idea came from - https://github.com/meta-llama/llama-stack/pull/2984#issuecomment-3140400830
