### PR TITLE
fix: sambanova inference provider

### DIFF
--- a/llama_stack/providers/remote/inference/sambanova/sambanova.py
+++ b/llama_stack/providers/remote/inference/sambanova/sambanova.py
@@ -29,9 +29,3 @@ class SambaNovaInferenceAdapter(LiteLLMOpenAIMixin):
             download_images=True,  # SambaNova requires base64 image encoding
             json_schema_strict=False,  # SambaNova doesn't support strict=True yet
         )
-
-    async def initialize(self):
-        await super().initialize()
-
-    async def shutdown(self):
-        await super().shutdown()

--- a/llama_stack/providers/remote/inference/sambanova/sambanova.py
+++ b/llama_stack/providers/remote/inference/sambanova/sambanova.py
@@ -38,6 +38,7 @@ class SambaNovaInferenceAdapter(LiteLLMOpenAIMixin):
             litellm_provider_name="sambanova",
             api_key_from_config=self.config.api_key.get_secret_value() if self.config.api_key else None,
             provider_data_api_key_field="sambanova_api_key",
+            openai_compat_api_base=self.config.url,
         )
 
     async def _get_params(self, request: ChatCompletionRequest) -> dict:
@@ -80,7 +81,7 @@ class SambaNovaInferenceAdapter(LiteLLMOpenAIMixin):
         return {
             "model": request.model,
             "api_key": self.get_api_key(),
-            "api_base": self.config.url,
+            "api_base": self.api_base,
             **input_dict,
             "stream": request.stream,
             **get_sampling_options(request.sampling_params),

--- a/llama_stack/providers/remote/inference/sambanova/sambanova.py
+++ b/llama_stack/providers/remote/inference/sambanova/sambanova.py
@@ -4,9 +4,6 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-import requests
-
-from llama_stack.apis.models import Model
 from llama_stack.log import get_logger
 from llama_stack.providers.utils.inference.litellm_openai_mixin import LiteLLMOpenAIMixin
 
@@ -32,22 +29,6 @@ class SambaNovaInferenceAdapter(LiteLLMOpenAIMixin):
             download_images=True,  # SambaNova requires base64 image encoding
             json_schema_strict=False,  # SambaNova doesn't support strict=True yet
         )
-
-    async def register_model(self, model: Model) -> Model:
-        model_id = self.get_provider_model_id(model.provider_resource_id)
-
-        list_models_url = self.config.url + "/models"
-        if len(self.environment_available_models) == 0:
-            try:
-                response = requests.get(list_models_url)
-                response.raise_for_status()
-            except requests.exceptions.RequestException as e:
-                raise RuntimeError(f"Request to {list_models_url} failed") from e
-            self.environment_available_models = [model.get("id") for model in response.json().get("data", {})]
-
-        if model_id.split("sambanova/")[-1] not in self.environment_available_models:
-            logger.warning(f"Model {model_id} not available in {list_models_url}")
-        return model
 
     async def initialize(self):
         await super().initialize()

--- a/llama_stack/providers/remote/inference/sambanova/sambanova.py
+++ b/llama_stack/providers/remote/inference/sambanova/sambanova.py
@@ -4,13 +4,10 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from llama_stack.log import get_logger
 from llama_stack.providers.utils.inference.litellm_openai_mixin import LiteLLMOpenAIMixin
 
 from .config import SambaNovaImplConfig
 from .models import MODEL_ENTRIES
-
-logger = get_logger(name=__name__, category="inference")
 
 
 class SambaNovaInferenceAdapter(LiteLLMOpenAIMixin):

--- a/llama_stack/providers/remote/inference/sambanova/sambanova.py
+++ b/llama_stack/providers/remote/inference/sambanova/sambanova.py
@@ -40,18 +40,6 @@ class SambaNovaInferenceAdapter(LiteLLMOpenAIMixin):
             provider_data_api_key_field="sambanova_api_key",
         )
 
-    def _get_api_key(self) -> str:
-        config_api_key = self.config.api_key if self.config.api_key else None
-        if config_api_key:
-            return config_api_key.get_secret_value()
-        else:
-            provider_data = self.get_request_provider_data()
-            if provider_data is None or not provider_data.sambanova_api_key:
-                raise ValueError(
-                    'Pass Sambanova API Key in the header X-LlamaStack-Provider-Data as { "sambanova_api_key": <your api key> }'
-                )
-            return provider_data.sambanova_api_key
-
     async def _get_params(self, request: ChatCompletionRequest) -> dict:
         input_dict = {}
 
@@ -94,7 +82,7 @@ class SambaNovaInferenceAdapter(LiteLLMOpenAIMixin):
         if provider_data and getattr(provider_data, key_field, None):
             api_key = getattr(provider_data, key_field)
         else:
-            api_key = self._get_api_key()
+            api_key = self.get_api_key()
 
         return {
             "model": request.model,

--- a/llama_stack/providers/remote/inference/sambanova/sambanova.py
+++ b/llama_stack/providers/remote/inference/sambanova/sambanova.py
@@ -77,16 +77,9 @@ class SambaNovaInferenceAdapter(LiteLLMOpenAIMixin):
                     else request.tool_config.tool_choice
                 )
 
-        provider_data = self.get_request_provider_data()
-        key_field = self.provider_data_api_key_field
-        if provider_data and getattr(provider_data, key_field, None):
-            api_key = getattr(provider_data, key_field)
-        else:
-            api_key = self.get_api_key()
-
         return {
             "model": request.model,
-            "api_key": api_key,
+            "api_key": self.get_api_key(),
             "api_base": self.config.url,
             **input_dict,
             "stream": request.stream,

--- a/llama_stack/providers/remote/inference/sambanova/sambanova.py
+++ b/llama_stack/providers/remote/inference/sambanova/sambanova.py
@@ -14,8 +14,6 @@ logger = get_logger(name=__name__, category="inference")
 
 
 class SambaNovaInferenceAdapter(LiteLLMOpenAIMixin):
-    _config: SambaNovaImplConfig
-
     def __init__(self, config: SambaNovaImplConfig):
         self.config = config
         self.environment_available_models = []

--- a/llama_stack/providers/utils/inference/openai_compat.py
+++ b/llama_stack/providers/utils/inference/openai_compat.py
@@ -564,6 +564,7 @@ class UnparseableToolCall(BaseModel):
 
 async def convert_message_to_openai_dict_new(
     message: Message | dict,
+    download_images: bool = False,
 ) -> OpenAIChatCompletionMessage:
     """
     Convert a Message to an OpenAI API-compatible dictionary.
@@ -607,7 +608,9 @@ async def convert_message_to_openai_dict_new(
             elif isinstance(content_, ImageContentItem):
                 return OpenAIChatCompletionContentPartImageParam(
                     type="image_url",
-                    image_url=OpenAIImageURL(url=await convert_image_content_to_url(content_)),
+                    image_url=OpenAIImageURL(
+                        url=await convert_image_content_to_url(content_, download=download_images)
+                    ),
                 )
             elif isinstance(content_, list):
                 return [await impl(item) for item in content_]


### PR DESCRIPTION
# What does this PR do?

closes #2995 

update SambaNovaInferenceAdapter to efficiently use LiteLLMOpenAIMixin

## Test Plan

```
$ uv run pytest -s -v tests/integration/inference --stack-config inference=sambanova --text-model sambanova/Meta-Llama-3.1-8B-Instruct
...
======================== 10 passed, 84 skipped, 3 xfailed, 51 warnings in 8.14s ========================
```

