### PR TITLE
feat: switch to async completion in LiteLLM OpenAI mixin

### DIFF
--- a/llama_stack/providers/utils/inference/litellm_openai_mixin.py
+++ b/llama_stack/providers/utils/inference/litellm_openai_mixin.py
@@ -158,9 +158,8 @@ class LiteLLMOpenAIMixin(
         params["model"] = self.get_litellm_model_name(params["model"])
 
         logger.debug(f"params to litellm (openai compat): {params}")
-        # unfortunately, we need to use synchronous litellm.completion here because litellm
-        # caches various httpx.client objects in a non-eventloop aware manner
-        response = litellm.completion(**params)
+        # see https://docs.litellm.ai/docs/completion/stream#async-completion
+        response = await litellm.acompletion(**params)
         if stream:
             return self._stream_chat_completion(response)
         else:
@@ -170,7 +169,7 @@ class LiteLLMOpenAIMixin(
         self, response: litellm.ModelResponse
     ) -> AsyncIterator[ChatCompletionResponseStreamChunk]:
         async def _stream_generator():
-            for chunk in response:
+            async for chunk in response:
                 yield chunk
 
         async for chunk in convert_openai_chat_completion_stream(

--- a/tests/integration/test_cases/inference/chat_completion.json
+++ b/tests/integration/test_cases/inference/chat_completion.json
@@ -78,7 +78,7 @@
         },
         {
           "role": "user",
-          "content": "What's the weather like in San Francisco?"
+          "content": "What's the weather like in San Francisco, CA?"
         }
       ],
       "tools": [


### PR DESCRIPTION
# What does this PR do?
Improves async compatibility in the inference provider

- Replace synchronous litellm.completion() with async litellm.acompletion()
- Update comment to reference official LiteLLM async completion docs

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->
# This should fix: 
https://github.com/meta-llama/llama-stack/blob/218c89fff11a5e81b38d3c10ea2ed7d0c164f2ea/llama_stack/providers/utils/inference/litellm_openai_mixin.py#L155-L157

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->
```
uv run --group unit pytest tests/integration/inference/ --stack-config="inference=gemini" --text-model="gemini/gemini/gemini-2.0-flash" -v
==================================================================================================================== test session starts =====================================================================================================================
platform linux -- Python 3.12.9, pytest-8.4.1, pluggy-1.6.0 -- /home/eran/go/src/github/eranco74/llama-stack/.venv/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.12.9', 'Platform': 'Linux-6.12.9-200.fc41.x86_64-x86_64-with-glibc2.40', 'Packages': {'pytest': '8.4.1', 'pluggy': '1.6.0'}, 'Plugins': {'html': '4.1.1', 'nbval': '0.11.0', 'json-report': '1.5.0', 'timeout': '2.4.0', 'metadata': '3.1.1', 'socket': '0.7.0', 'asyncio': '1.1.0', 'cov': '6.2.1', 'anyio': '4.9.0'}, 'JAVA_HOME': '/usr/lib/jvm/jre-17-openjdk-17.0.8.0.7-1.fc37.x86_64/'}
rootdir: /home/eran/go/src/github/eranco74/llama-stack
configfile: pyproject.toml
plugins: html-4.1.1, nbval-0.11.0, json-report-1.5.0, timeout-2.4.0, metadata-3.1.1, socket-0.7.0, asyncio-1.1.0, cov-6.2.1, anyio-4.9.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 97 items                                                                                                                                                                                                                                           

tests/integration/inference/test_batch_inference.py::test_batch_completion_non_streaming[txt=gemini/gemini/gemini-2.0-flash-inference:completion:batch_completion] SKIPPED (Model gemini/gemini/gemini-2.0-flash hosted by remote::gemini doesn't ...) [  1%]
tests/integration/inference/test_batch_inference.py::test_batch_chat_completion_non_streaming[txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:batch_completion] SKIPPED (Model gemini/gemini/gemini-2.0-flash hosted by remote::gemin...) [  2%]
tests/integration/inference/test_openai_completion.py::test_openai_completion_non_streaming[txt=gemini/gemini/gemini-2.0-flash-inference:completion:sanity] PASSED                                                                                     [  3%]
tests/integration/inference/test_openai_completion.py::test_openai_completion_non_streaming_suffix[txt=gemini/gemini/gemini-2.0-flash-inference:completion:suffix] SKIPPED (Suffix is not supported for the model: gemini/gemini/gemini-2.0-flash.)    [  4%]
tests/integration/inference/test_openai_completion.py::test_openai_completion_streaming[txt=gemini/gemini/gemini-2.0-flash-inference:completion:sanity] PASSED                                                                                         [  5%]
tests/integration/inference/test_openai_completion.py::test_openai_completion_prompt_logprobs[txt=gemini/gemini/gemini-2.0-flash-1] SKIPPED (Model gemini/gemini/gemini-2.0-flash hosted by remote::gemini doesn't support vllm extra_body paramet...) [  6%]
tests/integration/inference/test_openai_completion.py::test_openai_completion_guided_choice[txt=gemini/gemini/gemini-2.0-flash] SKIPPED (Model gemini/gemini/gemini-2.0-flash hosted by remote::gemini doesn't support vllm extra_body parameters.)    [  7%]
tests/integration/inference/test_openai_completion.py::test_openai_chat_completion_non_streaming[openai_client-txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:non_streaming_01] SKIPPED (OpenAI chat completions are not supported w...) [  8%]
tests/integration/inference/test_openai_completion.py::test_openai_chat_completion_streaming[openai_client-txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:streaming_01] SKIPPED (OpenAI chat completions are not supported when test...) [  9%]
tests/integration/inference/test_openai_completion.py::test_openai_chat_completion_streaming_with_n[openai_client-txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:streaming_01] SKIPPED (OpenAI chat completions are not supported wh...) [ 10%]
tests/integration/inference/test_openai_completion.py::test_inference_store[openai_client-txt=gemini/gemini/gemini-2.0-flash-True] SKIPPED (OpenAI chat completions are not supported when testing with library client yet.)                           [ 11%]
tests/integration/inference/test_openai_completion.py::test_inference_store_tool_calls[openai_client-txt=gemini/gemini/gemini-2.0-flash-True] SKIPPED (OpenAI chat completions are not supported when testing with library client yet.)                [ 12%]
tests/integration/inference/test_openai_completion.py::test_openai_chat_completion_non_streaming_with_file[txt=gemini/gemini/gemini-2.0-flash] SKIPPED (Model gemini/gemini/gemini-2.0-flash hosted by remote::gemini doesn't support chat complet...) [ 13%]
tests/integration/inference/test_openai_embeddings.py::test_openai_embeddings_single_string[openai_client-gemini/gemini/gemini-2.0-flash-None-None-None-384] SKIPPED (embedding_model_id empty - skipping test)                                        [ 14%]
tests/integration/inference/test_openai_embeddings.py::test_openai_embeddings_multiple_strings[openai_client-gemini/gemini/gemini-2.0-flash-None-None-None-384] SKIPPED (embedding_model_id empty - skipping test)                                     [ 15%]
tests/integration/inference/test_openai_embeddings.py::test_openai_embeddings_with_encoding_format_float[openai_client-gemini/gemini/gemini-2.0-flash-None-None-None-384] SKIPPED (embedding_model_id empty - skipping test)                           [ 16%]
tests/integration/inference/test_openai_embeddings.py::test_openai_embeddings_with_dimensions[openai_client-gemini/gemini/gemini-2.0-flash-None-None-None-384] SKIPPED (embedding_model_id empty - skipping test)                                      [ 17%]
tests/integration/inference/test_openai_embeddings.py::test_openai_embeddings_with_user_parameter[openai_client-gemini/gemini/gemini-2.0-flash-None-None-None-384] SKIPPED (embedding_model_id empty - skipping test)                                  [ 18%]
tests/integration/inference/test_openai_embeddings.py::test_openai_embeddings_empty_list_error[openai_client-gemini/gemini/gemini-2.0-flash-None-None-None-384] SKIPPED (embedding_model_id empty - skipping test)                                     [ 19%]
tests/integration/inference/test_openai_embeddings.py::test_openai_embeddings_invalid_model_error[openai_client-gemini/gemini/gemini-2.0-flash-None-None-None-384] SKIPPED (embedding_model_id empty - skipping test)                                  [ 20%]
tests/integration/inference/test_openai_embeddings.py::test_openai_embeddings_different_inputs_different_outputs[openai_client-gemini/gemini/gemini-2.0-flash-None-None-None-384] SKIPPED (embedding_model_id empty - skipping test)                   [ 21%]
tests/integration/inference/test_openai_embeddings.py::test_openai_embeddings_with_encoding_format_base64[openai_client-gemini/gemini/gemini-2.0-flash-None-None-None-384] SKIPPED (embedding_model_id empty - skipping test)                          [ 22%]
tests/integration/inference/test_openai_embeddings.py::test_openai_embeddings_base64_batch_processing[openai_client-gemini/gemini/gemini-2.0-flash-None-None-None-384] SKIPPED (embedding_model_id empty - skipping test)                              [ 23%]
tests/integration/inference/test_text_inference.py::test_text_completion_non_streaming[txt=gemini/gemini/gemini-2.0-flash-inference:completion:sanity] SKIPPED (Model gemini/gemini/gemini-2.0-flash hosted by remote::gemini doesn't support comp...) [ 24%]
tests/integration/inference/test_text_inference.py::test_text_completion_streaming[txt=gemini/gemini/gemini-2.0-flash-inference:completion:sanity] SKIPPED (Model gemini/gemini/gemini-2.0-flash hosted by remote::gemini doesn't support completion)  [ 25%]
tests/integration/inference/test_text_inference.py::test_text_completion_stop_sequence[txt=gemini/gemini/gemini-2.0-flash-inference:completion:stop_sequence] SKIPPED (Model gemini/gemini/gemini-2.0-flash hosted by remote::gemini doesn't suppo...) [ 26%]
tests/integration/inference/test_text_inference.py::test_text_completion_log_probs_non_streaming[txt=gemini/gemini/gemini-2.0-flash-inference:completion:log_probs] SKIPPED (Model gemini/gemini/gemini-2.0-flash hosted by remote::gemini doesn't...) [ 27%]
tests/integration/inference/test_text_inference.py::test_text_completion_log_probs_streaming[txt=gemini/gemini/gemini-2.0-flash-inference:completion:log_probs] SKIPPED (Model gemini/gemini/gemini-2.0-flash hosted by remote::gemini doesn't sup...) [ 28%]
tests/integration/inference/test_text_inference.py::test_text_completion_structured_output[txt=gemini/gemini/gemini-2.0-flash-inference:completion:structured_output] SKIPPED (Model gemini/gemini/gemini-2.0-flash hosted by remote::gemini doesn...) [ 29%]
tests/integration/inference/test_text_inference.py::test_text_chat_completion_non_streaming[txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:non_streaming_01] PASSED                                                                      [ 30%]
tests/integration/inference/test_text_inference.py::test_text_chat_completion_streaming[txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:streaming_01] PASSED                                                                              [ 31%]
tests/integration/inference/test_text_inference.py::test_text_chat_completion_with_tool_calling_and_non_streaming[txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:tool_calling] PASSED                                                    [ 32%]
tests/integration/inference/test_text_inference.py::test_text_chat_completion_with_tool_calling_and_streaming[txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:tool_calling] PASSED                                                        [ 34%]
tests/integration/inference/test_text_inference.py::test_text_chat_completion_with_tool_choice_required[txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:tool_calling] PASSED                                                              [ 35%]
tests/integration/inference/test_text_inference.py::test_text_chat_completion_with_tool_choice_none[txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:tool_calling] PASSED                                                                  [ 36%]
tests/integration/inference/test_text_inference.py::test_text_chat_completion_structured_output[txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:structured_output] PASSED                                                                 [ 37%]
tests/integration/inference/test_text_inference.py::test_text_chat_completion_tool_calling_tools_not_in_request[txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:tool_calling_tools_absent-True] PASSED                                    [ 38%]
tests/integration/inference/test_text_inference.py::test_text_chat_completion_with_multi_turn_tool_calling[txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:text_then_tool] XFAIL (Not tested for non-llama4 models yet)                   [ 39%]
tests/integration/inference/test_vision_inference.py::test_image_chat_completion_non_streaming[gemini/gemini/gemini-2.0-flash-None-None-None-384] SKIPPED (vision_model_id empty - skipping test)                                                      [ 40%]
tests/integration/inference/test_vision_inference.py::test_image_chat_completion_multiple_images[gemini/gemini/gemini-2.0-flash-None-None-None-384-True] SKIPPED (vision_model_id empty - skipping test)                                               [ 41%]
tests/integration/inference/test_vision_inference.py::test_image_chat_completion_streaming[gemini/gemini/gemini-2.0-flash-None-None-None-384] SKIPPED (vision_model_id empty - skipping test)                                                          [ 42%]
tests/integration/inference/test_vision_inference.py::test_image_chat_completion_base64[gemini/gemini/gemini-2.0-flash-None-None-None-384] SKIPPED (vision_model_id empty - skipping test)                                                             [ 43%]
tests/integration/inference/test_embedding.py::test_embedding_text[None-list[string]] SKIPPED (embedding_model_id empty - skipping test)                                                                                                               [ 44%]
tests/integration/inference/test_embedding.py::test_embedding_image[None-list[url,base64]] SKIPPED (embedding_model_id empty - skipping test)                                                                                                          [ 45%]
tests/integration/inference/test_embedding.py::test_embedding_truncation[None-long-end] SKIPPED (embedding_model_id empty - skipping test)                                                                                                             [ 46%]
tests/integration/inference/test_embedding.py::test_embedding_truncation_error[None-long-text-None] SKIPPED (embedding_model_id empty - skipping test)                                                                                                 [ 47%]
tests/integration/inference/test_embedding.py::test_embedding_output_dimension[None] SKIPPED (embedding_model_id empty - skipping test)                                                                                                                [ 48%]
tests/integration/inference/test_embedding.py::test_embedding_task_type[None] SKIPPED (embedding_model_id empty - skipping test)                                                                                                                       [ 49%]
tests/integration/inference/test_embedding.py::test_embedding_text_truncation[None-None] SKIPPED (embedding_model_id empty - skipping test)                                                                                                            [ 50%]
tests/integration/inference/test_embedding.py::test_embedding_text_truncation_error[None-NONE] SKIPPED (embedding_model_id empty - skipping test)                                                                                                      [ 51%]
tests/integration/inference/test_embedding.py::test_embedding_text[None-list[text]] SKIPPED (embedding_model_id empty - skipping test)                                                                                                                 [ 52%]
tests/integration/inference/test_embedding.py::test_embedding_image[None-list[url,string,base64,text]] SKIPPED (embedding_model_id empty - skipping test)                                                                                              [ 53%]
tests/integration/inference/test_embedding.py::test_embedding_truncation[None-long-start] SKIPPED (embedding_model_id empty - skipping test)                                                                                                           [ 54%]
tests/integration/inference/test_embedding.py::test_embedding_truncation_error[None-long-text-none] SKIPPED (embedding_model_id empty - skipping test)                                                                                                 [ 55%]
tests/integration/inference/test_embedding.py::test_embedding_text_truncation[None-none] SKIPPED (embedding_model_id empty - skipping test)                                                                                                            [ 56%]
tests/integration/inference/test_embedding.py::test_embedding_text_truncation_error[None-END] SKIPPED (embedding_model_id empty - skipping test)                                                                                                       [ 57%]
tests/integration/inference/test_openai_completion.py::test_openai_completion_prompt_logprobs[txt=gemini/gemini/gemini-2.0-flash-0] SKIPPED (Model gemini/gemini/gemini-2.0-flash hosted by remote::gemini doesn't support vllm extra_body paramet...) [ 58%]
tests/integration/inference/test_openai_completion.py::test_openai_chat_completion_non_streaming[openai_client-txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:non_streaming_02] SKIPPED (OpenAI chat completions are not supported w...) [ 59%]
tests/integration/inference/test_openai_completion.py::test_openai_chat_completion_streaming[openai_client-txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:streaming_02] SKIPPED (OpenAI chat completions are not supported when test...) [ 60%]
tests/integration/inference/test_openai_completion.py::test_openai_chat_completion_streaming_with_n[openai_client-txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:streaming_02] SKIPPED (OpenAI chat completions are not supported wh...) [ 61%]
tests/integration/inference/test_openai_completion.py::test_inference_store[openai_client-txt=gemini/gemini/gemini-2.0-flash-False] SKIPPED (OpenAI chat completions are not supported when testing with library client yet.)                          [ 62%]
tests/integration/inference/test_openai_completion.py::test_inference_store_tool_calls[openai_client-txt=gemini/gemini/gemini-2.0-flash-False] SKIPPED (OpenAI chat completions are not supported when testing with library client yet.)               [ 63%]
tests/integration/inference/test_openai_embeddings.py::test_openai_embeddings_single_string[llama_stack_client-gemini/gemini/gemini-2.0-flash-None-None-None-384] SKIPPED (embedding_model_id empty - skipping test)                                   [ 64%]
tests/integration/inference/test_openai_embeddings.py::test_openai_embeddings_multiple_strings[llama_stack_client-gemini/gemini/gemini-2.0-flash-None-None-None-384] SKIPPED (embedding_model_id empty - skipping test)                                [ 65%]
tests/integration/inference/test_openai_embeddings.py::test_openai_embeddings_with_encoding_format_float[llama_stack_client-gemini/gemini/gemini-2.0-flash-None-None-None-384] SKIPPED (embedding_model_id empty - skipping test)                      [ 67%]
tests/integration/inference/test_openai_embeddings.py::test_openai_embeddings_with_dimensions[llama_stack_client-gemini/gemini/gemini-2.0-flash-None-None-None-384] SKIPPED (embedding_model_id empty - skipping test)                                 [ 68%]
tests/integration/inference/test_openai_embeddings.py::test_openai_embeddings_with_user_parameter[llama_stack_client-gemini/gemini/gemini-2.0-flash-None-None-None-384] SKIPPED (embedding_model_id empty - skipping test)                             [ 69%]
tests/integration/inference/test_openai_embeddings.py::test_openai_embeddings_empty_list_error[llama_stack_client-gemini/gemini/gemini-2.0-flash-None-None-None-384] SKIPPED (embedding_model_id empty - skipping test)                                [ 70%]
tests/integration/inference/test_openai_embeddings.py::test_openai_embeddings_invalid_model_error[llama_stack_client-gemini/gemini/gemini-2.0-flash-None-None-None-384] SKIPPED (embedding_model_id empty - skipping test)                             [ 71%]
tests/integration/inference/test_openai_embeddings.py::test_openai_embeddings_different_inputs_different_outputs[llama_stack_client-gemini/gemini/gemini-2.0-flash-None-None-None-384] SKIPPED (embedding_model_id empty - skipping test)              [ 72%]
tests/integration/inference/test_openai_embeddings.py::test_openai_embeddings_with_encoding_format_base64[llama_stack_client-gemini/gemini/gemini-2.0-flash-None-None-None-384] SKIPPED (embedding_model_id empty - skipping test)                     [ 73%]
tests/integration/inference/test_openai_embeddings.py::test_openai_embeddings_base64_batch_processing[llama_stack_client-gemini/gemini/gemini-2.0-flash-None-None-None-384] SKIPPED (embedding_model_id empty - skipping test)                         [ 74%]
tests/integration/inference/test_text_inference.py::test_text_chat_completion_non_streaming[txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:non_streaming_02] PASSED                                                                      [ 75%]
tests/integration/inference/test_text_inference.py::test_text_chat_completion_streaming[txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:streaming_02] PASSED                                                                              [ 76%]
tests/integration/inference/test_text_inference.py::test_text_chat_completion_tool_calling_tools_not_in_request[txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:tool_calling_tools_absent-False] PASSED                                   [ 77%]
tests/integration/inference/test_text_inference.py::test_text_chat_completion_with_multi_turn_tool_calling[txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:tool_then_answer] XFAIL (Not tested for non-llama4 models yet)                 [ 78%]
tests/integration/inference/test_vision_inference.py::test_image_chat_completion_multiple_images[gemini/gemini/gemini-2.0-flash-None-None-None-384-False] SKIPPED (vision_model_id empty - skipping test)                                              [ 79%]
tests/integration/inference/test_embedding.py::test_embedding_truncation[None-short-end] SKIPPED (embedding_model_id empty - skipping test)                                                                                                            [ 80%]
tests/integration/inference/test_embedding.py::test_embedding_truncation_error[None-long-str-None] SKIPPED (embedding_model_id empty - skipping test)                                                                                                  [ 81%]
tests/integration/inference/test_embedding.py::test_embedding_text_truncation[None-end] SKIPPED (embedding_model_id empty - skipping test)                                                                                                             [ 82%]
tests/integration/inference/test_embedding.py::test_embedding_text_truncation_error[None-START] SKIPPED (embedding_model_id empty - skipping test)                                                                                                     [ 83%]
tests/integration/inference/test_openai_completion.py::test_openai_chat_completion_non_streaming[llama_stack_client-txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:non_streaming_01] SKIPPED (OpenAI chat completions are not suppor...) [ 84%]
tests/integration/inference/test_openai_completion.py::test_openai_chat_completion_streaming[llama_stack_client-txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:streaming_01] SKIPPED (OpenAI chat completions are not supported when...) [ 85%]
tests/integration/inference/test_openai_completion.py::test_openai_chat_completion_streaming_with_n[llama_stack_client-txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:streaming_01] SKIPPED (OpenAI chat completions are not support...) [ 86%]
tests/integration/inference/test_openai_completion.py::test_inference_store[llama_stack_client-txt=gemini/gemini/gemini-2.0-flash-True] SKIPPED (OpenAI chat completions are not supported when testing with library client yet.)                      [ 87%]
tests/integration/inference/test_openai_completion.py::test_inference_store_tool_calls[llama_stack_client-txt=gemini/gemini/gemini-2.0-flash-True] SKIPPED (OpenAI chat completions are not supported when testing with library client yet.)           [ 88%]
tests/integration/inference/test_text_inference.py::test_text_chat_completion_with_multi_turn_tool_calling[txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:array_parameter] XFAIL (Not tested for non-llama4 models yet)                  [ 89%]
tests/integration/inference/test_embedding.py::test_embedding_truncation[None-short-start] SKIPPED (embedding_model_id empty - skipping test)                                                                                                          [ 90%]
tests/integration/inference/test_embedding.py::test_embedding_truncation_error[None-long-str-none] SKIPPED (embedding_model_id empty - skipping test)                                                                                                  [ 91%]
tests/integration/inference/test_embedding.py::test_embedding_text_truncation[None-start] SKIPPED (embedding_model_id empty - skipping test)                                                                                                           [ 92%]
tests/integration/inference/test_embedding.py::test_embedding_text_truncation_error[None-left] SKIPPED (embedding_model_id empty - skipping test)                                                                                                      [ 93%]
tests/integration/inference/test_openai_completion.py::test_openai_chat_completion_non_streaming[llama_stack_client-txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:non_streaming_02] SKIPPED (OpenAI chat completions are not suppor...) [ 94%]
tests/integration/inference/test_openai_completion.py::test_openai_chat_completion_streaming[llama_stack_client-txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:streaming_02] SKIPPED (OpenAI chat completions are not supported when...) [ 95%]
tests/integration/inference/test_openai_completion.py::test_openai_chat_completion_streaming_with_n[llama_stack_client-txt=gemini/gemini/gemini-2.0-flash-inference:chat_completion:streaming_02] SKIPPED (OpenAI chat completions are not support...) [ 96%]
tests/integration/inference/test_openai_completion.py::test_inference_store[llama_stack_client-txt=gemini/gemini/gemini-2.0-flash-False] SKIPPED (OpenAI chat completions are not supported when testing with library client yet.)                     [ 97%]
tests/integration/inference/test_openai_completion.py::test_inference_store_tool_calls[llama_stack_client-txt=gemini/gemini/gemini-2.0-flash-False] SKIPPED (OpenAI chat completions are not supported when testing with library client yet.)          [ 98%]
tests/integration/inference/test_embedding.py::test_embedding_text_truncation_error[None-right] SKIPPED (embedding_model_id empty - skipping test)                                                                                                     [100%]

================================================================================================== 13 passed, 81 skipped, 3 xfailed, 66 warnings in 11.30s ===================================================================================================
```
