### PR TITLE
feat: Implement keyword search in FAISS

### DIFF
--- a/tests/integration/vector_io/test_openai_vector_stores.py
+++ b/tests/integration/vector_io/test_openai_vector_stores.py
@@ -52,6 +52,7 @@ def skip_if_provider_doesnt_support_openai_vector_stores_search(client_with_mode
         ],
         "keyword": [
             "inline::sqlite-vec",
+            "inline::faiss",
         ],
         "hybrid": [
             "inline::sqlite-vec",


### PR DESCRIPTION
# What does this PR do?
This PR implements basic keyword search in FAISS

Closes: #https://github.com/meta-llama/llama-stack/issues/3012

## Test Plan
```
pytest tests/unit/providers/vector_io/test_faiss.py -v -s --tb=long --disable-warnings --asyncio-mode=auto
========================================================= test session starts ==========================================================
platform darwin -- Python 3.12.11, pytest-7.4.4, pluggy-1.5.0 -- /Users/vnarsing/miniconda3/envs/stack-client/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.12.11', 'Platform': 'macOS-14.7.6-arm64-arm-64bit', 'Packages': {'pytest': '7.4.4', 'pluggy': '1.5.0'}, 'Plugins': {'asyncio': '0.23.8', 'cov': '6.0.0', 'timeout': '2.2.0', 'socket': '0.7.0', 'html': '3.1.1', 'langsmith': '0.3.39', 'anyio': '4.8.0', 'metadata': '3.0.0'}}
rootdir: /Users/vnarsing/go/src/github/meta-llama/llama-stack
configfile: pyproject.toml
plugins: asyncio-0.23.8, cov-6.0.0, timeout-2.2.0, socket-0.7.0, html-3.1.1, langsmith-0.3.39, anyio-4.8.0, metadata-3.0.0
asyncio: mode=Mode.AUTO
collected 9 items                                                                                                                      

tests/unit/providers/vector_io/test_faiss.py::test_faiss_query_vector_returns_infinity_when_query_and_embedding_are_identical PASSED
tests/unit/providers/vector_io/test_faiss.py::test_health_success PASSED
tests/unit/providers/vector_io/test_faiss.py::test_health_failure PASSED
tests/unit/providers/vector_io/test_faiss.py::test_faiss_keyword_search_basic PASSED
tests/unit/providers/vector_io/test_faiss.py::test_faiss_keyword_search_no_matches PASSED
tests/unit/providers/vector_io/test_faiss.py::test_faiss_keyword_search_score_threshold PASSED
tests/unit/providers/vector_io/test_faiss.py::test_faiss_keyword_search_empty_index PASSED
tests/unit/providers/vector_io/test_faiss.py::test_faiss_keyword_search_empty_query PASSED
tests/unit/providers/vector_io/test_faiss.py::test_faiss_keyword_search_case_insensitive PASSED
```