### PR TITLE
feat: get Session missing fields from session info

### DIFF
--- a/llama_stack/providers/inline/agents/meta_reference/persistence.py
+++ b/llama_stack/providers/inline/agents/meta_reference/persistence.py
@@ -196,8 +196,8 @@ class AgentPersistence:
                     session_info = await self.get_session_info(session_data["session_id"])
                     session_data["session_name"] = session_info.session_name
                     session_data["turns"] = [t.dict() for t in session_info.turns]
-                session_info = Session(**session_data)
-                sessions.append(session_info)
+                session = Session(**session_data)
+                sessions.append(session)
             except Exception as e:
                 log.error(f"Error parsing session info: {e}")
                 continue


### PR DESCRIPTION
# What does this PR do?
get session info when listing sessions to add session name and turns to the session data, before creating a Session object.

<!-- If resolving an issue, uncomment and update the line below -->
Closes #3048

## Test Plan
ran the code locally and saw the errors described in the issue are no longer appearing.
