### PR TITLE
chore(logging)!: use comma as a delimiter

### DIFF
--- a/llama_stack/log.py
+++ b/llama_stack/log.py
@@ -99,7 +99,8 @@ def parse_environment_config(env_config: str) -> dict[str, int]:
         Dict[str, int]: A dictionary mapping categories to their log levels.
     """
     category_levels = {}
-    for pair in env_config.split(";"):
+    delimiter = ","
+    for pair in env_config.split(delimiter):
         if not pair.strip():
             continue
 


### PR DESCRIPTION
Using commas is much more shell-friendly. A semi-colon is a statement delimiter and must be escaped.

This change is backwards incompatible but I imagine not many people are using this. I could be wrong. Looking for feedback.
