### PR TITLE
fix(api): make sure vector store file content is not returned as a type

### DIFF
--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -14849,27 +14849,6 @@
                 "type": "object",
                 "title": "Response"
             },
-            "VectorStoreContent": {
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "const": "text",
-                        "description": "Content type, currently only \"text\" is supported"
-                    },
-                    "text": {
-                        "type": "string",
-                        "description": "The actual text content"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "type",
-                    "text"
-                ],
-                "title": "VectorStoreContent",
-                "description": "Content item from a vector store file or search result."
-            },
             "VectorStoreFileContentsResponse": {
                 "type": "object",
                 "properties": {
@@ -14910,7 +14889,25 @@
                     "content": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/VectorStoreContent"
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "const": "text",
+                                    "description": "Content type, currently only \"text\" is supported"
+                                },
+                                "text": {
+                                    "type": "string",
+                                    "description": "The actual text content"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "type",
+                                "text"
+                            ],
+                            "title": "VectorStoreContent",
+                            "description": "Content item from a vector store file or search result."
                         },
                         "description": "List of content items from the file"
                     }
@@ -15038,7 +15035,25 @@
                     "content": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/VectorStoreContent"
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "const": "text",
+                                    "description": "Content type, currently only \"text\" is supported"
+                                },
+                                "text": {
+                                    "type": "string",
+                                    "description": "The actual text content"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "type",
+                                "text"
+                            ],
+                            "title": "VectorStoreContent",
+                            "description": "Content item from a vector store file or search result."
                         },
                         "description": "List of content items matching the search query"
                     }

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -11021,24 +11021,6 @@ components:
     Response:
       type: object
       title: Response
-    VectorStoreContent:
-      type: object
-      properties:
-        type:
-          type: string
-          const: text
-          description: >-
-            Content type, currently only "text" is supported
-        text:
-          type: string
-          description: The actual text content
-      additionalProperties: false
-      required:
-        - type
-        - text
-      title: VectorStoreContent
-      description: >-
-        Content item from a vector store file or search result.
     VectorStoreFileContentsResponse:
       type: object
       properties:
@@ -11063,7 +11045,23 @@ components:
         content:
           type: array
           items:
-            $ref: '#/components/schemas/VectorStoreContent'
+            type: object
+            properties:
+              type:
+                type: string
+                const: text
+                description: >-
+                  Content type, currently only "text" is supported
+              text:
+                type: string
+                description: The actual text content
+            additionalProperties: false
+            required:
+              - type
+              - text
+            title: VectorStoreContent
+            description: >-
+              Content item from a vector store file or search result.
           description: List of content items from the file
       additionalProperties: false
       required:
@@ -11154,7 +11152,23 @@ components:
         content:
           type: array
           items:
-            $ref: '#/components/schemas/VectorStoreContent'
+            type: object
+            properties:
+              type:
+                type: string
+                const: text
+                description: >-
+                  Content type, currently only "text" is supported
+              text:
+                type: string
+                description: The actual text content
+            additionalProperties: false
+            required:
+              - type
+              - text
+            title: VectorStoreContent
+            description: >-
+              Content item from a vector store file or search result.
           description: >-
             List of content items matching the search query
       additionalProperties: false

--- a/llama_stack/apis/vector_io/vector_io.py
+++ b/llama_stack/apis/vector_io/vector_io.py
@@ -220,7 +220,6 @@ class VectorStoreSearchRequest(BaseModel):
     rewrite_query: bool = False
 
 
-@json_schema_type
 class VectorStoreContent(BaseModel):
     """Content item from a vector store file or search result.
 


### PR DESCRIPTION
`openai-python` seems to not return it as a typed object but a loosely typed dict. That is: you are supposed to access sub-fields as `contents["type"]` not `content.type`.

## Test Plan

Will regenerate client and test with `test_openai_vector_stores.py`
