### PR TITLE
feat(cli): make venv the default image type

### DIFF
--- a/llama_stack/cli/stack/_build.py
+++ b/llama_stack/cli/stack/_build.py
@@ -92,15 +92,7 @@ def run_stack_build_command(args: argparse.Namespace) -> None:
             )
             sys.exit(1)
         build_config = available_distros[distro_name]
-        if args.image_type:
-            build_config.image_type = args.image_type
-        else:
-            cprint(
-                f"Please specify a image-type ({' | '.join(e.value for e in ImageType)}) for {distro_name}",
-                color="red",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+        build_config.image_type = args.image_type
     elif args.providers:
         provider_list: dict[str, list[BuildProvider]] = dict()
         for api_provider in args.providers.split(","):
@@ -137,13 +129,6 @@ def run_stack_build_command(args: argparse.Namespace) -> None:
             providers=provider_list,
             description=",".join(args.providers),
         )
-        if not args.image_type:
-            cprint(
-                f"Please specify a image-type (container | venv) for {args.template}",
-                color="red",
-                file=sys.stderr,
-            )
-            sys.exit(1)
 
         build_config = BuildConfig(image_type=args.image_type, distribution_spec=distribution_spec)
     elif not args.config and not distro_name:
@@ -217,8 +202,7 @@ def run_stack_build_command(args: argparse.Namespace) -> None:
                 contents = yaml.safe_load(f)
                 contents = replace_env_vars(contents)
                 build_config = BuildConfig(**contents)
-                if args.image_type:
-                    build_config.image_type = args.image_type
+                build_config.image_type = args.image_type
             except Exception as e:
                 cprint(
                     f"Could not parse config file {args.config}: {e}",

--- a/llama_stack/cli/stack/build.py
+++ b/llama_stack/cli/stack/build.py
@@ -59,7 +59,7 @@ class StackBuild(Subcommand):
             type=str,
             help="Image Type to use for the build. If not specified, will use the image type from the template config.",
             choices=[e.value for e in ImageType],
-            default=None,  # no default so we can detect if a user specified --image-type and override image_type in the config
+            default=ImageType.VENV.value,
         )
 
         self.parser.add_argument(


### PR DESCRIPTION
We have removed conda now so we can make `venv` the default. Just doing `llama stack build --distro starter` is now enough for the most part.
