### PR TITLE
chore(ci): dont run llama stack server always

### DIFF
--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -133,6 +133,10 @@ else
     EXTRA_PARAMS=""
 fi
 
+THIS_DIR=$(dirname "$0")
+ROOT_DIR="$THIS_DIR/.."
+cd $ROOT_DIR
+
 # Set recording directory
 if [[ "$RUN_VISION_TESTS" == "true" ]]; then
     export LLAMA_STACK_TEST_RECORDING_DIR="tests/integration/recordings/vision"


### PR DESCRIPTION
Sometimes the server has already been started (e.g., via docker). Just a convenience here so we can reuse this script more.
