### PR TITLE
feat: group deps by provider

### DIFF
--- a/llama_stack/cli/stack/_build.py
+++ b/llama_stack/cli/stack/_build.py
@@ -230,12 +230,31 @@ def run_stack_build_command(args: argparse.Namespace) -> None:
     if args.print_deps_only:
         print(f"# Dependencies for {distro_name or args.config or image_name}")
         normal_deps, special_deps, external_provider_dependencies = get_provider_dependencies(build_config)
-        normal_deps += SERVER_DEPENDENCIES
-        print(f"uv pip install {' '.join(normal_deps)}")
-        for special_dep in special_deps:
-            print(f"uv pip install {special_dep}")
-        for external_dep in external_provider_dependencies:
-            print(f"uv pip install {external_dep}")
+        normal_deps["default"] += SERVER_DEPENDENCIES
+        cprint(
+            "Please install needed dependencies using the following commands:",
+            color="yellow",
+            file=sys.stderr,
+        )
+
+        for prov, deps in normal_deps.items():
+            if len(deps) == 0:
+                continue
+            cprint(f"# Normal Dependencies for {prov}", color="yellow")
+            cprint(f"uv pip install {' '.join(deps)}", file=sys.stderr)
+
+        for prov, deps in special_deps.items():
+            if len(deps) == 0:
+                continue
+            cprint(f"# Special Dependencies for {prov}", color="yellow")
+            cprint(f"uv pip install {' '.join(deps)}", file=sys.stderr)
+
+        for prov, deps in external_provider_dependencies.items():
+            if len(deps) == 0:
+                continue
+            cprint(f"# External Provider Dependencies for {prov}", color="yellow")
+            cprint(f"uv pip install {' '.join(deps)}", file=sys.stderr)
+        print()
         return
 
     try:


### PR DESCRIPTION
# What does this PR do?

dependencies are currently installed and listed in an unassociated way with the provider they come from.

From a user POV, associating deps with the specific provider introducing them is crucial in order to eliminate unwanted dependences if using a larger distro like starter.

For example, If I am using starter on a daily basis but then go `llama stack build --distro starter...` and get 15 NEW dependencies, there is currently NO way for me to tell which provider introduced them.

This work fixes the output of the build process and `--print-deps-only`

## Test Plan

`llama stack build --distro starter --image-type venv`

```
Installing normal dependencies for provider 'remote::fireworks'
Using Python 3.12.11 environment at: venv
Resolved 97 packages in 10ms
Uninstalled 3 packages in 48ms
Installed 3 packages in 7ms
 - openai==1.99.9
 + openai==1.78.1
 - protobuf==6.32.0
 + protobuf==5.29.3
 - rich==13.5.3
 + rich==14.1.0
 ...
 ```

`llama stack build --distro starter --print-deps-only --image type venv`

```
Please install needed dependencies using the following commands:
# Normal Dependencies for remote::cerebras
uv pip install cerebras_cloud_sdk
# Normal Dependencies for remote::ollama
uv pip install ollama aiohttp h11>=0.16.0
# Normal Dependencies for remote::vllm
uv pip install openai
# Normal Dependencies for remote::tgi
uv pip install huggingface_hub aiohttp
# Normal Dependencies for remote::fireworks
uv pip install fireworks-ai
# Normal Dependencies for remote::together
uv pip install together
# Normal Dependencies for remote::bedrock
uv pip install boto3
# Normal Dependencies for remote::nvidia
uv pip install openai
# Normal Dependencies for remote::openai
uv pip install litellm
# Normal Dependencies for remote::anthropic
uv pip install litellm
# Normal Dependencies for remote::gemini
uv pip install litellm
# Normal Dependencies for remote::vertexai
```
