### PR TITLE
chore: indicate to mypy that InferenceProvider.rerank is concrete

### DIFF
--- a/llama_stack/apis/inference/inference.py
+++ b/llama_stack/apis/inference/inference.py
@@ -1170,6 +1170,7 @@ class InferenceProvider(Protocol):
         :returns: RerankResponse with indices sorted by relevance score (descending).
         """
         raise NotImplementedError("Reranking is not implemented")
+        return  # this is so mypy's safe-super rule will consider the method concrete
 
     @webmethod(route="/openai/v1/completions", method="POST")
     async def openai_completion(

--- a/llama_stack/providers/inline/inference/meta_reference/inference.py
+++ b/llama_stack/providers/inline/inference/meta_reference/inference.py
@@ -33,9 +33,6 @@ from llama_stack.apis.inference import (
     InterleavedContent,
     LogProbConfig,
     Message,
-    OpenAIChatCompletionContentPartImageParam,
-    OpenAIChatCompletionContentPartTextParam,
-    RerankResponse,
     ResponseFormat,
     SamplingParams,
     StopReason,
@@ -444,15 +441,6 @@ class MetaReferenceInferenceImpl(
 
         results = await self._nonstream_chat_completion(request_batch)
         return BatchChatCompletionResponse(batch=results)
-
-    async def rerank(
-        self,
-        model: str,
-        query: str | OpenAIChatCompletionContentPartTextParam | OpenAIChatCompletionContentPartImageParam,
-        items: list[str | OpenAIChatCompletionContentPartTextParam | OpenAIChatCompletionContentPartImageParam],
-        max_num_results: int | None = None,
-    ) -> RerankResponse:
-        raise NotImplementedError("Reranking is not supported for Meta Reference")
 
     async def _nonstream_chat_completion(
         self, request_batch: list[ChatCompletionRequest]

--- a/llama_stack/providers/inline/inference/sentence_transformers/sentence_transformers.py
+++ b/llama_stack/providers/inline/inference/sentence_transformers/sentence_transformers.py
@@ -12,9 +12,6 @@ from llama_stack.apis.inference import (
     InterleavedContent,
     LogProbConfig,
     Message,
-    OpenAIChatCompletionContentPartImageParam,
-    OpenAIChatCompletionContentPartTextParam,
-    RerankResponse,
     ResponseFormat,
     SamplingParams,
     ToolChoice,
@@ -125,12 +122,3 @@ class SentenceTransformersInferenceImpl(
         logprobs: LogProbConfig | None = None,
     ):
         raise NotImplementedError("Batch chat completion is not supported for Sentence Transformers")
-
-    async def rerank(
-        self,
-        model: str,
-        query: str | OpenAIChatCompletionContentPartTextParam | OpenAIChatCompletionContentPartImageParam,
-        items: list[str | OpenAIChatCompletionContentPartTextParam | OpenAIChatCompletionContentPartImageParam],
-        max_num_results: int | None = None,
-    ) -> RerankResponse:
-        raise NotImplementedError("Reranking is not supported for Sentence Transformers")

--- a/llama_stack/providers/remote/inference/llama_openai_compat/llama.py
+++ b/llama_stack/providers/remote/inference/llama_openai_compat/llama.py
@@ -3,11 +3,6 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
-from llama_stack.apis.inference import (
-    OpenAIChatCompletionContentPartImageParam,
-    OpenAIChatCompletionContentPartTextParam,
-    RerankResponse,
-)
 from llama_stack.log import get_logger
 from llama_stack.providers.remote.inference.llama_openai_compat.config import LlamaCompatConfig
 from llama_stack.providers.utils.inference.litellm_openai_mixin import LiteLLMOpenAIMixin
@@ -59,12 +54,3 @@ class LlamaCompatInferenceAdapter(OpenAIMixin, LiteLLMOpenAIMixin):
 
     async def shutdown(self):
         await super().shutdown()
-
-    async def rerank(
-        self,
-        model: str,
-        query: str | OpenAIChatCompletionContentPartTextParam | OpenAIChatCompletionContentPartImageParam,
-        items: list[str | OpenAIChatCompletionContentPartTextParam | OpenAIChatCompletionContentPartImageParam],
-        max_num_results: int | None = None,
-    ) -> RerankResponse:
-        raise NotImplementedError("Reranking is not supported for Llama OpenAI Compat")

--- a/llama_stack/providers/remote/inference/ollama/ollama.py
+++ b/llama_stack/providers/remote/inference/ollama/ollama.py
@@ -37,14 +37,11 @@ from llama_stack.apis.inference import (
     Message,
     OpenAIChatCompletion,
     OpenAIChatCompletionChunk,
-    OpenAIChatCompletionContentPartImageParam,
-    OpenAIChatCompletionContentPartTextParam,
     OpenAICompletion,
     OpenAIEmbeddingsResponse,
     OpenAIEmbeddingUsage,
     OpenAIMessageParam,
     OpenAIResponseFormatParam,
-    RerankResponse,
     ResponseFormat,
     SamplingParams,
     TextTruncation,
@@ -643,15 +640,6 @@ class OllamaInferenceAdapter(
         logprobs: LogProbConfig | None = None,
     ):
         raise NotImplementedError("Batch chat completion is not supported for Ollama")
-
-    async def rerank(
-        self,
-        model: str,
-        query: str | OpenAIChatCompletionContentPartTextParam | OpenAIChatCompletionContentPartImageParam,
-        items: list[str | OpenAIChatCompletionContentPartTextParam | OpenAIChatCompletionContentPartImageParam],
-        max_num_results: int | None = None,
-    ) -> RerankResponse:
-        raise NotImplementedError("Reranking is not supported for Ollama")
 
 
 async def convert_message_to_openai_dict_for_ollama(message: Message) -> list[dict]:

--- a/llama_stack/providers/remote/inference/vllm/vllm.py
+++ b/llama_stack/providers/remote/inference/vllm/vllm.py
@@ -39,15 +39,12 @@ from llama_stack.apis.inference import (
     Message,
     ModelStore,
     OpenAIChatCompletion,
-    OpenAIChatCompletionContentPartImageParam,
-    OpenAIChatCompletionContentPartTextParam,
     OpenAICompletion,
     OpenAIEmbeddingData,
     OpenAIEmbeddingsResponse,
     OpenAIEmbeddingUsage,
     OpenAIMessageParam,
     OpenAIResponseFormatParam,
-    RerankResponse,
     ResponseFormat,
     SamplingParams,
     TextTruncation,
@@ -736,12 +733,3 @@ class VLLMInferenceAdapter(Inference, ModelsProtocolPrivate):
         logprobs: LogProbConfig | None = None,
     ):
         raise NotImplementedError("Batch chat completion is not supported for vLLM")
-
-    async def rerank(
-        self,
-        model: str,
-        query: str | OpenAIChatCompletionContentPartTextParam | OpenAIChatCompletionContentPartImageParam,
-        items: list[str | OpenAIChatCompletionContentPartTextParam | OpenAIChatCompletionContentPartImageParam],
-        max_num_results: int | None = None,
-    ) -> RerankResponse:
-        raise NotImplementedError("Reranking is not supported for vLLM")


### PR DESCRIPTION
# What does this PR do?

related to https://github.com/llamastack/llama-stack/issues/3236

immediate fix for `pre-commit run mypy -a` errors present on main

```
mypy.........................................................................Failed
- hook id: mypy
- exit code: 1

llama_stack/providers/remote/inference/vertexai/__init__.py:13: error: Cannot instantiate abstract class "VertexAIInferenceAdapter" with abstract attribute "rerank"  [abstract]
Found 1 error in 1 file (checked 426 source files)
```