### PR TITLE
feat: Add vector_db_id to chunk metadata

### DIFF
--- a/llama_stack/providers/inline/tool_runtime/rag/memory.py
+++ b/llama_stack/providers/inline/tool_runtime/rag/memory.py
@@ -202,6 +202,7 @@ class MemoryToolRuntimeImpl(ToolGroupsProtocolPrivate, ToolRuntime, RAGToolRunti
                 "document_ids": [c.metadata["document_id"] for c in chunks[: len(picked)]],
                 "chunks": [c.content for c in chunks[: len(picked)]],
                 "scores": scores[: len(picked)],
+                "vector_db_ids": [c.metadata["vector_db_id"] for c in chunks[: len(picked)]],
             },
         )
 

--- a/tests/unit/rag/test_rag_query.py
+++ b/tests/unit/rag/test_rag_query.py
@@ -54,7 +54,9 @@ class TestRagQuery:
         result = await rag_tool.query(content=content, vector_db_ids=vector_db_ids)
 
         assert result is not None
-        expected_metadata_string = "Metadata: {'chunk_id': 'chunk1', 'document_id': 'doc1', 'source': 'test_source', 'key1': 'value1', 'vector_db_id': 'db1'}"
+        expected_metadata_string = (
+            "Metadata: {'chunk_id': 'chunk1', 'document_id': 'doc1', 'source': 'test_source', 'key1': 'value1'}"
+        )
         assert expected_metadata_string in result.content[1].text
         assert result.content is not None
 
@@ -124,22 +126,9 @@ class TestRagQuery:
         returned_chunks = result.metadata["chunks"]
         returned_scores = result.metadata["scores"]
         returned_doc_ids = result.metadata["document_ids"]
+        returned_vector_db_ids = result.metadata["vector_db_ids"]
 
         assert returned_chunks == ["chunk from db1", "chunk from db2"]
         assert returned_scores == (0.9, 0.8)
         assert returned_doc_ids == ["doc1", "doc2"]
-
-        # Parse metadata from query result
-        def parse_metadata(s):
-            import ast
-            import re
-
-            match = re.search(r"Metadata:\s*(\{.*\})", s)
-            if not match:
-                raise ValueError(f"No metadata found in string: {s}")
-            return ast.literal_eval(match.group(1))
-
-        returned_metadata = [
-            parse_metadata(item.text)["vector_db_id"] for item in result.content if "Metadata:" in item.text
-        ]
-        assert returned_metadata == ["db1", "db2"]
+        assert returned_vector_db_ids == ["db1", "db2"]


### PR DESCRIPTION
# What does this PR do?

When running RAG in a multi vector DB setting, it can be difficult to trace where retrieved chunks originate from. This PR adds the `vector_db_id` into each chunk’s metadata, making it easier to understand which database a given chunk came from. This is helpful for debugging and for analyzing retrieval behavior of multiple DBs.

Relevant code:

```python
for vector_db_id, result in zip(vector_db_ids, results):
    for chunk, score in zip(result.chunks, result.scores):
        if not hasattr(chunk, "metadata") or chunk.metadata is None:
            chunk.metadata = {}
        chunk.metadata["vector_db_id"] = vector_db_id

        chunks.append(chunk)
        scores.append(score)
```

## Test Plan

* Ran Llama Stack in debug mode.
* Verified that `vector_db_id` was added to each chunk’s metadata.
* Confirmed that the metadata was printed in the console when using the RAG tool.