### PR TITLE
fix/model-type

### DIFF
--- a/llama_stack/providers/utils/inference/model_registry.py
+++ b/llama_stack/providers/utils/inference/model_registry.py
@@ -35,6 +35,11 @@ class ProviderModelEntry(BaseModel):
     llama_model: str | None = None
     model_type: ModelType = ModelType.llm
     metadata: dict[str, Any] = Field(default_factory=dict)
+    
+    def __init__(self, **data):
+        super().__init__(**data)
+        if self.model_type == ModelType.embedding and "embedding_dimension" not in self.metadata:
+            raise ValueError("Embedding models must specify 'embedding_dimension' in metadata")
 
 
 def get_huggingface_repo(model_descriptor: str) -> str | None:

--- a/tests/unit/providers/inference/test_model_registry.py
+++ b/tests/unit/providers/inference/test_model_registry.py
@@ -15,9 +15,9 @@ class TestProviderDataValidator(BaseModel):
     test_api_key: str | None = Field(default=None)
 
 MODEL_ENTRIES_WITHOUT_ALIASES = [
-        ProviderModelEntry(model_type=ModelType.llm, provider_model_id="test-llm-model", aliases=[]),
-        ProviderModelEntry(model_type=ModelType.embedding, provider_model_id="test-text-embedding-model", aliases=[], metadata={"embedding_dimension": 1536, "context_length": 8192}),
-    ]
+    ProviderModelEntry(model_type=ModelType.llm, provider_model_id="test-llm-model", aliases=[]),
+    ProviderModelEntry(model_type=ModelType.embedding, provider_model_id="test-text-embedding-model", aliases=[], metadata={"embedding_dimension": 1536, "context_length": 8192}),
+]
 
 class TestLiteLLMAdapterWithModelEntries(LiteLLMOpenAIMixin):
     def __init__(self, config: TestConfig):
@@ -38,7 +38,6 @@ def adapter_with_model_entries():
 
     return adapter
 
-
 async def test_model_types_are_correct(adapter_with_model_entries):
     """Test that model types are correct"""
     model_entries = adapter_with_model_entries.model_entries
@@ -54,4 +53,20 @@ async def test_model_types_are_correct(adapter_with_model_entries):
 
     embedding_models = [m for m in models if m.model_type == ModelType.embedding]
     assert len(embedding_models) == len(embedding_model_entries)
+
+def test_embedding_metadata_is_required():
+    with pytest.raises(ValueError):
+        entry1 = ProviderModelEntry(
+            model_type=ModelType.embedding,
+            provider_model_id="test-text-embedding-model",
+            aliases=[],
+            metadata={}
+        )
     
+    entry2 = ProviderModelEntry(
+        model_type=ModelType.embedding,
+        provider_model_id="test-text-embedding-model",
+        aliases=[],
+        metadata={"embedding_dimension": 1536}
+    )
+    assert entry2.metadata["embedding_dimension"] == 1536


### PR DESCRIPTION
# What does this PR do?
I noticed that the ModelRegistryHelper.list_models has hardcoded model type 

<!-- If resolving an issue, uncomment and update the line below -->
Closes #[3330]

## Test Plan
Create a test file to verify its expected behaviour
