### PR TITLE
fix: distro-codegen pre-commit hook file pattern

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,7 +86,7 @@ repos:
         language: python
         pass_filenames: false
         require_serial: true
-        files: ^llama_stack/templates/.*$|^llama_stack/providers/.*/inference/.*/models\.py$
+        files: ^llama_stack/distributions/.*$|^llama_stack/providers/.*/inference/.*/models\.py$
       - id: provider-codegen
         name: Provider Codegen
         additional_dependencies:


### PR DESCRIPTION
Update the file pattern from 'llama_stack/templates' to 'llama_stack/distributions' to properly trigger the Distribution Template Codegen hook when distribution files change.
