### PR TITLE
feat: make distance_metric configurable in vector stores

### DIFF
--- a/llama_stack/apis/vector_stores/vector_stores.py
+++ b/llama_stack/apis/vector_stores/vector_stores.py
@@ -18,6 +18,7 @@ class VectorStore(Resource):
     :param type: Type of resource, always 'vector_store' for vector stores
     :param embedding_model: Name of the embedding model to use for vector generation
     :param embedding_dimension: Dimension of the embedding vectors
+    :param distance_metric: Distance metric for vector similarity calculations (e.g., 'COSINE', 'L2', 'INNER_PRODUCT')
     """
 
     type: Literal[ResourceType.vector_store] = ResourceType.vector_store
@@ -25,6 +26,7 @@ class VectorStore(Resource):
     embedding_model: str
     embedding_dimension: int
     vector_store_name: str | None = None
+    distance_metric: str | None = None
 
     @property
     def vector_store_id(self) -> str:
@@ -42,6 +44,7 @@ class VectorStoreInput(BaseModel):
     :param embedding_model: Name of the embedding model to use for vector generation
     :param embedding_dimension: Dimension of the embedding vectors
     :param provider_vector_store_id: (Optional) Provider-specific identifier for the vector store
+    :param distance_metric: (Optional) Distance metric for vector similarity calculations
     """
 
     vector_store_id: str
@@ -49,3 +52,4 @@ class VectorStoreInput(BaseModel):
     embedding_dimension: int
     provider_id: str | None = None
     provider_vector_store_id: str | None = None
+    distance_metric: str | None = None

--- a/llama_stack/core/routers/vector_io.py
+++ b/llama_stack/core/routers/vector_io.py
@@ -105,6 +105,7 @@ class VectorIORouter(VectorIO):
         embedding_model = extra.get("embedding_model")
         embedding_dimension = extra.get("embedding_dimension")
         provider_id = extra.get("provider_id")
+        distance_metric = extra.get("distance_metric")
 
         # Use default embedding model if not specified
         if (
@@ -154,6 +155,7 @@ class VectorIORouter(VectorIO):
             provider_id=provider_id,
             provider_vector_store_id=vector_store_id,
             vector_store_name=params.name,
+            distance_metric=distance_metric,
         )
         provider = await self.routing_table.get_provider_impl(registered_vector_store.identifier)
 
@@ -162,6 +164,8 @@ class VectorIORouter(VectorIO):
             params.model_extra = {}
         params.model_extra["provider_vector_store_id"] = registered_vector_store.provider_resource_id
         params.model_extra["provider_id"] = registered_vector_store.provider_id
+        if distance_metric is not None:
+            params.model_extra["distance_metric"] = distance_metric
         if embedding_model is not None:
             params.model_extra["embedding_model"] = embedding_model
         if embedding_dimension is not None:

--- a/llama_stack/core/routing_tables/vector_stores.py
+++ b/llama_stack/core/routing_tables/vector_stores.py
@@ -49,6 +49,7 @@ class VectorStoresRoutingTable(CommonRoutingTableImpl):
         provider_id: str | None = None,
         provider_vector_store_id: str | None = None,
         vector_store_name: str | None = None,
+        distance_metric: str | None = None,
     ) -> Any:
         if provider_id is None:
             if len(self.impls_by_provider_id) > 0:
@@ -73,6 +74,7 @@ class VectorStoresRoutingTable(CommonRoutingTableImpl):
             embedding_model=embedding_model,
             embedding_dimension=embedding_dimension,
             vector_store_name=vector_store_name,
+            distance_metric=distance_metric,
         )
         await self.register_object(vector_store)
         return vector_store

--- a/llama_stack/providers/utils/memory/openai_vector_store_mixin.py
+++ b/llama_stack/providers/utils/memory/openai_vector_store_mixin.py
@@ -392,6 +392,9 @@ class OpenAIVectorStoreMixin(ABC):
         if provider_id is None:
             raise ValueError("Provider ID is required but was not provided")
 
+        # Extract distance_metric from extra_body if provided
+        distance_metric = extra_body.get("distance_metric")
+
         # call to the provider to create any index, etc.
         vector_store = VectorStore(
             identifier=vector_store_id,
@@ -400,6 +403,7 @@ class OpenAIVectorStoreMixin(ABC):
             provider_id=provider_id,
             provider_resource_id=vector_store_id,
             vector_store_name=params.name,
+            distance_metric=distance_metric,
         )
         await self.register_vector_store(vector_store)
 


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
Make `distance_metric` configurable in vector stores:
- Configurable distance_metric enabled for PGVector.
- Added plumbing to support configuring more distance metrics for each vector provider.

We should create GitHub issues for each provider.

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->
Closes #3213 

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->

- Added test cases: 
  - TBC
