### PR TITLE
fix: use dataset version 4.0.0 or above

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ test = [
     "psycopg2-binary>=2.9.0",
     "pypdf",
     "mcp",
-    "datasets",
+    "datasets>=4.0.0",
     "autoevals",
     "transformers",
     "sqlalchemy",


### PR DESCRIPTION
# What does this PR do?
This PR is trying to fix the failures in testing with dataset<>pyarrow incompatibility https://github.com/llamastack/llama-stack-ops/actions/runs/17558098764/job/49867351745 throwing error like `E   AttributeError: module 'pyarrow' has no attribute 'PyExtensionType'. Did you mean: 'ExtensionType'?` when older dataset packages is used



## Test Plan
CI
