### PR TITLE
fix: unbound variable PR_HEAD_REPO

### DIFF
--- a/scripts/github/schedule-record-workflow.sh
+++ b/scripts/github/schedule-record-workflow.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 
 # Default values
 BRANCH=""
+PR_HEAD_REPO=""
 TEST_SUBDIRS=""
 TEST_SETUP="ollama"
 TEST_SUITE="base"


### PR DESCRIPTION
Add default value for PR_HEAD_REPO to prevent 'unbound variable' error when no PR exists for a branch.
