### PR TITLE
fix: Set provider_id in NVIDIA notebook when registering dataset

### DIFF
--- a/docs/notebooks/nvidia/tool_calling/2_finetuning_and_inference.ipynb
+++ b/docs/notebooks/nvidia/tool_calling/2_finetuning_and_inference.ipynb
@@ -373,7 +373,7 @@
     "    metadata={\n",
     "        \"format\": \"json\",\n",
     "        \"description\": \"Tool calling xLAM dataset in OpenAI ChatCompletions format\",\n",
-    "        \"provider\": \"nvidia\"\n",
+    "        \"provider_id\": \"nvidia\"\n",
     "    }\n",
     ")\n",
     "print(response)"


### PR DESCRIPTION
# What does this PR do?
When registering a dataset for NVIDIA, the DatasetsRoutingTable expects `nvidia` to be passed via the `provider_id` [here](https://github.com/llamastack/llama-stack/blob/main/llama_stack/core/routing_tables/datasets.py#L61).

This PR fixes a notebook to correctly use `provider_id`.

<!-- If resolving an issue, uncomment and update the line below -->
Closes #3308

## Test Plan
Manually execute the notebook steps to verify the dataset is registered.