### PR TITLE
fix: mcp tool with array type should include items

### DIFF
--- a/tests/unit/providers/inline/__init__.py
+++ b/tests/unit/providers/inline/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.

--- a/tests/unit/providers/inline/agents/__init__.py
+++ b/tests/unit/providers/inline/agents/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.

--- a/tests/unit/providers/inline/agents/meta_reference/__init__.py
+++ b/tests/unit/providers/inline/agents/meta_reference/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.

--- a/tests/unit/providers/inline/agents/meta_reference/responses/__init__.py
+++ b/tests/unit/providers/inline/agents/meta_reference/responses/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.

--- a/tests/unit/providers/inline/agents/meta_reference/responses/test_streaming.py
+++ b/tests/unit/providers/inline/agents/meta_reference/responses/test_streaming.py
@@ -1,0 +1,42 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from llama_stack.apis.tools import ToolDef, ToolParameter
+from llama_stack.providers.inline.agents.meta_reference.responses.streaming import (
+    convert_tooldef_to_chat_tool,
+)
+
+
+def test_convert_tooldef_to_chat_tool_preserves_items_field():
+    """Test that array parameters preserve the items field during conversion.
+
+    This test ensures that when converting ToolDef with array-type parameters
+    to OpenAI ChatCompletionToolParam format, the 'items' field is preserved.
+    Without this fix, array parameters would be missing schema information about their items.
+    """
+    tool_def = ToolDef(
+        name="test_tool",
+        description="A test tool with array parameter",
+        parameters=[
+            ToolParameter(
+                name="tags",
+                parameter_type="array",
+                description="List of tags",
+                required=True,
+                items={"type": "string"},
+            )
+        ],
+    )
+
+    result = convert_tooldef_to_chat_tool(tool_def)
+
+    assert result["type"] == "function"
+    assert result["function"]["name"] == "test_tool"
+
+    tags_param = result["function"]["parameters"]["properties"]["tags"]
+    assert tags_param["type"] == "array"
+    assert "items" in tags_param, "items field should be preserved for array parameters"
+    assert tags_param["items"] == {"type": "string"}


### PR DESCRIPTION

# What does this PR do?
Fixes error:
```
[ERROR] Error executing endpoint route='/v1/openai/v1/responses'  
         method='post': Error code: 400 - {'error': {'message': "Invalid schema for function 'pods_exec': In context=('properties', 'command'), array 
         schema missing items.", 'type': 'invalid_request_error', 'param': 'tools[7].function.parameters', 'code': 'invalid_function_parameters'}} 
```

From script:
```
#!/usr/bin/env python3
"""
Script to test Responses API with kubernetes-mcp-server.

This script:
1. Connects to the llama stack server
2. Uses the Responses API with MCP tools
3. Asks for the list of Kubernetes namespaces using the kubernetes-mcp-server
"""

import json

from openai import OpenAI

# Connect to the llama stack server
base_url = "http://localhost:8321/v1/openai/v1"
client = OpenAI(base_url=base_url, api_key="fake")

# Define the MCP tool pointing to the kubernetes-mcp-server
# The kubernetes-mcp-server is running on port 3000 with SSE endpoint at /sse
mcp_server_url = "http://localhost:3000/sse"

tools = [
    {
        "type": "mcp",
        "server_label": "k8s",
        "server_url": mcp_server_url,
    }
]

# Create a response request asking for k8s namespaces
print("Sending request to list Kubernetes namespaces...")
print(f"Using MCP server at: {mcp_server_url}")
print("Available tools will be listed automatically by the MCP server.")
print()

response = client.responses.create(
    # model="meta-llama/Llama-3.2-3B-Instruct",  # Using the vllm model
    model="openai/gpt-4o",
    input="what are all the Kubernetes namespaces? Use tool call to `namespaces_list`. make sure to adhere to the tool calling format.",
    tools=tools,
    stream=False,
)

print("\n" + "=" * 80)
print("RESPONSE OUTPUT:")
print("=" * 80)

# Print the output
for i, output in enumerate(response.output):
    print(f"\n[Output {i + 1}] Type: {output.type}")
    if output.type == "mcp_list_tools":
        print(f"  Server: {output.server_label}")
        print(f"  Tools available: {[t.name for t in output.tools]}")
    elif output.type == "mcp_call":
        print(f"  Tool called: {output.name}")
        print(f"  Arguments: {output.arguments}")
        print(f"  Result: {output.output}")
        if output.error:
            print(f"  Error: {output.error}")
    elif output.type == "message":
        print(f"  Role: {output.role}")
        print(f"  Content: {output.content}")

print("\n" + "=" * 80)
print("FINAL RESPONSE TEXT:")
print("=" * 80)
print(response.output_text)
```


## Test Plan
new unit tests
script now runs successfully
