### PR TITLE
chore: remove together inference adapter's custom check_model_availability

### DIFF
--- a/llama_stack/providers/remote/inference/together/together.py
+++ b/llama_stack/providers/remote/inference/together/together.py
@@ -66,9 +66,6 @@ class TogetherInferenceAdapter(OpenAIMixin, NeedsRequestProviderData):
     async def should_refresh_models(self) -> bool:
         return True
 
-    async def check_model_availability(self, model):
-        return model in self._model_cache
-
     async def openai_embeddings(
         self,
         model: str,


### PR DESCRIPTION
# What does this PR do?

remove Together inference adapter's check_model_availability impl, rely on standard impl instead


## Test Plan

ci