### PR TITLE
chore: fix closing error

### DIFF
--- a/llama_stack/providers/utils/inference/openai_mixin.py
+++ b/llama_stack/providers/utils/inference/openai_mixin.py
@@ -132,7 +132,10 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
 
         :return: An iterable of model IDs or None if not implemented
         """
-        return [m.id async for m in self.client.models.list()]
+        client = self.client
+        async with client:
+            model_ids = [m.id async for m in client.models.list()]
+        return model_ids
 
     async def initialize(self) -> None:
         """


### PR DESCRIPTION

# What does this PR do?
Gets rid of this error message below (disclaimer: not sure why, but it does).

ERROR    2025-10-06 12:04:22,837 asyncio:118 uncategorized: Task exception was never retrieved
         future: <Task finished name='Task-36' coro=<AsyncClient.aclose() done, defined at
         /Users/erichuang/projects/llama-stack-git2/.venv/lib/python3.12/site-packages/httpx/_client.py:1978> exception=RuntimeError('unable to perform operation on <TCPTransport
         closed=True reading=False 0x122dc7ad0>; the handler is closed')>
         ╭─────────────────────────────────────────────────────────────────── Traceback (most recent call last) ───────────────────────────────────────────────────────────────────╮
         │ /Users/erichuang/projects/llama-stack-git2/.venv/lib/python3.12/site-packages/httpx/_client.py:1985 in aclose                                                           │
         │                                                                                                                                                                         │
         │   1982 │   │   if self._state != ClientState.CLOSED:                                                                                                                    │
         │   1983 │   │   │   self._state = ClientState.CLOSED                                                                                                                     │
         │   1984 │   │   │                                                                                                                                                        │
         │ ❱ 1985 │   │   │   await self._transport.aclose()                                                                                                                       │
         │   1986 │   │   │   for proxy in self._mounts.values():                                                                                                                  │
         │   1987 │   │   │   │   if proxy is not None:                                                                                                                            │
         │   1988 │   │   │   │   │   await proxy.aclose()                                                                                                                         │
         │                                                                                                                                                                         │
         │ /Users/erichuang/projects/llama-stack-git2/.venv/lib/python3.12/site-packages/httpx/_transports/default.py:406 in aclose                                                │
         │                                                                                                                                                                         │
         │   403 │   │   )                                                                                                                                                         │
         │   404 │                                                                                                                                                                 │
         │   405 │   async def aclose(self) -> None:                                                                                                                               │
         │ ❱ 406 │   │   await self._pool.aclose()                                                                                                                                 │
         │   407                                                                                                                                                                   │
         │                                                                                                                                                                         │
         │ /Users/erichuang/projects/llama-stack-git2/.venv/lib/python3.12/site-packages/httpcore/_async/connection_pool.py:353 in aclose                                          │
         │                                                                                                                                                                         │
         │   350 │   │   with self._optional_thread_lock:                                                                                                                          │
         │   351 │   │   │   closing_connections = list(self._connections)                                                                                                         │
         │   352 │   │   │   self._connections = []                                                                                                                                │
         │ ❱ 353 │   │   await self._close_connections(closing_connections)                                                                                                        │
         │   354 │                                                                                                                                                                 │
         │   355 │   async def __aenter__(self) -> AsyncConnectionPool:                                                                                                            │
         │   356 │   │   return self                                                                                                                                               │
         │                                                                                                                                                                         │
         │ /Users/erichuang/projects/llama-stack-git2/.venv/lib/python3.12/site-packages/httpcore/_async/connection_pool.py:345 in _close_connections                              │
         │                                                                                                                                                                         │
         │   342 │   │   # Close connections which have been removed from the pool.                                                                                                │
         │   343 │   │   with AsyncShieldCancellation():                                                                                                                           │
         │   344 │   │   │   for connection in closing:                                                                                                                            │
         │ ❱ 345 │   │   │   │   await connection.aclose()                                                                                                                         │
         │   346 │                                                                                                                                                                 │
         │   347 │   async def aclose(self) -> None:                                                                                                                               │
         │   348 │   │   # Explicitly close the connection pool.                                                                                                                   │
         │                                                                                                                                                                         │
         │ /Users/erichuang/projects/llama-stack-git2/.venv/lib/python3.12/site-packages/httpcore/_async/connection.py:173 in aclose                                               │
         │                                                                                                                                                                         │
         │   170 │   async def aclose(self) -> None:                                                                                                                               │
         │   171 │   │   if self._connection is not None:                                                                                                                          │
         │   172 │   │   │   async with Trace("close", logger, None, {}):                                                                                                          │
         │ ❱ 173 │   │   │   │   await self._connection.aclose()                                                                                                                   │
         │   174 │                                                                                                                                                                 │
         │   175 │   def is_available(self) -> bool:                                                                                                                               │
         │   176 │   │   if self._connection is None:                                                                                                                              │
         │                                                                                                                                                                         │
         │ /Users/erichuang/projects/llama-stack-git2/.venv/lib/python3.12/site-packages/httpcore/_async/http11.py:258 in aclose                                                   │
         │                                                                                                                                                                         │
         │   255 │   │   # Note that this method unilaterally closes the connection, and does                                                                                      │
         │   256 │   │   # not have any kind of locking in place around it.                                                                                                        │
         │   257 │   │   self._state = HTTPConnectionState.CLOSED                                                                                                                  │
         │ ❱ 258 │   │   await self._network_stream.aclose()                                                                                                                       │
         │   259 │                                                                                                                                                                 │
         │   260 │   # The AsyncConnectionInterface methods provide information about the state of                                                                                 │
         │   261 │   # the connection, allowing for a connection pooling implementation to                                                                                         │
         │                                                                                                                                                                         │
         │ /Users/erichuang/projects/llama-stack-git2/.venv/lib/python3.12/site-packages/httpcore/_backends/anyio.py:53 in aclose                                                  │
         │                                                                                                                                                                         │
         │    50 │   │   │   │   await self._stream.send(item=buffer)                                                                                                              │
         │    51 │                                                                                                                                                                 │
         │    52 │   async def aclose(self) -> None:                                                                                                                               │
         │ ❱  53 │   │   await self._stream.aclose()                                                                                                                               │
         │    54 │                                                                                                                                                                 │
         │    55 │   async def start_tls(                                                                                                                                          │
         │    56 │   │   self,                                                                                                                                                     │
         │                                                                                                                                                                         │
         │ /Users/erichuang/projects/llama-stack-git2/.venv/lib/python3.12/site-packages/anyio/streams/tls.py:216 in aclose                                                        │
         │                                                                                                                                                                         │
         │   213 │   │   │   │   await aclose_forcefully(self.transport_stream)                                                                                                    │
         │   214 │   │   │   │   raise                                                                                                                                             │
         │   215 │   │                                                                                                                                                             │
         │ ❱ 216 │   │   await self.transport_stream.aclose()                                                                                                                      │
         │   217 │                                                                                                                                                                 │
         │   218 │   async def receive(self, max_bytes: int = 65536) -> bytes:                                                                                                     │
         │   219 │   │   data = await self._call_sslobject_method(self._ssl_object.read, max_bytes)                                                                                │
         │                                                                                                                                                                         │
         │ /Users/erichuang/projects/llama-stack-git2/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py:1310 in aclose                                                │
         │                                                                                                                                                                         │
         │   1307 │   │   if not self._transport.is_closing():                                                                                                                     │
         │   1308 │   │   │   self._closed = True                                                                                                                                  │
         │   1309 │   │   │   try:                                                                                                                                                 │
         │ ❱ 1310 │   │   │   │   self._transport.write_eof()                                                                                                                      │
         │   1311 │   │   │   except OSError:                                                                                                                                      │
         │   1312 │   │   │   │   pass                                                                                                                                             │
         │   1313                                                                                                                                                                  │
         │                                                                                                                                                                         │
         │ in uvloop.loop.UVStream.write_eof:703                                                                                                                                   │
         │                                                                                                                                                                         │
         │ in uvloop.loop.UVHandle._ensure_alive:159                                                                                                                               │
         ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
         RuntimeError: unable to perform operation on <TCPTransport closed=True reading=False 0x122dc7ad0>; the handler is closed

## Test Plan
Run
uv run --with llama-stack llama stack build --distro=starter --image-type=venv --run

No more error
