### PR TITLE
feat(tests): allow cleanup of stray artifacts for local test runs

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -40,6 +40,16 @@ Model parameters can be influenced by the following options:
 Each of these are comma-separated lists and can be used to generate multiple parameter combinations. Note that tests will be skipped
 if no model is specified.
 
+### Database Cleanup
+
+Tests create persistent databases and files in `~/.llama/distributions/{distro_name}/`. Use when running locally, you can use the `--clean-artifacts` flag to remove once a test finishes executing.
+
+```bash
+pytest tests/integration/ --stack-config=server:starter --clean-artifacts
+```
+
+Artifacts cleaned: `*.db`, `*.log`, and batch files in `files/` directory.
+
 ### Suites and Setups
 
 - `--suite`: single named suite that narrows which tests are collected.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -139,6 +139,11 @@ def pytest_addoption(parser):
     )
     parser.addoption("--env", action="append", help="Set environment variables, e.g. --env KEY=value")
     parser.addoption(
+        "--clean-artifacts",
+        action="store_true",
+        help="Clean up all artifacts (databases, logs, batch input/output files) after test execution",
+    )
+    parser.addoption(
         "--text-model",
         help="comma-separated list of text models. Fixture name: text_model_id",
     )


### PR DESCRIPTION
Running the integration tests leaves a ton of artifacts on your system, some of which can impact the integration tests. This is fine in github actions since the environments are ephemeral, but for local development its a headache. This adds a new `--clean-artifacts` flag that you can optionally set to purge all .db, .log, and batch files from a llama stack distro after an integration test run. 