### PR TITLE
chore: refactor (chat)completions endpoints to use shared params struct

### DIFF
--- a/docs/openapi_generator/pyopenapi/utility.py
+++ b/docs/openapi_generator/pyopenapi/utility.py
@@ -8,10 +8,11 @@ import json
 import typing
 import inspect
 from pathlib import Path
-from typing import TextIO
-from typing import Any, List, Optional, Union, get_type_hints, get_origin, get_args
+from typing import Any, List, Optional, TextIO, Union, get_type_hints, get_origin, get_args
 
+from pydantic import BaseModel
 from llama_stack.strong_typing.schema import object_to_json, StrictJsonType
+from llama_stack.strong_typing.inspection import is_unwrapped_body_param
 from llama_stack.core.resolver import api_protocol_map
 
 from .generator import Generator
@@ -205,6 +206,14 @@ def _validate_has_return_in_docstring(method) -> str | None:
 def _validate_has_params_in_docstring(method) -> str | None:
     source = inspect.getsource(method)
     sig = inspect.signature(method)
+
+    params_list = [p for p in sig.parameters.values() if p.name != "self"]
+    if len(params_list) == 1:
+        param = params_list[0]
+        param_type = param.annotation
+        if is_unwrapped_body_param(param_type):
+            return
+
     # Only check if the method has more than one parameter
     if len(sig.parameters) > 1 and ":param" not in source:
         return "does not have a ':param' in its docstring"

--- a/docs/static/deprecated-llama-stack-spec.html
+++ b/docs/static/deprecated-llama-stack-spec.html
@@ -1527,7 +1527,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/OpenaiChatCompletionRequest"
+                                "$ref": "#/components/schemas/OpenAIChatCompletionRequest"
                             }
                         }
                     },
@@ -1617,7 +1617,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/OpenaiCompletionRequest"
+                                "$ref": "#/components/schemas/OpenAICompletionRequest"
                             }
                         }
                     },
@@ -7522,7 +7522,7 @@
                 "title": "OpenAIResponseFormatText",
                 "description": "Text response format for OpenAI-compatible chat completion requests."
             },
-            "OpenaiChatCompletionRequest": {
+            "OpenAIChatCompletionRequest": {
                 "type": "object",
                 "properties": {
                     "model": {
@@ -7769,7 +7769,8 @@
                     "model",
                     "messages"
                 ],
-                "title": "OpenaiChatCompletionRequest"
+                "title": "OpenAIChatCompletionRequest",
+                "description": "Request parameters for OpenAI-compatible chat completion endpoint."
             },
             "OpenAIChatCompletion": {
                 "type": "object",
@@ -7965,7 +7966,7 @@
                 ],
                 "title": "OpenAICompletionWithInputMessages"
             },
-            "OpenaiCompletionRequest": {
+            "OpenAICompletionRequest": {
                 "type": "object",
                 "properties": {
                     "model": {
@@ -8100,10 +8101,12 @@
                         "type": "array",
                         "items": {
                             "type": "string"
-                        }
+                        },
+                        "description": "(Optional) vLLM-specific parameter for guided generation with a list of choices."
                     },
                     "prompt_logprobs": {
-                        "type": "integer"
+                        "type": "integer",
+                        "description": "(Optional) vLLM-specific parameter for number of log probabilities to return for prompt tokens."
                     },
                     "suffix": {
                         "type": "string",
@@ -8115,7 +8118,8 @@
                     "model",
                     "prompt"
                 ],
-                "title": "OpenaiCompletionRequest"
+                "title": "OpenAICompletionRequest",
+                "description": "Request parameters for OpenAI-compatible completion endpoint."
             },
             "OpenAICompletion": {
                 "type": "object",

--- a/docs/static/deprecated-llama-stack-spec.yaml
+++ b/docs/static/deprecated-llama-stack-spec.yaml
@@ -1098,7 +1098,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OpenaiChatCompletionRequest'
+              $ref: '#/components/schemas/OpenAIChatCompletionRequest'
         required: true
       deprecated: true
   /v1/openai/v1/chat/completions/{completion_id}:
@@ -1167,7 +1167,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OpenaiCompletionRequest'
+              $ref: '#/components/schemas/OpenAICompletionRequest'
         required: true
       deprecated: true
   /v1/openai/v1/embeddings:
@@ -5575,7 +5575,7 @@ components:
       title: OpenAIResponseFormatText
       description: >-
         Text response format for OpenAI-compatible chat completion requests.
-    OpenaiChatCompletionRequest:
+    OpenAIChatCompletionRequest:
       type: object
       properties:
         model:
@@ -5717,7 +5717,9 @@ components:
       required:
         - model
         - messages
-      title: OpenaiChatCompletionRequest
+      title: OpenAIChatCompletionRequest
+      description: >-
+        Request parameters for OpenAI-compatible chat completion endpoint.
     OpenAIChatCompletion:
       type: object
       properties:
@@ -5883,7 +5885,7 @@ components:
         - model
         - input_messages
       title: OpenAICompletionWithInputMessages
-    OpenaiCompletionRequest:
+    OpenAICompletionRequest:
       type: object
       properties:
         model:
@@ -5975,8 +5977,14 @@ components:
           type: array
           items:
             type: string
+          description: >-
+            (Optional) vLLM-specific parameter for guided generation with a list of
+            choices.
         prompt_logprobs:
           type: integer
+          description: >-
+            (Optional) vLLM-specific parameter for number of log probabilities to
+            return for prompt tokens.
         suffix:
           type: string
           description: >-
@@ -5985,7 +5993,9 @@ components:
       required:
         - model
         - prompt
-      title: OpenaiCompletionRequest
+      title: OpenAICompletionRequest
+      description: >-
+        Request parameters for OpenAI-compatible completion endpoint.
     OpenAICompletion:
       type: object
       properties:

--- a/docs/static/llama-stack-spec.html
+++ b/docs/static/llama-stack-spec.html
@@ -153,7 +153,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/OpenaiChatCompletionRequest"
+                                "$ref": "#/components/schemas/OpenAIChatCompletionRequest"
                             }
                         }
                     },
@@ -243,7 +243,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/OpenaiCompletionRequest"
+                                "$ref": "#/components/schemas/OpenAICompletionRequest"
                             }
                         }
                     },
@@ -5018,7 +5018,7 @@
                 "title": "OpenAIResponseFormatText",
                 "description": "Text response format for OpenAI-compatible chat completion requests."
             },
-            "OpenaiChatCompletionRequest": {
+            "OpenAIChatCompletionRequest": {
                 "type": "object",
                 "properties": {
                     "model": {
@@ -5265,7 +5265,8 @@
                     "model",
                     "messages"
                 ],
-                "title": "OpenaiChatCompletionRequest"
+                "title": "OpenAIChatCompletionRequest",
+                "description": "Request parameters for OpenAI-compatible chat completion endpoint."
             },
             "OpenAIChatCompletion": {
                 "type": "object",
@@ -5461,7 +5462,7 @@
                 ],
                 "title": "OpenAICompletionWithInputMessages"
             },
-            "OpenaiCompletionRequest": {
+            "OpenAICompletionRequest": {
                 "type": "object",
                 "properties": {
                     "model": {
@@ -5596,10 +5597,12 @@
                         "type": "array",
                         "items": {
                             "type": "string"
-                        }
+                        },
+                        "description": "(Optional) vLLM-specific parameter for guided generation with a list of choices."
                     },
                     "prompt_logprobs": {
-                        "type": "integer"
+                        "type": "integer",
+                        "description": "(Optional) vLLM-specific parameter for number of log probabilities to return for prompt tokens."
                     },
                     "suffix": {
                         "type": "string",
@@ -5611,7 +5614,8 @@
                     "model",
                     "prompt"
                 ],
-                "title": "OpenaiCompletionRequest"
+                "title": "OpenAICompletionRequest",
+                "description": "Request parameters for OpenAI-compatible completion endpoint."
             },
             "OpenAICompletion": {
                 "type": "object",

--- a/docs/static/llama-stack-spec.yaml
+++ b/docs/static/llama-stack-spec.yaml
@@ -98,7 +98,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OpenaiChatCompletionRequest'
+              $ref: '#/components/schemas/OpenAIChatCompletionRequest'
         required: true
       deprecated: false
   /v1/chat/completions/{completion_id}:
@@ -167,7 +167,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OpenaiCompletionRequest'
+              $ref: '#/components/schemas/OpenAICompletionRequest'
         required: true
       deprecated: false
   /v1/conversations:
@@ -3824,7 +3824,7 @@ components:
       title: OpenAIResponseFormatText
       description: >-
         Text response format for OpenAI-compatible chat completion requests.
-    OpenaiChatCompletionRequest:
+    OpenAIChatCompletionRequest:
       type: object
       properties:
         model:
@@ -3966,7 +3966,9 @@ components:
       required:
         - model
         - messages
-      title: OpenaiChatCompletionRequest
+      title: OpenAIChatCompletionRequest
+      description: >-
+        Request parameters for OpenAI-compatible chat completion endpoint.
     OpenAIChatCompletion:
       type: object
       properties:
@@ -4132,7 +4134,7 @@ components:
         - model
         - input_messages
       title: OpenAICompletionWithInputMessages
-    OpenaiCompletionRequest:
+    OpenAICompletionRequest:
       type: object
       properties:
         model:
@@ -4224,8 +4226,14 @@ components:
           type: array
           items:
             type: string
+          description: >-
+            (Optional) vLLM-specific parameter for guided generation with a list of
+            choices.
         prompt_logprobs:
           type: integer
+          description: >-
+            (Optional) vLLM-specific parameter for number of log probabilities to
+            return for prompt tokens.
         suffix:
           type: string
           description: >-
@@ -4234,7 +4242,9 @@ components:
       required:
         - model
         - prompt
-      title: OpenaiCompletionRequest
+      title: OpenAICompletionRequest
+      description: >-
+        Request parameters for OpenAI-compatible completion endpoint.
     OpenAICompletion:
       type: object
       properties:

--- a/docs/static/stainless-llama-stack-spec.html
+++ b/docs/static/stainless-llama-stack-spec.html
@@ -153,7 +153,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/OpenaiChatCompletionRequest"
+                                "$ref": "#/components/schemas/OpenAIChatCompletionRequest"
                             }
                         }
                     },
@@ -243,7 +243,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/OpenaiCompletionRequest"
+                                "$ref": "#/components/schemas/OpenAICompletionRequest"
                             }
                         }
                     },
@@ -7027,7 +7027,7 @@
                 "title": "OpenAIResponseFormatText",
                 "description": "Text response format for OpenAI-compatible chat completion requests."
             },
-            "OpenaiChatCompletionRequest": {
+            "OpenAIChatCompletionRequest": {
                 "type": "object",
                 "properties": {
                     "model": {
@@ -7274,7 +7274,8 @@
                     "model",
                     "messages"
                 ],
-                "title": "OpenaiChatCompletionRequest"
+                "title": "OpenAIChatCompletionRequest",
+                "description": "Request parameters for OpenAI-compatible chat completion endpoint."
             },
             "OpenAIChatCompletion": {
                 "type": "object",
@@ -7470,7 +7471,7 @@
                 ],
                 "title": "OpenAICompletionWithInputMessages"
             },
-            "OpenaiCompletionRequest": {
+            "OpenAICompletionRequest": {
                 "type": "object",
                 "properties": {
                     "model": {
@@ -7605,10 +7606,12 @@
                         "type": "array",
                         "items": {
                             "type": "string"
-                        }
+                        },
+                        "description": "(Optional) vLLM-specific parameter for guided generation with a list of choices."
                     },
                     "prompt_logprobs": {
-                        "type": "integer"
+                        "type": "integer",
+                        "description": "(Optional) vLLM-specific parameter for number of log probabilities to return for prompt tokens."
                     },
                     "suffix": {
                         "type": "string",
@@ -7620,7 +7623,8 @@
                     "model",
                     "prompt"
                 ],
-                "title": "OpenaiCompletionRequest"
+                "title": "OpenAICompletionRequest",
+                "description": "Request parameters for OpenAI-compatible completion endpoint."
             },
             "OpenAICompletion": {
                 "type": "object",

--- a/docs/static/stainless-llama-stack-spec.yaml
+++ b/docs/static/stainless-llama-stack-spec.yaml
@@ -101,7 +101,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OpenaiChatCompletionRequest'
+              $ref: '#/components/schemas/OpenAIChatCompletionRequest'
         required: true
       deprecated: false
   /v1/chat/completions/{completion_id}:
@@ -170,7 +170,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OpenaiCompletionRequest'
+              $ref: '#/components/schemas/OpenAICompletionRequest'
         required: true
       deprecated: false
   /v1/conversations:
@@ -5269,7 +5269,7 @@ components:
       title: OpenAIResponseFormatText
       description: >-
         Text response format for OpenAI-compatible chat completion requests.
-    OpenaiChatCompletionRequest:
+    OpenAIChatCompletionRequest:
       type: object
       properties:
         model:
@@ -5411,7 +5411,9 @@ components:
       required:
         - model
         - messages
-      title: OpenaiChatCompletionRequest
+      title: OpenAIChatCompletionRequest
+      description: >-
+        Request parameters for OpenAI-compatible chat completion endpoint.
     OpenAIChatCompletion:
       type: object
       properties:
@@ -5577,7 +5579,7 @@ components:
         - model
         - input_messages
       title: OpenAICompletionWithInputMessages
-    OpenaiCompletionRequest:
+    OpenAICompletionRequest:
       type: object
       properties:
         model:
@@ -5669,8 +5671,14 @@ components:
           type: array
           items:
             type: string
+          description: >-
+            (Optional) vLLM-specific parameter for guided generation with a list of
+            choices.
         prompt_logprobs:
           type: integer
+          description: >-
+            (Optional) vLLM-specific parameter for number of log probabilities to
+            return for prompt tokens.
         suffix:
           type: string
           description: >-
@@ -5679,7 +5687,9 @@ components:
       required:
         - model
         - prompt
-      title: OpenaiCompletionRequest
+      title: OpenAICompletionRequest
+      description: >-
+        Request parameters for OpenAI-compatible completion endpoint.
     OpenAICompletion:
       type: object
       properties:

--- a/llama_stack/core/server/server.py
+++ b/llama_stack/core/server/server.py
@@ -184,7 +184,17 @@ async def lifespan(app: StackApp):
 
 def is_streaming_request(func_name: str, request: Request, **kwargs):
     # TODO: pass the api method and punt it to the Protocol definition directly
-    return kwargs.get("stream", False)
+    # If there's a stream parameter at top level, use it
+    if "stream" in kwargs:
+        return kwargs["stream"]
+
+    # If there's a stream parameter inside a "params" parameter, e.g. openai_chat_completion() use it
+    if "params" in kwargs:
+        params = kwargs["params"]
+        if hasattr(params, "stream"):
+            return params.stream
+
+    return False
 
 
 async def maybe_await(value):

--- a/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agent_instance.py
@@ -49,6 +49,7 @@ from llama_stack.apis.inference import (
     Inference,
     Message,
     OpenAIAssistantMessageParam,
+    OpenAIChatCompletionRequest,
     OpenAIDeveloperMessageParam,
     OpenAIMessageParam,
     OpenAISystemMessageParam,
@@ -582,7 +583,7 @@ class ChatAgent(ShieldRunnerMixin):
                 max_tokens = getattr(sampling_params, "max_tokens", None)
 
                 # Use OpenAI chat completion
-                openai_stream = await self.inference_api.openai_chat_completion(
+                params = OpenAIChatCompletionRequest(
                     model=self.agent_config.model,
                     messages=openai_messages,
                     tools=openai_tools if openai_tools else None,
@@ -593,6 +594,7 @@ class ChatAgent(ShieldRunnerMixin):
                     max_tokens=max_tokens,
                     stream=True,
                 )
+                openai_stream = await self.inference_api.openai_chat_completion(params)
 
                 # Convert OpenAI stream back to Llama Stack format
                 response_stream = convert_openai_chat_completion_stream(

--- a/llama_stack/providers/inline/agents/meta_reference/responses/streaming.py
+++ b/llama_stack/providers/inline/agents/meta_reference/responses/streaming.py
@@ -49,6 +49,7 @@ from llama_stack.apis.inference import (
     OpenAIAssistantMessageParam,
     OpenAIChatCompletion,
     OpenAIChatCompletionChunk,
+    OpenAIChatCompletionRequest,
     OpenAIChatCompletionToolCall,
     OpenAIChoice,
     OpenAIMessageParam,
@@ -168,7 +169,7 @@ class StreamingResponseOrchestrator:
                 # (some providers don't support non-empty response_format when tools are present)
                 response_format = None if self.ctx.response_format.type == "text" else self.ctx.response_format
                 logger.debug(f"calling openai_chat_completion with tools: {self.ctx.chat_tools}")
-                completion_result = await self.inference_api.openai_chat_completion(
+                params = OpenAIChatCompletionRequest(
                     model=self.ctx.model,
                     messages=messages,
                     tools=self.ctx.chat_tools,
@@ -179,6 +180,7 @@ class StreamingResponseOrchestrator:
                         "include_usage": True,
                     },
                 )
+                completion_result = await self.inference_api.openai_chat_completion(params)
 
                 # Process streaming chunks and build complete response
                 completion_result_data = None

--- a/llama_stack/providers/inline/batches/reference/batches.py
+++ b/llama_stack/providers/inline/batches/reference/batches.py
@@ -22,6 +22,8 @@ from llama_stack.apis.files import Files, OpenAIFilePurpose
 from llama_stack.apis.inference import (
     Inference,
     OpenAIAssistantMessageParam,
+    OpenAIChatCompletionRequest,
+    OpenAICompletionRequest,
     OpenAIDeveloperMessageParam,
     OpenAIMessageParam,
     OpenAISystemMessageParam,
@@ -606,7 +608,8 @@ class ReferenceBatchesImpl(Batches):
             # TODO(SECURITY): review body for security issues
             if request.url == "/v1/chat/completions":
                 request.body["messages"] = [convert_to_openai_message_param(msg) for msg in request.body["messages"]]
-                chat_response = await self.inference_api.openai_chat_completion(**request.body)
+                chat_params = OpenAIChatCompletionRequest(**request.body)
+                chat_response = await self.inference_api.openai_chat_completion(chat_params)
 
                 # this is for mypy, we don't allow streaming so we'll get the right type
                 assert hasattr(chat_response, "model_dump_json"), "Chat response must have model_dump_json method"
@@ -620,7 +623,8 @@ class ReferenceBatchesImpl(Batches):
                     },
                 }
             elif request.url == "/v1/completions":
-                completion_response = await self.inference_api.openai_completion(**request.body)
+                completion_params = OpenAICompletionRequest(**request.body)
+                completion_response = await self.inference_api.openai_completion(completion_params)
 
                 # this is for mypy, we don't allow streaming so we'll get the right type
                 assert hasattr(completion_response, "model_dump_json"), (

--- a/llama_stack/providers/inline/inference/meta_reference/inference.py
+++ b/llama_stack/providers/inline/inference/meta_reference/inference.py
@@ -6,16 +6,16 @@
 
 import asyncio
 from collections.abc import AsyncIterator
-from typing import Any
 
 from llama_stack.apis.inference import (
     InferenceProvider,
+    OpenAIChatCompletionRequest,
+    OpenAICompletionRequest,
 )
 from llama_stack.apis.inference.inference import (
     OpenAIChatCompletion,
     OpenAIChatCompletionChunk,
-    OpenAIMessageParam,
-    OpenAIResponseFormatParam,
+    OpenAICompletion,
 )
 from llama_stack.apis.models import Model, ModelType
 from llama_stack.log import get_logger
@@ -65,7 +65,10 @@ class MetaReferenceInferenceImpl(
         if self.config.create_distributed_process_group:
             self.generator.stop()
 
-    async def openai_completion(self, *args, **kwargs):
+    async def openai_completion(
+        self,
+        params: OpenAICompletionRequest,
+    ) -> OpenAICompletion:
         raise NotImplementedError("OpenAI completion not supported by meta reference provider")
 
     async def should_refresh_models(self) -> bool:
@@ -150,28 +153,6 @@ class MetaReferenceInferenceImpl(
 
     async def openai_chat_completion(
         self,
-        model: str,
-        messages: list[OpenAIMessageParam],
-        frequency_penalty: float | None = None,
-        function_call: str | dict[str, Any] | None = None,
-        functions: list[dict[str, Any]] | None = None,
-        logit_bias: dict[str, float] | None = None,
-        logprobs: bool | None = None,
-        max_completion_tokens: int | None = None,
-        max_tokens: int | None = None,
-        n: int | None = None,
-        parallel_tool_calls: bool | None = None,
-        presence_penalty: float | None = None,
-        response_format: OpenAIResponseFormatParam | None = None,
-        seed: int | None = None,
-        stop: str | list[str] | None = None,
-        stream: bool | None = None,
-        stream_options: dict[str, Any] | None = None,
-        temperature: float | None = None,
-        tool_choice: str | dict[str, Any] | None = None,
-        tools: list[dict[str, Any]] | None = None,
-        top_logprobs: int | None = None,
-        top_p: float | None = None,
-        user: str | None = None,
+        params: OpenAIChatCompletionRequest,
     ) -> OpenAIChatCompletion | AsyncIterator[OpenAIChatCompletionChunk]:
         raise NotImplementedError("OpenAI chat completion not supported by meta-reference inference provider")

--- a/llama_stack/providers/inline/inference/sentence_transformers/sentence_transformers.py
+++ b/llama_stack/providers/inline/inference/sentence_transformers/sentence_transformers.py
@@ -5,17 +5,16 @@
 # the root directory of this source tree.
 
 from collections.abc import AsyncIterator
-from typing import Any
 
 from llama_stack.apis.inference import (
     InferenceProvider,
+    OpenAIChatCompletionRequest,
+    OpenAICompletionRequest,
 )
 from llama_stack.apis.inference.inference import (
     OpenAIChatCompletion,
     OpenAIChatCompletionChunk,
     OpenAICompletion,
-    OpenAIMessageParam,
-    OpenAIResponseFormatParam,
 )
 from llama_stack.apis.models import ModelType
 from llama_stack.log import get_logger
@@ -73,56 +72,12 @@ class SentenceTransformersInferenceImpl(
 
     async def openai_completion(
         self,
-        # Standard OpenAI completion parameters
-        model: str,
-        prompt: str | list[str] | list[int] | list[list[int]],
-        best_of: int | None = None,
-        echo: bool | None = None,
-        frequency_penalty: float | None = None,
-        logit_bias: dict[str, float] | None = None,
-        logprobs: bool | None = None,
-        max_tokens: int | None = None,
-        n: int | None = None,
-        presence_penalty: float | None = None,
-        seed: int | None = None,
-        stop: str | list[str] | None = None,
-        stream: bool | None = None,
-        stream_options: dict[str, Any] | None = None,
-        temperature: float | None = None,
-        top_p: float | None = None,
-        user: str | None = None,
-        # vLLM-specific parameters
-        guided_choice: list[str] | None = None,
-        prompt_logprobs: int | None = None,
-        # for fill-in-the-middle type completion
-        suffix: str | None = None,
+        params: OpenAICompletionRequest,
     ) -> OpenAICompletion:
         raise NotImplementedError("OpenAI completion not supported by sentence transformers provider")
 
     async def openai_chat_completion(
         self,
-        model: str,
-        messages: list[OpenAIMessageParam],
-        frequency_penalty: float | None = None,
-        function_call: str | dict[str, Any] | None = None,
-        functions: list[dict[str, Any]] | None = None,
-        logit_bias: dict[str, float] | None = None,
-        logprobs: bool | None = None,
-        max_completion_tokens: int | None = None,
-        max_tokens: int | None = None,
-        n: int | None = None,
-        parallel_tool_calls: bool | None = None,
-        presence_penalty: float | None = None,
-        response_format: OpenAIResponseFormatParam | None = None,
-        seed: int | None = None,
-        stop: str | list[str] | None = None,
-        stream: bool | None = None,
-        stream_options: dict[str, Any] | None = None,
-        temperature: float | None = None,
-        tool_choice: str | dict[str, Any] | None = None,
-        tools: list[dict[str, Any]] | None = None,
-        top_logprobs: int | None = None,
-        top_p: float | None = None,
-        user: str | None = None,
+        params: OpenAIChatCompletionRequest,
     ) -> OpenAIChatCompletion | AsyncIterator[OpenAIChatCompletionChunk]:
         raise NotImplementedError("OpenAI chat completion not supported by sentence transformers provider")

--- a/llama_stack/providers/inline/scoring/llm_as_judge/scoring_fn/llm_as_judge_scoring_fn.py
+++ b/llama_stack/providers/inline/scoring/llm_as_judge/scoring_fn/llm_as_judge_scoring_fn.py
@@ -6,7 +6,7 @@
 import re
 from typing import Any
 
-from llama_stack.apis.inference import Inference
+from llama_stack.apis.inference import Inference, OpenAIChatCompletionRequest
 from llama_stack.apis.scoring import ScoringResultRow
 from llama_stack.apis.scoring_functions import ScoringFnParams
 from llama_stack.providers.utils.scoring.base_scoring_fn import RegisteredBaseScoringFn
@@ -55,7 +55,7 @@ class LlmAsJudgeScoringFn(RegisteredBaseScoringFn):
             generated_answer=generated_answer,
         )
 
-        judge_response = await self.inference_api.openai_chat_completion(
+        params = OpenAIChatCompletionRequest(
             model=fn_def.params.judge_model,
             messages=[
                 {
@@ -64,6 +64,7 @@ class LlmAsJudgeScoringFn(RegisteredBaseScoringFn):
                 }
             ],
         )
+        judge_response = await self.inference_api.openai_chat_completion(params)
         content = judge_response.choices[0].message.content
         rating_regexes = fn_def.params.judge_score_regexes
 

--- a/llama_stack/providers/inline/tool_runtime/rag/context_retriever.py
+++ b/llama_stack/providers/inline/tool_runtime/rag/context_retriever.py
@@ -8,7 +8,7 @@
 from jinja2 import Template
 
 from llama_stack.apis.common.content_types import InterleavedContent
-from llama_stack.apis.inference import OpenAIUserMessageParam
+from llama_stack.apis.inference import OpenAIChatCompletionRequest, OpenAIUserMessageParam
 from llama_stack.apis.tools.rag_tool import (
     DefaultRAGQueryGeneratorConfig,
     LLMRAGQueryGeneratorConfig,
@@ -65,11 +65,12 @@ async def llm_rag_query_generator(
 
     model = config.model
     message = OpenAIUserMessageParam(content=rendered_content)
-    response = await inference_api.openai_chat_completion(
+    params = OpenAIChatCompletionRequest(
         model=model,
         messages=[message],
         stream=False,
     )
+    response = await inference_api.openai_chat_completion(params)
 
     query = response.choices[0].message.content
 

--- a/llama_stack/providers/remote/inference/bedrock/bedrock.py
+++ b/llama_stack/providers/remote/inference/bedrock/bedrock.py
@@ -6,21 +6,20 @@
 
 import json
 from collections.abc import AsyncIterator
-from typing import Any
 
 from botocore.client import BaseClient
 
 from llama_stack.apis.inference import (
     ChatCompletionRequest,
     Inference,
+    OpenAIChatCompletionRequest,
+    OpenAICompletionRequest,
     OpenAIEmbeddingsResponse,
 )
 from llama_stack.apis.inference.inference import (
     OpenAIChatCompletion,
     OpenAIChatCompletionChunk,
     OpenAICompletion,
-    OpenAIMessageParam,
-    OpenAIResponseFormatParam,
 )
 from llama_stack.providers.remote.inference.bedrock.config import BedrockConfig
 from llama_stack.providers.utils.bedrock.client import create_bedrock_client
@@ -135,56 +134,12 @@ class BedrockInferenceAdapter(
 
     async def openai_completion(
         self,
-        # Standard OpenAI completion parameters
-        model: str,
-        prompt: str | list[str] | list[int] | list[list[int]],
-        best_of: int | None = None,
-        echo: bool | None = None,
-        frequency_penalty: float | None = None,
-        logit_bias: dict[str, float] | None = None,
-        logprobs: bool | None = None,
-        max_tokens: int | None = None,
-        n: int | None = None,
-        presence_penalty: float | None = None,
-        seed: int | None = None,
-        stop: str | list[str] | None = None,
-        stream: bool | None = None,
-        stream_options: dict[str, Any] | None = None,
-        temperature: float | None = None,
-        top_p: float | None = None,
-        user: str | None = None,
-        # vLLM-specific parameters
-        guided_choice: list[str] | None = None,
-        prompt_logprobs: int | None = None,
-        # for fill-in-the-middle type completion
-        suffix: str | None = None,
+        params: OpenAICompletionRequest,
     ) -> OpenAICompletion:
         raise NotImplementedError("OpenAI completion not supported by the Bedrock provider")
 
     async def openai_chat_completion(
         self,
-        model: str,
-        messages: list[OpenAIMessageParam],
-        frequency_penalty: float | None = None,
-        function_call: str | dict[str, Any] | None = None,
-        functions: list[dict[str, Any]] | None = None,
-        logit_bias: dict[str, float] | None = None,
-        logprobs: bool | None = None,
-        max_completion_tokens: int | None = None,
-        max_tokens: int | None = None,
-        n: int | None = None,
-        parallel_tool_calls: bool | None = None,
-        presence_penalty: float | None = None,
-        response_format: OpenAIResponseFormatParam | None = None,
-        seed: int | None = None,
-        stop: str | list[str] | None = None,
-        stream: bool | None = None,
-        stream_options: dict[str, Any] | None = None,
-        temperature: float | None = None,
-        tool_choice: str | dict[str, Any] | None = None,
-        tools: list[dict[str, Any]] | None = None,
-        top_logprobs: int | None = None,
-        top_p: float | None = None,
-        user: str | None = None,
+        params: OpenAIChatCompletionRequest,
     ) -> OpenAIChatCompletion | AsyncIterator[OpenAIChatCompletionChunk]:
         raise NotImplementedError("OpenAI chat completion not supported by the Bedrock provider")

--- a/llama_stack/providers/remote/inference/databricks/databricks.py
+++ b/llama_stack/providers/remote/inference/databricks/databricks.py
@@ -5,11 +5,10 @@
 # the root directory of this source tree.
 
 from collections.abc import Iterable
-from typing import Any
 
 from databricks.sdk import WorkspaceClient
 
-from llama_stack.apis.inference import OpenAICompletion
+from llama_stack.apis.inference import OpenAICompletion, OpenAICompletionRequest
 from llama_stack.log import get_logger
 from llama_stack.providers.utils.inference.openai_mixin import OpenAIMixin
 
@@ -40,25 +39,6 @@ class DatabricksInferenceAdapter(OpenAIMixin):
 
     async def openai_completion(
         self,
-        model: str,
-        prompt: str | list[str] | list[int] | list[list[int]],
-        best_of: int | None = None,
-        echo: bool | None = None,
-        frequency_penalty: float | None = None,
-        logit_bias: dict[str, float] | None = None,
-        logprobs: bool | None = None,
-        max_tokens: int | None = None,
-        n: int | None = None,
-        presence_penalty: float | None = None,
-        seed: int | None = None,
-        stop: str | list[str] | None = None,
-        stream: bool | None = None,
-        stream_options: dict[str, Any] | None = None,
-        temperature: float | None = None,
-        top_p: float | None = None,
-        user: str | None = None,
-        guided_choice: list[str] | None = None,
-        prompt_logprobs: int | None = None,
-        suffix: str | None = None,
+        params: OpenAICompletionRequest,
     ) -> OpenAICompletion:
         raise NotImplementedError()

--- a/llama_stack/providers/remote/inference/llama_openai_compat/llama.py
+++ b/llama_stack/providers/remote/inference/llama_openai_compat/llama.py
@@ -3,9 +3,7 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
-from typing import Any
-
-from llama_stack.apis.inference.inference import OpenAICompletion, OpenAIEmbeddingsResponse
+from llama_stack.apis.inference.inference import OpenAICompletion, OpenAICompletionRequest, OpenAIEmbeddingsResponse
 from llama_stack.log import get_logger
 from llama_stack.providers.remote.inference.llama_openai_compat.config import LlamaCompatConfig
 from llama_stack.providers.utils.inference.openai_mixin import OpenAIMixin
@@ -31,26 +29,7 @@ class LlamaCompatInferenceAdapter(OpenAIMixin):
 
     async def openai_completion(
         self,
-        model: str,
-        prompt: str | list[str] | list[int] | list[list[int]],
-        best_of: int | None = None,
-        echo: bool | None = None,
-        frequency_penalty: float | None = None,
-        logit_bias: dict[str, float] | None = None,
-        logprobs: bool | None = None,
-        max_tokens: int | None = None,
-        n: int | None = None,
-        presence_penalty: float | None = None,
-        seed: int | None = None,
-        stop: str | list[str] | None = None,
-        stream: bool | None = None,
-        stream_options: dict[str, Any] | None = None,
-        temperature: float | None = None,
-        top_p: float | None = None,
-        user: str | None = None,
-        guided_choice: list[str] | None = None,
-        prompt_logprobs: int | None = None,
-        suffix: str | None = None,
+        params: OpenAICompletionRequest,
     ) -> OpenAICompletion:
         raise NotImplementedError()
 

--- a/llama_stack/providers/remote/inference/runpod/runpod.py
+++ b/llama_stack/providers/remote/inference/runpod/runpod.py
@@ -4,11 +4,12 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from typing import Any
+from collections.abc import AsyncIterator
 
 from llama_stack.apis.inference import (
-    OpenAIMessageParam,
-    OpenAIResponseFormatParam,
+    OpenAIChatCompletion,
+    OpenAIChatCompletionChunk,
+    OpenAIChatCompletionRequest,
 )
 from llama_stack.providers.utils.inference.openai_mixin import OpenAIMixin
 
@@ -30,56 +31,12 @@ class RunpodInferenceAdapter(OpenAIMixin):
 
     async def openai_chat_completion(
         self,
-        model: str,
-        messages: list[OpenAIMessageParam],
-        frequency_penalty: float | None = None,
-        function_call: str | dict[str, Any] | None = None,
-        functions: list[dict[str, Any]] | None = None,
-        logit_bias: dict[str, float] | None = None,
-        logprobs: bool | None = None,
-        max_completion_tokens: int | None = None,
-        max_tokens: int | None = None,
-        n: int | None = None,
-        parallel_tool_calls: bool | None = None,
-        presence_penalty: float | None = None,
-        response_format: OpenAIResponseFormatParam | None = None,
-        seed: int | None = None,
-        stop: str | list[str] | None = None,
-        stream: bool | None = None,
-        stream_options: dict[str, Any] | None = None,
-        temperature: float | None = None,
-        tool_choice: str | dict[str, Any] | None = None,
-        tools: list[dict[str, Any]] | None = None,
-        top_logprobs: int | None = None,
-        top_p: float | None = None,
-        user: str | None = None,
-    ):
+        params: OpenAIChatCompletionRequest,
+    ) -> OpenAIChatCompletion | AsyncIterator[OpenAIChatCompletionChunk]:
         """Override to add RunPod-specific stream_options requirement."""
-        if stream and not stream_options:
-            stream_options = {"include_usage": True}
+        params = params.model_copy()
 
-        return await super().openai_chat_completion(
-            model=model,
-            messages=messages,
-            frequency_penalty=frequency_penalty,
-            function_call=function_call,
-            functions=functions,
-            logit_bias=logit_bias,
-            logprobs=logprobs,
-            max_completion_tokens=max_completion_tokens,
-            max_tokens=max_tokens,
-            n=n,
-            parallel_tool_calls=parallel_tool_calls,
-            presence_penalty=presence_penalty,
-            response_format=response_format,
-            seed=seed,
-            stop=stop,
-            stream=stream,
-            stream_options=stream_options,
-            temperature=temperature,
-            tool_choice=tool_choice,
-            tools=tools,
-            top_logprobs=top_logprobs,
-            top_p=top_p,
-            user=user,
-        )
+        if params.stream and not params.stream_options:
+            params.stream_options = {"include_usage": True}
+
+        return await super().openai_chat_completion(params)

--- a/llama_stack/providers/remote/inference/vllm/vllm.py
+++ b/llama_stack/providers/remote/inference/vllm/vllm.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 from collections.abc import AsyncIterator
-from typing import Any
 from urllib.parse import urljoin
 
 import httpx
@@ -15,8 +14,7 @@ from pydantic import ConfigDict
 
 from llama_stack.apis.inference import (
     OpenAIChatCompletion,
-    OpenAIMessageParam,
-    OpenAIResponseFormatParam,
+    OpenAIChatCompletionRequest,
     ToolChoice,
 )
 from llama_stack.log import get_logger
@@ -95,61 +93,19 @@ class VLLMInferenceAdapter(OpenAIMixin):
 
     async def openai_chat_completion(
         self,
-        model: str,
-        messages: list[OpenAIMessageParam],
-        frequency_penalty: float | None = None,
-        function_call: str | dict[str, Any] | None = None,
-        functions: list[dict[str, Any]] | None = None,
-        logit_bias: dict[str, float] | None = None,
-        logprobs: bool | None = None,
-        max_completion_tokens: int | None = None,
-        max_tokens: int | None = None,
-        n: int | None = None,
-        parallel_tool_calls: bool | None = None,
-        presence_penalty: float | None = None,
-        response_format: OpenAIResponseFormatParam | None = None,
-        seed: int | None = None,
-        stop: str | list[str] | None = None,
-        stream: bool | None = None,
-        stream_options: dict[str, Any] | None = None,
-        temperature: float | None = None,
-        tool_choice: str | dict[str, Any] | None = None,
-        tools: list[dict[str, Any]] | None = None,
-        top_logprobs: int | None = None,
-        top_p: float | None = None,
-        user: str | None = None,
+        params: OpenAIChatCompletionRequest,
     ) -> OpenAIChatCompletion | AsyncIterator[OpenAIChatCompletionChunk]:
-        max_tokens = max_tokens or self.config.max_tokens
+        params = params.model_copy()
+
+        # Apply vLLM-specific defaults
+        if params.max_tokens is None and self.config.max_tokens:
+            params.max_tokens = self.config.max_tokens
 
         # This is to be consistent with OpenAI API and support vLLM <= v0.6.3
         # References:
         #   * https://platform.openai.com/docs/api-reference/chat/create#chat-create-tool_choice
         #   * https://github.com/vllm-project/vllm/pull/10000
-        if not tools and tool_choice is not None:
-            tool_choice = ToolChoice.none.value
+        if not params.tools and params.tool_choice is not None:
+            params.tool_choice = ToolChoice.none.value
 
-        return await super().openai_chat_completion(
-            model=model,
-            messages=messages,
-            frequency_penalty=frequency_penalty,
-            function_call=function_call,
-            functions=functions,
-            logit_bias=logit_bias,
-            logprobs=logprobs,
-            max_completion_tokens=max_completion_tokens,
-            max_tokens=max_tokens,
-            n=n,
-            parallel_tool_calls=parallel_tool_calls,
-            presence_penalty=presence_penalty,
-            response_format=response_format,
-            seed=seed,
-            stop=stop,
-            stream=stream,
-            stream_options=stream_options,
-            temperature=temperature,
-            tool_choice=tool_choice,
-            tools=tools,
-            top_logprobs=top_logprobs,
-            top_p=top_p,
-            user=user,
-        )
+        return await super().openai_chat_completion(params)

--- a/llama_stack/strong_typing/inspection.py
+++ b/llama_stack/strong_typing/inspection.py
@@ -50,6 +50,10 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import TypeGuard
 
+
+from pydantic import BaseModel
+from pydantic.fields import FieldInfo
+
 S = TypeVar("S")
 T = TypeVar("T")
 K = TypeVar("K")
@@ -570,7 +574,8 @@ def get_class_properties(typ: type) -> Iterable[Tuple[str, type | str]]:
     elif hasattr(typ, "model_fields"):
         # Pydantic BaseModel - use model_fields to exclude ClassVar and other non-field attributes
         # Reconstruct Annotated type if discriminator exists to preserve metadata
-        from typing import Annotated, Any, cast
+        from typing import Annotated, Any
+
         from pydantic.fields import FieldInfo
 
         def get_field_type(name: str, field: Any) -> type | str:
@@ -1049,3 +1054,32 @@ def check_recursive(
         pred = lambda typ, obj: True  # noqa: E731
 
     return RecursiveChecker(pred).check(type(obj), obj)
+
+
+def is_unwrapped_body_param(param_type: Any) -> bool:
+    """
+    Check if a parameter type represents an unwrapped body parameter.
+    An unwrapped body parameter is an Annotated type with Body(embed=False)
+
+    This is used to determine whether request parameters should be flattened
+    in OpenAPI specs and client libraries (matching FastAPI's embed=False behavior).
+
+    Args:
+        param_type: The parameter type annotation to check
+
+    Returns:
+        True if the parameter should be treated as an unwrapped body parameter
+    """
+    # Check if it's Annotated with Body(embed=False)
+    if typing.get_origin(param_type) is Annotated:
+        args = typing.get_args(param_type)
+        base_type = args[0]
+        metadata = args[1:]
+
+        # Look for Body annotation with embed=False
+        # Body() returns a FieldInfo object, so we check for that type and the embed attribute
+        for item in metadata:
+            if isinstance(item, FieldInfo) and hasattr(item, "embed") and not item.embed:
+                return inspect.isclass(base_type) and issubclass(base_type, BaseModel)
+
+    return False

--- a/tests/unit/providers/agents/meta_reference/test_openai_responses.py
+++ b/tests/unit/providers/agents/meta_reference/test_openai_responses.py
@@ -33,6 +33,7 @@ from llama_stack.apis.agents.openai_responses import (
 from llama_stack.apis.inference import (
     OpenAIAssistantMessageParam,
     OpenAIChatCompletionContentPartTextParam,
+    OpenAIChatCompletionRequest,
     OpenAIDeveloperMessageParam,
     OpenAIJSONSchema,
     OpenAIResponseFormatJSONObject,
@@ -161,15 +162,17 @@ async def test_create_openai_response_with_string_input(openai_responses_impl, m
     chunks = [chunk async for chunk in result]
 
     mock_inference_api.openai_chat_completion.assert_called_once_with(
-        model=model,
-        messages=[OpenAIUserMessageParam(role="user", content="What is the capital of Ireland?", name=None)],
-        response_format=None,
-        tools=None,
-        stream=True,
-        temperature=0.1,
-        stream_options={
-            "include_usage": True,
-        },
+        OpenAIChatCompletionRequest(
+            model=model,
+            messages=[OpenAIUserMessageParam(role="user", content="What is the capital of Ireland?", name=None)],
+            response_format=None,
+            tools=None,
+            stream=True,
+            temperature=0.1,
+            stream_options={
+                "include_usage": True,
+            },
+        )
     )
 
     # Should have content part events for text streaming
@@ -256,13 +259,15 @@ async def test_create_openai_response_with_string_input_with_tools(openai_respon
 
         # Verify
         first_call = mock_inference_api.openai_chat_completion.call_args_list[0]
-        assert first_call.kwargs["messages"][0].content == "What is the capital of Ireland?"
-        assert first_call.kwargs["tools"] is not None
-        assert first_call.kwargs["temperature"] == 0.1
+        first_params = first_call.args[0]
+        assert first_params.messages[0].content == "What is the capital of Ireland?"
+        assert first_params.tools is not None
+        assert first_params.temperature == 0.1
 
         second_call = mock_inference_api.openai_chat_completion.call_args_list[1]
-        assert second_call.kwargs["messages"][-1].content == "Dublin"
-        assert second_call.kwargs["temperature"] == 0.1
+        second_params = second_call.args[0]
+        assert second_params.messages[-1].content == "Dublin"
+        assert second_params.temperature == 0.1
 
         openai_responses_impl.tool_groups_api.get_tool.assert_called_once_with("web_search")
         openai_responses_impl.tool_runtime_api.invoke_tool.assert_called_once_with(
@@ -348,9 +353,10 @@ async def test_create_openai_response_with_tool_call_type_none(openai_responses_
 
     # Verify inference API was called correctly (after iterating over result)
     first_call = mock_inference_api.openai_chat_completion.call_args_list[0]
-    assert first_call.kwargs["messages"][0].content == input_text
-    assert first_call.kwargs["tools"] is not None
-    assert first_call.kwargs["temperature"] == 0.1
+    first_params = first_call.args[0]
+    assert first_params.messages[0].content == input_text
+    assert first_params.tools is not None
+    assert first_params.temperature == 0.1
 
     # Check response.created event (should have empty output)
     assert len(chunks[0].response.output) == 0
@@ -394,9 +400,10 @@ async def test_create_openai_response_with_tool_call_function_arguments_none(ope
 
     def assert_common_expectations(chunks) -> None:
         first_call = mock_inference_api.openai_chat_completion.call_args_list[0]
-        assert first_call.kwargs["messages"][0].content == input_text
-        assert first_call.kwargs["tools"] is not None
-        assert first_call.kwargs["temperature"] == 0.1
+        first_params = first_call.args[0]
+        assert first_params.messages[0].content == input_text
+        assert first_params.tools is not None
+        assert first_params.temperature == 0.1
         assert len(chunks[0].response.output) == 0
         completed_chunk = chunks[-1]
         assert completed_chunk.type == "response.completed"
@@ -512,7 +519,9 @@ async def test_create_openai_response_with_multiple_messages(openai_responses_im
 
     # Verify the the correct messages were sent to the inference API i.e.
     # All of the responses message were convered to the chat completion message objects
-    inference_messages = mock_inference_api.openai_chat_completion.call_args_list[0].kwargs["messages"]
+    call_args = mock_inference_api.openai_chat_completion.call_args_list[0]
+    params = call_args.args[0]
+    inference_messages = params.messages
     for i, m in enumerate(input_messages):
         if isinstance(m.content, str):
             assert inference_messages[i].content == m.content
@@ -680,7 +689,8 @@ async def test_create_openai_response_with_instructions(openai_responses_impl, m
     # Verify
     mock_inference_api.openai_chat_completion.assert_called_once()
     call_args = mock_inference_api.openai_chat_completion.call_args
-    sent_messages = call_args.kwargs["messages"]
+    params = call_args.args[0]
+    sent_messages = params.messages
 
     # Check that instructions were prepended as a system message
     assert len(sent_messages) == 2
@@ -718,7 +728,8 @@ async def test_create_openai_response_with_instructions_and_multiple_messages(
     # Verify
     mock_inference_api.openai_chat_completion.assert_called_once()
     call_args = mock_inference_api.openai_chat_completion.call_args
-    sent_messages = call_args.kwargs["messages"]
+    params = call_args.args[0]
+    sent_messages = params.messages
 
     # Check that instructions were prepended as a system message
     assert len(sent_messages) == 4  # 1 system + 3 input messages
@@ -778,7 +789,8 @@ async def test_create_openai_response_with_instructions_and_previous_response(
     # Verify
     mock_inference_api.openai_chat_completion.assert_called_once()
     call_args = mock_inference_api.openai_chat_completion.call_args
-    sent_messages = call_args.kwargs["messages"]
+    params = call_args.args[0]
+    sent_messages = params.messages
 
     # Check that instructions were prepended as a system message
     assert len(sent_messages) == 4, sent_messages
@@ -1018,7 +1030,8 @@ async def test_reuse_mcp_tool_list(
     )
     assert len(mock_inference_api.openai_chat_completion.call_args_list) == 2
     second_call = mock_inference_api.openai_chat_completion.call_args_list[1]
-    tools_seen = second_call.kwargs["tools"]
+    second_params = second_call.args[0]
+    tools_seen = second_params.tools
     assert len(tools_seen) == 1
     assert tools_seen[0]["function"]["name"] == "test_tool"
     assert tools_seen[0]["function"]["description"] == "a test tool"
@@ -1065,8 +1078,9 @@ async def test_create_openai_response_with_text_format(
 
     # Verify
     first_call = mock_inference_api.openai_chat_completion.call_args_list[0]
-    assert first_call.kwargs["messages"][0].content == input_text
-    assert first_call.kwargs["response_format"] == response_format
+    first_params = first_call.args[0]
+    assert first_params.messages[0].content == input_text
+    assert first_params.response_format == response_format
 
 
 async def test_create_openai_response_with_invalid_text_format(openai_responses_impl, mock_inference_api):

--- a/tests/unit/providers/utils/inference/test_openai_mixin.py
+++ b/tests/unit/providers/utils/inference/test_openai_mixin.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, PropertyMock, patch
 import pytest
 from pydantic import BaseModel, Field
 
-from llama_stack.apis.inference import Model, OpenAIUserMessageParam
+from llama_stack.apis.inference import Model, OpenAIChatCompletionRequest, OpenAIUserMessageParam
 from llama_stack.apis.models import ModelType
 from llama_stack.core.request_headers import request_provider_data_context
 from llama_stack.providers.utils.inference.model_registry import RemoteInferenceProviderConfig
@@ -271,7 +271,8 @@ class TestOpenAIMixinImagePreprocessing:
             with patch("llama_stack.providers.utils.inference.openai_mixin.localize_image_content") as mock_localize:
                 mock_localize.return_value = (b"fake_image_data", "jpeg")
 
-                await mixin.openai_chat_completion(model="test-model", messages=[message])
+                params = OpenAIChatCompletionRequest(model="test-model", messages=[message])
+                await mixin.openai_chat_completion(params)
 
             mock_localize.assert_called_once_with("http://example.com/image.jpg")
 
@@ -303,7 +304,8 @@ class TestOpenAIMixinImagePreprocessing:
 
         with patch.object(type(mixin), "client", new_callable=PropertyMock, return_value=mock_client):
             with patch("llama_stack.providers.utils.inference.openai_mixin.localize_image_content") as mock_localize:
-                await mixin.openai_chat_completion(model="test-model", messages=[message])
+                params = OpenAIChatCompletionRequest(model="test-model", messages=[message])
+                await mixin.openai_chat_completion(params)
 
             mock_localize.assert_not_called()
 


### PR DESCRIPTION
# What does this PR do?

Converts openai(_chat)_completions params to pydantic BaseModel to reduce code duplication across all providers.

## Test Plan
CI









---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/llamastack/llama-stack/pull/3761).
* #3777
* __->__ #3761