### PR TITLE
feat(responses)!: add in_progress, failed, content part events

### DIFF
--- a/docs/static/deprecated-llama-stack-spec.html
+++ b/docs/static/deprecated-llama-stack-spec.html
@@ -10005,10 +10005,71 @@
                     "type": {
                         "type": "string",
                         "const": "output_text",
-                        "default": "output_text"
+                        "default": "output_text",
+                        "description": "Content part type identifier, always \"output_text\""
                     },
                     "text": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Text emitted for this content part"
+                    },
+                    "annotations": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/OpenAIResponseAnnotations"
+                        },
+                        "description": "Structured annotations associated with the text"
+                    },
+                    "logprobs": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "oneOf": [
+                                    {
+                                        "type": "null"
+                                    },
+                                    {
+                                        "type": "boolean"
+                                    },
+                                    {
+                                        "type": "number"
+                                    },
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "object"
+                                    }
+                                ]
+                            }
+                        },
+                        "description": "(Optional) Token log probability details"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "type",
+                    "text",
+                    "annotations"
+                ],
+                "title": "OpenAIResponseContentPartOutputText",
+                "description": "Text content within a streamed response part."
+            },
+            "OpenAIResponseContentPartReasoningText": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "const": "reasoning_text",
+                        "default": "reasoning_text",
+                        "description": "Content part type identifier, always \"reasoning_text\""
+                    },
+                    "text": {
+                        "type": "string",
+                        "description": "Reasoning text supplied by the model"
                     }
                 },
                 "additionalProperties": false,
@@ -10016,7 +10077,8 @@
                     "type",
                     "text"
                 ],
-                "title": "OpenAIResponseContentPartOutputText"
+                "title": "OpenAIResponseContentPartReasoningText",
+                "description": "Reasoning text emitted as part of a streamed response."
             },
             "OpenAIResponseContentPartRefusal": {
                 "type": "object",
@@ -10024,10 +10086,12 @@
                     "type": {
                         "type": "string",
                         "const": "refusal",
-                        "default": "refusal"
+                        "default": "refusal",
+                        "description": "Content part type identifier, always \"refusal\""
                     },
                     "refusal": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Refusal text supplied by the model"
                     }
                 },
                 "additionalProperties": false,
@@ -10035,12 +10099,16 @@
                     "type",
                     "refusal"
                 ],
-                "title": "OpenAIResponseContentPartRefusal"
+                "title": "OpenAIResponseContentPartRefusal",
+                "description": "Refusal content within a streamed response part."
             },
             "OpenAIResponseObjectStream": {
                 "oneOf": [
                     {
                         "$ref": "#/components/schemas/OpenAIResponseObjectStreamResponseCreated"
+                    },
+                    {
+                        "$ref": "#/components/schemas/OpenAIResponseObjectStreamResponseInProgress"
                     },
                     {
                         "$ref": "#/components/schemas/OpenAIResponseObjectStreamResponseOutputItemAdded"
@@ -10100,6 +10168,12 @@
                         "$ref": "#/components/schemas/OpenAIResponseObjectStreamResponseContentPartDone"
                     },
                     {
+                        "$ref": "#/components/schemas/OpenAIResponseObjectStreamResponseIncomplete"
+                    },
+                    {
+                        "$ref": "#/components/schemas/OpenAIResponseObjectStreamResponseFailed"
+                    },
+                    {
                         "$ref": "#/components/schemas/OpenAIResponseObjectStreamResponseCompleted"
                     }
                 ],
@@ -10107,6 +10181,7 @@
                     "propertyName": "type",
                     "mapping": {
                         "response.created": "#/components/schemas/OpenAIResponseObjectStreamResponseCreated",
+                        "response.in_progress": "#/components/schemas/OpenAIResponseObjectStreamResponseInProgress",
                         "response.output_item.added": "#/components/schemas/OpenAIResponseObjectStreamResponseOutputItemAdded",
                         "response.output_item.done": "#/components/schemas/OpenAIResponseObjectStreamResponseOutputItemDone",
                         "response.output_text.delta": "#/components/schemas/OpenAIResponseObjectStreamResponseOutputTextDelta",
@@ -10126,6 +10201,8 @@
                         "response.mcp_call.completed": "#/components/schemas/OpenAIResponseObjectStreamResponseMcpCallCompleted",
                         "response.content_part.added": "#/components/schemas/OpenAIResponseObjectStreamResponseContentPartAdded",
                         "response.content_part.done": "#/components/schemas/OpenAIResponseObjectStreamResponseContentPartDone",
+                        "response.incomplete": "#/components/schemas/OpenAIResponseObjectStreamResponseIncomplete",
+                        "response.failed": "#/components/schemas/OpenAIResponseObjectStreamResponseFailed",
                         "response.completed": "#/components/schemas/OpenAIResponseObjectStreamResponseCompleted"
                     }
                 }
@@ -10135,7 +10212,7 @@
                 "properties": {
                     "response": {
                         "$ref": "#/components/schemas/OpenAIResponseObject",
-                        "description": "The completed response object"
+                        "description": "Completed response object"
                     },
                     "type": {
                         "type": "string",
@@ -10155,6 +10232,10 @@
             "OpenAIResponseObjectStreamResponseContentPartAdded": {
                 "type": "object",
                 "properties": {
+                    "content_index": {
+                        "type": "integer",
+                        "description": "Index position of the part within the content array"
+                    },
                     "response_id": {
                         "type": "string",
                         "description": "Unique identifier of the response containing this content"
@@ -10163,6 +10244,10 @@
                         "type": "string",
                         "description": "Unique identifier of the output item containing this content part"
                     },
+                    "output_index": {
+                        "type": "integer",
+                        "description": "Index position of the output item in the response"
+                    },
                     "part": {
                         "oneOf": [
                             {
@@ -10170,13 +10255,17 @@
                             },
                             {
                                 "$ref": "#/components/schemas/OpenAIResponseContentPartRefusal"
+                            },
+                            {
+                                "$ref": "#/components/schemas/OpenAIResponseContentPartReasoningText"
                             }
                         ],
                         "discriminator": {
                             "propertyName": "type",
                             "mapping": {
                                 "output_text": "#/components/schemas/OpenAIResponseContentPartOutputText",
-                                "refusal": "#/components/schemas/OpenAIResponseContentPartRefusal"
+                                "refusal": "#/components/schemas/OpenAIResponseContentPartRefusal",
+                                "reasoning_text": "#/components/schemas/OpenAIResponseContentPartReasoningText"
                             }
                         },
                         "description": "The content part that was added"
@@ -10194,8 +10283,10 @@
                 },
                 "additionalProperties": false,
                 "required": [
+                    "content_index",
                     "response_id",
                     "item_id",
+                    "output_index",
                     "part",
                     "sequence_number",
                     "type"
@@ -10206,6 +10297,10 @@
             "OpenAIResponseObjectStreamResponseContentPartDone": {
                 "type": "object",
                 "properties": {
+                    "content_index": {
+                        "type": "integer",
+                        "description": "Index position of the part within the content array"
+                    },
                     "response_id": {
                         "type": "string",
                         "description": "Unique identifier of the response containing this content"
@@ -10214,6 +10309,10 @@
                         "type": "string",
                         "description": "Unique identifier of the output item containing this content part"
                     },
+                    "output_index": {
+                        "type": "integer",
+                        "description": "Index position of the output item in the response"
+                    },
                     "part": {
                         "oneOf": [
                             {
@@ -10221,13 +10320,17 @@
                             },
                             {
                                 "$ref": "#/components/schemas/OpenAIResponseContentPartRefusal"
+                            },
+                            {
+                                "$ref": "#/components/schemas/OpenAIResponseContentPartReasoningText"
                             }
                         ],
                         "discriminator": {
                             "propertyName": "type",
                             "mapping": {
                                 "output_text": "#/components/schemas/OpenAIResponseContentPartOutputText",
-                                "refusal": "#/components/schemas/OpenAIResponseContentPartRefusal"
+                                "refusal": "#/components/schemas/OpenAIResponseContentPartRefusal",
+                                "reasoning_text": "#/components/schemas/OpenAIResponseContentPartReasoningText"
                             }
                         },
                         "description": "The completed content part"
@@ -10245,8 +10348,10 @@
                 },
                 "additionalProperties": false,
                 "required": [
+                    "content_index",
                     "response_id",
                     "item_id",
+                    "output_index",
                     "part",
                     "sequence_number",
                     "type"
@@ -10259,7 +10364,7 @@
                 "properties": {
                     "response": {
                         "$ref": "#/components/schemas/OpenAIResponseObject",
-                        "description": "The newly created response object"
+                        "description": "The response object that was created"
                     },
                     "type": {
                         "type": "string",
@@ -10275,6 +10380,33 @@
                 ],
                 "title": "OpenAIResponseObjectStreamResponseCreated",
                 "description": "Streaming event indicating a new response has been created."
+            },
+            "OpenAIResponseObjectStreamResponseFailed": {
+                "type": "object",
+                "properties": {
+                    "response": {
+                        "$ref": "#/components/schemas/OpenAIResponseObject",
+                        "description": "Response object describing the failure"
+                    },
+                    "sequence_number": {
+                        "type": "integer",
+                        "description": "Sequential number for ordering streaming events"
+                    },
+                    "type": {
+                        "type": "string",
+                        "const": "response.failed",
+                        "default": "response.failed",
+                        "description": "Event type identifier, always \"response.failed\""
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "response",
+                    "sequence_number",
+                    "type"
+                ],
+                "title": "OpenAIResponseObjectStreamResponseFailed",
+                "description": "Streaming event emitted when a response fails."
             },
             "OpenAIResponseObjectStreamResponseFunctionCallArgumentsDelta": {
                 "type": "object",
@@ -10349,6 +10481,60 @@
                 ],
                 "title": "OpenAIResponseObjectStreamResponseFunctionCallArgumentsDone",
                 "description": "Streaming event for when function call arguments are completed."
+            },
+            "OpenAIResponseObjectStreamResponseInProgress": {
+                "type": "object",
+                "properties": {
+                    "response": {
+                        "$ref": "#/components/schemas/OpenAIResponseObject",
+                        "description": "Current response state while in progress"
+                    },
+                    "sequence_number": {
+                        "type": "integer",
+                        "description": "Sequential number for ordering streaming events"
+                    },
+                    "type": {
+                        "type": "string",
+                        "const": "response.in_progress",
+                        "default": "response.in_progress",
+                        "description": "Event type identifier, always \"response.in_progress\""
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "response",
+                    "sequence_number",
+                    "type"
+                ],
+                "title": "OpenAIResponseObjectStreamResponseInProgress",
+                "description": "Streaming event indicating the response remains in progress."
+            },
+            "OpenAIResponseObjectStreamResponseIncomplete": {
+                "type": "object",
+                "properties": {
+                    "response": {
+                        "$ref": "#/components/schemas/OpenAIResponseObject",
+                        "description": "Response object describing the incomplete state"
+                    },
+                    "sequence_number": {
+                        "type": "integer",
+                        "description": "Sequential number for ordering streaming events"
+                    },
+                    "type": {
+                        "type": "string",
+                        "const": "response.incomplete",
+                        "default": "response.incomplete",
+                        "description": "Event type identifier, always \"response.incomplete\""
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "response",
+                    "sequence_number",
+                    "type"
+                ],
+                "title": "OpenAIResponseObjectStreamResponseIncomplete",
+                "description": "Streaming event emitted when a response ends in an incomplete state."
             },
             "OpenAIResponseObjectStreamResponseMcpCallArgumentsDelta": {
                 "type": "object",

--- a/docs/static/deprecated-llama-stack-spec.yaml
+++ b/docs/static/deprecated-llama-stack-spec.yaml
@@ -7441,13 +7441,57 @@ components:
           type: string
           const: output_text
           default: output_text
+          description: >-
+            Content part type identifier, always "output_text"
         text:
           type: string
+          description: Text emitted for this content part
+        annotations:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAIResponseAnnotations'
+          description: >-
+            Structured annotations associated with the text
+        logprobs:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              oneOf:
+                - type: 'null'
+                - type: boolean
+                - type: number
+                - type: string
+                - type: array
+                - type: object
+          description: (Optional) Token log probability details
       additionalProperties: false
       required:
         - type
         - text
+        - annotations
       title: OpenAIResponseContentPartOutputText
+      description: >-
+        Text content within a streamed response part.
+    OpenAIResponseContentPartReasoningText:
+      type: object
+      properties:
+        type:
+          type: string
+          const: reasoning_text
+          default: reasoning_text
+          description: >-
+            Content part type identifier, always "reasoning_text"
+        text:
+          type: string
+          description: Reasoning text supplied by the model
+      additionalProperties: false
+      required:
+        - type
+        - text
+      title: OpenAIResponseContentPartReasoningText
+      description: >-
+        Reasoning text emitted as part of a streamed response.
     OpenAIResponseContentPartRefusal:
       type: object
       properties:
@@ -7455,16 +7499,22 @@ components:
           type: string
           const: refusal
           default: refusal
+          description: >-
+            Content part type identifier, always "refusal"
         refusal:
           type: string
+          description: Refusal text supplied by the model
       additionalProperties: false
       required:
         - type
         - refusal
       title: OpenAIResponseContentPartRefusal
+      description: >-
+        Refusal content within a streamed response part.
     OpenAIResponseObjectStream:
       oneOf:
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseCreated'
+        - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseInProgress'
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseOutputItemAdded'
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseOutputItemDone'
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseOutputTextDelta'
@@ -7484,11 +7534,14 @@ components:
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseMcpCallCompleted'
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseContentPartAdded'
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseContentPartDone'
+        - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseIncomplete'
+        - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseFailed'
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseCompleted'
       discriminator:
         propertyName: type
         mapping:
           response.created: '#/components/schemas/OpenAIResponseObjectStreamResponseCreated'
+          response.in_progress: '#/components/schemas/OpenAIResponseObjectStreamResponseInProgress'
           response.output_item.added: '#/components/schemas/OpenAIResponseObjectStreamResponseOutputItemAdded'
           response.output_item.done: '#/components/schemas/OpenAIResponseObjectStreamResponseOutputItemDone'
           response.output_text.delta: '#/components/schemas/OpenAIResponseObjectStreamResponseOutputTextDelta'
@@ -7508,13 +7561,15 @@ components:
           response.mcp_call.completed: '#/components/schemas/OpenAIResponseObjectStreamResponseMcpCallCompleted'
           response.content_part.added: '#/components/schemas/OpenAIResponseObjectStreamResponseContentPartAdded'
           response.content_part.done: '#/components/schemas/OpenAIResponseObjectStreamResponseContentPartDone'
+          response.incomplete: '#/components/schemas/OpenAIResponseObjectStreamResponseIncomplete'
+          response.failed: '#/components/schemas/OpenAIResponseObjectStreamResponseFailed'
           response.completed: '#/components/schemas/OpenAIResponseObjectStreamResponseCompleted'
     "OpenAIResponseObjectStreamResponseCompleted":
       type: object
       properties:
         response:
           $ref: '#/components/schemas/OpenAIResponseObject'
-          description: The completed response object
+          description: Completed response object
         type:
           type: string
           const: response.completed
@@ -7532,6 +7587,10 @@ components:
     "OpenAIResponseObjectStreamResponseContentPartAdded":
       type: object
       properties:
+        content_index:
+          type: integer
+          description: >-
+            Index position of the part within the content array
         response_id:
           type: string
           description: >-
@@ -7540,15 +7599,21 @@ components:
           type: string
           description: >-
             Unique identifier of the output item containing this content part
+        output_index:
+          type: integer
+          description: >-
+            Index position of the output item in the response
         part:
           oneOf:
             - $ref: '#/components/schemas/OpenAIResponseContentPartOutputText'
             - $ref: '#/components/schemas/OpenAIResponseContentPartRefusal'
+            - $ref: '#/components/schemas/OpenAIResponseContentPartReasoningText'
           discriminator:
             propertyName: type
             mapping:
               output_text: '#/components/schemas/OpenAIResponseContentPartOutputText'
               refusal: '#/components/schemas/OpenAIResponseContentPartRefusal'
+              reasoning_text: '#/components/schemas/OpenAIResponseContentPartReasoningText'
           description: The content part that was added
         sequence_number:
           type: integer
@@ -7562,8 +7627,10 @@ components:
             Event type identifier, always "response.content_part.added"
       additionalProperties: false
       required:
+        - content_index
         - response_id
         - item_id
+        - output_index
         - part
         - sequence_number
         - type
@@ -7574,6 +7641,10 @@ components:
     "OpenAIResponseObjectStreamResponseContentPartDone":
       type: object
       properties:
+        content_index:
+          type: integer
+          description: >-
+            Index position of the part within the content array
         response_id:
           type: string
           description: >-
@@ -7582,15 +7653,21 @@ components:
           type: string
           description: >-
             Unique identifier of the output item containing this content part
+        output_index:
+          type: integer
+          description: >-
+            Index position of the output item in the response
         part:
           oneOf:
             - $ref: '#/components/schemas/OpenAIResponseContentPartOutputText'
             - $ref: '#/components/schemas/OpenAIResponseContentPartRefusal'
+            - $ref: '#/components/schemas/OpenAIResponseContentPartReasoningText'
           discriminator:
             propertyName: type
             mapping:
               output_text: '#/components/schemas/OpenAIResponseContentPartOutputText'
               refusal: '#/components/schemas/OpenAIResponseContentPartRefusal'
+              reasoning_text: '#/components/schemas/OpenAIResponseContentPartReasoningText'
           description: The completed content part
         sequence_number:
           type: integer
@@ -7604,8 +7681,10 @@ components:
             Event type identifier, always "response.content_part.done"
       additionalProperties: false
       required:
+        - content_index
         - response_id
         - item_id
+        - output_index
         - part
         - sequence_number
         - type
@@ -7618,7 +7697,7 @@ components:
       properties:
         response:
           $ref: '#/components/schemas/OpenAIResponseObject'
-          description: The newly created response object
+          description: The response object that was created
         type:
           type: string
           const: response.created
@@ -7633,6 +7712,30 @@ components:
         OpenAIResponseObjectStreamResponseCreated
       description: >-
         Streaming event indicating a new response has been created.
+    OpenAIResponseObjectStreamResponseFailed:
+      type: object
+      properties:
+        response:
+          $ref: '#/components/schemas/OpenAIResponseObject'
+          description: Response object describing the failure
+        sequence_number:
+          type: integer
+          description: >-
+            Sequential number for ordering streaming events
+        type:
+          type: string
+          const: response.failed
+          default: response.failed
+          description: >-
+            Event type identifier, always "response.failed"
+      additionalProperties: false
+      required:
+        - response
+        - sequence_number
+        - type
+      title: OpenAIResponseObjectStreamResponseFailed
+      description: >-
+        Streaming event emitted when a response fails.
     "OpenAIResponseObjectStreamResponseFunctionCallArgumentsDelta":
       type: object
       properties:
@@ -7705,6 +7808,57 @@ components:
         OpenAIResponseObjectStreamResponseFunctionCallArgumentsDone
       description: >-
         Streaming event for when function call arguments are completed.
+    "OpenAIResponseObjectStreamResponseInProgress":
+      type: object
+      properties:
+        response:
+          $ref: '#/components/schemas/OpenAIResponseObject'
+          description: Current response state while in progress
+        sequence_number:
+          type: integer
+          description: >-
+            Sequential number for ordering streaming events
+        type:
+          type: string
+          const: response.in_progress
+          default: response.in_progress
+          description: >-
+            Event type identifier, always "response.in_progress"
+      additionalProperties: false
+      required:
+        - response
+        - sequence_number
+        - type
+      title: >-
+        OpenAIResponseObjectStreamResponseInProgress
+      description: >-
+        Streaming event indicating the response remains in progress.
+    "OpenAIResponseObjectStreamResponseIncomplete":
+      type: object
+      properties:
+        response:
+          $ref: '#/components/schemas/OpenAIResponseObject'
+          description: >-
+            Response object describing the incomplete state
+        sequence_number:
+          type: integer
+          description: >-
+            Sequential number for ordering streaming events
+        type:
+          type: string
+          const: response.incomplete
+          default: response.incomplete
+          description: >-
+            Event type identifier, always "response.incomplete"
+      additionalProperties: false
+      required:
+        - response
+        - sequence_number
+        - type
+      title: >-
+        OpenAIResponseObjectStreamResponseIncomplete
+      description: >-
+        Streaming event emitted when a response ends in an incomplete state.
     "OpenAIResponseObjectStreamResponseMcpCallArgumentsDelta":
       type: object
       properties:

--- a/docs/static/llama-stack-spec.html
+++ b/docs/static/llama-stack-spec.html
@@ -8100,10 +8100,71 @@
                     "type": {
                         "type": "string",
                         "const": "output_text",
-                        "default": "output_text"
+                        "default": "output_text",
+                        "description": "Content part type identifier, always \"output_text\""
                     },
                     "text": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Text emitted for this content part"
+                    },
+                    "annotations": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/OpenAIResponseAnnotations"
+                        },
+                        "description": "Structured annotations associated with the text"
+                    },
+                    "logprobs": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "oneOf": [
+                                    {
+                                        "type": "null"
+                                    },
+                                    {
+                                        "type": "boolean"
+                                    },
+                                    {
+                                        "type": "number"
+                                    },
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "object"
+                                    }
+                                ]
+                            }
+                        },
+                        "description": "(Optional) Token log probability details"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "type",
+                    "text",
+                    "annotations"
+                ],
+                "title": "OpenAIResponseContentPartOutputText",
+                "description": "Text content within a streamed response part."
+            },
+            "OpenAIResponseContentPartReasoningText": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "const": "reasoning_text",
+                        "default": "reasoning_text",
+                        "description": "Content part type identifier, always \"reasoning_text\""
+                    },
+                    "text": {
+                        "type": "string",
+                        "description": "Reasoning text supplied by the model"
                     }
                 },
                 "additionalProperties": false,
@@ -8111,7 +8172,8 @@
                     "type",
                     "text"
                 ],
-                "title": "OpenAIResponseContentPartOutputText"
+                "title": "OpenAIResponseContentPartReasoningText",
+                "description": "Reasoning text emitted as part of a streamed response."
             },
             "OpenAIResponseContentPartRefusal": {
                 "type": "object",
@@ -8119,10 +8181,12 @@
                     "type": {
                         "type": "string",
                         "const": "refusal",
-                        "default": "refusal"
+                        "default": "refusal",
+                        "description": "Content part type identifier, always \"refusal\""
                     },
                     "refusal": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Refusal text supplied by the model"
                     }
                 },
                 "additionalProperties": false,
@@ -8130,12 +8194,16 @@
                     "type",
                     "refusal"
                 ],
-                "title": "OpenAIResponseContentPartRefusal"
+                "title": "OpenAIResponseContentPartRefusal",
+                "description": "Refusal content within a streamed response part."
             },
             "OpenAIResponseObjectStream": {
                 "oneOf": [
                     {
                         "$ref": "#/components/schemas/OpenAIResponseObjectStreamResponseCreated"
+                    },
+                    {
+                        "$ref": "#/components/schemas/OpenAIResponseObjectStreamResponseInProgress"
                     },
                     {
                         "$ref": "#/components/schemas/OpenAIResponseObjectStreamResponseOutputItemAdded"
@@ -8195,6 +8263,12 @@
                         "$ref": "#/components/schemas/OpenAIResponseObjectStreamResponseContentPartDone"
                     },
                     {
+                        "$ref": "#/components/schemas/OpenAIResponseObjectStreamResponseIncomplete"
+                    },
+                    {
+                        "$ref": "#/components/schemas/OpenAIResponseObjectStreamResponseFailed"
+                    },
+                    {
                         "$ref": "#/components/schemas/OpenAIResponseObjectStreamResponseCompleted"
                     }
                 ],
@@ -8202,6 +8276,7 @@
                     "propertyName": "type",
                     "mapping": {
                         "response.created": "#/components/schemas/OpenAIResponseObjectStreamResponseCreated",
+                        "response.in_progress": "#/components/schemas/OpenAIResponseObjectStreamResponseInProgress",
                         "response.output_item.added": "#/components/schemas/OpenAIResponseObjectStreamResponseOutputItemAdded",
                         "response.output_item.done": "#/components/schemas/OpenAIResponseObjectStreamResponseOutputItemDone",
                         "response.output_text.delta": "#/components/schemas/OpenAIResponseObjectStreamResponseOutputTextDelta",
@@ -8221,6 +8296,8 @@
                         "response.mcp_call.completed": "#/components/schemas/OpenAIResponseObjectStreamResponseMcpCallCompleted",
                         "response.content_part.added": "#/components/schemas/OpenAIResponseObjectStreamResponseContentPartAdded",
                         "response.content_part.done": "#/components/schemas/OpenAIResponseObjectStreamResponseContentPartDone",
+                        "response.incomplete": "#/components/schemas/OpenAIResponseObjectStreamResponseIncomplete",
+                        "response.failed": "#/components/schemas/OpenAIResponseObjectStreamResponseFailed",
                         "response.completed": "#/components/schemas/OpenAIResponseObjectStreamResponseCompleted"
                     }
                 }
@@ -8230,7 +8307,7 @@
                 "properties": {
                     "response": {
                         "$ref": "#/components/schemas/OpenAIResponseObject",
-                        "description": "The completed response object"
+                        "description": "Completed response object"
                     },
                     "type": {
                         "type": "string",
@@ -8250,6 +8327,10 @@
             "OpenAIResponseObjectStreamResponseContentPartAdded": {
                 "type": "object",
                 "properties": {
+                    "content_index": {
+                        "type": "integer",
+                        "description": "Index position of the part within the content array"
+                    },
                     "response_id": {
                         "type": "string",
                         "description": "Unique identifier of the response containing this content"
@@ -8258,6 +8339,10 @@
                         "type": "string",
                         "description": "Unique identifier of the output item containing this content part"
                     },
+                    "output_index": {
+                        "type": "integer",
+                        "description": "Index position of the output item in the response"
+                    },
                     "part": {
                         "oneOf": [
                             {
@@ -8265,13 +8350,17 @@
                             },
                             {
                                 "$ref": "#/components/schemas/OpenAIResponseContentPartRefusal"
+                            },
+                            {
+                                "$ref": "#/components/schemas/OpenAIResponseContentPartReasoningText"
                             }
                         ],
                         "discriminator": {
                             "propertyName": "type",
                             "mapping": {
                                 "output_text": "#/components/schemas/OpenAIResponseContentPartOutputText",
-                                "refusal": "#/components/schemas/OpenAIResponseContentPartRefusal"
+                                "refusal": "#/components/schemas/OpenAIResponseContentPartRefusal",
+                                "reasoning_text": "#/components/schemas/OpenAIResponseContentPartReasoningText"
                             }
                         },
                         "description": "The content part that was added"
@@ -8289,8 +8378,10 @@
                 },
                 "additionalProperties": false,
                 "required": [
+                    "content_index",
                     "response_id",
                     "item_id",
+                    "output_index",
                     "part",
                     "sequence_number",
                     "type"
@@ -8301,6 +8392,10 @@
             "OpenAIResponseObjectStreamResponseContentPartDone": {
                 "type": "object",
                 "properties": {
+                    "content_index": {
+                        "type": "integer",
+                        "description": "Index position of the part within the content array"
+                    },
                     "response_id": {
                         "type": "string",
                         "description": "Unique identifier of the response containing this content"
@@ -8309,6 +8404,10 @@
                         "type": "string",
                         "description": "Unique identifier of the output item containing this content part"
                     },
+                    "output_index": {
+                        "type": "integer",
+                        "description": "Index position of the output item in the response"
+                    },
                     "part": {
                         "oneOf": [
                             {
@@ -8316,13 +8415,17 @@
                             },
                             {
                                 "$ref": "#/components/schemas/OpenAIResponseContentPartRefusal"
+                            },
+                            {
+                                "$ref": "#/components/schemas/OpenAIResponseContentPartReasoningText"
                             }
                         ],
                         "discriminator": {
                             "propertyName": "type",
                             "mapping": {
                                 "output_text": "#/components/schemas/OpenAIResponseContentPartOutputText",
-                                "refusal": "#/components/schemas/OpenAIResponseContentPartRefusal"
+                                "refusal": "#/components/schemas/OpenAIResponseContentPartRefusal",
+                                "reasoning_text": "#/components/schemas/OpenAIResponseContentPartReasoningText"
                             }
                         },
                         "description": "The completed content part"
@@ -8340,8 +8443,10 @@
                 },
                 "additionalProperties": false,
                 "required": [
+                    "content_index",
                     "response_id",
                     "item_id",
+                    "output_index",
                     "part",
                     "sequence_number",
                     "type"
@@ -8354,7 +8459,7 @@
                 "properties": {
                     "response": {
                         "$ref": "#/components/schemas/OpenAIResponseObject",
-                        "description": "The newly created response object"
+                        "description": "The response object that was created"
                     },
                     "type": {
                         "type": "string",
@@ -8370,6 +8475,33 @@
                 ],
                 "title": "OpenAIResponseObjectStreamResponseCreated",
                 "description": "Streaming event indicating a new response has been created."
+            },
+            "OpenAIResponseObjectStreamResponseFailed": {
+                "type": "object",
+                "properties": {
+                    "response": {
+                        "$ref": "#/components/schemas/OpenAIResponseObject",
+                        "description": "Response object describing the failure"
+                    },
+                    "sequence_number": {
+                        "type": "integer",
+                        "description": "Sequential number for ordering streaming events"
+                    },
+                    "type": {
+                        "type": "string",
+                        "const": "response.failed",
+                        "default": "response.failed",
+                        "description": "Event type identifier, always \"response.failed\""
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "response",
+                    "sequence_number",
+                    "type"
+                ],
+                "title": "OpenAIResponseObjectStreamResponseFailed",
+                "description": "Streaming event emitted when a response fails."
             },
             "OpenAIResponseObjectStreamResponseFunctionCallArgumentsDelta": {
                 "type": "object",
@@ -8444,6 +8576,60 @@
                 ],
                 "title": "OpenAIResponseObjectStreamResponseFunctionCallArgumentsDone",
                 "description": "Streaming event for when function call arguments are completed."
+            },
+            "OpenAIResponseObjectStreamResponseInProgress": {
+                "type": "object",
+                "properties": {
+                    "response": {
+                        "$ref": "#/components/schemas/OpenAIResponseObject",
+                        "description": "Current response state while in progress"
+                    },
+                    "sequence_number": {
+                        "type": "integer",
+                        "description": "Sequential number for ordering streaming events"
+                    },
+                    "type": {
+                        "type": "string",
+                        "const": "response.in_progress",
+                        "default": "response.in_progress",
+                        "description": "Event type identifier, always \"response.in_progress\""
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "response",
+                    "sequence_number",
+                    "type"
+                ],
+                "title": "OpenAIResponseObjectStreamResponseInProgress",
+                "description": "Streaming event indicating the response remains in progress."
+            },
+            "OpenAIResponseObjectStreamResponseIncomplete": {
+                "type": "object",
+                "properties": {
+                    "response": {
+                        "$ref": "#/components/schemas/OpenAIResponseObject",
+                        "description": "Response object describing the incomplete state"
+                    },
+                    "sequence_number": {
+                        "type": "integer",
+                        "description": "Sequential number for ordering streaming events"
+                    },
+                    "type": {
+                        "type": "string",
+                        "const": "response.incomplete",
+                        "default": "response.incomplete",
+                        "description": "Event type identifier, always \"response.incomplete\""
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "response",
+                    "sequence_number",
+                    "type"
+                ],
+                "title": "OpenAIResponseObjectStreamResponseIncomplete",
+                "description": "Streaming event emitted when a response ends in an incomplete state."
             },
             "OpenAIResponseObjectStreamResponseMcpCallArgumentsDelta": {
                 "type": "object",

--- a/docs/static/llama-stack-spec.yaml
+++ b/docs/static/llama-stack-spec.yaml
@@ -6137,13 +6137,57 @@ components:
           type: string
           const: output_text
           default: output_text
+          description: >-
+            Content part type identifier, always "output_text"
         text:
           type: string
+          description: Text emitted for this content part
+        annotations:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAIResponseAnnotations'
+          description: >-
+            Structured annotations associated with the text
+        logprobs:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              oneOf:
+                - type: 'null'
+                - type: boolean
+                - type: number
+                - type: string
+                - type: array
+                - type: object
+          description: (Optional) Token log probability details
       additionalProperties: false
       required:
         - type
         - text
+        - annotations
       title: OpenAIResponseContentPartOutputText
+      description: >-
+        Text content within a streamed response part.
+    OpenAIResponseContentPartReasoningText:
+      type: object
+      properties:
+        type:
+          type: string
+          const: reasoning_text
+          default: reasoning_text
+          description: >-
+            Content part type identifier, always "reasoning_text"
+        text:
+          type: string
+          description: Reasoning text supplied by the model
+      additionalProperties: false
+      required:
+        - type
+        - text
+      title: OpenAIResponseContentPartReasoningText
+      description: >-
+        Reasoning text emitted as part of a streamed response.
     OpenAIResponseContentPartRefusal:
       type: object
       properties:
@@ -6151,16 +6195,22 @@ components:
           type: string
           const: refusal
           default: refusal
+          description: >-
+            Content part type identifier, always "refusal"
         refusal:
           type: string
+          description: Refusal text supplied by the model
       additionalProperties: false
       required:
         - type
         - refusal
       title: OpenAIResponseContentPartRefusal
+      description: >-
+        Refusal content within a streamed response part.
     OpenAIResponseObjectStream:
       oneOf:
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseCreated'
+        - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseInProgress'
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseOutputItemAdded'
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseOutputItemDone'
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseOutputTextDelta'
@@ -6180,11 +6230,14 @@ components:
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseMcpCallCompleted'
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseContentPartAdded'
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseContentPartDone'
+        - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseIncomplete'
+        - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseFailed'
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseCompleted'
       discriminator:
         propertyName: type
         mapping:
           response.created: '#/components/schemas/OpenAIResponseObjectStreamResponseCreated'
+          response.in_progress: '#/components/schemas/OpenAIResponseObjectStreamResponseInProgress'
           response.output_item.added: '#/components/schemas/OpenAIResponseObjectStreamResponseOutputItemAdded'
           response.output_item.done: '#/components/schemas/OpenAIResponseObjectStreamResponseOutputItemDone'
           response.output_text.delta: '#/components/schemas/OpenAIResponseObjectStreamResponseOutputTextDelta'
@@ -6204,13 +6257,15 @@ components:
           response.mcp_call.completed: '#/components/schemas/OpenAIResponseObjectStreamResponseMcpCallCompleted'
           response.content_part.added: '#/components/schemas/OpenAIResponseObjectStreamResponseContentPartAdded'
           response.content_part.done: '#/components/schemas/OpenAIResponseObjectStreamResponseContentPartDone'
+          response.incomplete: '#/components/schemas/OpenAIResponseObjectStreamResponseIncomplete'
+          response.failed: '#/components/schemas/OpenAIResponseObjectStreamResponseFailed'
           response.completed: '#/components/schemas/OpenAIResponseObjectStreamResponseCompleted'
     "OpenAIResponseObjectStreamResponseCompleted":
       type: object
       properties:
         response:
           $ref: '#/components/schemas/OpenAIResponseObject'
-          description: The completed response object
+          description: Completed response object
         type:
           type: string
           const: response.completed
@@ -6228,6 +6283,10 @@ components:
     "OpenAIResponseObjectStreamResponseContentPartAdded":
       type: object
       properties:
+        content_index:
+          type: integer
+          description: >-
+            Index position of the part within the content array
         response_id:
           type: string
           description: >-
@@ -6236,15 +6295,21 @@ components:
           type: string
           description: >-
             Unique identifier of the output item containing this content part
+        output_index:
+          type: integer
+          description: >-
+            Index position of the output item in the response
         part:
           oneOf:
             - $ref: '#/components/schemas/OpenAIResponseContentPartOutputText'
             - $ref: '#/components/schemas/OpenAIResponseContentPartRefusal'
+            - $ref: '#/components/schemas/OpenAIResponseContentPartReasoningText'
           discriminator:
             propertyName: type
             mapping:
               output_text: '#/components/schemas/OpenAIResponseContentPartOutputText'
               refusal: '#/components/schemas/OpenAIResponseContentPartRefusal'
+              reasoning_text: '#/components/schemas/OpenAIResponseContentPartReasoningText'
           description: The content part that was added
         sequence_number:
           type: integer
@@ -6258,8 +6323,10 @@ components:
             Event type identifier, always "response.content_part.added"
       additionalProperties: false
       required:
+        - content_index
         - response_id
         - item_id
+        - output_index
         - part
         - sequence_number
         - type
@@ -6270,6 +6337,10 @@ components:
     "OpenAIResponseObjectStreamResponseContentPartDone":
       type: object
       properties:
+        content_index:
+          type: integer
+          description: >-
+            Index position of the part within the content array
         response_id:
           type: string
           description: >-
@@ -6278,15 +6349,21 @@ components:
           type: string
           description: >-
             Unique identifier of the output item containing this content part
+        output_index:
+          type: integer
+          description: >-
+            Index position of the output item in the response
         part:
           oneOf:
             - $ref: '#/components/schemas/OpenAIResponseContentPartOutputText'
             - $ref: '#/components/schemas/OpenAIResponseContentPartRefusal'
+            - $ref: '#/components/schemas/OpenAIResponseContentPartReasoningText'
           discriminator:
             propertyName: type
             mapping:
               output_text: '#/components/schemas/OpenAIResponseContentPartOutputText'
               refusal: '#/components/schemas/OpenAIResponseContentPartRefusal'
+              reasoning_text: '#/components/schemas/OpenAIResponseContentPartReasoningText'
           description: The completed content part
         sequence_number:
           type: integer
@@ -6300,8 +6377,10 @@ components:
             Event type identifier, always "response.content_part.done"
       additionalProperties: false
       required:
+        - content_index
         - response_id
         - item_id
+        - output_index
         - part
         - sequence_number
         - type
@@ -6314,7 +6393,7 @@ components:
       properties:
         response:
           $ref: '#/components/schemas/OpenAIResponseObject'
-          description: The newly created response object
+          description: The response object that was created
         type:
           type: string
           const: response.created
@@ -6329,6 +6408,30 @@ components:
         OpenAIResponseObjectStreamResponseCreated
       description: >-
         Streaming event indicating a new response has been created.
+    OpenAIResponseObjectStreamResponseFailed:
+      type: object
+      properties:
+        response:
+          $ref: '#/components/schemas/OpenAIResponseObject'
+          description: Response object describing the failure
+        sequence_number:
+          type: integer
+          description: >-
+            Sequential number for ordering streaming events
+        type:
+          type: string
+          const: response.failed
+          default: response.failed
+          description: >-
+            Event type identifier, always "response.failed"
+      additionalProperties: false
+      required:
+        - response
+        - sequence_number
+        - type
+      title: OpenAIResponseObjectStreamResponseFailed
+      description: >-
+        Streaming event emitted when a response fails.
     "OpenAIResponseObjectStreamResponseFunctionCallArgumentsDelta":
       type: object
       properties:
@@ -6401,6 +6504,57 @@ components:
         OpenAIResponseObjectStreamResponseFunctionCallArgumentsDone
       description: >-
         Streaming event for when function call arguments are completed.
+    "OpenAIResponseObjectStreamResponseInProgress":
+      type: object
+      properties:
+        response:
+          $ref: '#/components/schemas/OpenAIResponseObject'
+          description: Current response state while in progress
+        sequence_number:
+          type: integer
+          description: >-
+            Sequential number for ordering streaming events
+        type:
+          type: string
+          const: response.in_progress
+          default: response.in_progress
+          description: >-
+            Event type identifier, always "response.in_progress"
+      additionalProperties: false
+      required:
+        - response
+        - sequence_number
+        - type
+      title: >-
+        OpenAIResponseObjectStreamResponseInProgress
+      description: >-
+        Streaming event indicating the response remains in progress.
+    "OpenAIResponseObjectStreamResponseIncomplete":
+      type: object
+      properties:
+        response:
+          $ref: '#/components/schemas/OpenAIResponseObject'
+          description: >-
+            Response object describing the incomplete state
+        sequence_number:
+          type: integer
+          description: >-
+            Sequential number for ordering streaming events
+        type:
+          type: string
+          const: response.incomplete
+          default: response.incomplete
+          description: >-
+            Event type identifier, always "response.incomplete"
+      additionalProperties: false
+      required:
+        - response
+        - sequence_number
+        - type
+      title: >-
+        OpenAIResponseObjectStreamResponseIncomplete
+      description: >-
+        Streaming event emitted when a response ends in an incomplete state.
     "OpenAIResponseObjectStreamResponseMcpCallArgumentsDelta":
       type: object
       properties:

--- a/docs/static/stainless-llama-stack-spec.html
+++ b/docs/static/stainless-llama-stack-spec.html
@@ -10109,10 +10109,71 @@
                     "type": {
                         "type": "string",
                         "const": "output_text",
-                        "default": "output_text"
+                        "default": "output_text",
+                        "description": "Content part type identifier, always \"output_text\""
                     },
                     "text": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Text emitted for this content part"
+                    },
+                    "annotations": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/OpenAIResponseAnnotations"
+                        },
+                        "description": "Structured annotations associated with the text"
+                    },
+                    "logprobs": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "oneOf": [
+                                    {
+                                        "type": "null"
+                                    },
+                                    {
+                                        "type": "boolean"
+                                    },
+                                    {
+                                        "type": "number"
+                                    },
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "object"
+                                    }
+                                ]
+                            }
+                        },
+                        "description": "(Optional) Token log probability details"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "type",
+                    "text",
+                    "annotations"
+                ],
+                "title": "OpenAIResponseContentPartOutputText",
+                "description": "Text content within a streamed response part."
+            },
+            "OpenAIResponseContentPartReasoningText": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "const": "reasoning_text",
+                        "default": "reasoning_text",
+                        "description": "Content part type identifier, always \"reasoning_text\""
+                    },
+                    "text": {
+                        "type": "string",
+                        "description": "Reasoning text supplied by the model"
                     }
                 },
                 "additionalProperties": false,
@@ -10120,7 +10181,8 @@
                     "type",
                     "text"
                 ],
-                "title": "OpenAIResponseContentPartOutputText"
+                "title": "OpenAIResponseContentPartReasoningText",
+                "description": "Reasoning text emitted as part of a streamed response."
             },
             "OpenAIResponseContentPartRefusal": {
                 "type": "object",
@@ -10128,10 +10190,12 @@
                     "type": {
                         "type": "string",
                         "const": "refusal",
-                        "default": "refusal"
+                        "default": "refusal",
+                        "description": "Content part type identifier, always \"refusal\""
                     },
                     "refusal": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Refusal text supplied by the model"
                     }
                 },
                 "additionalProperties": false,
@@ -10139,12 +10203,16 @@
                     "type",
                     "refusal"
                 ],
-                "title": "OpenAIResponseContentPartRefusal"
+                "title": "OpenAIResponseContentPartRefusal",
+                "description": "Refusal content within a streamed response part."
             },
             "OpenAIResponseObjectStream": {
                 "oneOf": [
                     {
                         "$ref": "#/components/schemas/OpenAIResponseObjectStreamResponseCreated"
+                    },
+                    {
+                        "$ref": "#/components/schemas/OpenAIResponseObjectStreamResponseInProgress"
                     },
                     {
                         "$ref": "#/components/schemas/OpenAIResponseObjectStreamResponseOutputItemAdded"
@@ -10204,6 +10272,12 @@
                         "$ref": "#/components/schemas/OpenAIResponseObjectStreamResponseContentPartDone"
                     },
                     {
+                        "$ref": "#/components/schemas/OpenAIResponseObjectStreamResponseIncomplete"
+                    },
+                    {
+                        "$ref": "#/components/schemas/OpenAIResponseObjectStreamResponseFailed"
+                    },
+                    {
                         "$ref": "#/components/schemas/OpenAIResponseObjectStreamResponseCompleted"
                     }
                 ],
@@ -10211,6 +10285,7 @@
                     "propertyName": "type",
                     "mapping": {
                         "response.created": "#/components/schemas/OpenAIResponseObjectStreamResponseCreated",
+                        "response.in_progress": "#/components/schemas/OpenAIResponseObjectStreamResponseInProgress",
                         "response.output_item.added": "#/components/schemas/OpenAIResponseObjectStreamResponseOutputItemAdded",
                         "response.output_item.done": "#/components/schemas/OpenAIResponseObjectStreamResponseOutputItemDone",
                         "response.output_text.delta": "#/components/schemas/OpenAIResponseObjectStreamResponseOutputTextDelta",
@@ -10230,6 +10305,8 @@
                         "response.mcp_call.completed": "#/components/schemas/OpenAIResponseObjectStreamResponseMcpCallCompleted",
                         "response.content_part.added": "#/components/schemas/OpenAIResponseObjectStreamResponseContentPartAdded",
                         "response.content_part.done": "#/components/schemas/OpenAIResponseObjectStreamResponseContentPartDone",
+                        "response.incomplete": "#/components/schemas/OpenAIResponseObjectStreamResponseIncomplete",
+                        "response.failed": "#/components/schemas/OpenAIResponseObjectStreamResponseFailed",
                         "response.completed": "#/components/schemas/OpenAIResponseObjectStreamResponseCompleted"
                     }
                 }
@@ -10239,7 +10316,7 @@
                 "properties": {
                     "response": {
                         "$ref": "#/components/schemas/OpenAIResponseObject",
-                        "description": "The completed response object"
+                        "description": "Completed response object"
                     },
                     "type": {
                         "type": "string",
@@ -10259,6 +10336,10 @@
             "OpenAIResponseObjectStreamResponseContentPartAdded": {
                 "type": "object",
                 "properties": {
+                    "content_index": {
+                        "type": "integer",
+                        "description": "Index position of the part within the content array"
+                    },
                     "response_id": {
                         "type": "string",
                         "description": "Unique identifier of the response containing this content"
@@ -10267,6 +10348,10 @@
                         "type": "string",
                         "description": "Unique identifier of the output item containing this content part"
                     },
+                    "output_index": {
+                        "type": "integer",
+                        "description": "Index position of the output item in the response"
+                    },
                     "part": {
                         "oneOf": [
                             {
@@ -10274,13 +10359,17 @@
                             },
                             {
                                 "$ref": "#/components/schemas/OpenAIResponseContentPartRefusal"
+                            },
+                            {
+                                "$ref": "#/components/schemas/OpenAIResponseContentPartReasoningText"
                             }
                         ],
                         "discriminator": {
                             "propertyName": "type",
                             "mapping": {
                                 "output_text": "#/components/schemas/OpenAIResponseContentPartOutputText",
-                                "refusal": "#/components/schemas/OpenAIResponseContentPartRefusal"
+                                "refusal": "#/components/schemas/OpenAIResponseContentPartRefusal",
+                                "reasoning_text": "#/components/schemas/OpenAIResponseContentPartReasoningText"
                             }
                         },
                         "description": "The content part that was added"
@@ -10298,8 +10387,10 @@
                 },
                 "additionalProperties": false,
                 "required": [
+                    "content_index",
                     "response_id",
                     "item_id",
+                    "output_index",
                     "part",
                     "sequence_number",
                     "type"
@@ -10310,6 +10401,10 @@
             "OpenAIResponseObjectStreamResponseContentPartDone": {
                 "type": "object",
                 "properties": {
+                    "content_index": {
+                        "type": "integer",
+                        "description": "Index position of the part within the content array"
+                    },
                     "response_id": {
                         "type": "string",
                         "description": "Unique identifier of the response containing this content"
@@ -10318,6 +10413,10 @@
                         "type": "string",
                         "description": "Unique identifier of the output item containing this content part"
                     },
+                    "output_index": {
+                        "type": "integer",
+                        "description": "Index position of the output item in the response"
+                    },
                     "part": {
                         "oneOf": [
                             {
@@ -10325,13 +10424,17 @@
                             },
                             {
                                 "$ref": "#/components/schemas/OpenAIResponseContentPartRefusal"
+                            },
+                            {
+                                "$ref": "#/components/schemas/OpenAIResponseContentPartReasoningText"
                             }
                         ],
                         "discriminator": {
                             "propertyName": "type",
                             "mapping": {
                                 "output_text": "#/components/schemas/OpenAIResponseContentPartOutputText",
-                                "refusal": "#/components/schemas/OpenAIResponseContentPartRefusal"
+                                "refusal": "#/components/schemas/OpenAIResponseContentPartRefusal",
+                                "reasoning_text": "#/components/schemas/OpenAIResponseContentPartReasoningText"
                             }
                         },
                         "description": "The completed content part"
@@ -10349,8 +10452,10 @@
                 },
                 "additionalProperties": false,
                 "required": [
+                    "content_index",
                     "response_id",
                     "item_id",
+                    "output_index",
                     "part",
                     "sequence_number",
                     "type"
@@ -10363,7 +10468,7 @@
                 "properties": {
                     "response": {
                         "$ref": "#/components/schemas/OpenAIResponseObject",
-                        "description": "The newly created response object"
+                        "description": "The response object that was created"
                     },
                     "type": {
                         "type": "string",
@@ -10379,6 +10484,33 @@
                 ],
                 "title": "OpenAIResponseObjectStreamResponseCreated",
                 "description": "Streaming event indicating a new response has been created."
+            },
+            "OpenAIResponseObjectStreamResponseFailed": {
+                "type": "object",
+                "properties": {
+                    "response": {
+                        "$ref": "#/components/schemas/OpenAIResponseObject",
+                        "description": "Response object describing the failure"
+                    },
+                    "sequence_number": {
+                        "type": "integer",
+                        "description": "Sequential number for ordering streaming events"
+                    },
+                    "type": {
+                        "type": "string",
+                        "const": "response.failed",
+                        "default": "response.failed",
+                        "description": "Event type identifier, always \"response.failed\""
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "response",
+                    "sequence_number",
+                    "type"
+                ],
+                "title": "OpenAIResponseObjectStreamResponseFailed",
+                "description": "Streaming event emitted when a response fails."
             },
             "OpenAIResponseObjectStreamResponseFunctionCallArgumentsDelta": {
                 "type": "object",
@@ -10453,6 +10585,60 @@
                 ],
                 "title": "OpenAIResponseObjectStreamResponseFunctionCallArgumentsDone",
                 "description": "Streaming event for when function call arguments are completed."
+            },
+            "OpenAIResponseObjectStreamResponseInProgress": {
+                "type": "object",
+                "properties": {
+                    "response": {
+                        "$ref": "#/components/schemas/OpenAIResponseObject",
+                        "description": "Current response state while in progress"
+                    },
+                    "sequence_number": {
+                        "type": "integer",
+                        "description": "Sequential number for ordering streaming events"
+                    },
+                    "type": {
+                        "type": "string",
+                        "const": "response.in_progress",
+                        "default": "response.in_progress",
+                        "description": "Event type identifier, always \"response.in_progress\""
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "response",
+                    "sequence_number",
+                    "type"
+                ],
+                "title": "OpenAIResponseObjectStreamResponseInProgress",
+                "description": "Streaming event indicating the response remains in progress."
+            },
+            "OpenAIResponseObjectStreamResponseIncomplete": {
+                "type": "object",
+                "properties": {
+                    "response": {
+                        "$ref": "#/components/schemas/OpenAIResponseObject",
+                        "description": "Response object describing the incomplete state"
+                    },
+                    "sequence_number": {
+                        "type": "integer",
+                        "description": "Sequential number for ordering streaming events"
+                    },
+                    "type": {
+                        "type": "string",
+                        "const": "response.incomplete",
+                        "default": "response.incomplete",
+                        "description": "Event type identifier, always \"response.incomplete\""
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "response",
+                    "sequence_number",
+                    "type"
+                ],
+                "title": "OpenAIResponseObjectStreamResponseIncomplete",
+                "description": "Streaming event emitted when a response ends in an incomplete state."
             },
             "OpenAIResponseObjectStreamResponseMcpCallArgumentsDelta": {
                 "type": "object",

--- a/docs/static/stainless-llama-stack-spec.yaml
+++ b/docs/static/stainless-llama-stack-spec.yaml
@@ -7582,13 +7582,57 @@ components:
           type: string
           const: output_text
           default: output_text
+          description: >-
+            Content part type identifier, always "output_text"
         text:
           type: string
+          description: Text emitted for this content part
+        annotations:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAIResponseAnnotations'
+          description: >-
+            Structured annotations associated with the text
+        logprobs:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              oneOf:
+                - type: 'null'
+                - type: boolean
+                - type: number
+                - type: string
+                - type: array
+                - type: object
+          description: (Optional) Token log probability details
       additionalProperties: false
       required:
         - type
         - text
+        - annotations
       title: OpenAIResponseContentPartOutputText
+      description: >-
+        Text content within a streamed response part.
+    OpenAIResponseContentPartReasoningText:
+      type: object
+      properties:
+        type:
+          type: string
+          const: reasoning_text
+          default: reasoning_text
+          description: >-
+            Content part type identifier, always "reasoning_text"
+        text:
+          type: string
+          description: Reasoning text supplied by the model
+      additionalProperties: false
+      required:
+        - type
+        - text
+      title: OpenAIResponseContentPartReasoningText
+      description: >-
+        Reasoning text emitted as part of a streamed response.
     OpenAIResponseContentPartRefusal:
       type: object
       properties:
@@ -7596,16 +7640,22 @@ components:
           type: string
           const: refusal
           default: refusal
+          description: >-
+            Content part type identifier, always "refusal"
         refusal:
           type: string
+          description: Refusal text supplied by the model
       additionalProperties: false
       required:
         - type
         - refusal
       title: OpenAIResponseContentPartRefusal
+      description: >-
+        Refusal content within a streamed response part.
     OpenAIResponseObjectStream:
       oneOf:
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseCreated'
+        - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseInProgress'
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseOutputItemAdded'
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseOutputItemDone'
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseOutputTextDelta'
@@ -7625,11 +7675,14 @@ components:
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseMcpCallCompleted'
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseContentPartAdded'
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseContentPartDone'
+        - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseIncomplete'
+        - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseFailed'
         - $ref: '#/components/schemas/OpenAIResponseObjectStreamResponseCompleted'
       discriminator:
         propertyName: type
         mapping:
           response.created: '#/components/schemas/OpenAIResponseObjectStreamResponseCreated'
+          response.in_progress: '#/components/schemas/OpenAIResponseObjectStreamResponseInProgress'
           response.output_item.added: '#/components/schemas/OpenAIResponseObjectStreamResponseOutputItemAdded'
           response.output_item.done: '#/components/schemas/OpenAIResponseObjectStreamResponseOutputItemDone'
           response.output_text.delta: '#/components/schemas/OpenAIResponseObjectStreamResponseOutputTextDelta'
@@ -7649,13 +7702,15 @@ components:
           response.mcp_call.completed: '#/components/schemas/OpenAIResponseObjectStreamResponseMcpCallCompleted'
           response.content_part.added: '#/components/schemas/OpenAIResponseObjectStreamResponseContentPartAdded'
           response.content_part.done: '#/components/schemas/OpenAIResponseObjectStreamResponseContentPartDone'
+          response.incomplete: '#/components/schemas/OpenAIResponseObjectStreamResponseIncomplete'
+          response.failed: '#/components/schemas/OpenAIResponseObjectStreamResponseFailed'
           response.completed: '#/components/schemas/OpenAIResponseObjectStreamResponseCompleted'
     "OpenAIResponseObjectStreamResponseCompleted":
       type: object
       properties:
         response:
           $ref: '#/components/schemas/OpenAIResponseObject'
-          description: The completed response object
+          description: Completed response object
         type:
           type: string
           const: response.completed
@@ -7673,6 +7728,10 @@ components:
     "OpenAIResponseObjectStreamResponseContentPartAdded":
       type: object
       properties:
+        content_index:
+          type: integer
+          description: >-
+            Index position of the part within the content array
         response_id:
           type: string
           description: >-
@@ -7681,15 +7740,21 @@ components:
           type: string
           description: >-
             Unique identifier of the output item containing this content part
+        output_index:
+          type: integer
+          description: >-
+            Index position of the output item in the response
         part:
           oneOf:
             - $ref: '#/components/schemas/OpenAIResponseContentPartOutputText'
             - $ref: '#/components/schemas/OpenAIResponseContentPartRefusal'
+            - $ref: '#/components/schemas/OpenAIResponseContentPartReasoningText'
           discriminator:
             propertyName: type
             mapping:
               output_text: '#/components/schemas/OpenAIResponseContentPartOutputText'
               refusal: '#/components/schemas/OpenAIResponseContentPartRefusal'
+              reasoning_text: '#/components/schemas/OpenAIResponseContentPartReasoningText'
           description: The content part that was added
         sequence_number:
           type: integer
@@ -7703,8 +7768,10 @@ components:
             Event type identifier, always "response.content_part.added"
       additionalProperties: false
       required:
+        - content_index
         - response_id
         - item_id
+        - output_index
         - part
         - sequence_number
         - type
@@ -7715,6 +7782,10 @@ components:
     "OpenAIResponseObjectStreamResponseContentPartDone":
       type: object
       properties:
+        content_index:
+          type: integer
+          description: >-
+            Index position of the part within the content array
         response_id:
           type: string
           description: >-
@@ -7723,15 +7794,21 @@ components:
           type: string
           description: >-
             Unique identifier of the output item containing this content part
+        output_index:
+          type: integer
+          description: >-
+            Index position of the output item in the response
         part:
           oneOf:
             - $ref: '#/components/schemas/OpenAIResponseContentPartOutputText'
             - $ref: '#/components/schemas/OpenAIResponseContentPartRefusal'
+            - $ref: '#/components/schemas/OpenAIResponseContentPartReasoningText'
           discriminator:
             propertyName: type
             mapping:
               output_text: '#/components/schemas/OpenAIResponseContentPartOutputText'
               refusal: '#/components/schemas/OpenAIResponseContentPartRefusal'
+              reasoning_text: '#/components/schemas/OpenAIResponseContentPartReasoningText'
           description: The completed content part
         sequence_number:
           type: integer
@@ -7745,8 +7822,10 @@ components:
             Event type identifier, always "response.content_part.done"
       additionalProperties: false
       required:
+        - content_index
         - response_id
         - item_id
+        - output_index
         - part
         - sequence_number
         - type
@@ -7759,7 +7838,7 @@ components:
       properties:
         response:
           $ref: '#/components/schemas/OpenAIResponseObject'
-          description: The newly created response object
+          description: The response object that was created
         type:
           type: string
           const: response.created
@@ -7774,6 +7853,30 @@ components:
         OpenAIResponseObjectStreamResponseCreated
       description: >-
         Streaming event indicating a new response has been created.
+    OpenAIResponseObjectStreamResponseFailed:
+      type: object
+      properties:
+        response:
+          $ref: '#/components/schemas/OpenAIResponseObject'
+          description: Response object describing the failure
+        sequence_number:
+          type: integer
+          description: >-
+            Sequential number for ordering streaming events
+        type:
+          type: string
+          const: response.failed
+          default: response.failed
+          description: >-
+            Event type identifier, always "response.failed"
+      additionalProperties: false
+      required:
+        - response
+        - sequence_number
+        - type
+      title: OpenAIResponseObjectStreamResponseFailed
+      description: >-
+        Streaming event emitted when a response fails.
     "OpenAIResponseObjectStreamResponseFunctionCallArgumentsDelta":
       type: object
       properties:
@@ -7846,6 +7949,57 @@ components:
         OpenAIResponseObjectStreamResponseFunctionCallArgumentsDone
       description: >-
         Streaming event for when function call arguments are completed.
+    "OpenAIResponseObjectStreamResponseInProgress":
+      type: object
+      properties:
+        response:
+          $ref: '#/components/schemas/OpenAIResponseObject'
+          description: Current response state while in progress
+        sequence_number:
+          type: integer
+          description: >-
+            Sequential number for ordering streaming events
+        type:
+          type: string
+          const: response.in_progress
+          default: response.in_progress
+          description: >-
+            Event type identifier, always "response.in_progress"
+      additionalProperties: false
+      required:
+        - response
+        - sequence_number
+        - type
+      title: >-
+        OpenAIResponseObjectStreamResponseInProgress
+      description: >-
+        Streaming event indicating the response remains in progress.
+    "OpenAIResponseObjectStreamResponseIncomplete":
+      type: object
+      properties:
+        response:
+          $ref: '#/components/schemas/OpenAIResponseObject'
+          description: >-
+            Response object describing the incomplete state
+        sequence_number:
+          type: integer
+          description: >-
+            Sequential number for ordering streaming events
+        type:
+          type: string
+          const: response.incomplete
+          default: response.incomplete
+          description: >-
+            Event type identifier, always "response.incomplete"
+      additionalProperties: false
+      required:
+        - response
+        - sequence_number
+        - type
+      title: >-
+        OpenAIResponseObjectStreamResponseIncomplete
+      description: >-
+        Streaming event emitted when a response ends in an incomplete state.
     "OpenAIResponseObjectStreamResponseMcpCallArgumentsDelta":
       type: object
       properties:

--- a/llama_stack/apis/agents/openai_responses.py
+++ b/llama_stack/apis/agents/openai_responses.py
@@ -400,7 +400,7 @@ class OpenAIDeleteResponseObject(BaseModel):
 class OpenAIResponseObjectStreamResponseCreated(BaseModel):
     """Streaming event indicating a new response has been created.
 
-    :param response: The newly created response object
+    :param response: The response object that was created
     :param type: Event type identifier, always "response.created"
     """
 
@@ -409,15 +409,57 @@ class OpenAIResponseObjectStreamResponseCreated(BaseModel):
 
 
 @json_schema_type
+class OpenAIResponseObjectStreamResponseInProgress(BaseModel):
+    """Streaming event indicating the response remains in progress.
+
+    :param response: Current response state while in progress
+    :param sequence_number: Sequential number for ordering streaming events
+    :param type: Event type identifier, always "response.in_progress"
+    """
+
+    response: OpenAIResponseObject
+    sequence_number: int
+    type: Literal["response.in_progress"] = "response.in_progress"
+
+
+@json_schema_type
 class OpenAIResponseObjectStreamResponseCompleted(BaseModel):
     """Streaming event indicating a response has been completed.
 
-    :param response: The completed response object
+    :param response: Completed response object
     :param type: Event type identifier, always "response.completed"
     """
 
     response: OpenAIResponseObject
     type: Literal["response.completed"] = "response.completed"
+
+
+@json_schema_type
+class OpenAIResponseObjectStreamResponseIncomplete(BaseModel):
+    """Streaming event emitted when a response ends in an incomplete state.
+
+    :param response: Response object describing the incomplete state
+    :param sequence_number: Sequential number for ordering streaming events
+    :param type: Event type identifier, always "response.incomplete"
+    """
+
+    response: OpenAIResponseObject
+    sequence_number: int
+    type: Literal["response.incomplete"] = "response.incomplete"
+
+
+@json_schema_type
+class OpenAIResponseObjectStreamResponseFailed(BaseModel):
+    """Streaming event emitted when a response fails.
+
+    :param response: Response object describing the failure
+    :param sequence_number: Sequential number for ordering streaming events
+    :param type: Event type identifier, always "response.failed"
+    """
+
+    response: OpenAIResponseObject
+    sequence_number: int
+    type: Literal["response.failed"] = "response.failed"
 
 
 @json_schema_type
@@ -650,19 +692,46 @@ class OpenAIResponseObjectStreamResponseMcpCallCompleted(BaseModel):
 
 @json_schema_type
 class OpenAIResponseContentPartOutputText(BaseModel):
+    """Text content within a streamed response part.
+
+    :param type: Content part type identifier, always "output_text"
+    :param text: Text emitted for this content part
+    :param annotations: Structured annotations associated with the text
+    :param logprobs: (Optional) Token log probability details
+    """
+
     type: Literal["output_text"] = "output_text"
     text: str
-    # TODO: add annotations, logprobs, etc.
+    annotations: list[OpenAIResponseAnnotations] = Field(default_factory=list)
+    logprobs: list[dict[str, Any]] | None = None
 
 
 @json_schema_type
 class OpenAIResponseContentPartRefusal(BaseModel):
+    """Refusal content within a streamed response part.
+
+    :param type: Content part type identifier, always "refusal"
+    :param refusal: Refusal text supplied by the model
+    """
+
     type: Literal["refusal"] = "refusal"
     refusal: str
 
 
+@json_schema_type
+class OpenAIResponseContentPartReasoningText(BaseModel):
+    """Reasoning text emitted as part of a streamed response.
+
+    :param type: Content part type identifier, always "reasoning_text"
+    :param text: Reasoning text supplied by the model
+    """
+
+    type: Literal["reasoning_text"] = "reasoning_text"
+    text: str
+
+
 OpenAIResponseContentPart = Annotated[
-    OpenAIResponseContentPartOutputText | OpenAIResponseContentPartRefusal,
+    OpenAIResponseContentPartOutputText | OpenAIResponseContentPartRefusal | OpenAIResponseContentPartReasoningText,
     Field(discriminator="type"),
 ]
 register_schema(OpenAIResponseContentPart, name="OpenAIResponseContentPart")
@@ -672,15 +741,19 @@ register_schema(OpenAIResponseContentPart, name="OpenAIResponseContentPart")
 class OpenAIResponseObjectStreamResponseContentPartAdded(BaseModel):
     """Streaming event for when a new content part is added to a response item.
 
+    :param content_index: Index position of the part within the content array
     :param response_id: Unique identifier of the response containing this content
     :param item_id: Unique identifier of the output item containing this content part
+    :param output_index: Index position of the output item in the response
     :param part: The content part that was added
     :param sequence_number: Sequential number for ordering streaming events
     :param type: Event type identifier, always "response.content_part.added"
     """
 
+    content_index: int
     response_id: str
     item_id: str
+    output_index: int
     part: OpenAIResponseContentPart
     sequence_number: int
     type: Literal["response.content_part.added"] = "response.content_part.added"
@@ -690,15 +763,19 @@ class OpenAIResponseObjectStreamResponseContentPartAdded(BaseModel):
 class OpenAIResponseObjectStreamResponseContentPartDone(BaseModel):
     """Streaming event for when a content part is completed.
 
+    :param content_index: Index position of the part within the content array
     :param response_id: Unique identifier of the response containing this content
     :param item_id: Unique identifier of the output item containing this content part
+    :param output_index: Index position of the output item in the response
     :param part: The completed content part
     :param sequence_number: Sequential number for ordering streaming events
     :param type: Event type identifier, always "response.content_part.done"
     """
 
+    content_index: int
     response_id: str
     item_id: str
+    output_index: int
     part: OpenAIResponseContentPart
     sequence_number: int
     type: Literal["response.content_part.done"] = "response.content_part.done"
@@ -706,6 +783,7 @@ class OpenAIResponseObjectStreamResponseContentPartDone(BaseModel):
 
 OpenAIResponseObjectStream = Annotated[
     OpenAIResponseObjectStreamResponseCreated
+    | OpenAIResponseObjectStreamResponseInProgress
     | OpenAIResponseObjectStreamResponseOutputItemAdded
     | OpenAIResponseObjectStreamResponseOutputItemDone
     | OpenAIResponseObjectStreamResponseOutputTextDelta
@@ -725,6 +803,8 @@ OpenAIResponseObjectStream = Annotated[
     | OpenAIResponseObjectStreamResponseMcpCallCompleted
     | OpenAIResponseObjectStreamResponseContentPartAdded
     | OpenAIResponseObjectStreamResponseContentPartDone
+    | OpenAIResponseObjectStreamResponseIncomplete
+    | OpenAIResponseObjectStreamResponseFailed
     | OpenAIResponseObjectStreamResponseCompleted,
     Field(discriminator="type"),
 ]

--- a/llama_stack/providers/inline/agents/meta_reference/responses/streaming.py
+++ b/llama_stack/providers/inline/agents/meta_reference/responses/streaming.py
@@ -13,6 +13,7 @@ from llama_stack.apis.agents.openai_responses import (
     ApprovalFilter,
     MCPListToolsTool,
     OpenAIResponseContentPartOutputText,
+    OpenAIResponseError,
     OpenAIResponseInputTool,
     OpenAIResponseInputToolMCP,
     OpenAIResponseMCPApprovalRequest,
@@ -22,8 +23,11 @@ from llama_stack.apis.agents.openai_responses import (
     OpenAIResponseObjectStreamResponseContentPartAdded,
     OpenAIResponseObjectStreamResponseContentPartDone,
     OpenAIResponseObjectStreamResponseCreated,
+    OpenAIResponseObjectStreamResponseFailed,
     OpenAIResponseObjectStreamResponseFunctionCallArgumentsDelta,
     OpenAIResponseObjectStreamResponseFunctionCallArgumentsDone,
+    OpenAIResponseObjectStreamResponseIncomplete,
+    OpenAIResponseObjectStreamResponseInProgress,
     OpenAIResponseObjectStreamResponseMcpCallArgumentsDelta,
     OpenAIResponseObjectStreamResponseMcpCallArgumentsDone,
     OpenAIResponseObjectStreamResponseMcpListToolsCompleted,
@@ -100,21 +104,46 @@ class StreamingResponseOrchestrator:
         # mapping for annotations
         self.citation_files: dict[str, str] = {}
 
-    async def create_response(self) -> AsyncIterator[OpenAIResponseObjectStream]:
-        # Initialize output messages
-        output_messages: list[OpenAIResponseOutput] = []
-        # Create initial response and emit response.created immediately
-        initial_response = OpenAIResponseObject(
+    def _clone_outputs(self, outputs: list[OpenAIResponseOutput]) -> list[OpenAIResponseOutput]:
+        cloned: list[OpenAIResponseOutput] = []
+        for item in outputs:
+            if hasattr(item, "model_copy"):
+                cloned.append(item.model_copy(deep=True))
+            else:
+                cloned.append(item)
+        return cloned
+
+    def _snapshot_response(
+        self,
+        status: str,
+        outputs: list[OpenAIResponseOutput],
+        *,
+        error: OpenAIResponseError | None = None,
+    ) -> OpenAIResponseObject:
+        return OpenAIResponseObject(
             created_at=self.created_at,
             id=self.response_id,
             model=self.ctx.model,
             object="response",
-            status="in_progress",
-            output=output_messages.copy(),
+            status=status,
+            output=self._clone_outputs(outputs),
             text=self.text,
+            error=error,
         )
 
-        yield OpenAIResponseObjectStreamResponseCreated(response=initial_response)
+    async def create_response(self) -> AsyncIterator[OpenAIResponseObjectStream]:
+        output_messages: list[OpenAIResponseOutput] = []
+
+        # Emit response.created followed by response.in_progress to align with OpenAI streaming
+        yield OpenAIResponseObjectStreamResponseCreated(
+            response=self._snapshot_response("in_progress", output_messages)
+        )
+
+        self.sequence_number += 1
+        yield OpenAIResponseObjectStreamResponseInProgress(
+            response=self._snapshot_response("in_progress", output_messages),
+            sequence_number=self.sequence_number,
+        )
 
         # Process all tools (including MCP tools) and emit streaming events
         if self.ctx.response_tools:
@@ -123,87 +152,114 @@ class StreamingResponseOrchestrator:
 
         n_iter = 0
         messages = self.ctx.messages.copy()
+        final_status = "completed"
+        last_completion_result: ChatCompletionResult | None = None
 
-        while True:
-            # Text is the default response format for chat completion so don't need to pass it
-            # (some providers don't support non-empty response_format when tools are present)
-            response_format = None if self.ctx.response_format.type == "text" else self.ctx.response_format
-            logger.debug(f"calling openai_chat_completion with tools: {self.ctx.chat_tools}")
-            completion_result = await self.inference_api.openai_chat_completion(
-                model=self.ctx.model,
-                messages=messages,
-                tools=self.ctx.chat_tools,
-                stream=True,
-                temperature=self.ctx.temperature,
-                response_format=response_format,
-            )
+        try:
+            while True:
+                # Text is the default response format for chat completion so don't need to pass it
+                # (some providers don't support non-empty response_format when tools are present)
+                response_format = None if self.ctx.response_format.type == "text" else self.ctx.response_format
+                logger.debug(f"calling openai_chat_completion with tools: {self.ctx.chat_tools}")
+                completion_result = await self.inference_api.openai_chat_completion(
+                    model=self.ctx.model,
+                    messages=messages,
+                    tools=self.ctx.chat_tools,
+                    stream=True,
+                    temperature=self.ctx.temperature,
+                    response_format=response_format,
+                )
 
-            # Process streaming chunks and build complete response
-            completion_result_data = None
-            async for stream_event_or_result in self._process_streaming_chunks(completion_result, output_messages):
-                if isinstance(stream_event_or_result, ChatCompletionResult):
-                    completion_result_data = stream_event_or_result
-                else:
-                    yield stream_event_or_result
-            if not completion_result_data:
-                raise ValueError("Streaming chunk processor failed to return completion data")
-            current_response = self._build_chat_completion(completion_result_data)
+                # Process streaming chunks and build complete response
+                completion_result_data = None
+                async for stream_event_or_result in self._process_streaming_chunks(completion_result, output_messages):
+                    if isinstance(stream_event_or_result, ChatCompletionResult):
+                        completion_result_data = stream_event_or_result
+                    else:
+                        yield stream_event_or_result
+                if not completion_result_data:
+                    raise ValueError("Streaming chunk processor failed to return completion data")
+                last_completion_result = completion_result_data
+                current_response = self._build_chat_completion(completion_result_data)
 
-            function_tool_calls, non_function_tool_calls, approvals, next_turn_messages = self._separate_tool_calls(
-                current_response, messages
-            )
+                (
+                    function_tool_calls,
+                    non_function_tool_calls,
+                    approvals,
+                    next_turn_messages,
+                ) = self._separate_tool_calls(current_response, messages)
 
-            # add any approval requests required
-            for tool_call in approvals:
-                async for evt in self._add_mcp_approval_request(
-                    tool_call.function.name, tool_call.function.arguments, output_messages
+                # add any approval requests required
+                for tool_call in approvals:
+                    async for evt in self._add_mcp_approval_request(
+                        tool_call.function.name, tool_call.function.arguments, output_messages
+                    ):
+                        yield evt
+
+                # Handle choices with no tool calls
+                for choice in current_response.choices:
+                    if not (choice.message.tool_calls and self.ctx.response_tools):
+                        output_messages.append(
+                            await convert_chat_choice_to_response_message(
+                                choice,
+                                self.citation_files,
+                                message_id=completion_result_data.message_item_id,
+                            )
+                        )
+
+                # Execute tool calls and coordinate results
+                async for stream_event in self._coordinate_tool_execution(
+                    function_tool_calls,
+                    non_function_tool_calls,
+                    completion_result_data,
+                    output_messages,
+                    next_turn_messages,
                 ):
-                    yield evt
+                    yield stream_event
 
-            # Handle choices with no tool calls
-            for choice in current_response.choices:
-                if not (choice.message.tool_calls and self.ctx.response_tools):
-                    output_messages.append(await convert_chat_choice_to_response_message(choice, self.citation_files))
+                messages = next_turn_messages
 
-            # Execute tool calls and coordinate results
-            async for stream_event in self._coordinate_tool_execution(
-                function_tool_calls,
-                non_function_tool_calls,
-                completion_result_data,
-                output_messages,
-                next_turn_messages,
-            ):
-                yield stream_event
+                if not function_tool_calls and not non_function_tool_calls:
+                    break
 
-            messages = next_turn_messages
+                if function_tool_calls:
+                    logger.info("Exiting inference loop since there is a function (client-side) tool call")
+                    break
 
-            if not function_tool_calls and not non_function_tool_calls:
-                break
+                n_iter += 1
+                if n_iter >= self.max_infer_iters:
+                    logger.info(
+                        f"Exiting inference loop since iteration count({n_iter}) exceeds {self.max_infer_iters=}"
+                    )
+                    final_status = "incomplete"
+                    break
 
-            if function_tool_calls:
-                logger.info("Exiting inference loop since there is a function (client-side) tool call")
-                break
+            if last_completion_result and last_completion_result.finish_reason == "length":
+                final_status = "incomplete"
 
-            n_iter += 1
-            if n_iter >= self.max_infer_iters:
-                logger.info(f"Exiting inference loop since iteration count({n_iter}) exceeds {self.max_infer_iters=}")
-                break
+        except Exception as exc:  # noqa: BLE001
+            self.final_messages = messages.copy()
+            self.sequence_number += 1
+            error = OpenAIResponseError(code="internal_error", message=str(exc))
+            failure_response = self._snapshot_response("failed", output_messages, error=error)
+            yield OpenAIResponseObjectStreamResponseFailed(
+                response=failure_response,
+                sequence_number=self.sequence_number,
+            )
+            return
 
         self.final_messages = messages.copy()
 
-        # Create final response
-        final_response = OpenAIResponseObject(
-            created_at=self.created_at,
-            id=self.response_id,
-            model=self.ctx.model,
-            object="response",
-            status="completed",
-            text=self.text,
-            output=output_messages,
-        )
-
-        # Emit response.completed
-        yield OpenAIResponseObjectStreamResponseCompleted(response=final_response)
+        if final_status == "incomplete":
+            self.sequence_number += 1
+            final_response = self._snapshot_response("incomplete", output_messages)
+            yield OpenAIResponseObjectStreamResponseIncomplete(
+                response=final_response,
+                sequence_number=self.sequence_number,
+            )
+        else:
+            final_response = self._snapshot_response("completed", output_messages)
+            yield OpenAIResponseObjectStreamResponseCompleted(response=final_response)
 
     def _separate_tool_calls(self, current_response, messages) -> tuple[list, list, list, list]:
         """Separate tool calls into function and non-function categories."""
@@ -260,6 +316,8 @@ class StreamingResponseOrchestrator:
         tool_call_item_ids: dict[int, str] = {}
         # Track content parts for streaming events
         content_part_emitted = False
+        content_index = 0
+        message_output_index = len(output_messages)
 
         async for chunk in completion_result:
             chat_response_id = chunk.id
@@ -273,8 +331,10 @@ class StreamingResponseOrchestrator:
                         content_part_emitted = True
                         self.sequence_number += 1
                         yield OpenAIResponseObjectStreamResponseContentPartAdded(
+                            content_index=content_index,
                             response_id=self.response_id,
                             item_id=message_item_id,
+                            output_index=message_output_index,
                             part=OpenAIResponseContentPartOutputText(
                                 text="",  # Will be filled incrementally via text deltas
                             ),
@@ -282,10 +342,10 @@ class StreamingResponseOrchestrator:
                         )
                     self.sequence_number += 1
                     yield OpenAIResponseObjectStreamResponseOutputTextDelta(
-                        content_index=0,
+                        content_index=content_index,
                         delta=chunk_choice.delta.content,
                         item_id=message_item_id,
-                        output_index=0,
+                        output_index=message_output_index,
                         sequence_number=self.sequence_number,
                     )
 
@@ -385,8 +445,10 @@ class StreamingResponseOrchestrator:
             final_text = "".join(chat_response_content)
             self.sequence_number += 1
             yield OpenAIResponseObjectStreamResponseContentPartDone(
+                content_index=content_index,
                 response_id=self.response_id,
                 item_id=message_item_id,
+                output_index=message_output_index,
                 part=OpenAIResponseContentPartOutputText(
                     text=final_text,
                 ),

--- a/llama_stack/providers/inline/agents/meta_reference/responses/utils.py
+++ b/llama_stack/providers/inline/agents/meta_reference/responses/utils.py
@@ -48,7 +48,10 @@ from llama_stack.apis.inference import (
 
 
 async def convert_chat_choice_to_response_message(
-    choice: OpenAIChoice, citation_files: dict[str, str] | None = None
+    choice: OpenAIChoice,
+    citation_files: dict[str, str] | None = None,
+    *,
+    message_id: str | None = None,
 ) -> OpenAIResponseMessage:
     """Convert an OpenAI Chat Completion choice into an OpenAI Response output message."""
     output_content = ""
@@ -64,7 +67,7 @@ async def convert_chat_choice_to_response_message(
     annotations, clean_text = _extract_citations_from_text(output_content, citation_files or {})
 
     return OpenAIResponseMessage(
-        id=f"msg_{uuid.uuid4()}",
+        id=message_id or f"msg_{uuid.uuid4()}",
         content=[OpenAIResponseOutputMessageContentOutputText(text=clean_text, annotations=annotations)],
         status="completed",
         role="assistant",


### PR DESCRIPTION
## Summary
- add schema + runtime support for response.in_progress / response.failed / response.incomplete
- stream content parts with proper indexes and reasoning slots
- align tests + docs with the richer event payloads

## Testing
- uv run pytest tests/unit/providers/agents/meta_reference/test_openai_responses.py::test_create_openai_response_with_string_input
- uv run pytest tests/unit/providers/agents/meta_reference/test_response_conversion_utils.py
