### PR TITLE
fix(ci): remove responses from CI for now

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -61,7 +61,7 @@ jobs:
               && fromJSON('[{"setup": "vllm", "suite": "base"}]')
             || github.event.inputs.test-setup == 'ollama-vision'
               && fromJSON('[{"setup": "ollama-vision", "suite": "vision"}]')
-            || fromJSON('[{"setup": "ollama", "suite": "base"}, {"setup": "ollama-vision", "suite": "vision"}, {"setup": "gpt", "suite": "responses"}]')
+            || fromJSON('[{"setup": "ollama", "suite": "base"}, {"setup": "ollama-vision", "suite": "vision"}]')
           }}
 
     steps:


### PR DESCRIPTION
There are many changes to responses which are landing. They are introducing fundamental new types. This means re-recordings even from the inference calls. Let's avoid that for now. 

Once everything lands I will re-record everything, make things pass and re-enable.
