### PR TITLE
fix: test id not being set in headers

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -42,7 +42,7 @@ def pytest_sessionstart(session):
 
     # Set test stack config type for api_recorder test isolation
     stack_config = session.config.getoption("--stack-config", default=None)
-    if stack_config and stack_config.startswith("server:"):
+    if stack_config and (stack_config.startswith("server:") or stack_config.startswith("http")):
         os.environ["LLAMA_STACK_TEST_STACK_CONFIG_TYPE"] = "server"
         logger.info(f"Test stack config type: server (stack_config={stack_config})")
     else:


### PR DESCRIPTION
# What does this PR do?
When stack config is set to server in docker STACK_CONFIG_ARG=--stack-config=http://localhost:8321, the env variable was not getting correctly set and test id not set, causing 
This is needed for test-and-cut to work 
E   openai.BadRequestError: Error code: 400 - {'detail': 'Invalid value: Test ID is required for file ID allocation'}


https://github.com/llamastack/llama-stack-ops/actions/runs/18546211522/job/52864614068

## Test Plan
CI