### PR TITLE
chore: distrogen enables telemetry by default

### DIFF
--- a/llama_stack/core/resolver.py
+++ b/llama_stack/core/resolver.py
@@ -26,6 +26,7 @@ from llama_stack.apis.safety import Safety
 from llama_stack.apis.scoring import Scoring
 from llama_stack.apis.scoring_functions import ScoringFunctions
 from llama_stack.apis.shields import Shields
+from llama_stack.apis.telemetry import Telemetry
 from llama_stack.apis.tools import ToolGroups, ToolRuntime
 from llama_stack.apis.vector_io import VectorIO
 from llama_stack.apis.version import LLAMA_STACK_API_V1ALPHA
@@ -94,6 +95,7 @@ def api_protocol_map(external_apis: dict[Api, ExternalApiSpec] | None = None) ->
         Api.files: Files,
         Api.prompts: Prompts,
         Api.conversations: Conversations,
+        Api.telemetry: Telemetry,
     }
 
     if external_apis:

--- a/llama_stack/distributions/ci-tests/run.yaml
+++ b/llama_stack/distributions/ci-tests/run.yaml
@@ -237,3 +237,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true

--- a/llama_stack/distributions/dell/run-with-safety.yaml
+++ b/llama_stack/distributions/dell/run-with-safety.yaml
@@ -122,3 +122,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true

--- a/llama_stack/distributions/dell/run.yaml
+++ b/llama_stack/distributions/dell/run.yaml
@@ -113,3 +113,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true

--- a/llama_stack/distributions/meta-reference-gpu/run-with-safety.yaml
+++ b/llama_stack/distributions/meta-reference-gpu/run-with-safety.yaml
@@ -135,3 +135,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true

--- a/llama_stack/distributions/meta-reference-gpu/run.yaml
+++ b/llama_stack/distributions/meta-reference-gpu/run.yaml
@@ -120,3 +120,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true

--- a/llama_stack/distributions/nvidia/run-with-safety.yaml
+++ b/llama_stack/distributions/nvidia/run-with-safety.yaml
@@ -118,3 +118,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true

--- a/llama_stack/distributions/nvidia/run.yaml
+++ b/llama_stack/distributions/nvidia/run.yaml
@@ -97,3 +97,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true

--- a/llama_stack/distributions/open-benchmark/run.yaml
+++ b/llama_stack/distributions/open-benchmark/run.yaml
@@ -233,3 +233,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true

--- a/llama_stack/distributions/postgres-demo/run.yaml
+++ b/llama_stack/distributions/postgres-demo/run.yaml
@@ -104,3 +104,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true

--- a/llama_stack/distributions/starter-gpu/run.yaml
+++ b/llama_stack/distributions/starter-gpu/run.yaml
@@ -240,3 +240,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true

--- a/llama_stack/distributions/starter/run.yaml
+++ b/llama_stack/distributions/starter/run.yaml
@@ -237,3 +237,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true

--- a/llama_stack/distributions/template.py
+++ b/llama_stack/distributions/template.py
@@ -25,6 +25,7 @@ from llama_stack.core.datatypes import (
     ModelInput,
     Provider,
     ShieldInput,
+    TelemetryConfig,
     ToolGroupInput,
 )
 from llama_stack.core.distribution import get_provider_registry
@@ -182,6 +183,7 @@ class RunConfigSettings(BaseModel):
     metadata_store: dict | None = None
     inference_store: dict | None = None
     conversations_store: dict | None = None
+    telemetry: TelemetryConfig = Field(default_factory=lambda: TelemetryConfig(enabled=True))
 
     def run_config(
         self,
@@ -256,6 +258,7 @@ class RunConfigSettings(BaseModel):
             "server": {
                 "port": 8321,
             },
+            "telemetry": self.telemetry.model_dump(exclude_none=True) if self.telemetry else None,
         }
 
 

--- a/llama_stack/distributions/watsonx/run.yaml
+++ b/llama_stack/distributions/watsonx/run.yaml
@@ -114,3 +114,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true


### PR DESCRIPTION

# What does this PR do?
leftover from #3815

## Test Plan
CI


---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/llamastack/llama-stack/pull/3828).
* #3830
* __->__ #3828