### PR TITLE
fix: enable telemetry for all distros

### DIFF
--- a/llama_stack/core/datatypes.py
+++ b/llama_stack/core/datatypes.py
@@ -177,7 +177,7 @@ class DistributionSpec(BaseModel):
 
 
 class TelemetryConfig(BaseModel):
-    enabled: bool = Field(default=False, description="enable or disable telemetry")
+    enabled: bool = Field(default=True, description="enable or disable telemetry")
 
 
 class LoggingConfig(BaseModel):

--- a/llama_stack/core/resolver.py
+++ b/llama_stack/core/resolver.py
@@ -26,6 +26,7 @@ from llama_stack.apis.safety import Safety
 from llama_stack.apis.scoring import Scoring
 from llama_stack.apis.scoring_functions import ScoringFunctions
 from llama_stack.apis.shields import Shields
+from llama_stack.apis.telemetry import Telemetry
 from llama_stack.apis.tools import ToolGroups, ToolRuntime
 from llama_stack.apis.vector_io import VectorIO
 from llama_stack.apis.version import LLAMA_STACK_API_V1ALPHA
@@ -87,6 +88,7 @@ def api_protocol_map(external_apis: dict[Api, ExternalApiSpec] | None = None) ->
         Api.scoring: Scoring,
         Api.scoring_functions: ScoringFunctions,
         Api.eval: Eval,
+        Api.telemetry: Telemetry,
         Api.benchmarks: Benchmarks,
         Api.post_training: PostTraining,
         Api.tool_groups: ToolGroups,

--- a/llama_stack/distributions/ci-tests/run.yaml
+++ b/llama_stack/distributions/ci-tests/run.yaml
@@ -237,3 +237,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true

--- a/llama_stack/distributions/dell/run-with-safety.yaml
+++ b/llama_stack/distributions/dell/run-with-safety.yaml
@@ -122,3 +122,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true

--- a/llama_stack/distributions/dell/run.yaml
+++ b/llama_stack/distributions/dell/run.yaml
@@ -113,3 +113,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true

--- a/llama_stack/distributions/meta-reference-gpu/run-with-safety.yaml
+++ b/llama_stack/distributions/meta-reference-gpu/run-with-safety.yaml
@@ -135,3 +135,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true

--- a/llama_stack/distributions/meta-reference-gpu/run.yaml
+++ b/llama_stack/distributions/meta-reference-gpu/run.yaml
@@ -120,3 +120,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true

--- a/llama_stack/distributions/nvidia/run-with-safety.yaml
+++ b/llama_stack/distributions/nvidia/run-with-safety.yaml
@@ -118,3 +118,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true

--- a/llama_stack/distributions/nvidia/run.yaml
+++ b/llama_stack/distributions/nvidia/run.yaml
@@ -97,3 +97,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true

--- a/llama_stack/distributions/open-benchmark/run.yaml
+++ b/llama_stack/distributions/open-benchmark/run.yaml
@@ -233,3 +233,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true

--- a/llama_stack/distributions/postgres-demo/run.yaml
+++ b/llama_stack/distributions/postgres-demo/run.yaml
@@ -104,3 +104,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true

--- a/llama_stack/distributions/starter-gpu/run.yaml
+++ b/llama_stack/distributions/starter-gpu/run.yaml
@@ -240,3 +240,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true

--- a/llama_stack/distributions/starter/run.yaml
+++ b/llama_stack/distributions/starter/run.yaml
@@ -237,3 +237,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true

--- a/llama_stack/distributions/template.py
+++ b/llama_stack/distributions/template.py
@@ -256,6 +256,7 @@ class RunConfigSettings(BaseModel):
             "server": {
                 "port": 8321,
             },
+            "telemetry": {"enabled": True},
         }
 
 

--- a/llama_stack/distributions/watsonx/run.yaml
+++ b/llama_stack/distributions/watsonx/run.yaml
@@ -114,3 +114,5 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
+telemetry:
+  enabled: true


### PR DESCRIPTION
# What does this PR do?

telemetry should be enabled for all distros (for now) for feature parity
## Test Plan

all tests should pass with telemetry enabled.
