### PR TITLE
fix(telemetry): remove dependency on old telemetry config

### DIFF
--- a/llama_stack/core/datatypes.py
+++ b/llama_stack/core/datatypes.py
@@ -177,6 +177,18 @@ class DistributionSpec(BaseModel):
 
 
 class TelemetryConfig(BaseModel):
+    """
+    Configuration for telemetry.
+
+    Llama Stack uses OpenTelemetry for telemetry. Please refer to https://opentelemetry.io/docs/languages/sdk-configuration/
+    for env variables to configure the OpenTelemetry SDK.
+
+    Example:
+    ```bash
+    OTEL_SERVICE_NAME=llama-stack OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 uv run llama stack run starter
+    ```
+    """
+
     enabled: bool = Field(default=False, description="enable or disable telemetry")
 
 


### PR DESCRIPTION
# What does this PR do?
old telemetry config was removed in #3815

## Test Plan

❯ OTEL_SERVICE_NAME=aloha OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 uv run llama stack run starter
<img width="1888" height="605" alt="image" src="https://github.com/user-attachments/assets/dd5cc9f0-213a-4dc6-9385-f61a3a13b4c3" />


