### PR TITLE
docs: fix sidebar of `Detailed Tutorial`

### DIFF
--- a/docs/docs/getting_started/detailed_tutorial.mdx
+++ b/docs/docs/getting_started/detailed_tutorial.mdx
@@ -308,7 +308,7 @@ stream = agent.create_turn(
 for event in AgentEventLogger().log(stream):
     event.print()
 ```
-### ii. Run the Script
+#### ii. Run the Script
 Let's run the script using `uv`
 ```bash
 uv run python agent.py


### PR DESCRIPTION
# What does this PR do?

the sidebar currently has an extra `ii. Run the Script` because its incorrectly put into the doc as an H3 not an H4 (like the other ones)


<img width="239" height="218" alt="Screenshot 2025-10-20 at 1 04 54 PM" src="https://github.com/user-attachments/assets/eb8cb26e-7ea9-4b61-9101-d64965b39647" />

Fix this which will update the sidebar
