### PR TITLE
chore: install client first

### DIFF
--- a/containers/Containerfile
+++ b/containers/Containerfile
@@ -60,6 +60,17 @@ ENV RUN_CONFIG_PATH=${RUN_CONFIG_PATH}
 # Copy the repository so editable installs and run configurations are available.
 COPY . /workspace
 
+# Install the client package if it is provided
+# NOTE: this is installed before llama-stack since llama-stack depends on llama-stack-client-python
+RUN set -eux; \
+    if [ -n "$LLAMA_STACK_CLIENT_DIR" ]; then \
+        if [ ! -d "$LLAMA_STACK_CLIENT_DIR" ]; then \
+            echo "LLAMA_STACK_CLIENT_DIR is set but $LLAMA_STACK_CLIENT_DIR does not exist" >&2; \
+            exit 1; \
+        fi; \
+        uv pip install --no-cache-dir -e "$LLAMA_STACK_CLIENT_DIR"; \
+    fi;
+
 # Install llama-stack
 RUN set -eux; \
     if [ "$INSTALL_MODE" = "editable" ]; then \
@@ -81,16 +92,6 @@ RUN set -eux; \
         else \
             uv pip install --no-cache-dir llama-stack; \
         fi; \
-    fi;
-
-# Install the client package if it is provided
-RUN set -eux; \
-    if [ -n "$LLAMA_STACK_CLIENT_DIR" ]; then \
-        if [ ! -d "$LLAMA_STACK_CLIENT_DIR" ]; then \
-            echo "LLAMA_STACK_CLIENT_DIR is set but $LLAMA_STACK_CLIENT_DIR does not exist" >&2; \
-            exit 1; \
-        fi; \
-        uv pip install --no-cache-dir -e "$LLAMA_STACK_CLIENT_DIR"; \
     fi;
 
 # Install the dependencies for the distribution


### PR DESCRIPTION
# What does this PR do?
mirrors build_container.sh

trying to resolve: 

0.105 + [ editable = editable ]
0.105 + [ ! -d /workspace/llama-stack ]
0.105 + uv pip install --no-cache-dir -e /workspace/llama-stack
0.261 Using Python 3.12.12 environment at: /usr/local
0.479   × No solution found when resolving dependencies:
0.479   ╰─▶ Because only llama-stack-client<=0.2.23 is available and
0.479       llama-stack==0.3.0rc4 depends on llama-stack-client>=0.3.0rc4, we can
0.479       conclude that llama-stack==0.3.0rc4 cannot be used.
0.479       And because only llama-stack==0.3.0rc4 is available and you require
0.479       llama-stack, we can conclude that your requirements are unsatisfiable.
------

## Test Plan

