### PR TITLE
fix: fix segfault in load model

### DIFF
--- a/llama_stack/providers/utils/inference/embedding_mixin.py
+++ b/llama_stack/providers/utils/inference/embedding_mixin.py
@@ -93,11 +93,7 @@ class SentenceTransformerEmbeddingMixin:
                 # PyTorch's OpenMP kernels can segfault on macOS when spawned from background
                 # threads with the default parallel settings, so force a single-threaded CPU run.
                 log.debug(f"Constraining torch threads on {platform_name} to a single worker")
-                try:
-                    torch.set_num_threads(1)
-                    torch.set_num_interop_threads(1)
-                except Exception:
-                    log.debug(f"Failed to adjust torch thread counts on {platform_name}", exc_info=True)
+                torch.set_num_threads(1)
 
             return SentenceTransformer(model, trust_remote_code=True)
 


### PR DESCRIPTION
# What does this PR do?
Fix segfault with load model
The cc-vec integration failed with segfault when used with default embedding model on macOS
         `model_id: nomic-ai/nomic-embed-text-v1.5` and `provider_id: sentence-transformers`
Checked crash report and see this is due to torch OPENMP settings. Constrainting to 1 thread works without crashes.
(Codex used)

## Test Plan
Tested with cc-vec integration 
1. start server llama stack run starter
2.  Do the setup in https://github.com/raghotham/cc-vec to set env variables and try
`uv run cc-vec index --url-patterns "%.github.io" --vector-store-name "ml-research" --limit 50 --chunk-size 800 --overlap 400`


