### PR TITLE
docs: fix the building distro file

### DIFF
--- a/docs/docs/distributions/building_distro.mdx
+++ b/docs/docs/distributions/building_distro.mdx
@@ -19,6 +19,7 @@ Browse that folder to understand available providers and copy a distribution to 
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+
 <Tabs>
 <TabItem value="container" label="Building a container">
 


### PR DESCRIPTION
# What does this PR do?
* Fixes the doc server build (which expects a blank line after imports)

## Test Plan
* `cd docs && npm run build`