### PR TITLE
chore: better error messages for moderations API

### DIFF
--- a/llama_stack/core/routers/safety.py
+++ b/llama_stack/core/routers/safety.py
@@ -65,12 +65,16 @@ class SafetyRouter(Safety):
             """Get Shield id from model (provider_resource_id) of shield."""
             list_shields_response = await self.routing_table.list_shields()
 
-            matches = [s.identifier for s in list_shields_response.data if model == s.provider_resource_id]
+            matches: list[str] = [s.identifier for s in list_shields_response.data if model == s.provider_resource_id]
 
             if not matches:
-                raise ValueError(f"No shield associated with provider_resource id {model}")
+                raise ValueError(
+                    f"No shield associated with provider_resource id {model}: choose from {[s.provider_resource_id for s in list_shields_response.data]}"
+                )
             if len(matches) > 1:
-                raise ValueError(f"Multiple shields associated with provider_resource id {model}")
+                raise ValueError(
+                    f"Multiple shields associated with provider_resource id {model}: matched shields {matches}"
+                )
             return matches[0]
 
         shield_id = await get_shield_id(self, model)


### PR DESCRIPTION

# What does this PR do?


## Test Plan
```
~/projects/lst3 remotes/origin/HEAD*
.venv ❯ curl http://localhost:8321/v1/moderations \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-4o-mini",
    "input": [
        "hello"
    ]
  }'
{"detail":"Invalid value: No shield associated with provider_resource id gpt-4o-mini: choose from ['together/meta-llama/Llama-Guard-4-12B']"}
```
