### PR TITLE
fix(responses): sync conversation before yielding terminal events in streaming

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -43,6 +43,7 @@ def pytest_sessionstart(session):
 
     if "SQLITE_STORE_DIR" not in os.environ:
         os.environ["SQLITE_STORE_DIR"] = tempfile.mkdtemp()
+        logger.info(f"Setting SQLITE_STORE_DIR: {os.environ['SQLITE_STORE_DIR']}")
 
     # Set test stack config type for api_recorder test isolation
     stack_config = session.config.getoption("--stack-config", default=None)

--- a/tests/integration/fixtures/common.py
+++ b/tests/integration/fixtures/common.py
@@ -40,7 +40,12 @@ def is_port_available(port: int, host: str = "localhost") -> bool:
 
 def start_llama_stack_server(config_name: str) -> subprocess.Popen:
     """Start a llama stack server with the given config."""
-    cmd = f"uv run llama stack run {config_name}"
+
+    # remove server.log if it exists
+    if os.path.exists("server.log"):
+        os.remove("server.log")
+
+    cmd = f"llama stack run {config_name}"
     devnull = open(os.devnull, "w")
     process = subprocess.Popen(
         shlex.split(cmd),


### PR DESCRIPTION
Move conversation sync logic before yield to ensure it executes even when
streaming consumers break early after receiving response.completed event.

## Test Plan

```
OLLAMA_URL=http://localhost:11434 \
  pytest -sv tests/integration/responses/ \
  --stack-config server:ci-tests \
  --text-model ollama/llama3.2:3b-instruct-fp16 \
  --inference-mode live \
  -k conversation_multi
```

This test now passes.
