### PR TITLE
chore: support default model in moderations API

### DIFF
--- a/client-sdks/stainless/openapi.yml
+++ b/client-sdks/stainless/openapi.yml
@@ -6443,11 +6443,10 @@ components:
         model:
           type: string
           description: >-
-            The content moderation model you would like to use.
+            (Optional) The content moderation model you would like to use.
       additionalProperties: false
       required:
         - input
-        - model
       title: RunModerationRequest
     ModerationObject:
       type: object

--- a/docs/static/deprecated-llama-stack-spec.html
+++ b/docs/static/deprecated-llama-stack-spec.html
@@ -8185,13 +8185,12 @@
                     },
                     "model": {
                         "type": "string",
-                        "description": "The content moderation model you would like to use."
+                        "description": "(Optional) The content moderation model you would like to use."
                     }
                 },
                 "additionalProperties": false,
                 "required": [
-                    "input",
-                    "model"
+                    "input"
                 ],
                 "title": "RunModerationRequest"
             },

--- a/docs/static/deprecated-llama-stack-spec.yaml
+++ b/docs/static/deprecated-llama-stack-spec.yaml
@@ -6104,11 +6104,10 @@ components:
         model:
           type: string
           description: >-
-            The content moderation model you would like to use.
+            (Optional) The content moderation model you would like to use.
       additionalProperties: false
       required:
         - input
-        - model
       title: RunModerationRequest
     ModerationObject:
       type: object

--- a/docs/static/llama-stack-spec.html
+++ b/docs/static/llama-stack-spec.html
@@ -6919,13 +6919,12 @@
                     },
                     "model": {
                         "type": "string",
-                        "description": "The content moderation model you would like to use."
+                        "description": "(Optional) The content moderation model you would like to use."
                     }
                 },
                 "additionalProperties": false,
                 "required": [
-                    "input",
-                    "model"
+                    "input"
                 ],
                 "title": "RunModerationRequest"
             },

--- a/docs/static/llama-stack-spec.yaml
+++ b/docs/static/llama-stack-spec.yaml
@@ -5230,11 +5230,10 @@ components:
         model:
           type: string
           description: >-
-            The content moderation model you would like to use.
+            (Optional) The content moderation model you would like to use.
       additionalProperties: false
       required:
         - input
-        - model
       title: RunModerationRequest
     ModerationObject:
       type: object

--- a/docs/static/stainless-llama-stack-spec.html
+++ b/docs/static/stainless-llama-stack-spec.html
@@ -8591,13 +8591,12 @@
                     },
                     "model": {
                         "type": "string",
-                        "description": "The content moderation model you would like to use."
+                        "description": "(Optional) The content moderation model you would like to use."
                     }
                 },
                 "additionalProperties": false,
                 "required": [
-                    "input",
-                    "model"
+                    "input"
                 ],
                 "title": "RunModerationRequest"
             },

--- a/docs/static/stainless-llama-stack-spec.yaml
+++ b/docs/static/stainless-llama-stack-spec.yaml
@@ -6443,11 +6443,10 @@ components:
         model:
           type: string
           description: >-
-            The content moderation model you would like to use.
+            (Optional) The content moderation model you would like to use.
       additionalProperties: false
       required:
         - input
-        - model
       title: RunModerationRequest
     ModerationObject:
       type: object

--- a/llama_stack/apis/safety/safety.py
+++ b/llama_stack/apis/safety/safety.py
@@ -123,13 +123,13 @@ class Safety(Protocol):
 
     @webmethod(route="/openai/v1/moderations", method="POST", level=LLAMA_STACK_API_V1, deprecated=True)
     @webmethod(route="/moderations", method="POST", level=LLAMA_STACK_API_V1)
-    async def run_moderation(self, input: str | list[str], model: str) -> ModerationObject:
+    async def run_moderation(self, input: str | list[str], model: str | None = None) -> ModerationObject:
         """Create moderation.
 
         Classifies if text and/or image inputs are potentially harmful.
         :param input: Input (or inputs) to classify.
         Can be a single string, an array of strings, or an array of multi-modal input objects similar to other models.
-        :param model: The content moderation model you would like to use.
+        :param model: (Optional) The content moderation model you would like to use.
         :returns: A moderation object.
         """
         ...

--- a/llama_stack/core/datatypes.py
+++ b/llama_stack/core/datatypes.py
@@ -374,6 +374,15 @@ class VectorStoresConfig(BaseModel):
     )
 
 
+class SafetyConfig(BaseModel):
+    """Configuration for default moderations model."""
+
+    default_shield_id: str | None = Field(
+        default=None,
+        description="ID of the shield to use for when `model` is not specified in the `moderations` API request.",
+    )
+
+
 class QuotaPeriod(StrEnum):
     DAY = "day"
 
@@ -530,6 +539,11 @@ can be instantiated multiple times (with different configs) if necessary.
     vector_stores: VectorStoresConfig | None = Field(
         default=None,
         description="Configuration for vector stores, including default embedding model",
+    )
+
+    safety: SafetyConfig | None = Field(
+        default=None,
+        description="Configuration for default moderations model",
     )
 
     @field_validator("external_providers_dir")

--- a/llama_stack/core/routers/__init__.py
+++ b/llama_stack/core/routers/__init__.py
@@ -95,6 +95,8 @@ async def get_auto_router_impl(
 
     elif api == Api.vector_io:
         api_to_dep_impl["vector_stores_config"] = run_config.vector_stores
+    elif api == Api.safety:
+        api_to_dep_impl["safety_config"] = run_config.safety
 
     impl = api_to_routers[api.value](routing_table, **api_to_dep_impl)
     await impl.initialize()

--- a/llama_stack/distributions/ci-tests/run.yaml
+++ b/llama_stack/distributions/ci-tests/run.yaml
@@ -274,3 +274,5 @@ vector_stores:
   default_embedding_model:
     provider_id: sentence-transformers
     model_id: nomic-ai/nomic-embed-text-v1.5
+safety:
+  default_shield_id: llama-guard

--- a/llama_stack/distributions/starter-gpu/run.yaml
+++ b/llama_stack/distributions/starter-gpu/run.yaml
@@ -277,3 +277,5 @@ vector_stores:
   default_embedding_model:
     provider_id: sentence-transformers
     model_id: nomic-ai/nomic-embed-text-v1.5
+safety:
+  default_shield_id: llama-guard

--- a/llama_stack/distributions/starter/run.yaml
+++ b/llama_stack/distributions/starter/run.yaml
@@ -274,3 +274,5 @@ vector_stores:
   default_embedding_model:
     provider_id: sentence-transformers
     model_id: nomic-ai/nomic-embed-text-v1.5
+safety:
+  default_shield_id: llama-guard

--- a/llama_stack/distributions/starter/starter.py
+++ b/llama_stack/distributions/starter/starter.py
@@ -12,6 +12,7 @@ from llama_stack.core.datatypes import (
     Provider,
     ProviderSpec,
     QualifiedModel,
+    SafetyConfig,
     ShieldInput,
     ToolGroupInput,
     VectorStoresConfig,
@@ -255,6 +256,9 @@ def get_distribution_template(name: str = "starter") -> DistributionTemplate:
                         provider_id="sentence-transformers",
                         model_id="nomic-ai/nomic-embed-text-v1.5",
                     ),
+                ),
+                safety_config=SafetyConfig(
+                    default_shield_id="llama-guard",
                 ),
             ),
         },

--- a/llama_stack/distributions/template.py
+++ b/llama_stack/distributions/template.py
@@ -24,6 +24,7 @@ from llama_stack.core.datatypes import (
     DistributionSpec,
     ModelInput,
     Provider,
+    SafetyConfig,
     ShieldInput,
     TelemetryConfig,
     ToolGroupInput,
@@ -188,6 +189,7 @@ class RunConfigSettings(BaseModel):
     default_datasets: list[DatasetInput] | None = None
     default_benchmarks: list[BenchmarkInput] | None = None
     vector_stores_config: VectorStoresConfig | None = None
+    safety_config: SafetyConfig | None = None
     telemetry: TelemetryConfig = Field(default_factory=lambda: TelemetryConfig(enabled=True))
     storage_backends: dict[str, Any] | None = None
     storage_stores: dict[str, Any] | None = None
@@ -289,6 +291,9 @@ class RunConfigSettings(BaseModel):
 
         if self.vector_stores_config:
             config["vector_stores"] = self.vector_stores_config.model_dump(exclude_none=True)
+
+        if self.safety_config:
+            config["safety"] = self.safety_config.model_dump(exclude_none=True)
 
         return config
 

--- a/llama_stack/providers/inline/safety/code_scanner/code_scanner.py
+++ b/llama_stack/providers/inline/safety/code_scanner/code_scanner.py
@@ -101,7 +101,10 @@ class MetaReferenceCodeScannerSafetyImpl(Safety):
             metadata=metadata,
         )
 
-    async def run_moderation(self, input: str | list[str], model: str) -> ModerationObject:
+    async def run_moderation(self, input: str | list[str], model: str | None = None) -> ModerationObject:
+        if model is None:
+            raise ValueError("Code scanner moderation requires a model identifier.")
+
         inputs = input if isinstance(input, list) else [input]
         results = []
 

--- a/llama_stack/providers/inline/safety/llama_guard/llama_guard.py
+++ b/llama_stack/providers/inline/safety/llama_guard/llama_guard.py
@@ -200,7 +200,10 @@ class LlamaGuardSafetyImpl(Safety, ShieldsProtocolPrivate):
 
         return await impl.run(messages)
 
-    async def run_moderation(self, input: str | list[str], model: str) -> ModerationObject:
+    async def run_moderation(self, input: str | list[str], model: str | None = None) -> ModerationObject:
+        if model is None:
+            raise ValueError("Llama Guard moderation requires a model identifier.")
+
         if isinstance(input, list):
             messages = input.copy()
         else:

--- a/llama_stack/providers/inline/safety/prompt_guard/prompt_guard.py
+++ b/llama_stack/providers/inline/safety/prompt_guard/prompt_guard.py
@@ -63,7 +63,7 @@ class PromptGuardSafetyImpl(Safety, ShieldsProtocolPrivate):
 
         return await self.shield.run(messages)
 
-    async def run_moderation(self, input: str | list[str], model: str) -> ModerationObject:
+    async def run_moderation(self, input: str | list[str], model: str | None = None) -> ModerationObject:
         raise NotImplementedError("run_moderation is not implemented for Prompt Guard")
 
 

--- a/llama_stack/providers/remote/safety/nvidia/nvidia.py
+++ b/llama_stack/providers/remote/safety/nvidia/nvidia.py
@@ -66,7 +66,7 @@ class NVIDIASafetyAdapter(Safety, ShieldsProtocolPrivate):
         self.shield = NeMoGuardrails(self.config, shield.shield_id)
         return await self.shield.run(messages)
 
-    async def run_moderation(self, input: str | list[str], model: str) -> ModerationObject:
+    async def run_moderation(self, input: str | list[str], model: str | None = None) -> ModerationObject:
         raise NotImplementedError("NVIDIA safety provider currently does not implement run_moderation")
 
 

--- a/tests/unit/core/routers/test_safety_router.py
+++ b/tests/unit/core/routers/test_safety_router.py
@@ -1,0 +1,43 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from unittest.mock import AsyncMock
+
+from llama_stack.apis.safety.safety import ModerationObject, ModerationObjectResults
+from llama_stack.apis.shields import ListShieldsResponse, Shield
+from llama_stack.core.datatypes import SafetyConfig
+from llama_stack.core.routers.safety import SafetyRouter
+
+
+async def test_run_moderation_uses_default_shield_when_model_missing():
+    routing_table = AsyncMock()
+    shield = Shield(
+        identifier="shield-1",
+        provider_resource_id="provider/shield-model",
+        provider_id="provider-id",
+        params={},
+    )
+    routing_table.list_shields.return_value = ListShieldsResponse(data=[shield])
+
+    moderation_response = ModerationObject(
+        id="mid",
+        model="shield-1",
+        results=[ModerationObjectResults(flagged=False)],
+    )
+    provider = AsyncMock()
+    provider.run_moderation.return_value = moderation_response
+    routing_table.get_provider_impl.return_value = provider
+
+    router = SafetyRouter(routing_table=routing_table, safety_config=SafetyConfig(default_shield_id="shield-1"))
+
+    result = await router.run_moderation("hello world")
+
+    assert result is moderation_response
+    routing_table.get_provider_impl.assert_awaited_once_with("shield-1")
+    provider.run_moderation.assert_awaited_once()
+    _, kwargs = provider.run_moderation.call_args
+    assert kwargs["model"] == "provider/shield-model"
+    assert kwargs["input"] == "hello world"

--- a/tests/unit/core/test_stack_validation.py
+++ b/tests/unit/core/test_stack_validation.py
@@ -11,8 +11,9 @@ from unittest.mock import AsyncMock
 import pytest
 
 from llama_stack.apis.models import ListModelsResponse, Model, ModelType
-from llama_stack.core.datatypes import QualifiedModel, StackRunConfig, StorageConfig, VectorStoresConfig
-from llama_stack.core.stack import validate_vector_stores_config
+from llama_stack.apis.shields import ListShieldsResponse, Shield
+from llama_stack.core.datatypes import QualifiedModel, SafetyConfig, StackRunConfig, StorageConfig, VectorStoresConfig
+from llama_stack.core.stack import validate_safety_config, validate_vector_stores_config
 from llama_stack.providers.datatypes import Api
 
 
@@ -65,3 +66,37 @@ class TestVectorStoresValidation:
         )
 
         await validate_vector_stores_config(run_config.vector_stores, {Api.models: mock_models})
+
+
+class TestSafetyConfigValidation:
+    async def test_validate_success(self):
+        safety_config = SafetyConfig(default_shield_id="shield-1")
+
+        shield = Shield(
+            identifier="shield-1",
+            provider_id="provider-x",
+            provider_resource_id="model-x",
+            params={},
+        )
+
+        shields_impl = AsyncMock()
+        shields_impl.list_shields.return_value = ListShieldsResponse(data=[shield])
+
+        await validate_safety_config(safety_config, {Api.shields: shields_impl, Api.safety: AsyncMock()})
+
+    async def test_validate_wrong_shield_id(self):
+        safety_config = SafetyConfig(default_shield_id="wrong-shield-id")
+
+        shields_impl = AsyncMock()
+        shields_impl.list_shields.return_value = ListShieldsResponse(
+            data=[
+                Shield(
+                    identifier="shield-1",
+                    provider_resource_id="model-x",
+                    provider_id="provider-x",
+                    params={},
+                )
+            ]
+        )
+        with pytest.raises(ValueError, match="wrong-shield-id"):
+            await validate_safety_config(safety_config, {Api.shields: shields_impl, Api.safety: AsyncMock()})


### PR DESCRIPTION
# What does this PR do?
https://platform.openai.com/docs/api-reference/moderations supports optional model parameter.

This PR adds support for using moderations API with model=None if a default shield id is provided via safety config.

## Test Plan
added tests

manual test:
```
> SAFETY_MODEL='together/meta-llama/Llama-Guard-4-12B'   uv run llama stack run starter
> curl http://localhost:8321/v1/moderations \
  -H "Content-Type: application/json" \
  -d '{
    "input": [
        "hello"
    ]
  }'
```