### PR TITLE
chore(misc): update datasets, benchmarks to use alpha, beta prefixes

### DIFF
--- a/llama_stack/core/server/server.py
+++ b/llama_stack/core/server/server.py
@@ -174,7 +174,9 @@ class StackApp(FastAPI):
 
 @asynccontextmanager
 async def lifespan(app: StackApp):
-    logger.info("Starting up")
+    server_version = parse_version("llama-stack")
+
+    logger.info(f"Starting up Llama Stack server (version: {server_version})")
     assert app.stack is not None
     app.stack.create_registry_refresh_task()
     yield

--- a/tests/integration/datasets/test_datasets.py
+++ b/tests/integration/datasets/test_datasets.py
@@ -78,18 +78,18 @@ def data_url_from_file(file_path: str) -> str:
     ],
 )
 def test_register_and_iterrows(llama_stack_client, purpose, source, provider_id, limit):
-    dataset = llama_stack_client.datasets.register(
+    dataset = llama_stack_client.beta.datasets.register(
         purpose=purpose,
         source=source,
     )
     assert dataset.identifier is not None
     assert dataset.provider_id == provider_id
-    iterrow_response = llama_stack_client.datasets.iterrows(dataset.identifier, limit=limit)
+    iterrow_response = llama_stack_client.beta.datasets.iterrows(dataset.identifier, limit=limit)
     assert len(iterrow_response.data) == limit
 
-    dataset_list = llama_stack_client.datasets.list()
+    dataset_list = llama_stack_client.beta.datasets.list()
     assert dataset.identifier in [d.identifier for d in dataset_list]
 
-    llama_stack_client.datasets.unregister(dataset.identifier)
-    dataset_list = llama_stack_client.datasets.list()
+    llama_stack_client.beta.datasets.unregister(dataset.identifier)
+    dataset_list = llama_stack_client.beta.datasets.list()
     assert dataset.identifier not in [d.identifier for d in dataset_list]

--- a/tests/integration/eval/test_eval.py
+++ b/tests/integration/eval/test_eval.py
@@ -17,17 +17,17 @@ from ..datasets.test_datasets import data_url_from_file
 
 @pytest.mark.parametrize("scoring_fn_id", ["basic::equality"])
 def test_evaluate_rows(llama_stack_client, text_model_id, scoring_fn_id):
-    dataset = llama_stack_client.datasets.register(
+    dataset = llama_stack_client.beta.datasets.register(
         purpose="eval/messages-answer",
         source={
             "type": "uri",
             "uri": data_url_from_file(Path(__file__).parent.parent / "datasets" / "test_dataset.csv"),
         },
     )
-    response = llama_stack_client.datasets.list()
+    response = llama_stack_client.beta.datasets.list()
     assert any(x.identifier == dataset.identifier for x in response)
 
-    rows = llama_stack_client.datasets.iterrows(
+    rows = llama_stack_client.beta.datasets.iterrows(
         dataset_id=dataset.identifier,
         limit=3,
     )
@@ -37,12 +37,12 @@ def test_evaluate_rows(llama_stack_client, text_model_id, scoring_fn_id):
         scoring_fn_id,
     ]
     benchmark_id = str(uuid.uuid4())
-    llama_stack_client.benchmarks.register(
+    llama_stack_client.alpha.benchmarks.register(
         benchmark_id=benchmark_id,
         dataset_id=dataset.identifier,
         scoring_functions=scoring_functions,
     )
-    list_benchmarks = llama_stack_client.benchmarks.list()
+    list_benchmarks = llama_stack_client.alpha.benchmarks.list()
     assert any(x.identifier == benchmark_id for x in list_benchmarks)
 
     response = llama_stack_client.alpha.eval.evaluate_rows(
@@ -66,7 +66,7 @@ def test_evaluate_rows(llama_stack_client, text_model_id, scoring_fn_id):
 
 @pytest.mark.parametrize("scoring_fn_id", ["basic::subset_of"])
 def test_evaluate_benchmark(llama_stack_client, text_model_id, scoring_fn_id):
-    dataset = llama_stack_client.datasets.register(
+    dataset = llama_stack_client.beta.datasets.register(
         purpose="eval/messages-answer",
         source={
             "type": "uri",
@@ -74,7 +74,7 @@ def test_evaluate_benchmark(llama_stack_client, text_model_id, scoring_fn_id):
         },
     )
     benchmark_id = str(uuid.uuid4())
-    llama_stack_client.benchmarks.register(
+    llama_stack_client.alpha.benchmarks.register(
         benchmark_id=benchmark_id,
         dataset_id=dataset.identifier,
         scoring_functions=[scoring_fn_id],


### PR DESCRIPTION
This will be landed together with https://github.com/llamastack/llama-stack-client-python/pull/282 (hence CI will be red on this one.)

I have verified locally that tests pass with the updated version of the client-sdk.
