### PR TITLE
fix(tests): limit vector store providers for record mode in CI tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -363,8 +363,8 @@ def vector_provider_wrapper(func):
 
         return func(*args, **kwargs)
 
-    # For replay tests, only use providers that are available in ci-tests environment
-    if os.environ.get("LLAMA_STACK_TEST_INFERENCE_MODE") == "replay":
+    # For CI tests (replay/record), only use providers that are available in ci-tests environment
+    if os.environ.get("LLAMA_STACK_TEST_INFERENCE_MODE") in ("replay", "record"):
         all_providers = ["faiss", "sqlite-vec"]
     else:
         # For live tests, try all providers (they'll skip if not available)


### PR DESCRIPTION
The vector_provider_wrapper was only limiting providers to faiss/sqlite-vec for replay mode, but CI tests also run in record mode with the same limited set of providers. This caused test failures when trying to test against milvus, chromadb, pgvector, weaviate, and qdrant which aren't configured in the record job.
