### PR TITLE
fix: add missing shutdown methods to PromptServiceImpl and ConversationServiceImpl

### DIFF
--- a/src/llama_stack/core/conversations/conversations.py
+++ b/src/llama_stack/core/conversations/conversations.py
@@ -312,3 +312,6 @@ class ConversationServiceImpl(Conversations):
 
         logger.debug(f"Deleted item {item_id} from conversation {conversation_id}")
         return ConversationItemDeletedResource(id=item_id)
+
+    async def shutdown(self) -> None:
+        pass

--- a/src/llama_stack/core/prompts/prompts.py
+++ b/src/llama_stack/core/prompts/prompts.py
@@ -230,3 +230,6 @@ class PromptServiceImpl(Prompts):
         await self.kvstore.set(default_key, str(version))
 
         return self._deserialize_prompt(data)
+
+    async def shutdown(self) -> None:
+        pass


### PR DESCRIPTION
Change is visible in server shutdown logs, changes `WARNING` loglines to `INFO`