### PR TITLE
fix(mypy): resolve SQLAlchemy typing issues in sqlalchemy_sqlstore.py

### DIFF
--- a/src/llama_stack/providers/utils/sqlstore/sqlalchemy_sqlstore.py
+++ b/src/llama_stack/providers/utils/sqlstore/sqlalchemy_sqlstore.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 from collections.abc import Mapping, Sequence
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from sqlalchemy import (
     JSON,
@@ -55,17 +55,17 @@ def _build_where_expr(column: ColumnElement, value: Any) -> ColumnElement:
             raise ValueError(f"Operator mapping must have a single operator, got: {value}")
         op, operand = next(iter(value.items()))
         if op == "==" or op == "=":
-            return column == operand
+            return cast(ColumnElement[Any], column == operand)
         if op == ">":
-            return column > operand
+            return cast(ColumnElement[Any], column > operand)
         if op == "<":
-            return column < operand
+            return cast(ColumnElement[Any], column < operand)
         if op == ">=":
-            return column >= operand
+            return cast(ColumnElement[Any], column >= operand)
         if op == "<=":
-            return column <= operand
+            return cast(ColumnElement[Any], column <= operand)
         raise ValueError(f"Unsupported operator '{op}' in where mapping")
-    return column == value
+    return cast(ColumnElement[Any], column == value)
 
 
 class SqlAlchemySqlStoreImpl(SqlStore):
@@ -210,10 +210,8 @@ class SqlAlchemySqlStoreImpl(SqlStore):
                 query = query.limit(fetch_limit)
 
             result = await session.execute(query)
-            if result.rowcount == 0:
-                rows = []
-            else:
-                rows = [dict(row._mapping) for row in result]
+            # Iterate directly - if no rows, list comprehension yields empty list
+            rows = [dict(row._mapping) for row in result]
 
             # Always return pagination result
             has_more = False


### PR DESCRIPTION
## Summary

Fix all 7 mypy type checking errors in `sqlalchemy_sqlstore.py` without using any type suppressions.

**Changes:**
- Add `cast()` import for type assertions
- Use `cast(ColumnElement[Any], ...)` for all comparison operators in `_build_where_expr()`
  - Handles ==, >, <, >=, <= operators
- Remove unnecessary `rowcount` check before iteration
  - SQLAlchemy Result can be iterated directly - empty results yield empty list naturally

**Errors Fixed:**
- 6 `no-any-return` errors in `_build_where_expr` (comparison operators)
- 1 `attr-defined` error (`Result.rowcount`)

**Testing:**
```bash
uv run mypy src/llama_stack/providers/utils/sqlstore/sqlalchemy_sqlstore.py
# Success: no issues found
```

**Part of:** Mypy suppression removal plan (Phase 2b/4)

**Stack:**
- [Phase 1] Add type stubs (#3930)
- [Phase 2a] Fix OpenTelemetry types (#3931)
- [Phase 2b] Fix SQLAlchemy types (this PR)
- [Phase 2c+] Fix remaining errors (upcoming)
- [Phase 3] Remove inline suppressions (upcoming)
- [Phase 4] Un-exclude files from mypy (upcoming)