### PR TITLE
fix: typo in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,6 @@ CLAUDE.md
 docs/.docusaurus/
 docs/node_modules/
 docs/static/imported-files/
-docs/api-deprecated/
-docs/api-experimental/
-docs/api/
+docs/docs/api-deprecated/
+docs/docs/api-experimental/
+docs/docs/api/


### PR DESCRIPTION
typo in https://github.com/llamastack/llama-stack/pull/3959 (whoops)