### PR TITLE
fix(docs): remove leftover telemetry sidebar section

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -244,15 +244,6 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'category',
-          label: 'Telemetry',
-          collapsed: true,
-          items: [
-            'providers/telemetry/index',
-            'providers/telemetry/inline_meta-reference'
-          ],
-        },
-        {
-          type: 'category',
           label: 'Batches',
           collapsed: true,
           items: [


### PR DESCRIPTION
Leftover telemetry section was preventing `npm run build` from completing successfully
