### PR TITLE
fix(ci): show pre-commit output easily on failure

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -63,7 +63,7 @@ jobs:
         id: precommit
         run: |
           set +e
-          pre-commit run --show-diff-on-failure --color=always --all-files 2>&1 | tee precommit.log
+          pre-commit run --show-diff-on-failure --color=always --all-files 2>&1 | tee /tmp/precommit.log
           status=${PIPESTATUS[0]}
           echo "status=$status" >> $GITHUB_OUTPUT
           exit 0
@@ -77,7 +77,7 @@ jobs:
           echo "::error::Pre-commit hooks failed. Please run 'pre-commit run --all-files' locally and commit the fixes."
           echo ""
           echo "Failed hooks output:"
-          cat precommit.log
+          cat /tmp/precommit.log
           exit 1
 
       - name: Debug


### PR DESCRIPTION
Right now, the failed Step which is opened by GH by default tells me to just go up and click and scroll through for no reason.
