### PR TITLE
ci: target release-X.Y.x branches instead of release-X.Y.x-maint

### DIFF
--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -47,7 +47,7 @@ runs:
           # Check if PR is targeting a release branch
           TARGET_BRANCH="${{ github.base_ref }}"
 
-          if [[ "$TARGET_BRANCH" =~ ^release-[0-9]+\.[0-9]+\.x-maint$ ]]; then
+          if [[ "$TARGET_BRANCH" =~ ^release-([0-9]+\.){1,3}[0-9]+$ ]]; then
             echo "PR targets release branch: $TARGET_BRANCH"
             echo "Checking if matching branch exists in llama-stack-client-python..."
 

--- a/.github/workflows/backward-compat.yml
+++ b/.github/workflows/backward-compat.yml
@@ -6,7 +6,9 @@ on:
   pull_request:
     branches:
       - main
-      - 'release-[0-9]+.[0-9]+.x-maint'
+      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+'
     paths:
       - 'src/llama_stack/core/datatypes.py'
       - 'src/llama_stack/providers/datatypes.py'

--- a/.github/workflows/integration-auth-tests.yml
+++ b/.github/workflows/integration-auth-tests.yml
@@ -6,11 +6,15 @@ on:
   push:
     branches:
       - main
-      - 'release-[0-9]+.[0-9]+.x-maint'
+      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+'
   pull_request:
     branches:
       - main
-      - 'release-[0-9]+.[0-9]+.x-maint'
+      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+'
     paths:
       - 'distributions/**'
       - 'src/llama_stack/**'

--- a/.github/workflows/integration-sql-store-tests.yml
+++ b/.github/workflows/integration-sql-store-tests.yml
@@ -6,11 +6,15 @@ on:
   push:
     branches:
       - main
-      - 'release-[0-9]+.[0-9]+.x-maint'
+      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+'
   pull_request:
     branches:
       - main
-      - 'release-[0-9]+.[0-9]+.x-maint'
+      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+'
     paths:
       - 'src/llama_stack/providers/utils/sqlstore/**'
       - 'tests/integration/sqlstore/**'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -6,11 +6,15 @@ on:
   push:
     branches:
       - main
-      - 'release-[0-9]+.[0-9]+.x-maint'
+      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+'
   pull_request:
     branches:
       - main
-      - 'release-[0-9]+.[0-9]+.x-maint'
+      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+'
     types: [opened, synchronize, reopened]
     paths:
       - 'src/llama_stack/**'

--- a/.github/workflows/integration-vector-io-tests.yml
+++ b/.github/workflows/integration-vector-io-tests.yml
@@ -6,11 +6,15 @@ on:
   push:
     branches:
       - main
-      - 'release-[0-9]+.[0-9]+.x-maint'
+      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+'
   pull_request:
     branches:
       - main
-      - 'release-[0-9]+.[0-9]+.x-maint'
+      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+'
     paths:
       - 'src/llama_stack/**'
       - '!src/llama_stack/ui/**'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,7 +7,9 @@ on:
   push:
     branches:
       - main
-      - 'release-[0-9]+.[0-9]+.x-maint'
+      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,11 +6,15 @@ on:
   push:
     branches:
       - main
-      - 'release-[0-9]+.[0-9]+.x-maint'
+      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+'
   pull_request:
     branches:
       - main
-      - 'release-[0-9]+.[0-9]+.x-maint'
+      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+'
     paths:
       - 'src/llama_stack/**'
       - '!src/llama_stack/ui/**'


### PR DESCRIPTION
We will be updating our release procedure to be more "normal" or "sane". We will 
- create release branches like normal people
- land cherry-picks onto those branches
- run releases off of those branches
- no more "rc" branch pollution either

Given that, this PR cleans things up a bit
- Remove `-maint` suffix from release branch patterns in CI workflows
- Update branch matching to `release-X.Y.x` format
