### PR TITLE
ci: standardize release branch pattern to release-X.Y.x

### DIFF
--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -47,7 +47,7 @@ runs:
           # Check if PR is targeting a release branch
           TARGET_BRANCH="${{ github.base_ref }}"
 
-          if [[ "$TARGET_BRANCH" =~ ^release-([0-9]+\.){1,3}[0-9]+$ ]]; then
+          if [[ "$TARGET_BRANCH" =~ ^release-[0-9]+\.[0-9]+\.x$ ]]; then
             echo "PR targets release branch: $TARGET_BRANCH"
             echo "Checking if matching branch exists in llama-stack-client-python..."
 

--- a/.github/workflows/integration-auth-tests.yml
+++ b/.github/workflows/integration-auth-tests.yml
@@ -6,15 +6,11 @@ on:
   push:
     branches:
       - main
-      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.x'
   pull_request:
     branches:
       - main
-      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.x'
     paths:
       - 'distributions/**'
       - 'src/llama_stack/**'

--- a/.github/workflows/integration-sql-store-tests.yml
+++ b/.github/workflows/integration-sql-store-tests.yml
@@ -6,15 +6,11 @@ on:
   push:
     branches:
       - main
-      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.x'
   pull_request:
     branches:
       - main
-      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.x'
     paths:
       - 'src/llama_stack/providers/utils/sqlstore/**'
       - 'tests/integration/sqlstore/**'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -6,15 +6,11 @@ on:
   push:
     branches:
       - main
-      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.x'
   pull_request:
     branches:
       - main
-      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.x'
     types: [opened, synchronize, reopened]
     paths:
       - 'src/llama_stack/**'

--- a/.github/workflows/integration-vector-io-tests.yml
+++ b/.github/workflows/integration-vector-io-tests.yml
@@ -6,15 +6,11 @@ on:
   push:
     branches:
       - main
-      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.x'
   pull_request:
     branches:
       - main
-      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.x'
     paths:
       - 'src/llama_stack/**'
       - '!src/llama_stack/ui/**'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,9 +7,7 @@ on:
   push:
     branches:
       - main
-      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.x'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,15 +6,11 @@ on:
   push:
     branches:
       - main
-      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.x'
   pull_request:
     branches:
       - main
-      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.x'
     paths:
       - 'src/llama_stack/**'
       - '!src/llama_stack/ui/**'


### PR DESCRIPTION
Standardize CI workflows to use `release-X.Y.x` branch pattern instead of multiple numeric variants.

That's the pattern we are settling on. See https://github.com/llamastack/llama-stack-ops/pull/20 for reference.