### PR TITLE
fix: only set UV_INDEX_STRATEGY when UV_EXTRA_INDEX_URL is present

### DIFF
--- a/.github/actions/setup-runner/action.yml
+++ b/.github/actions/setup-runner/action.yml
@@ -28,12 +28,11 @@ runs:
       shell: bash
       env:
         UV_EXTRA_INDEX_URL: ${{ steps.client-config.outputs.uv-extra-index-url }}
-        UV_INDEX_STRATEGY: ${{ steps.client-config.outputs.uv-extra-index-url && 'unsafe-best-match' || '' }}
       run: |
         # Export UV env vars to GITHUB_ENV so they persist across steps
         if [ -n "$UV_EXTRA_INDEX_URL" ]; then
           echo "UV_EXTRA_INDEX_URL=$UV_EXTRA_INDEX_URL" >> $GITHUB_ENV
-          echo "UV_INDEX_STRATEGY=$UV_INDEX_STRATEGY" >> $GITHUB_ENV
+          echo "UV_INDEX_STRATEGY=unsafe-best-match" >> $GITHUB_ENV
           echo "Exported UV environment variables for subsequent steps"
         fi
 


### PR DESCRIPTION
Cherry-pick of bc12fe6c4 to release-0.3.x

Fixes GitHub Actions workflows failing with UV index strategy errors when testing on RC tags and non-release branches.

The issue was that UV_INDEX_STRATEGY was being set to an empty string in the environment, causing UV to fail with "error: a value is required for '--index-strategy'".

The fix removes UV_INDEX_STRATEGY from the env block and only sets it to 'unsafe-best-match' when UV_EXTRA_INDEX_URL is actually present.