### PR TITLE
fix(ci): export UV_INDEX_STRATEGY to current shell before running uv sync

### DIFF
--- a/.github/actions/setup-runner/action.yml
+++ b/.github/actions/setup-runner/action.yml
@@ -29,11 +29,12 @@ runs:
       env:
         UV_EXTRA_INDEX_URL: ${{ steps.client-config.outputs.uv-extra-index-url }}
       run: |
-        # Export UV env vars to GITHUB_ENV so they persist across steps
+        # Export UV env vars for current step and persist to GITHUB_ENV for subsequent steps
         if [ -n "$UV_EXTRA_INDEX_URL" ]; then
+          export UV_INDEX_STRATEGY=unsafe-best-match
           echo "UV_EXTRA_INDEX_URL=$UV_EXTRA_INDEX_URL" >> $GITHUB_ENV
-          echo "UV_INDEX_STRATEGY=unsafe-best-match" >> $GITHUB_ENV
-          echo "Exported UV environment variables for subsequent steps"
+          echo "UV_INDEX_STRATEGY=$UV_INDEX_STRATEGY" >> $GITHUB_ENV
+          echo "Exported UV environment variables for current and subsequent steps"
         fi
 
         echo "Updating project dependencies via uv sync"


### PR DESCRIPTION
Fixes latent bug where UV_INDEX_STRATEGY was only exported to GITHUB_ENV but not to the current shell.

While this bug doesn't currently affect main (since UV_EXTRA_INDEX_URL is only set on release branches), it's a latent bug that could cause issues if the logic changes in the future or if someone tests with UV_EXTRA_INDEX_URL set.

The setup-runner action only exported UV_INDEX_STRATEGY to GITHUB_ENV (for subsequent steps), not to the current shell environment. Since uv sync runs in the same step, it would never see the variable if it were set.

This fix adds `export UV_INDEX_STRATEGY=unsafe-best-match` to make the variable available in the current shell before running uv commands.

Related: #4019 (same fix for release-0.3.x where the bug is actively triggered)