### PR TITLE
fix(imports): library client not imported by services that do not use it

### DIFF
--- a/src/llama_stack/__init__.py
+++ b/src/llama_stack/__init__.py
@@ -3,8 +3,3 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
-
-from llama_stack.core.library_client import (  # noqa: F401
-    AsyncLlamaStackAsLibraryClient,
-    LlamaStackAsLibraryClient,
-)

--- a/tests/integration/fixtures/common.py
+++ b/tests/integration/fixtures/common.py
@@ -20,8 +20,8 @@ import yaml
 from llama_stack_client import LlamaStackClient
 from openai import OpenAI
 
-from llama_stack import LlamaStackAsLibraryClient
 from llama_stack.core.datatypes import VectorStoresConfig
+from llama_stack.core.library_client import LlamaStackAsLibraryClient
 from llama_stack.core.stack import run_config_from_adhoc_config_spec
 from llama_stack.env import get_env_or_fail
 

--- a/tests/integration/inference/test_provider_data_routing.py
+++ b/tests/integration/inference/test_provider_data_routing.py
@@ -16,7 +16,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from llama_stack import LlamaStackAsLibraryClient
 from llama_stack.apis.datatypes import Api
 from llama_stack.apis.inference.inference import (
     OpenAIAssistantMessageParam,
@@ -24,6 +23,7 @@ from llama_stack.apis.inference.inference import (
     OpenAIChatCompletionUsage,
     OpenAIChoice,
 )
+from llama_stack.core.library_client import LlamaStackAsLibraryClient
 from llama_stack.core.telemetry.telemetry import MetricEvent
 
 

--- a/tests/integration/inference/test_tools_with_schemas.py
+++ b/tests/integration/inference/test_tools_with_schemas.py
@@ -13,7 +13,7 @@ import json
 
 import pytest
 
-from llama_stack import LlamaStackAsLibraryClient
+from llama_stack.core.library_client import LlamaStackAsLibraryClient
 from llama_stack.models.llama.datatypes import ToolDefinition
 from tests.common.mcp import make_mcp_server
 

--- a/tests/integration/inspect/test_inspect.py
+++ b/tests/integration/inspect/test_inspect.py
@@ -7,7 +7,7 @@
 import pytest
 from llama_stack_client import LlamaStackClient
 
-from llama_stack import LlamaStackAsLibraryClient
+from llama_stack.core.library_client import LlamaStackAsLibraryClient
 
 
 class TestInspect:

--- a/tests/integration/providers/test_providers.py
+++ b/tests/integration/providers/test_providers.py
@@ -6,7 +6,7 @@
 
 from llama_stack_client import LlamaStackClient
 
-from llama_stack import LlamaStackAsLibraryClient
+from llama_stack.core.library_client import LlamaStackAsLibraryClient
 
 
 class TestProviders:

--- a/tests/integration/responses/fixtures/fixtures.py
+++ b/tests/integration/responses/fixtures/fixtures.py
@@ -11,7 +11,7 @@ import pytest
 import yaml
 from openai import OpenAI
 
-from llama_stack import LlamaStackAsLibraryClient
+from llama_stack.core.library_client import LlamaStackAsLibraryClient
 
 # --- Helper Functions ---
 

--- a/tests/integration/responses/test_file_search.py
+++ b/tests/integration/responses/test_file_search.py
@@ -9,7 +9,7 @@ import time
 
 import pytest
 
-from llama_stack import LlamaStackAsLibraryClient
+from llama_stack.core.library_client import LlamaStackAsLibraryClient
 
 from .helpers import new_vector_store, upload_file
 

--- a/tests/integration/responses/test_tool_responses.py
+++ b/tests/integration/responses/test_tool_responses.py
@@ -12,8 +12,8 @@ import httpx
 import openai
 import pytest
 
-from llama_stack import LlamaStackAsLibraryClient
 from llama_stack.core.datatypes import AuthenticationRequiredError
+from llama_stack.core.library_client import LlamaStackAsLibraryClient
 from tests.common.mcp import dependency_tools, make_mcp_server
 
 from .fixtures.test_cases import (

--- a/tests/integration/tool_runtime/test_mcp.py
+++ b/tests/integration/tool_runtime/test_mcp.py
@@ -10,7 +10,7 @@ import pytest
 from llama_stack_client.lib.agents.agent import Agent
 from llama_stack_client.lib.agents.turn_events import StepCompleted, StepProgress, ToolCallIssuedDelta
 
-from llama_stack import LlamaStackAsLibraryClient
+from llama_stack.core.library_client import LlamaStackAsLibraryClient
 
 AUTH_TOKEN = "test-token"
 

--- a/tests/integration/tool_runtime/test_mcp_json_schema.py
+++ b/tests/integration/tool_runtime/test_mcp_json_schema.py
@@ -13,7 +13,7 @@ import json
 
 import pytest
 
-from llama_stack import LlamaStackAsLibraryClient
+from llama_stack.core.library_client import LlamaStackAsLibraryClient
 from tests.common.mcp import make_mcp_server
 
 AUTH_TOKEN = "test-token"

--- a/tests/integration/tool_runtime/test_registration.py
+++ b/tests/integration/tool_runtime/test_registration.py
@@ -8,8 +8,8 @@ import re
 
 import pytest
 
-from llama_stack import LlamaStackAsLibraryClient
 from llama_stack.apis.common.errors import ToolGroupNotFoundError
+from llama_stack.core.library_client import LlamaStackAsLibraryClient
 from tests.common.mcp import MCP_TOOLGROUP_ID, make_mcp_server
 
 


### PR DESCRIPTION
# What does this PR do?
Removes unnecessary import in `__init__.py` of llama stack library client and defers the import to packages that need it

## Test Plan
CI
