### PR TITLE
chore: remove unused classes

### DIFF
--- a/src/llama_stack/apis/conversations/__init__.py
+++ b/src/llama_stack/apis/conversations/__init__.py
@@ -6,26 +6,22 @@
 
 from .conversations import (
     Conversation,
-    ConversationCreateRequest,
     ConversationDeletedResource,
     ConversationItem,
     ConversationItemCreateRequest,
     ConversationItemDeletedResource,
     ConversationItemList,
     Conversations,
-    ConversationUpdateRequest,
     Metadata,
 )
 
 __all__ = [
     "Conversation",
-    "ConversationCreateRequest",
     "ConversationDeletedResource",
     "ConversationItem",
     "ConversationItemCreateRequest",
     "ConversationItemDeletedResource",
     "ConversationItemList",
     "Conversations",
-    "ConversationUpdateRequest",
     "Metadata",
 ]

--- a/src/llama_stack/apis/conversations/conversations.py
+++ b/src/llama_stack/apis/conversations/conversations.py
@@ -103,32 +103,6 @@ register_schema(ConversationItem, name="ConversationItem")
 
 
 @json_schema_type
-class ConversationCreateRequest(BaseModel):
-    """Request body for creating a conversation."""
-
-    items: list[ConversationItem] | None = Field(
-        default=[],
-        description="Initial items to include in the conversation context. You may add up to 20 items at a time.",
-        max_length=20,
-    )
-    metadata: Metadata | None = Field(
-        default={},
-        description="Set of 16 key-value pairs that can be attached to an object. Useful for storing additional information",
-        max_length=16,
-    )
-
-
-@json_schema_type
-class ConversationUpdateRequest(BaseModel):
-    """Request body for updating a conversation."""
-
-    metadata: Metadata = Field(
-        ...,
-        description="Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format, and querying for objects via API or the dashboard. Keys are strings with a maximum length of 64 characters. Values are strings with a maximum length of 512 characters.",
-    )
-
-
-@json_schema_type
 class ConversationDeletedResource(BaseModel):
     """Response for deleted conversation."""
 

--- a/tests/unit/conversations/test_api_models.py
+++ b/tests/unit/conversations/test_api_models.py
@@ -7,16 +7,9 @@
 
 from llama_stack.apis.conversations.conversations import (
     Conversation,
-    ConversationCreateRequest,
     ConversationItem,
     ConversationItemList,
 )
-
-
-def test_conversation_create_request_defaults():
-    request = ConversationCreateRequest()
-    assert request.items == []
-    assert request.metadata == {}
 
 
 def test_conversation_model_defaults():


### PR DESCRIPTION
# What does this PR do?

These were maybe be included in the webmethod?
The unit test was pointless too since the request was never used
anywhere?

This shouldn't be in the API definition, if we never consume it.

## Test Plan

CI with pre-commit on OpenAPI spec generation.


