### PR TITLE
fix(sqlstore): increase connection pool size to prevent exhaustion

### DIFF
--- a/src/llama_stack/providers/utils/sqlstore/sqlalchemy_sqlstore.py
+++ b/src/llama_stack/providers/utils/sqlstore/sqlalchemy_sqlstore.py
@@ -84,9 +84,15 @@ class SqlAlchemySqlStoreImpl(SqlStore):
             connect_args["timeout"] = 5.0
             connect_args["check_same_thread"] = False  # Allow usage across asyncio tasks
 
+        # Configure connection pool for concurrent access
+        # Default pool_size=5 + max_overflow=10 = 15 total connections
+        # Increase to handle concurrent tests and API operations (especially with Postgres)
         engine = create_async_engine(
             self.config.engine_str,
             pool_pre_ping=True,
+            pool_size=20,  # Increased from default 5
+            max_overflow=30,  # Increased from default 10
+            pool_recycle=3600,  # Recycle connections after 1 hour to prevent stale connections
             connect_args=connect_args,
         )
 


### PR DESCRIPTION
# What does this PR do?

  Increases SQLAlchemy connection pool from default 5+10 to 20+30 to handle
  concurrent API operations and tests. Prevents deadlocks in conversation API
  integration tests when using Postgres, where multiple concurrent requests
  exhaust the small default pool.

  Also adds pool_recycle=3600 to prevent stale connections.


## Test Plan

the server GPT integration test should not hang.
