### PR TITLE
fix(docs): link to test replay-record docs for discoverability

### DIFF
--- a/tests/integration/recordings/README.md
+++ b/tests/integration/recordings/README.md
@@ -2,6 +2,10 @@
 
 This directory contains recorded inference API responses used for deterministic testing without requiring live API access.
 
+For more information, see the
+[docs](https://llamastack.github.io/docs/contributing/testing/record-replay).
+This README provides more technical information.
+
 ## Structure
 
 - `responses/` - JSON files containing request/response pairs for inference operations


### PR DESCRIPTION
Help users find the comprehensive integration testing docs by linking to the record-replay documentation. This clarifies that the technical README complements the main docs.
