### PR TITLE
fix: bind to proper default hosts

### DIFF
--- a/src/llama_stack/cli/stack/run.py
+++ b/src/llama_stack/cli/stack/run.py
@@ -197,7 +197,7 @@ class StackRun(Subcommand):
             config = StackRunConfig(**cast_image_name_to_string(replace_env_vars(config_contents)))
 
         port = args.port or config.server.port
-        host = config.server.host or "0.0.0.0"
+        host = config.server.host or ["::", "0.0.0.0"]
 
         # Set the config file in environment so create_app can find it
         os.environ["LLAMA_STACK_CONFIG"] = str(config_file)


### PR DESCRIPTION
# What does this PR do?

we used to have ` host = config.server.host or ["::", "0.0.0.0"]` but now only bind to ` host = config.server.host or "0.0.0.0"`

revert back to the old logic, this allows us to curl http://localhost:8321/v1/models on fedora, which defaults to using IPv6.


resolves #4210
