### PR TITLE
fix: call setup_logging early to apply category-specific log levels

### DIFF
--- a/src/llama_stack/cli/llama.py
+++ b/src/llama_stack/cli/llama.py
@@ -8,6 +8,9 @@ import argparse
 
 from llama_stack.log import setup_logging
 
+# Initialize logging early before any loggers get created
+setup_logging()
+
 from .stack import StackParser
 from .stack.utils import print_subcommand_description
 
@@ -44,9 +47,6 @@ class LlamaCLIParser:
 
 
 def main():
-    # Initialize logging from environment variables before any other operations
-    setup_logging()
-
     parser = LlamaCLIParser()
     args = parser.parse_args()
     parser.run(args)

--- a/src/llama_stack/core/server/server.py
+++ b/src/llama_stack/core/server/server.py
@@ -55,7 +55,7 @@ from llama_stack.core.telemetry.tracing import CURRENT_TRACE_CONTEXT, setup_logg
 from llama_stack.core.utils.config import redact_sensitive_fields
 from llama_stack.core.utils.config_resolution import Mode, resolve_config_or_distro
 from llama_stack.core.utils.context import preserve_contexts_async_generator
-from llama_stack.log import LoggingConfig, get_logger, setup_logging
+from llama_stack.log import LoggingConfig, get_logger
 from llama_stack_api import Api, ConflictError, PaginatedResponse, ResourceNotFoundError
 
 from .auth import AuthenticationMiddleware
@@ -367,9 +367,6 @@ def create_app() -> StackApp:
     Returns:
         Configured StackApp instance.
     """
-    # Initialize logging from environment variables first
-    setup_logging()
-
     config_file = os.getenv("LLAMA_STACK_CONFIG")
     if config_file is None:
         raise ValueError("LLAMA_STACK_CONFIG environment variable is required")

--- a/tests/integration/fixtures/common.py
+++ b/tests/integration/fixtures/common.py
@@ -14,6 +14,11 @@ import tempfile
 import time
 from urllib.parse import urlparse
 
+# Initialize logging early before any loggers get created
+from llama_stack.log import setup_logging
+
+setup_logging()
+
 import pytest
 import requests
 import yaml


### PR DESCRIPTION
    Category-specific log levels from LLAMA_STACK_LOGGING were not applied to
    loggers created before setup_logging() was called. This fix moves the
    setup_logging() call earlier in the initialization sequence to ensure all
    loggers respect their configured levels regardless of initialization timing.
    
    Closes: #4252