### PR TITLE
fix: correct parameter names in error messages

### DIFF
--- a/scripts/github/schedule-record-workflow.sh
+++ b/scripts/github/schedule-record-workflow.sh
@@ -55,7 +55,7 @@ EOF
 #     - jq must be installed for JSON parsing
 #     - You must be in a git repository that is a fork or clone of llamastack/llama-stack
 #     - The branch must exist on the remote repository where you want to run the workflow
-#     - You must specify test subdirectories to run with -s/--test-subdirs
+#     - You must specify test subdirectories to run with -s/--subdirs
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do

--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -116,13 +116,13 @@ if [[ -z "$STACK_CONFIG" && "$COLLECT_ONLY" == false ]]; then
 fi
 
 if [[ -z "$TEST_SETUP" && -n "$TEST_SUBDIRS" && "$COLLECT_ONLY" == false ]]; then
-    echo "Error: --test-setup is required when --test-subdirs is provided"
+    echo "Error: --setup is required when --subdirs is provided"
     usage
     exit 1
 fi
 
 if [[ -z "$TEST_SUITE" && -z "$TEST_SUBDIRS" ]]; then
-    echo "Error: --test-suite or --test-subdirs is required"
+    echo "Error: --suite or --subdirs is required"
     exit 1
 fi
 


### PR DESCRIPTION
Error messages were using --test-setup, --test-subdirs, and --test-suite instead of the actual parameter names: --setup, --subdirs, and --suite
