### PR TITLE
fix: access control to fail-closed when owner attributes are missing

### DIFF
--- a/src/llama_stack/core/access_control/access_control.py
+++ b/src/llama_stack/core/access_control/access_control.py
@@ -66,7 +66,17 @@ def default_policy() -> list[AccessRule]:
     return [
         AccessRule(
             permit=Scope(actions=list(Action)),
-            when=["user in owners " + name for name in ["roles", "teams", "projects", "namespaces"]],
+            when=["user in owners " + name],
+        )
+        for name in ["roles", "teams", "projects", "namespaces"]
+    ] + [
+        AccessRule(
+            permit=Scope(actions=list(Action)),
+            when=["user is owner"],
+        ),
+        AccessRule(
+            permit=Scope(actions=list(Action)),
+            when=["resource is unowned"],
         ),
     ]
 

--- a/src/llama_stack/core/access_control/conditions.py
+++ b/src/llama_stack/core/access_control/conditions.py
@@ -38,13 +38,13 @@ class UserInOwnersList:
             return None
 
     def matches(self, resource: ProtectedResource, user: User) -> bool:
-        required = self.owners_values(resource)
-        if not required:
-            return True
+        defined = self.owners_values(resource)
+        if not defined:
+            return False
         if not user.attributes or self.name not in user.attributes or not user.attributes[self.name]:
             return False
         user_values = user.attributes[self.name]
-        for value in required:
+        for value in defined:
             if value in user_values:
                 return True
         return False
@@ -106,6 +106,14 @@ class UserIsNotOwner:
         return "user is not owner"
 
 
+class ResourceIsUnowned:
+    def matches(self, resource: ProtectedResource, user: User) -> bool:
+        return not resource.owner
+
+    def __repr__(self):
+        return "resource is unowned"
+
+
 def parse_condition(condition: str) -> Condition:
     words = condition.split()
     match words:
@@ -121,6 +129,8 @@ def parse_condition(condition: str) -> Condition:
             return UserInOwnersList(name)
         case ["user", "not", "in", "owners", name]:
             return UserNotInOwnersList(name)
+        case ["resource", "is", "unowned"]:
+            return ResourceIsUnowned()
         case _:
             raise ValueError(f"Invalid condition: {condition}")
 

--- a/src/llama_stack/core/storage/sqlstore/authorized_sqlstore.py
+++ b/src/llama_stack/core/storage/sqlstore/authorized_sqlstore.py
@@ -23,17 +23,26 @@ logger = get_logger(name=__name__, category="providers::utils")
 # WARNING: If default_policy() changes, this constant must be updated accordingly
 # or SQL filtering will fall back to conservative mode (safe but less performant)
 #
-# This policy represents: "Permit all actions when user is in owners list for ALL attribute categories"
+# This policy represents: "Permit all actions when user is in owners list for ANY attribute category"
 # The corresponding SQL logic is implemented in _build_default_policy_where_clause():
 # - Public records (no access_attributes) are always accessible
-# - Records with access_attributes require user to match ALL categories that exist in the resource
-# - Missing categories in the resource are treated as "no restriction" (allow)
+# - Records with access_attributes require user to match ANY category that exists in the resource
 # - Within each category, user needs ANY matching value (OR logic)
-# - Between categories, user needs ALL categories to match (AND logic)
+# - Between categories, user needs ANY category to match (OR logic)
 SQL_OPTIMIZED_POLICY = [
     AccessRule(
         permit=Scope(actions=list(Action)),
-        when=["user in owners roles", "user in owners teams", "user in owners projects", "user in owners namespaces"],
+        when=["user in owners " + name],
+    )
+    for name in ["roles", "teams", "projects", "namespaces"]
+] + [
+    AccessRule(
+        permit=Scope(actions=list(Action)),
+        when=["user is owner"],
+    ),
+    AccessRule(
+        permit=Scope(actions=list(Action)),
+        when=["resource is unowned"],
     ),
 ]
 
@@ -279,53 +288,40 @@ class AuthorizedSqlStore:
 
         Public records are those with:
         - owner_principal = '' (empty string)
-        - access_attributes is either SQL NULL or JSON null
 
-        Note: Different databases serialize None differently:
-        - SQLite: None → JSON null (text = 'null')
-        - Postgres: None → SQL NULL (IS NULL)
+        The policy "resource is unowned" only checks if owner_principal is empty,
+        regardless of access_attributes.
         """
-        conditions = ["owner_principal = ''"]
-        if self.database_type == StorageBackendType.SQL_POSTGRES.value:
-            # Accept both SQL NULL and JSON null for Postgres compatibility
-            # This handles both old rows (SQL NULL) and new rows (JSON null)
-            conditions.append("(access_attributes IS NULL OR access_attributes::text = 'null')")
-        elif self.database_type == StorageBackendType.SQL_SQLITE.value:
-            # SQLite serializes None as JSON null
-            conditions.append("(access_attributes IS NULL OR access_attributes = 'null')")
-        else:
-            raise ValueError(f"Unsupported database type: {self.database_type}")
-        return conditions
+        return ["owner_principal = ''"]
 
     def _build_default_policy_where_clause(self, current_user: User | None) -> str:
         """Build SQL WHERE clause for the default policy.
 
         Default policy: permit all actions when user in owners [roles, teams, projects, namespaces]
-        This means user must match ALL attribute categories that exist in the resource.
+        This means user must match ANY attribute category that exists in the resource (OR logic).
         """
         base_conditions = self._get_public_access_conditions()
-        user_attr_conditions = []
 
-        if current_user and current_user.attributes:
-            for attr_key, user_values in current_user.attributes.items():
-                if user_values:
-                    value_conditions = []
-                    for value in user_values:
-                        # Check if JSON array contains the value
-                        escaped_value = value.replace("'", "''")
-                        json_text = self._json_extract_text("access_attributes", attr_key)
-                        value_conditions.append(f"({json_text} LIKE '%\"{escaped_value}\"%')")
+        if current_user:
+            # Add "user is owner" condition - user's principal matches owner_principal
+            escaped_principal = current_user.principal.replace("'", "''")
+            base_conditions.append(f"owner_principal = '{escaped_principal}'")
 
-                    if value_conditions:
-                        # Check if the category is missing (NULL)
-                        category_missing = f"{self._json_extract('access_attributes', attr_key)} IS NULL"
-                        user_matches_category = f"({' OR '.join(value_conditions)})"
-                        user_attr_conditions.append(f"({category_missing} OR {user_matches_category})")
+            # Add "user in owners" conditions for attribute matching
+            if current_user.attributes:
+                for attr_key, user_values in current_user.attributes.items():
+                    if user_values:
+                        value_conditions = []
+                        for value in user_values:
+                            # Check if JSON array contains the value
+                            escaped_value = value.replace("'", "''")
+                            json_text = self._json_extract_text("access_attributes", attr_key)
+                            value_conditions.append(f"({json_text} LIKE '%\"{escaped_value}\"%')")
 
-            if user_attr_conditions:
-                all_requirements_met = f"({' AND '.join(user_attr_conditions)})"
-                base_conditions.append(all_requirements_met)
-
+                        if value_conditions:
+                            # User matches this category if any of their values match
+                            user_matches_category = f"({' OR '.join(value_conditions)})"
+                            base_conditions.append(user_matches_category)
         return f"({' OR '.join(base_conditions)})"
 
     def _build_conservative_where_clause(self) -> str:

--- a/tests/integration/providers/utils/sqlstore/test_authorized_sqlstore.py
+++ b/tests/integration/providers/utils/sqlstore/test_authorized_sqlstore.py
@@ -184,6 +184,16 @@ async def test_authorized_store_attributes(mock_get_authenticated_user, authoriz
             f"Category missing logic failed: expected 4,5 but got {category_test_ids}"
         )
 
+        # Test a user that has all roles and teams (should generate SQL)
+        # owner_principal = ''
+        # owner_principal = 'super-user'
+        # ((JSON_EXTRACT(access_attributes, '$.roles') LIKE '%"admin"%') OR (JSON_EXTRACT(access_attributes, '$.roles') LIKE '%"user"%'))
+        # ((JSON_EXTRACT(access_attributes, '$.teams') LIKE '%"dev"%') OR (JSON_EXTRACT(access_attributes, '$.teams') LIKE '%"qa"%'))
+        super_user = User("super-user", {"roles": ["admin", "user"], "teams": ["dev", "qa"]})
+        mock_get_authenticated_user.return_value = super_user
+        result = await authorized_store.fetch_all(table_name)
+        assert len(result.data) == 6
+
     finally:
         # Clean up records
         await cleanup_records(authorized_store.sql_store, table_name, ["1", "2", "3", "4", "5", "6"])


### PR DESCRIPTION
Changed UserInOwnersList.matches() to return False instead of True when a resource's owner attributes are None. This prevents unintended access when resource when owner attributes arn't present.

For example, checking "user in owners teams" now returns False if the resource has no teams attribute, rather than defaulting to True.

Changed UserIsOwner.matches() to return True when a resource has no owner attribute set. This allows access to resources that don't use the owner attribute.

Updated default_policy to use multiple separate "user in owners" AccessRules instead of a single rule with multiple when clauses. With the new fail-closed behavior, only one rule needs to match. Added a "user is owner" rule to handle resources without attribute-based access.

Closes: #4272
