### PR TITLE
fix: Add policies to adapters

### DIFF
--- a/src/llama_stack/core/resolver.py
+++ b/src/llama_stack/core/resolver.py
@@ -374,6 +374,9 @@ async def instantiate_provider(
         method = "get_adapter_impl"
         args = [config, deps]
 
+        if "policy" in inspect.signature(getattr(module, method)).parameters:
+            args.append(policy)
+
     elif isinstance(provider_spec, AutoRoutedProviderSpec):
         method = "get_auto_router_impl"
 


### PR DESCRIPTION
The configured policy wasn't being passed in and instead the default was being used (e.g. in the s3 file provider)

Closes: #4276
