### PR TITLE
chore: add logging for empty model lists

### DIFF
--- a/src/llama_stack/core/routing_tables/models.py
+++ b/src/llama_stack/core/routing_tables/models.py
@@ -135,6 +135,14 @@ class ModelsRoutingTable(CommonRoutingTableImpl, Models):
 
         all_models = registry_models + unique_dynamic_models
 
+        # Log error if no models are found, log debug statement if either registry or dynamic is empty
+        if len(all_models) == 0:
+            logger.error("No models found from registry or providers data")
+        elif len(registry_models) == 0:
+            logger.debug("No models found in registry")
+        elif len(dynamic_models) == 0:
+            logger.debug("No models found via providers data")
+
         openai_models = [
             OpenAIModel(
                 id=model.identifier,


### PR DESCRIPTION


# What does this PR do?
previously there was no logging for empty model lists

add debug lines for individual registry and dynamic model lists, and error if no models are found from either

Closes #4031

## Test Plan
```bash
$ LLAMA_STACK_LOGGING=all=debug OPENAI_API_KEY=BOGUS uv run llama stack run --providers inference=remote::openai
...
```
```bash
$ curl http://localhost:8321/v1/models | jq
{
  "data": []
}
```
server logs
```bash
...
DEBUG    2025-12-02 14:41:15,064 llama_stack.core.routing_tables.models:129 core::routing_tables: No models found in    
         registry                                                                                                       
DEBUG    2025-12-02 14:41:15,066 llama_stack.core.routing_tables.models:134 core::routing_tables: No models found via   
         providers data                                                                                                 
ERROR    2025-12-02 14:41:15,066 llama_stack.core.routing_tables.models:142 core::routing_tables: No models found from  
         registry or providers data                                                                                     
INFO     2025-12-02 14:41:15,067 uvicorn.access:473 uncategorized: ::1:60260 - "GET /v1/models HTTP/1.1" 200
```