### PR TITLE
chore: Delete unused .github/TRIAGERS.md

### DIFF
--- a/.github/TRIAGERS.md
+++ b/.github/TRIAGERS.md
@@ -1,1 +1,0 @@
-# This file documents Triage members in the Llama Stack community


### PR DESCRIPTION
This file is not used. We should delete it.