### PR TITLE
fix: set SqlRecord owner to None when owner_principal is empty

### DIFF
--- a/src/llama_stack/core/access_control/conditions.py
+++ b/src/llama_stack/core/access_control/conditions.py
@@ -15,7 +15,7 @@ class User(Protocol):
 class ProtectedResource(Protocol):
     type: str
     identifier: str
-    owner: User
+    owner: User | None
 
 
 class Condition(Protocol):


### PR DESCRIPTION
Changes SqlRecord creation in AuthorizedSqlStore.fetch_all to use owner=None when owner_principal is empty/missing, matching the ResourceWithOwner pattern used in routing tables. This fixes an inconsistency where SQL store was creating User(principal="") while routing tables use owner=None for public resources.

Changes:
o Update ProtectedResource Protocol to allow owner: User | None 
o Update SqlRecord.__init__ to accept owner: User | None 
o Update fetch_all to create owner=None for records without owner_principal
