### PR TITLE
chore(cve): Update node-forge to 1.3.3

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -15217,9 +15217,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
+      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"

--- a/docs/package.json
+++ b/docs/package.json
@@ -32,7 +32,8 @@
     "remark-code-import": "^1.2.0"
   },
   "overrides": {
-    "glob": "^10.5.0"
+    "glob": "^10.5.0",
+    "node-forge": "^1.3.2"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
https://github.com/digitalbazaar/forge/security/advisories/GHSA-554w-wpv2-vw27

Taking on a direct dependency is not great
  1. We don't actually use node-forge - it's only needed by webpack-dev-server's dependency (selfsigned) for generating self-signed certificates during development
  2. Adding a direct dependency would be misleading - it suggests our code uses node-forge when it doesn't

In the dependency chain:

```
@docusaurus/core@3.8.1
  └─ webpack-dev-server@4.15.2
      └─ selfsigned@2.4.1
          └─ node-forge@1.3.1
```
Latest Docusaurus (3.9.2) uses webpack-dev-server 5.2.2, which still uses selfsigned 2.4.1

So, overriding dependency on node-forge is the only option