### PR TITLE
fix(ci): use latest version of setup-uv and remove pin

### DIFF
--- a/.github/actions/setup-runner/action.yml
+++ b/.github/actions/setup-runner/action.yml
@@ -13,10 +13,9 @@ runs:
   using: "composite"
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+      uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # v7.1.4
       with:
         python-version: ${{ inputs.python-version }}
-        version: 0.7.6
 
     - name: Configure client installation
       id: client-config

--- a/.github/workflows/python-build-test.yml
+++ b/.github/workflows/python-build-test.yml
@@ -28,7 +28,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         activate-environment: true
-        version: 0.7.6
 
     - name: Build Llama Stack API package
       working-directory: src/llama_stack_api


### PR DESCRIPTION
# What does this PR do?
this commit puts aligns all 'setup-uv' instances to the latest version and removes the pin keeping several actions on a very old version
