### PR TITLE
fix: check if distro dirs exist before listing

### DIFF
--- a/src/llama_stack/core/utils/config_resolution.py
+++ b/src/llama_stack/core/utils/config_resolution.py
@@ -111,15 +111,14 @@ Did you mean one of these distributions?
 
 def _get_available_distros() -> list[str]:
     """Get list of available distro names."""
-    if not DISTRO_DIR.exists() and not DISTRIBS_BASE_DIR.exists():
-        return []
 
-    return list(
-        set(
-            [d.name for d in DISTRO_DIR.iterdir() if d.is_dir() and not d.name.startswith(".")]
-            + [d.name for d in DISTRIBS_BASE_DIR.iterdir() if d.is_dir() and not d.name.startswith(".")]
-        )
-    )
+    distros = []
+    if DISTRO_DIR.exists():
+        distros.extend([d.name for d in DISTRO_DIR.iterdir() if d.is_dir() and not d.name.startswith(".")])
+    if DISTRIBS_BASE_DIR.exists():
+        distros.extend([d.name for d in DISTRIBS_BASE_DIR.iterdir() if d.is_dir() and not d.name.startswith(".")])
+
+    return list(set(distros))
 
 
 def _format_distro_suggestions(distros: list[str], user_input: str) -> str:


### PR DESCRIPTION
# What does this PR do?

DISTRO_DIR and DISTRIBS_BASE_DIR need to exist for them to be iterated. our current logic allows us to iterdir without checking if they exist

## Test Plan

rm ~/.llama/distributions

```
llama stack list-deps starter --format uv | sh
Using Python 3.12.11 environment at: venv
Audited 51 packages in 12ms
Using Python 3.12.11 environment at: venv
Audited 3 packages in 2ms
Using Python 3.12.11 environment at: venv
Audited 1 package in 3ms
Using Python 3.12.11 environment at: venv
Audited 3 packages in 5ms
```

