### PR TITLE
chore: Remove unused list_models method and ListModelsResponse

### DIFF
--- a/src/llama_stack/core/routing_tables/models.py
+++ b/src/llama_stack/core/routing_tables/models.py
@@ -16,7 +16,6 @@ from llama_stack.core.request_headers import PROVIDER_DATA_VAR, NeedsRequestProv
 from llama_stack.core.utils.dynamic import instantiate_class_type
 from llama_stack.log import get_logger
 from llama_stack_api import (
-    ListModelsResponse,
     Model,
     ModelNotFoundError,
     Models,
@@ -127,19 +126,6 @@ class ModelsRoutingTable(CommonRoutingTableImpl, Models):
                 continue
 
         return dynamic_models
-
-    async def list_models(self) -> ListModelsResponse:
-        # Get models from registry
-        registry_models = await self.get_all_with_type("model")
-
-        # Get additional models available via provider_data (user-specific, not cached)
-        dynamic_models = await self._get_dynamic_models_from_provider_data()
-
-        # Combine, avoiding duplicates (registry takes precedence)
-        registry_identifiers = {m.identifier for m in registry_models}
-        unique_dynamic_models = [m for m in dynamic_models if m.identifier not in registry_identifiers]
-
-        return ListModelsResponse(data=registry_models + unique_dynamic_models)
 
     async def openai_list_models(self) -> OpenAIListModelsResponse:
         # Get models from registry

--- a/src/llama_stack/core/stack.py
+++ b/src/llama_stack/core/stack.py
@@ -89,7 +89,7 @@ class LlamaStack(
 
 
 RESOURCES = [
-    ("models", Api.models, "register_model", "list_models"),
+    ("models", Api.models, "register_model", "openai_list_models"),
     ("shields", Api.shields, "register_shield", "list_shields"),
     ("datasets", Api.datasets, "register_dataset", "list_datasets"),
     (
@@ -156,14 +156,14 @@ async def validate_vector_stores_config(vector_stores_config: VectorStoresConfig
         raise ValueError(f"Models API is not available but vector_stores config requires model '{default_model_id}'")
 
     models_impl = impls[Api.models]
-    response = await models_impl.list_models()
-    models_list = {m.identifier: m for m in response.data if m.model_type == "embedding"}
+    response = await models_impl.openai_list_models()
+    models_list = {m.id: m for m in response.data if m.custom_metadata["model_type"] == "embedding"}
 
     default_model = models_list.get(default_model_id)
     if default_model is None:
         raise ValueError(f"Embedding model '{default_model_id}' not found. Available embedding models: {models_list}")
 
-    embedding_dimension = default_model.metadata.get("embedding_dimension")
+    embedding_dimension = default_model.custom_metadata.get("embedding_dimension")
     if embedding_dimension is None:
         raise ValueError(f"Embedding model '{default_model_id}' is missing 'embedding_dimension' in metadata")
 

--- a/src/llama_stack_api/__init__.py
+++ b/src/llama_stack_api/__init__.py
@@ -214,7 +214,6 @@ from .inspect import (
 )
 from .models import (
     CommonModelFields,
-    ListModelsResponse,
     Model,
     ModelInput,
     Models,
@@ -569,7 +568,6 @@ __all__ = [
     "RetrieveBatchRequest",
     "ListBenchmarksResponse",
     "ListDatasetsResponse",
-    "ListModelsResponse",
     "ListOpenAIChatCompletionResponse",
     "ListOpenAIFileResponse",
     "ListOpenAIResponseInputItem",

--- a/src/llama_stack_api/models.py
+++ b/src/llama_stack_api/models.py
@@ -77,10 +77,6 @@ class ModelInput(CommonModelFields):
     model_config = ConfigDict(protected_namespaces=())
 
 
-class ListModelsResponse(BaseModel):
-    data: list[Model]
-
-
 @json_schema_type
 class OpenAIModel(BaseModel):
     """A model from OpenAI.
@@ -106,13 +102,6 @@ class OpenAIListModelsResponse(BaseModel):
 
 @runtime_checkable
 class Models(Protocol):
-    async def list_models(self) -> ListModelsResponse:
-        """List all models.
-
-        :returns: A ListModelsResponse.
-        """
-        ...
-
     @webmethod(route="/models", method="GET", level=LLAMA_STACK_API_V1)
     async def openai_list_models(self) -> OpenAIListModelsResponse:
         """List models using the OpenAI API.

--- a/tests/unit/core/test_stack_validation.py
+++ b/tests/unit/core/test_stack_validation.py
@@ -13,7 +13,7 @@ import pytest
 from llama_stack.core.datatypes import QualifiedModel, SafetyConfig, StackRunConfig, VectorStoresConfig
 from llama_stack.core.stack import validate_safety_config, validate_vector_stores_config
 from llama_stack.core.storage.datatypes import ServerStoresConfig, StorageConfig
-from llama_stack_api import Api, ListModelsResponse, ListShieldsResponse, Model, ModelType, Shield
+from llama_stack_api import Api, ListShieldsResponse, ModelType, OpenAIListModelsResponse, OpenAIModel, Shield
 
 
 class TestVectorStoresValidation:
@@ -40,7 +40,7 @@ class TestVectorStoresValidation:
             ),
         )
         mock_models = AsyncMock()
-        mock_models.list_models.return_value = ListModelsResponse(data=[])
+        mock_models.openai_list_models.return_value = OpenAIListModelsResponse(data=[])
 
         with pytest.raises(ValueError, match="not found"):
             await validate_vector_stores_config(run_config.vector_stores, {Api.models: mock_models})
@@ -68,14 +68,19 @@ class TestVectorStoresValidation:
             ),
         )
         mock_models = AsyncMock()
-        mock_models.list_models.return_value = ListModelsResponse(
+        mock_models.openai_list_models.return_value = OpenAIListModelsResponse(
             data=[
-                Model(
-                    identifier="p/valid",  # Must match provider_id/model_id format
-                    model_type=ModelType.embedding,
-                    metadata={"embedding_dimension": 768},
-                    provider_id="p",
-                    provider_resource_id="valid",
+                OpenAIModel(
+                    id="p/valid",  # Must match provider_id/model_id format
+                    object="model",
+                    created=857142,
+                    owned_by="llama_stack",
+                    custom_metadata={
+                        "embedding_dimension": 768,
+                        "model_type": ModelType.embedding.value,
+                        "provider_id": "p",
+                        "provider_resource_id": "valid",
+                    },
                 )
             ]
         )

--- a/tests/unit/server/test_access_control.py
+++ b/tests/unit/server/test_access_control.py
@@ -68,7 +68,7 @@ async def test_access_control_with_cache(mock_get_authenticated_user, test_setup
     await registry.register(model_data_scientist)
 
     mock_get_authenticated_user.return_value = User("test-user", {"roles": ["admin"], "teams": ["management"]})
-    all_models = await routing_table.list_models()
+    all_models = await routing_table.openai_list_models()
     assert len(all_models.data) == 2
 
     model = await routing_table.get_model("model-public")
@@ -79,9 +79,9 @@ async def test_access_control_with_cache(mock_get_authenticated_user, test_setup
         await routing_table.get_model("model-data-scientist")
 
     mock_get_authenticated_user.return_value = User("test-user", {"roles": ["data-scientist"], "teams": ["other-team"]})
-    all_models = await routing_table.list_models()
+    all_models = await routing_table.openai_list_models()
     assert len(all_models.data) == 1
-    assert all_models.data[0].identifier == "model-public"
+    assert all_models.data[0].id == "model-public"
     model = await routing_table.get_model("model-public")
     assert model.identifier == "model-public"
     with pytest.raises(ValueError):
@@ -90,9 +90,9 @@ async def test_access_control_with_cache(mock_get_authenticated_user, test_setup
         await routing_table.get_model("model-data-scientist")
 
     mock_get_authenticated_user.return_value = User("test-user", {"roles": ["data-scientist"], "teams": ["ml-team"]})
-    all_models = await routing_table.list_models()
+    all_models = await routing_table.openai_list_models()
     assert len(all_models.data) == 2
-    model_ids = [m.identifier for m in all_models.data]
+    model_ids = [m.id for m in all_models.data]
     assert "model-public" in model_ids
     assert "model-data-scientist" in model_ids
     assert "model-admin" not in model_ids
@@ -161,8 +161,8 @@ async def test_access_control_empty_attributes(mock_get_authenticated_user, test
     )
     result = await routing_table.get_model("model-empty-attrs")
     assert result.identifier == "model-empty-attrs"
-    all_models = await routing_table.list_models()
-    model_ids = [m.identifier for m in all_models.data]
+    all_models = await routing_table.openai_list_models()
+    model_ids = [m.id for m in all_models.data]
     assert "model-empty-attrs" in model_ids
 
 
@@ -191,9 +191,9 @@ async def test_no_user_attributes(mock_get_authenticated_user, test_setup):
     with pytest.raises(ValueError):
         await routing_table.get_model("model-restricted")
 
-    all_models = await routing_table.list_models()
+    all_models = await routing_table.openai_list_models()
     assert len(all_models.data) == 1
-    assert all_models.data[0].identifier == "model-public-2"
+    assert all_models.data[0].id == "model-public-2"
 
 
 @patch("llama_stack.core.routing_tables.common.get_authenticated_user")
@@ -718,8 +718,8 @@ class TestModelListingRBACBypass:
         mock_get_user_common.return_value = admin_user
         mock_get_user_models.return_value = admin_user
 
-        result = await routing_table.list_models()
-        model_ids = [m.identifier for m in result.data]
+        result = await routing_table.openai_list_models()
+        model_ids = [m.id for m in result.data]
         assert "test-provider/dynamic-model-1" in model_ids
         assert "test-provider/dynamic-model-2" in model_ids
 
@@ -729,7 +729,7 @@ class TestModelListingRBACBypass:
         mock_get_user_common.return_value = restricted_user
         mock_get_user_models.return_value = restricted_user
 
-        result = await routing_table.list_models()
-        model_ids = [m.identifier for m in result.data]
+        result = await routing_table.openai_list_models()
+        model_ids = [m.id for m in result.data]
         # Restricted user should see no models (no ownership, not admin)
         assert len(model_ids) == 0


### PR DESCRIPTION
# What does this PR do?

This change removes the unused `list_models` method and `ListModelsResponse` class from the Llama Stack API.

Key changes:
- Removed `ListModelsResponse` from models.py and __init__.py
- Removed `list_models` method from the `Models` protocol
- Updated `ModelsRoutingTable` to remove the `list_models` implementation
- Modified `validate_vector_stores_config` in stack.py to use `openai_list_models`
- Updated all unit tests to use the new OpenAI-compatible API
- Removed unused imports across the codebase