### PR TITLE
chore(refactor): replace string-based resource registration with direct method calls

### DIFF
--- a/src/llama_stack_api/models.py
+++ b/src/llama_stack_api/models.py
@@ -9,7 +9,7 @@ from typing import Any, Literal, Protocol, runtime_checkable
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from llama_stack_api.resource import Resource, ResourceType
+from llama_stack_api.resource import ListResourcesResponse, Resource, ResourceType
 from llama_stack_api.schema_utils import json_schema_type, webmethod
 from llama_stack_api.version import LLAMA_STACK_API_V1
 
@@ -77,8 +77,8 @@ class ModelInput(CommonModelFields):
     model_config = ConfigDict(protected_namespaces=())
 
 
-class ListModelsResponse(BaseModel):
-    data: list[Model]
+class ListModelsResponse(ListResourcesResponse[Model]):
+    pass
 
 
 @json_schema_type

--- a/src/llama_stack_api/resource.py
+++ b/src/llama_stack_api/resource.py
@@ -35,3 +35,12 @@ class Resource(BaseModel):
     provider_id: str = Field(description="ID of the provider that owns this resource")
 
     type: ResourceType = Field(description="Type of resource (e.g. 'model', 'shield', 'vector_store', etc.)")
+
+
+class ListResourcesResponse[ResourceT: Resource](BaseModel):
+    """Base response type for listing resources.
+
+    :param data: List of resources
+    """
+
+    data: list[ResourceT]

--- a/src/llama_stack_api/scoring_functions.py
+++ b/src/llama_stack_api/scoring_functions.py
@@ -17,7 +17,7 @@ from typing import (
 from pydantic import BaseModel, Field
 
 from llama_stack_api.common.type_system import ParamType
-from llama_stack_api.resource import Resource, ResourceType
+from llama_stack_api.resource import ListResourcesResponse, Resource, ResourceType
 from llama_stack_api.schema_utils import json_schema_type, register_schema, webmethod
 from llama_stack_api.version import LLAMA_STACK_API_V1
 
@@ -156,8 +156,8 @@ class ScoringFnInput(CommonScoringFnFields, BaseModel):
 
 
 @json_schema_type
-class ListScoringFunctionsResponse(BaseModel):
-    data: list[ScoringFn]
+class ListScoringFunctionsResponse(ListResourcesResponse[ScoringFn]):
+    pass
 
 
 @runtime_checkable

--- a/src/llama_stack_api/shields.py
+++ b/src/llama_stack_api/shields.py
@@ -8,7 +8,7 @@ from typing import Any, Literal, Protocol, runtime_checkable
 
 from pydantic import BaseModel
 
-from llama_stack_api.resource import Resource, ResourceType
+from llama_stack_api.resource import ListResourcesResponse, Resource, ResourceType
 from llama_stack_api.schema_utils import json_schema_type, webmethod
 from llama_stack_api.version import LLAMA_STACK_API_V1
 
@@ -43,8 +43,8 @@ class ShieldInput(CommonShieldFields):
 
 
 @json_schema_type
-class ListShieldsResponse(BaseModel):
-    data: list[Shield]
+class ListShieldsResponse(ListResourcesResponse[Shield]):
+    pass
 
 
 @runtime_checkable

--- a/src/llama_stack_api/tools.py
+++ b/src/llama_stack_api/tools.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 from typing_extensions import runtime_checkable
 
 from llama_stack_api.common.content_types import URL, InterleavedContent
-from llama_stack_api.resource import Resource, ResourceType
+from llama_stack_api.resource import ListResourcesResponse, Resource, ResourceType
 from llama_stack_api.schema_utils import json_schema_type, webmethod
 from llama_stack_api.version import LLAMA_STACK_API_V1
 
@@ -88,13 +88,10 @@ class ToolStore(Protocol):
 
 
 @json_schema_type
-class ListToolGroupsResponse(BaseModel):
-    """Response containing a list of tool groups.
+class ListToolGroupsResponse(ListResourcesResponse[ToolGroup]):
+    """Response containing a list of tool groups."""
 
-    :param data: List of tool groups
-    """
-
-    data: list[ToolGroup]
+    pass
 
 
 @json_schema_type


### PR DESCRIPTION
# What does this PR do?

Remove RESOURCES list with string method names and replace with explicit typed calls for each resource type. Extract common registration logic into _register_resource helper with generic type parameters.

- Add ListResourcesResponse[ResourceT] generic base class to resource.py
- Update all list response types to inherit from generic base
- Replace getattr-based method lookup with direct impl method calls
- Add proper type hints using PEP 695 generics (InputT: BaseModel, ResourceT: Resource)