### PR TITLE
chore: Small Auth CI refactor 

### DIFF
--- a/.github/workflows/integration-auth-tests.yml
+++ b/.github/workflows/integration-auth-tests.yml
@@ -72,7 +72,7 @@ jobs:
         if: ${{ matrix.auth-provider == 'oauth2_token' }}
         run: |
           run_dir=$(mktemp -d)
-          cat <<'EOF' > $run_dir/run.yaml
+          cat <<EOF > $run_dir/run.yaml
           version: '2'
           image_name: kube
           apis: []


### PR DESCRIPTION
In preperation for ABAC addition (next PR)
```
    fix(ci): allow run_dir variable expansion in YAML heredoc
    
    Remove single quotes from EOF delimiter to allow $run_dir to
    be expanded by bash when creating the configuration file.
    Previously the literal string "$run_dir" was being written
    to the YAML instead of the actual temp directory path.
    
    drwxr-xr-x  3 runner runner   4096 Dec  5 12:56 $run_dir
```    
```
    test(ci): add test_endpoint helper function to auth tests
    
    Add reusable test_endpoint function to integration-auth-tests
    workflow for consistent API testing:
```