### PR TITLE
fix(security): redact JWT tokens in server logs

### DIFF
--- a/src/llama_stack/core/utils/config.py
+++ b/src/llama_stack/core/utils/config.py
@@ -9,7 +9,7 @@ from typing import Any
 
 def redact_sensitive_fields(data: dict[str, Any]) -> dict[str, Any]:
     """Redact sensitive information from config before printing."""
-    sensitive_patterns = ["api_key", "api_token", "password", "secret"]
+    sensitive_patterns = ["api_key", "api_token", "password", "secret", "token"]
 
     def _redact_value(v: Any) -> Any:
         if isinstance(v, dict):


### PR DESCRIPTION
Add "token" to sensitive field patterns in redact_sensitive_fields() to prevent JWT tokens from being logged in plaintext. Previously only api_key, api_token, password, and secret were filtered.

This prevents tokens like server.auth.provider_config.jwks.token from being exposed in server logs.

Closes: #4324
