### PR TITLE
feat: wire Stainless preview SDK into integration tests

### DIFF
--- a/.github/actions/install-llama-stack-client/action.yml
+++ b/.github/actions/install-llama-stack-client/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: 'Client version to install on non-release branches (latest or published). Ignored on release branches.'
     required: false
     default: ""
+  python_url:
+    description: 'URL to install Python SDK from (for testing preview builds). If provided, overrides client-version.'
+    required: false
+    default: ""
 
 outputs:
   uv-extra-index-url:
@@ -25,6 +29,14 @@ runs:
       id: configure
       shell: bash
       run: |
+        # If python_url is provided (e.g., from Stainless preview), use it directly
+        if [ -n "${{ inputs.python_url }}" ]; then
+          echo "Using provided python_url: ${{ inputs.python_url }}"
+          echo "install-after-sync=true" >> $GITHUB_OUTPUT
+          echo "install-source=${{ inputs.python_url }}" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
         # Determine the branch we're working with
         BRANCH="${{ github.base_ref || github.ref }}"
         BRANCH="${BRANCH#refs/heads/}"

--- a/.github/actions/setup-runner/action.yml
+++ b/.github/actions/setup-runner/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: The llama-stack-client-python version to test against (latest or published)
     required: false
     default: "latest"
+  python_url:
+    description: 'URL to install Python SDK from (for testing preview builds). If provided, overrides client-version.'
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -22,6 +26,7 @@ runs:
       uses: ./.github/actions/install-llama-stack-client
       with:
         client-version: ${{ inputs.client-version }}
+        python_url: ${{ inputs.python_url }}
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -8,6 +8,10 @@ inputs:
   client-version:
     description: 'Client version (latest or published)'
     required: true
+  python_url:
+    description: 'URL to install Python SDK from (for testing preview builds). If provided, overrides client-version.'
+    required: false
+    default: ''
   setup:
     description: 'Setup to configure (ollama, vllm, gpt, etc.)'
     required: false
@@ -28,6 +32,7 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         client-version: ${{ inputs.client-version }}
+        python_url: ${{ inputs.python_url }}
 
     - name: Setup ollama
       if: ${{ (inputs.setup == 'ollama' || inputs.setup == 'ollama-vision') && inputs.inference-mode == 'record' }}
@@ -64,6 +69,15 @@ runs:
           fi
           sleep 2
         done
+
+    - name: Verify client installation
+      shell: bash
+      run: |
+        echo "Verifying llama-stack-client installation:"
+        uv pip show llama-stack-client || echo "llama-stack-client not found"
+        echo ""
+        echo "All installed llama packages:"
+        uv pip list | grep llama || true
 
     - name: Build Llama Stack
       shell: bash

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -37,6 +37,22 @@ on:
         description: 'Test against a specific setup'
         type: string
         default: 'ollama'
+  workflow_call:
+    inputs:
+      python_url:
+        required: false
+        type: string
+        description: 'URL to install Python SDK from (for testing preview builds)'
+      matrix_key:
+        required: false
+        type: string
+        default: 'default'
+        description: 'Matrix configuration key from ci_matrix.json (e.g., "default", "stainless")'
+      test-all-client-versions:
+        required: false
+        type: boolean
+        default: false
+        description: 'Test against both the latest and published versions'
 
 concurrency:
   # Skip concurrency for pushes to main - each commit should be tested independently
@@ -55,11 +71,12 @@ jobs:
       - name: Generate test matrix
         id: set-matrix
         run: |
-          # Generate matrix from CI_MATRIX in tests/integration/suites.py
-          # Supports schedule-based and manual input overrides
+          # Generate matrix from CI_MATRIX in tests/integration/ci_matrix.json
+          # Supports schedule-based, manual input, and workflow_call overrides
           MATRIX=$(PYTHONPATH=. python3 scripts/generate_ci_matrix.py \
             --schedule "${{ github.event.schedule }}" \
-            --test-setup "${{ github.event.inputs.test-setup }}")
+            --test-setup "${{ github.event.inputs.test-setup || '' }}" \
+            --matrix-key "${{ inputs.matrix_key || 'default' }}")
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
           echo "Generated matrix: $MATRIX"
 
@@ -75,8 +92,8 @@ jobs:
         # Use Python 3.13 only on nightly schedule (daily latest client test), otherwise use 3.12
         python-version: ${{ github.event.schedule == '0 0 * * *' && fromJSON('["3.12", "3.13"]') || fromJSON('["3.12"]') }}
         node-version: [22]
-        client-version: ${{ (github.event.schedule == '0 0 * * *' || github.event.inputs.test-all-client-versions == 'true') && fromJSON('["published", "latest"]') || fromJSON('["latest"]') }}
-        # Test configurations: Generated from CI_MATRIX in tests/integration/suites.py
+        client-version: ${{ (github.event.schedule == '0 0 * * *' || github.event.inputs.test-all-client-versions == 'true' || inputs.test-all-client-versions == true) && fromJSON('["published", "latest"]') || fromJSON('["latest"]') }}
+        # Test configurations: Generated from CI_MATRIX in tests/integration/ci_matrix.json
         # See scripts/generate_ci_matrix.py for generation logic
         config: ${{ fromJSON(needs.generate-matrix.outputs.matrix).include }}
 
@@ -90,6 +107,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           client-version: ${{ matrix.client-version }}
+          python_url: ${{ inputs.python_url || '' }}
           setup: ${{ matrix.config.setup }}
           suite: ${{ matrix.config.suite }}
           inference-mode: 'replay'

--- a/.github/workflows/stainless-builds.yml
+++ b/.github/workflows/stainless-builds.yml
@@ -15,6 +15,7 @@ on:
       - closed
     paths:
       - "client-sdks/stainless/**"
+      - ".github/workflows/stainless-builds.yml" # this workflow
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -83,6 +84,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    outputs:
+      python_url: ${{ steps.run-preview.outputs.outcomes.python.install_url }}
     steps:
       # Checkout the PR's code to access the OpenAPI spec and config files.
       # This is necessary to read the spec/config from the PR (including from forks).
@@ -94,6 +97,7 @@ jobs:
           fetch-depth: 2
 
       - name: Run preview builds
+        id: run-preview
         uses: stainless-api/upload-openapi-spec-action/preview@a4d631c1e9ef9130430c1df7d25fba1ff6bddafd # 1.7.1
         with:
           stainless_api_key: ${{ secrets.STAINLESS_API_KEY }}
@@ -107,6 +111,15 @@ jobs:
           head_sha: ${{ github.event.pull_request.head.sha }}
           branch: ${{ needs.compute-branch.outputs.preview_branch }}
           base_branch: ${{ needs.compute-branch.outputs.base_branch }}
+
+  run-integration-tests:
+    needs: preview
+    if: github.event.action != 'closed'
+    uses: ./.github/workflows/integration-tests.yml
+    with:
+      python_url: ${{ needs.preview.outputs.python_url }}
+      matrix_key: 'stainless'
+      test-all-client-versions: false
 
   merge:
     needs: compute-branch

--- a/scripts/generate_ci_matrix.py
+++ b/scripts/generate_ci_matrix.py
@@ -24,24 +24,28 @@ DEFAULT_MATRIX = matrix_config["default"]
 SCHEDULE_MATRICES: dict[str, list[dict[str, str]]] = matrix_config.get("schedules", {})
 
 
-def generate_matrix(schedule="", test_setup=""):
+def generate_matrix(schedule="", test_setup="", matrix_key="default"):
     """
-    Generate test matrix based on schedule or manual input.
+    Generate test matrix based on schedule, manual input, or matrix key.
 
     Args:
         schedule: GitHub cron schedule string (e.g., "1 0 * * 0" for weekly)
         test_setup: Manual test setup input (e.g., "ollama-vision")
+        matrix_key: Matrix configuration key from ci_matrix.json (e.g., "default", "stainless")
 
     Returns:
         Matrix configuration as JSON string
     """
-    # Weekly scheduled test matrices
+    # Weekly scheduled test matrices (highest priority)
     if schedule and schedule in SCHEDULE_MATRICES:
         matrix = SCHEDULE_MATRICES[schedule]
     # Manual input for specific setup
     elif test_setup == "ollama-vision":
         matrix = [{"suite": "vision", "setup": "ollama-vision"}]
-    # Default: use JSON-defined matrix
+    # Use specified matrix key from ci_matrix.json
+    elif matrix_key and matrix_key in matrix_config:
+        matrix = matrix_config[matrix_key]
+    # Default: use JSON-defined default matrix
     else:
         matrix = DEFAULT_MATRIX
 
@@ -55,7 +59,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generate CI test matrix")
     parser.add_argument("--schedule", default="", help="GitHub schedule cron string")
     parser.add_argument("--test-setup", default="", help="Manual test setup input")
+    parser.add_argument("--matrix-key", default="default", help="Matrix configuration key from ci_matrix.json")
 
     args = parser.parse_args()
 
-    print(generate_matrix(args.schedule, args.test_setup))
+    print(generate_matrix(args.schedule, args.test_setup, args.matrix_key))

--- a/tests/integration/ci_matrix.json
+++ b/tests/integration/ci_matrix.json
@@ -6,6 +6,9 @@
     {"suite": "responses", "setup": "gpt"},
     {"suite": "base-vllm-subset", "setup": "vllm"}
   ],
+  "stainless": [
+    {"suite": "base", "setup": "ollama", "allowed_clients": ["library"]}
+  ],
   "schedules": {
     "1 0 * * 0": [
       {"suite": "base", "setup": "vllm"}


### PR DESCRIPTION
# What does this PR do?

Enable stainless-builds workflow to test preview SDKs by calling integration-tests workflow with python_url parameter. Add stainless matrix config for faster CI runs on SDK changes.

  - Make integration-tests.yml reusable with workflow_call inputs
  - Thread python_url through test setup actions to install preview SDK
  - Add matrix_key parameter to generate_ci_matrix.py for custom matrices
  - Update stainless-builds.yml to call integration tests with preview URL

This allows us to test a client on the PR introducing the new changes before merging. Contributors can even write new tests using the generated client which should pass on the PR, indicating that they will pass on main upon merge

## Test Plan

new integration runs should pass.