### PR TITLE
test: testing stainless changes

### DIFF
--- a/.github/workflows/stainless-builds.yml
+++ b/.github/workflows/stainless-builds.yml
@@ -49,6 +49,9 @@ env:
   # Options: "never" | "note" | "warning" | "error" | "fatal".
   FAIL_ON: error
 
+  # testing
+  FOO: bar
+
   # In your repo secrets, configure:
   # - STAINLESS_API_KEY: a Stainless API key, which you can generate on the
   #   Stainless organization dashboard


### PR DESCRIPTION
Do not merge:

opening a PR against the stainless branch to test workflow changes since `pull_request_target` only triggers against the base branch's workflow
