### PR TITLE
fix(inference): respect table_name config in InferenceStore

### DIFF
--- a/tests/unit/utils/inference/test_inference_store.py
+++ b/tests/unit/utils/inference/test_inference_store.py
@@ -210,3 +210,32 @@ async def test_inference_store_pagination_no_limit():
     assert result.data[0].id == "beta-second"  # Most recent first
     assert result.data[1].id == "omega-first"
     assert result.has_more is False
+
+
+async def test_inference_store_custom_table_name():
+    """Test that the table_name from config is respected."""
+    custom_table_name = "custom_inference_store"
+    reference = InferenceStoreReference(backend="sql_default", table_name=custom_table_name)
+    store = InferenceStore(reference, policy=[])
+    await store.initialize()
+
+    # Create and store a test chat completion
+    base_time = int(time.time())
+    completion = create_test_chat_completion("custom-table-test", base_time)
+    input_messages = [OpenAIUserMessageParam(role="user", content="Test custom table")]
+    await store.store_chat_completion(completion, input_messages)
+    await store.flush()
+
+    # Verify we can retrieve the completion
+    result = await store.get_chat_completion("custom-table-test")
+    assert result.id == "custom-table-test"
+    assert result.model == "test-model"
+
+    # Verify listing works
+    list_result = await store.list_chat_completions()
+    assert len(list_result.data) == 1
+    assert list_result.data[0].id == "custom-table-test"
+
+    # Verify the error message uses the custom table name
+    with pytest.raises(ValueError, match=f"Record with id='non-existent' not found in table '{custom_table_name}'"):
+        await store.list_chat_completions(after="non-existent", limit=2)


### PR DESCRIPTION
# What does this PR do?

The InferenceStore class was ignoring the table_name field from InferenceStoreReference and always using the hardcoded value "chat_completions". This meant that any custom table_name configured in the run config (e.g., "inference_store" in run-with-postgres-store.yaml) was silently ignored.

This change updates all SQL operations in InferenceStore to use self.reference.table_name instead of the hardcoded string, ensuring the configured table name is properly respected.

A new test has been added to verify that custom table names work correctly for storing, retrieving, and listing chat completions.

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan

CI

