### PR TITLE
fix: correctly unwrap provider data api_key from secret string

### DIFF
--- a/src/llama_stack/providers/remote/inference/azure/config.py
+++ b/src/llama_stack/providers/remote/inference/azure/config.py
@@ -7,14 +7,14 @@
 import os
 from typing import Any
 
-from pydantic import BaseModel, Field, HttpUrl, SecretStr
+from pydantic import BaseModel, Field, HttpUrl
 
 from llama_stack.providers.utils.inference.model_registry import RemoteInferenceProviderConfig
 from llama_stack_api import json_schema_type
 
 
 class AzureProviderDataValidator(BaseModel):
-    azure_api_key: SecretStr = Field(
+    azure_api_key: str = Field(
         description="Azure API key for Azure",
     )
     azure_api_base: HttpUrl = Field(


### PR DESCRIPTION
# What does this PR do?
Fix provider header API key handling by correctly unwrapping `SecretStr` values for provider data API keys. Previously the validator cast header keys to `SecretStr` but the value wasn’t unwrapped before use, causing authentication failures with providers like Azure.

Closes  https://github.com/llamastack/llama-stack/issues/4370