### PR TITLE
fix: remove run config from logs

### DIFF
--- a/src/llama_stack/cli/stack/run.py
+++ b/src/llama_stack/cli/stack/run.py
@@ -166,7 +166,7 @@ class StackRun(Subcommand):
             config_file = None
 
         if config_file:
-            logger.info(f"Using run configuration: {config_file}")
+            logger.info(f"Using stack configuration: {config_file}")
 
             try:
                 config_dict = yaml.safe_load(config_file.read_text())

--- a/src/llama_stack/core/server/server.py
+++ b/src/llama_stack/core/server/server.py
@@ -512,7 +512,7 @@ def create_app() -> StackApp:
 
 def _log_run_config(run_config: StackConfig):
     """Logs the run config with redacted fields and disabled providers removed."""
-    logger.info("Run configuration:")
+    logger.info("Stack Configuration:")
     safe_config = redact_sensitive_fields(run_config.model_dump(mode="json"))
     clean_config = remove_disabled_providers(safe_config)
     logger.info(yaml.dump(clean_config, indent=2))


### PR DESCRIPTION
# What does this PR do?
since run.yaml is gone, update logs to say "stack config" or "stack configuration" rather than run

## Test Plan
check logs
