### PR TITLE
feat: convert models API to use a FastAPI router

### DIFF
--- a/client-sdks/stainless/openapi.yml
+++ b/client-sdks/stainless/openapi.yml
@@ -991,7 +991,7 @@ paths:
     get:
       responses:
         '200':
-          description: A OpenAIListModelsResponse.
+          description: A list of OpenAI model objects.
           content:
             application/json:
               schema:
@@ -1010,13 +1010,13 @@ paths:
           $ref: '#/components/responses/DefaultError'
       tags:
       - Models
-      summary: Openai List Models
+      summary: List models using the OpenAI API.
       description: List models using the OpenAI API.
       operationId: openai_list_models_v1_models_get
     post:
       responses:
         '200':
-          description: A Model.
+          description: The registered model object.
           content:
             application/json:
               schema:
@@ -1035,11 +1035,8 @@ paths:
           $ref: '#/components/responses/DefaultError'
       tags:
       - Models
-      summary: Register Model
-      description: |-
-        Register model.
-
-        Register a model.
+      summary: Register a model.
+      description: Register a model.
       operationId: register_model_v1_models_post
       requestBody:
         content:
@@ -1052,30 +1049,27 @@ paths:
     get:
       responses:
         '200':
-          description: A Model.
+          description: The model object.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Model'
         '400':
-          description: Bad Request
           $ref: '#/components/responses/BadRequest400'
+          description: Bad Request
         '429':
-          description: Too Many Requests
           $ref: '#/components/responses/TooManyRequests429'
+          description: Too Many Requests
         '500':
-          description: Internal Server Error
           $ref: '#/components/responses/InternalServerError500'
+          description: Internal Server Error
         default:
-          description: Default Response
           $ref: '#/components/responses/DefaultError'
+          description: Default Response
       tags:
       - Models
-      summary: Get Model
-      description: |-
-        Get model.
-
-        Get a model by its identifier.
+      summary: Get a model by its identifier.
+      description: Get a model by its identifier.
       operationId: get_model_v1_models__model_id__get
       parameters:
       - name: model_id
@@ -1083,30 +1077,29 @@ paths:
         required: true
         schema:
           type: string
-        description: 'Path parameter: model_id'
+          description: The ID of the model to get.
+          title: Model Id
+        description: The ID of the model to get.
     delete:
       responses:
         '400':
-          description: Bad Request
           $ref: '#/components/responses/BadRequest400'
+          description: Bad Request
         '429':
-          description: Too Many Requests
           $ref: '#/components/responses/TooManyRequests429'
+          description: Too Many Requests
         '500':
-          description: Internal Server Error
           $ref: '#/components/responses/InternalServerError500'
+          description: Internal Server Error
         default:
-          description: Default Response
           $ref: '#/components/responses/DefaultError'
+          description: Default Response
         '204':
-          description: Successful Response
+          description: The model was successfully unregistered.
       tags:
       - Models
-      summary: Unregister Model
-      description: |-
-        Unregister model.
-
-        Unregister a model.
+      summary: Unregister a model.
+      description: Unregister a model.
       operationId: unregister_model_v1_models__model_id__delete
       parameters:
       - name: model_id
@@ -1114,7 +1107,9 @@ paths:
         required: true
         schema:
           type: string
-        description: 'Path parameter: model_id'
+          description: The ID of the model to unregister.
+          title: Model Id
+        description: The ID of the model to unregister.
       deprecated: true
   /v1/moderations:
     post:
@@ -6611,10 +6606,12 @@ components:
             $ref: '#/components/schemas/OpenAIModel'
           type: array
           title: Data
+          description: List of OpenAI model objects.
       type: object
       required:
       - data
       title: OpenAIListModelsResponse
+      description: Response containing a list of OpenAI model objects.
     Model:
       properties:
         identifier:
@@ -11618,29 +11615,35 @@ components:
         model_id:
           type: string
           title: Model Id
+          description: The identifier of the model to register.
         provider_model_id:
           anyOf:
           - type: string
           - type: 'null'
+          description: The identifier of the model in the provider.
         provider_id:
           anyOf:
           - type: string
           - type: 'null'
+          description: The identifier of the provider.
         metadata:
           anyOf:
           - additionalProperties: true
             type: object
           - type: 'null'
+          description: Any additional metadata for this model.
         model_type:
           anyOf:
           - $ref: '#/components/schemas/ModelType'
             title: ModelType
           - type: 'null'
+          description: The type of model to register.
           title: ModelType
       type: object
       required:
       - model_id
       title: RegisterModelRequest
+      description: Request model for registering a model.
     ParamType:
       discriminator:
         mapping:
@@ -13150,6 +13153,41 @@ components:
       required:
       - dataset_id
       title: UnregisterDatasetRequest
+      type: object
+    ListModelsResponse:
+      description: Response containing a list of model objects.
+      properties:
+        data:
+          description: List of model objects.
+          items:
+            $ref: '#/components/schemas/Model'
+          title: Data
+          type: array
+      required:
+      - data
+      title: ListModelsResponse
+      type: object
+    GetModelRequest:
+      description: Request model for getting a model by ID.
+      properties:
+        model_id:
+          description: The ID of the model to get.
+          title: Model Id
+          type: string
+      required:
+      - model_id
+      title: GetModelRequest
+      type: object
+    UnregisterModelRequest:
+      description: Request model for unregistering a model.
+      properties:
+        model_id:
+          description: The ID of the model to unregister.
+          title: Model Id
+          type: string
+      required:
+      - model_id
+      title: UnregisterModelRequest
       type: object
     DialogType:
       description: Parameter type for dialog data with semantic output labels.

--- a/docs/static/deprecated-llama-stack-spec.yaml
+++ b/docs/static/deprecated-llama-stack-spec.yaml
@@ -17,7 +17,7 @@ paths:
     get:
       responses:
         '200':
-          description: A OpenAIListModelsResponse.
+          description: A list of OpenAI model objects.
           content:
             application/json:
               schema:
@@ -36,13 +36,13 @@ paths:
           $ref: '#/components/responses/DefaultError'
       tags:
       - Models
-      summary: Openai List Models
+      summary: List models using the OpenAI API.
       description: List models using the OpenAI API.
       operationId: openai_list_models_v1_models_get
     post:
       responses:
         '200':
-          description: A Model.
+          description: The registered model object.
           content:
             application/json:
               schema:
@@ -61,11 +61,8 @@ paths:
           $ref: '#/components/responses/DefaultError'
       tags:
       - Models
-      summary: Register Model
-      description: |-
-        Register model.
-
-        Register a model.
+      summary: Register a model.
+      description: Register a model.
       operationId: register_model_v1_models_post
       requestBody:
         content:
@@ -78,30 +75,27 @@ paths:
     get:
       responses:
         '200':
-          description: A Model.
+          description: The model object.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Model'
         '400':
-          description: Bad Request
           $ref: '#/components/responses/BadRequest400'
+          description: Bad Request
         '429':
-          description: Too Many Requests
           $ref: '#/components/responses/TooManyRequests429'
+          description: Too Many Requests
         '500':
-          description: Internal Server Error
           $ref: '#/components/responses/InternalServerError500'
+          description: Internal Server Error
         default:
-          description: Default Response
           $ref: '#/components/responses/DefaultError'
+          description: Default Response
       tags:
       - Models
-      summary: Get Model
-      description: |-
-        Get model.
-
-        Get a model by its identifier.
+      summary: Get a model by its identifier.
+      description: Get a model by its identifier.
       operationId: get_model_v1_models__model_id__get
       parameters:
       - name: model_id
@@ -109,30 +103,29 @@ paths:
         required: true
         schema:
           type: string
-        description: 'Path parameter: model_id'
+          description: The ID of the model to get.
+          title: Model Id
+        description: The ID of the model to get.
     delete:
       responses:
         '400':
-          description: Bad Request
           $ref: '#/components/responses/BadRequest400'
+          description: Bad Request
         '429':
-          description: Too Many Requests
           $ref: '#/components/responses/TooManyRequests429'
+          description: Too Many Requests
         '500':
-          description: Internal Server Error
           $ref: '#/components/responses/InternalServerError500'
+          description: Internal Server Error
         default:
-          description: Default Response
           $ref: '#/components/responses/DefaultError'
+          description: Default Response
         '204':
-          description: Successful Response
+          description: The model was successfully unregistered.
       tags:
       - Models
-      summary: Unregister Model
-      description: |-
-        Unregister model.
-
-        Unregister a model.
+      summary: Unregister a model.
+      description: Unregister a model.
       operationId: unregister_model_v1_models__model_id__delete
       parameters:
       - name: model_id
@@ -140,7 +133,9 @@ paths:
         required: true
         schema:
           type: string
-        description: 'Path parameter: model_id'
+          description: The ID of the model to unregister.
+          title: Model Id
+        description: The ID of the model to unregister.
       deprecated: true
   /v1/scoring-functions:
     get:
@@ -3292,10 +3287,12 @@ components:
             $ref: '#/components/schemas/OpenAIModel'
           type: array
           title: Data
+          description: List of OpenAI model objects.
       type: object
       required:
       - data
       title: OpenAIListModelsResponse
+      description: Response containing a list of OpenAI model objects.
     Model:
       properties:
         identifier:
@@ -8299,29 +8296,35 @@ components:
         model_id:
           type: string
           title: Model Id
+          description: The identifier of the model to register.
         provider_model_id:
           anyOf:
           - type: string
           - type: 'null'
+          description: The identifier of the model in the provider.
         provider_id:
           anyOf:
           - type: string
           - type: 'null'
+          description: The identifier of the provider.
         metadata:
           anyOf:
           - additionalProperties: true
             type: object
           - type: 'null'
+          description: Any additional metadata for this model.
         model_type:
           anyOf:
           - $ref: '#/components/schemas/ModelType'
             title: ModelType
           - type: 'null'
+          description: The type of model to register.
           title: ModelType
       type: object
       required:
       - model_id
       title: RegisterModelRequest
+      description: Request model for registering a model.
     ParamType:
       discriminator:
         mapping:
@@ -9831,6 +9834,41 @@ components:
       required:
       - dataset_id
       title: UnregisterDatasetRequest
+      type: object
+    ListModelsResponse:
+      description: Response containing a list of model objects.
+      properties:
+        data:
+          description: List of model objects.
+          items:
+            $ref: '#/components/schemas/Model'
+          title: Data
+          type: array
+      required:
+      - data
+      title: ListModelsResponse
+      type: object
+    GetModelRequest:
+      description: Request model for getting a model by ID.
+      properties:
+        model_id:
+          description: The ID of the model to get.
+          title: Model Id
+          type: string
+      required:
+      - model_id
+      title: GetModelRequest
+      type: object
+    UnregisterModelRequest:
+      description: Request model for unregistering a model.
+      properties:
+        model_id:
+          description: The ID of the model to unregister.
+          title: Model Id
+          type: string
+      required:
+      - model_id
+      title: UnregisterModelRequest
       type: object
     DialogType:
       description: Parameter type for dialog data with semantic output labels.

--- a/docs/static/experimental-llama-stack-spec.yaml
+++ b/docs/static/experimental-llama-stack-spec.yaml
@@ -3240,10 +3240,12 @@ components:
             $ref: '#/components/schemas/OpenAIModel'
           type: array
           title: Data
+          description: List of OpenAI model objects.
       type: object
       required:
       - data
       title: OpenAIListModelsResponse
+      description: Response containing a list of OpenAI model objects.
     Model:
       properties:
         identifier:
@@ -7719,6 +7721,40 @@ components:
       - hyperparam_search_config
       - logger_config
       title: SupervisedFineTuneRequest
+    RegisterModelRequest:
+      properties:
+        model_id:
+          type: string
+          title: Model Id
+          description: The identifier of the model to register.
+        provider_model_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: The identifier of the model in the provider.
+        provider_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: The identifier of the provider.
+        metadata:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          description: Any additional metadata for this model.
+        model_type:
+          anyOf:
+          - $ref: '#/components/schemas/ModelType'
+            title: ModelType
+          - type: 'null'
+          description: The type of model to register.
+          title: ModelType
+      type: object
+      required:
+      - model_id
+      title: RegisterModelRequest
+      description: Request model for registering a model.
     ParamType:
       discriminator:
         mapping:
@@ -8902,6 +8938,41 @@ components:
       required:
       - dataset_id
       title: UnregisterDatasetRequest
+      type: object
+    ListModelsResponse:
+      description: Response containing a list of model objects.
+      properties:
+        data:
+          description: List of model objects.
+          items:
+            $ref: '#/components/schemas/Model'
+          title: Data
+          type: array
+      required:
+      - data
+      title: ListModelsResponse
+      type: object
+    GetModelRequest:
+      description: Request model for getting a model by ID.
+      properties:
+        model_id:
+          description: The ID of the model to get.
+          title: Model Id
+          type: string
+      required:
+      - model_id
+      title: GetModelRequest
+      type: object
+    UnregisterModelRequest:
+      description: Request model for unregistering a model.
+      properties:
+        model_id:
+          description: The ID of the model to unregister.
+          title: Model Id
+          type: string
+      required:
+      - model_id
+      title: UnregisterModelRequest
       type: object
     DialogType:
       description: Parameter type for dialog data with semantic output labels.

--- a/docs/static/llama-stack-spec.yaml
+++ b/docs/static/llama-stack-spec.yaml
@@ -989,7 +989,7 @@ paths:
     get:
       responses:
         '200':
-          description: A OpenAIListModelsResponse.
+          description: A list of OpenAI model objects.
           content:
             application/json:
               schema:
@@ -1008,37 +1008,34 @@ paths:
           $ref: '#/components/responses/DefaultError'
       tags:
       - Models
-      summary: Openai List Models
+      summary: List models using the OpenAI API.
       description: List models using the OpenAI API.
       operationId: openai_list_models_v1_models_get
   /v1/models/{model_id}:
     get:
       responses:
         '200':
-          description: A Model.
+          description: The model object.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Model'
         '400':
-          description: Bad Request
           $ref: '#/components/responses/BadRequest400'
+          description: Bad Request
         '429':
-          description: Too Many Requests
           $ref: '#/components/responses/TooManyRequests429'
+          description: Too Many Requests
         '500':
-          description: Internal Server Error
           $ref: '#/components/responses/InternalServerError500'
+          description: Internal Server Error
         default:
-          description: Default Response
           $ref: '#/components/responses/DefaultError'
+          description: Default Response
       tags:
       - Models
-      summary: Get Model
-      description: |-
-        Get model.
-
-        Get a model by its identifier.
+      summary: Get a model by its identifier.
+      description: Get a model by its identifier.
       operationId: get_model_v1_models__model_id__get
       parameters:
       - name: model_id
@@ -1046,7 +1043,9 @@ paths:
         required: true
         schema:
           type: string
-        description: 'Path parameter: model_id'
+          description: The ID of the model to get.
+          title: Model Id
+        description: The ID of the model to get.
   /v1/moderations:
     post:
       responses:
@@ -5096,10 +5095,12 @@ components:
             $ref: '#/components/schemas/OpenAIModel'
           type: array
           title: Data
+          description: List of OpenAI model objects.
       type: object
       required:
       - data
       title: OpenAIListModelsResponse
+      description: Response containing a list of OpenAI model objects.
     Model:
       properties:
         identifier:
@@ -9921,6 +9922,40 @@ components:
       - group_size
       title: QATFinetuningConfig
       description: Configuration for Quantization-Aware Training (QAT) fine-tuning.
+    RegisterModelRequest:
+      properties:
+        model_id:
+          type: string
+          title: Model Id
+          description: The identifier of the model to register.
+        provider_model_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: The identifier of the model in the provider.
+        provider_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: The identifier of the provider.
+        metadata:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          description: Any additional metadata for this model.
+        model_type:
+          anyOf:
+          - $ref: '#/components/schemas/ModelType'
+            title: ModelType
+          - type: 'null'
+          description: The type of model to register.
+          title: ModelType
+      type: object
+      required:
+      - model_id
+      title: RegisterModelRequest
+      description: Request model for registering a model.
     ParamType:
       discriminator:
         mapping:
@@ -11323,6 +11358,41 @@ components:
       required:
       - dataset_id
       title: UnregisterDatasetRequest
+      type: object
+    ListModelsResponse:
+      description: Response containing a list of model objects.
+      properties:
+        data:
+          description: List of model objects.
+          items:
+            $ref: '#/components/schemas/Model'
+          title: Data
+          type: array
+      required:
+      - data
+      title: ListModelsResponse
+      type: object
+    GetModelRequest:
+      description: Request model for getting a model by ID.
+      properties:
+        model_id:
+          description: The ID of the model to get.
+          title: Model Id
+          type: string
+      required:
+      - model_id
+      title: GetModelRequest
+      type: object
+    UnregisterModelRequest:
+      description: Request model for unregistering a model.
+      properties:
+        model_id:
+          description: The ID of the model to unregister.
+          title: Model Id
+          type: string
+      required:
+      - model_id
+      title: UnregisterModelRequest
       type: object
     DialogType:
       description: Parameter type for dialog data with semantic output labels.

--- a/docs/static/stainless-llama-stack-spec.yaml
+++ b/docs/static/stainless-llama-stack-spec.yaml
@@ -991,7 +991,7 @@ paths:
     get:
       responses:
         '200':
-          description: A OpenAIListModelsResponse.
+          description: A list of OpenAI model objects.
           content:
             application/json:
               schema:
@@ -1010,13 +1010,13 @@ paths:
           $ref: '#/components/responses/DefaultError'
       tags:
       - Models
-      summary: Openai List Models
+      summary: List models using the OpenAI API.
       description: List models using the OpenAI API.
       operationId: openai_list_models_v1_models_get
     post:
       responses:
         '200':
-          description: A Model.
+          description: The registered model object.
           content:
             application/json:
               schema:
@@ -1035,11 +1035,8 @@ paths:
           $ref: '#/components/responses/DefaultError'
       tags:
       - Models
-      summary: Register Model
-      description: |-
-        Register model.
-
-        Register a model.
+      summary: Register a model.
+      description: Register a model.
       operationId: register_model_v1_models_post
       requestBody:
         content:
@@ -1052,30 +1049,27 @@ paths:
     get:
       responses:
         '200':
-          description: A Model.
+          description: The model object.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Model'
         '400':
-          description: Bad Request
           $ref: '#/components/responses/BadRequest400'
+          description: Bad Request
         '429':
-          description: Too Many Requests
           $ref: '#/components/responses/TooManyRequests429'
+          description: Too Many Requests
         '500':
-          description: Internal Server Error
           $ref: '#/components/responses/InternalServerError500'
+          description: Internal Server Error
         default:
-          description: Default Response
           $ref: '#/components/responses/DefaultError'
+          description: Default Response
       tags:
       - Models
-      summary: Get Model
-      description: |-
-        Get model.
-
-        Get a model by its identifier.
+      summary: Get a model by its identifier.
+      description: Get a model by its identifier.
       operationId: get_model_v1_models__model_id__get
       parameters:
       - name: model_id
@@ -1083,30 +1077,29 @@ paths:
         required: true
         schema:
           type: string
-        description: 'Path parameter: model_id'
+          description: The ID of the model to get.
+          title: Model Id
+        description: The ID of the model to get.
     delete:
       responses:
         '400':
-          description: Bad Request
           $ref: '#/components/responses/BadRequest400'
+          description: Bad Request
         '429':
-          description: Too Many Requests
           $ref: '#/components/responses/TooManyRequests429'
+          description: Too Many Requests
         '500':
-          description: Internal Server Error
           $ref: '#/components/responses/InternalServerError500'
+          description: Internal Server Error
         default:
-          description: Default Response
           $ref: '#/components/responses/DefaultError'
+          description: Default Response
         '204':
-          description: Successful Response
+          description: The model was successfully unregistered.
       tags:
       - Models
-      summary: Unregister Model
-      description: |-
-        Unregister model.
-
-        Unregister a model.
+      summary: Unregister a model.
+      description: Unregister a model.
       operationId: unregister_model_v1_models__model_id__delete
       parameters:
       - name: model_id
@@ -1114,7 +1107,9 @@ paths:
         required: true
         schema:
           type: string
-        description: 'Path parameter: model_id'
+          description: The ID of the model to unregister.
+          title: Model Id
+        description: The ID of the model to unregister.
       deprecated: true
   /v1/moderations:
     post:
@@ -6611,10 +6606,12 @@ components:
             $ref: '#/components/schemas/OpenAIModel'
           type: array
           title: Data
+          description: List of OpenAI model objects.
       type: object
       required:
       - data
       title: OpenAIListModelsResponse
+      description: Response containing a list of OpenAI model objects.
     Model:
       properties:
         identifier:
@@ -11618,29 +11615,35 @@ components:
         model_id:
           type: string
           title: Model Id
+          description: The identifier of the model to register.
         provider_model_id:
           anyOf:
           - type: string
           - type: 'null'
+          description: The identifier of the model in the provider.
         provider_id:
           anyOf:
           - type: string
           - type: 'null'
+          description: The identifier of the provider.
         metadata:
           anyOf:
           - additionalProperties: true
             type: object
           - type: 'null'
+          description: Any additional metadata for this model.
         model_type:
           anyOf:
           - $ref: '#/components/schemas/ModelType'
             title: ModelType
           - type: 'null'
+          description: The type of model to register.
           title: ModelType
       type: object
       required:
       - model_id
       title: RegisterModelRequest
+      description: Request model for registering a model.
     ParamType:
       discriminator:
         mapping:
@@ -13150,6 +13153,41 @@ components:
       required:
       - dataset_id
       title: UnregisterDatasetRequest
+      type: object
+    ListModelsResponse:
+      description: Response containing a list of model objects.
+      properties:
+        data:
+          description: List of model objects.
+          items:
+            $ref: '#/components/schemas/Model'
+          title: Data
+          type: array
+      required:
+      - data
+      title: ListModelsResponse
+      type: object
+    GetModelRequest:
+      description: Request model for getting a model by ID.
+      properties:
+        model_id:
+          description: The ID of the model to get.
+          title: Model Id
+          type: string
+      required:
+      - model_id
+      title: GetModelRequest
+      type: object
+    UnregisterModelRequest:
+      description: Request model for unregistering a model.
+      properties:
+        model_id:
+          description: The ID of the model to unregister.
+          title: Model Id
+          type: string
+      required:
+      - model_id
+      title: UnregisterModelRequest
       type: object
     DialogType:
       description: Parameter type for dialog data with semantic output labels.

--- a/src/llama_stack/core/routers/inference.py
+++ b/src/llama_stack/core/routers/inference.py
@@ -46,6 +46,7 @@ from llama_stack_api import (
     OpenAITokenLogProb,
     OpenAITopLogProb,
     Order,
+    RegisterModelRequest,
     RerankResponse,
     RoutingTable,
 )
@@ -87,7 +88,14 @@ class InferenceRouter(Inference):
         logger.debug(
             f"InferenceRouter.register_model: {model_id=} {provider_model_id=} {provider_id=} {metadata=} {model_type=}",
         )
-        await self.routing_table.register_model(model_id, provider_model_id, provider_id, metadata, model_type)
+        request = RegisterModelRequest(
+            model_id=model_id,
+            provider_model_id=provider_model_id,
+            provider_id=provider_id,
+            metadata=metadata,
+            model_type=model_type,
+        )
+        await self.routing_table.register_model(request)
 
     async def _get_model_provider(self, model_id: str, expected_model_type: str) -> tuple[Inference, str]:
         model = await self.routing_table.get_object_by_identifier("model", model_id)

--- a/src/llama_stack/core/server/fastapi_router_registry.py
+++ b/src/llama_stack/core/server/fastapi_router_registry.py
@@ -16,7 +16,7 @@ from typing import Any, cast
 from fastapi import APIRouter
 from fastapi.routing import APIRoute
 
-from llama_stack_api import admin, batches, benchmarks, datasets, files, inspect_api, providers
+from llama_stack_api import admin, batches, benchmarks, datasets, files, inspect_api, models, providers
 
 # Router factories for APIs that have FastAPI routers
 # Add new APIs here as they are migrated to the router system
@@ -27,6 +27,7 @@ _ROUTER_FACTORIES: dict[str, Callable[[Any], APIRouter]] = {
     "batches": batches.fastapi_routes.create_router,
     "benchmarks": benchmarks.fastapi_routes.create_router,
     "datasets": datasets.fastapi_routes.create_router,
+    "models": models.fastapi_routes.create_router,
     "providers": providers.fastapi_routes.create_router,
     "inspect": inspect_api.fastapi_routes.create_router,
     "files": files.fastapi_routes.create_router,

--- a/src/llama_stack/providers/inline/batches/reference/batches.py
+++ b/src/llama_stack/providers/inline/batches/reference/batches.py
@@ -23,6 +23,7 @@ from llama_stack_api import (
     BatchObject,
     ConflictError,
     Files,
+    GetModelRequest,
     Inference,
     ListBatchesResponse,
     Models,
@@ -485,7 +486,7 @@ class ReferenceBatchesImpl(Batches):
 
                         if "model" in request_body and isinstance(request_body["model"], str):
                             try:
-                                await self.models_api.get_model(request_body["model"])
+                                await self.models_api.get_model(GetModelRequest(model_id=request_body["model"]))
                             except Exception:
                                 errors.append(
                                     BatchError(

--- a/src/llama_stack_api/__init__.py
+++ b/src/llama_stack_api/__init__.py
@@ -241,6 +241,7 @@ from .inference import (
 from .inspect_api import Inspect
 from .models import (
     CommonModelFields,
+    GetModelRequest,
     ListModelsResponse,
     Model,
     ModelInput,
@@ -248,6 +249,8 @@ from .models import (
     ModelType,
     OpenAIListModelsResponse,
     OpenAIModel,
+    RegisterModelRequest,
+    UnregisterModelRequest,
 )
 from .openai_responses import (
     AllowedToolsFilter,
@@ -648,6 +651,9 @@ __all__ = [
     "ModelType",
     "ModelTypeError",
     "Models",
+    "GetModelRequest",
+    "RegisterModelRequest",
+    "UnregisterModelRequest",
     "ModelsProtocolPrivate",
     "ModerationObject",
     "ModerationObjectResults",

--- a/src/llama_stack_api/models/__init__.py
+++ b/src/llama_stack_api/models/__init__.py
@@ -1,0 +1,47 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Models API protocol and models.
+
+This module contains the Models protocol definition.
+Pydantic models are defined in llama_stack_api.models.models.
+The FastAPI router is defined in llama_stack_api.models.fastapi_routes.
+"""
+
+# Import fastapi_routes for router factory access
+from . import fastapi_routes
+
+# Import new protocol for FastAPI router
+from .api import Models
+
+# Import models for re-export
+from .models import (
+    CommonModelFields,
+    GetModelRequest,
+    ListModelsResponse,
+    Model,
+    ModelInput,
+    ModelType,
+    OpenAIListModelsResponse,
+    OpenAIModel,
+    RegisterModelRequest,
+    UnregisterModelRequest,
+)
+
+__all__ = [
+    "CommonModelFields",
+    "fastapi_routes",
+    "GetModelRequest",
+    "ListModelsResponse",
+    "Model",
+    "ModelInput",
+    "Models",
+    "ModelType",
+    "OpenAIListModelsResponse",
+    "OpenAIModel",
+    "RegisterModelRequest",
+    "UnregisterModelRequest",
+]

--- a/src/llama_stack_api/models/api.py
+++ b/src/llama_stack_api/models/api.py
@@ -1,0 +1,38 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Models API protocol definition.
+
+This module contains the Models protocol definition.
+Pydantic models are defined in llama_stack_api.models.models.
+The FastAPI router is defined in llama_stack_api.models.fastapi_routes.
+"""
+
+from typing import Protocol, runtime_checkable
+
+from .models import (
+    GetModelRequest,
+    ListModelsResponse,
+    Model,
+    OpenAIListModelsResponse,
+    RegisterModelRequest,
+    UnregisterModelRequest,
+)
+
+
+@runtime_checkable
+class Models(Protocol):
+    """Protocol for model management operations."""
+
+    async def list_models(self) -> ListModelsResponse: ...
+
+    async def openai_list_models(self) -> OpenAIListModelsResponse: ...
+
+    async def get_model(self, request: GetModelRequest) -> Model: ...
+
+    async def register_model(self, request: RegisterModelRequest) -> Model: ...
+
+    async def unregister_model(self, request: UnregisterModelRequest) -> None: ...

--- a/src/llama_stack_api/models/fastapi_routes.py
+++ b/src/llama_stack_api/models/fastapi_routes.py
@@ -1,0 +1,104 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""FastAPI router for the Models API.
+
+This module defines the FastAPI router for the Models API using standard
+FastAPI route decorators.
+"""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Body, Depends
+
+from llama_stack_api.router_utils import create_path_dependency, standard_responses
+from llama_stack_api.version import LLAMA_STACK_API_V1
+
+from .api import Models
+from .models import (
+    GetModelRequest,
+    Model,
+    OpenAIListModelsResponse,
+    RegisterModelRequest,
+    UnregisterModelRequest,
+)
+
+# Path parameter dependencies for single-field models
+get_model_request = create_path_dependency(GetModelRequest)
+unregister_model_request = create_path_dependency(UnregisterModelRequest)
+
+
+def create_router(impl: Models) -> APIRouter:
+    """Create a FastAPI router for the Models API.
+
+    Args:
+        impl: The Models implementation instance
+
+    Returns:
+        APIRouter configured for the Models API
+    """
+    router = APIRouter(
+        prefix=f"/{LLAMA_STACK_API_V1}",
+        tags=["Models"],
+        responses=standard_responses,
+    )
+
+    @router.get(
+        "/models",
+        response_model=OpenAIListModelsResponse,
+        summary="List models using the OpenAI API.",
+        description="List models using the OpenAI API.",
+        responses={
+            200: {"description": "A list of OpenAI model objects."},
+        },
+    )
+    async def openai_list_models() -> OpenAIListModelsResponse:
+        return await impl.openai_list_models()
+
+    @router.get(
+        "/models/{model_id:path}",
+        response_model=Model,
+        summary="Get a model by its identifier.",
+        description="Get a model by its identifier.",
+        responses={
+            200: {"description": "The model object."},
+        },
+    )
+    async def get_model(
+        request: Annotated[GetModelRequest, Depends(get_model_request)],
+    ) -> Model:
+        return await impl.get_model(request)
+
+    @router.post(
+        "/models",
+        response_model=Model,
+        summary="Register a model.",
+        description="Register a model.",
+        responses={
+            200: {"description": "The registered model object."},
+        },
+        deprecated=True,
+    )
+    async def register_model(
+        request: Annotated[RegisterModelRequest, Body(...)],
+    ) -> Model:
+        return await impl.register_model(request)
+
+    @router.delete(
+        "/models/{model_id:path}",
+        summary="Unregister a model.",
+        description="Unregister a model.",
+        responses={
+            200: {"description": "The model was successfully unregistered."},
+        },
+        deprecated=True,
+    )
+    async def unregister_model(
+        request: Annotated[UnregisterModelRequest, Depends(unregister_model_request)],
+    ) -> None:
+        return await impl.unregister_model(request)
+
+    return router


### PR DESCRIPTION
# What does this PR do?
Migrate from @webmethod decorators to FastAPI router pattern

Closes #4347
