### PR TITLE
ci: record-if-missing when coming from stainless

### DIFF
--- a/.github/actions/run-and-record-tests/action.yml
+++ b/.github/actions/run-and-record-tests/action.yml
@@ -62,7 +62,7 @@ runs:
 
 
     - name: Commit and push recordings
-      if: ${{ inputs.inference-mode == 'record' }}
+      if: ${{ inputs.inference-mode == 'record' ||  inputs.inference-mode == 'record-if-missing' }}
       shell: bash
       run: |
         echo "Checking for recording changes"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -48,6 +48,10 @@ on:
         type: string
         default: 'default'
         description: 'Matrix configuration key from ci_matrix.json (e.g., "default", "stainless")'
+      pr_head_sha:
+        required: false
+        type: string
+        description: 'The SHA of the pull request head to checkout'
       test-all-client-versions:
         required: false
         type: boolean
@@ -67,6 +71,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ inputs.pr_head_sha || github.event.pull_request.head.sha || github.sha }}
 
       - name: Generate test matrix
         id: set-matrix
@@ -100,6 +106,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ inputs.pr_head_sha || github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup test environment
         if: ${{ matrix.config.allowed_clients == null || contains(matrix.config.allowed_clients, matrix.client) }}
@@ -110,7 +118,7 @@ jobs:
           sdk_install_url: ${{ inputs.sdk_install_url || '' }}
           setup: ${{ matrix.config.setup }}
           suite: ${{ matrix.config.suite }}
-          inference-mode: 'replay'
+          inference-mode: ${{ matrix.config.inference_mode || 'replay' }}
 
       - name: Setup Node.js for TypeScript client tests
         if: ${{ matrix.client == 'server' }}
@@ -140,5 +148,5 @@ jobs:
                 || (matrix.client == 'server' && 'server:ci-tests')
                 || 'docker:ci-tests' }}
           setup: ${{ matrix.config.setup }}
-          inference-mode: 'replay'
+          inference-mode: ${{ matrix.config.inference_mode || 'replay' }}
           suite: ${{ matrix.config.suite }}

--- a/.github/workflows/stainless-builds.yml
+++ b/.github/workflows/stainless-builds.yml
@@ -181,6 +181,7 @@ jobs:
       sdk_install_url: ${{ inputs.sdk_install_url || needs.preview.outputs.sdk_install_url }}
       matrix_key: 'stainless'
       test-all-client-versions: false
+      pr_head_sha: ${{ needs.compute-branch.outputs.pr_head_sha }}
 
   merge:
     needs: compute-branch

--- a/tests/integration/ci_matrix.json
+++ b/tests/integration/ci_matrix.json
@@ -7,7 +7,7 @@
     {"suite": "base-vllm-subset", "setup": "vllm"}
   ],
   "stainless": [
-    {"suite": "base", "setup": "ollama", "allowed_clients": ["library"]}
+    {"suite": "base", "setup": "ollama", "allowed_clients": ["library"], "inference_mode": "record-if-missing"}
   ],
   "schedules": {
     "1 0 * * 0": [


### PR DESCRIPTION
# What does this PR do?

we will typically need to record the missing json for net new APIs. use record-if-missing so that the integration tests can re-record and commit the files to the PR

set the stainless inference mode to record-if-missing, and properly pass the pr_head_sha on workflow_call.

## Test Plan

see https://github.com/llamastack/llama-stack/actions/runs/20318245671 which uses this commit. 