### PR TITLE
chore: censor pgvector password in initialization log

### DIFF
--- a/src/llama_stack/providers/remote/vector_io/pgvector/pgvector.py
+++ b/src/llama_stack/providers/remote/vector_io/pgvector/pgvector.py
@@ -341,7 +341,9 @@ class PGVectorVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProt
         self.metadata_collection_name = "openai_vector_stores_metadata"
 
     async def initialize(self) -> None:
-        log.info(f"Initializing PGVector memory adapter with config: {self.config}")
+        # Create a safe config representation with masked password for logging
+        safe_config = {**self.config.model_dump(exclude={"password"}), "password": "******"}
+        log.info(f"Initializing PGVector memory adapter with config: {safe_config}")
         self.kvstore = await kvstore_impl(self.config.persistence)
         await self.initialize_openai_vector_stores()
 


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
Add a `safe_config` with censored password for PGVector initialisation log. 

BEFORE:
``` bash
llama_stack.providers.remote.vector_io.pgvector.pgvector:339 vector_io::pgvector:      
         Initializing PGVector memory adapter with config: host='vector-io-pgvector-service' port=5432 db='pgvector'    
         user='pgvector_user' password='realpassword'
```
AFTER:
``` bash
llama_stack.providers.remote.vector_io.pgvector.pgvector:346 vector_io::pgvector:      
         Initializing PGVector memory adapter with config: {'host': 'localhost', 'port': 5432, 'db': 'mydatabase',      
         'user': 'myuser', 'persistence': {'namespace': 'vector_io::pgvector', 'backend': 'kv_default'}, 'password':    
         '******'} 
```
<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->
Run Llama Stack with PGVector and check initialisation logs show no password.
