### PR TITLE
feat: implement OpenTelemetry metrics for inference operations

### DIFF
--- a/scripts/start_otlp_collector.py
+++ b/scripts/start_otlp_collector.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Start OTLP HTTP test collector for integration tests."""
+
+import os
+import sys
+import time
+
+# Add ROOT_DIR to path (not tests/integration, which shadows stdlib inspect module)
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT_DIR)
+
+from tests.integration.telemetry.collectors import OtlpHttpTestCollector
+
+if __name__ == "__main__":
+    collector_port = os.environ.get("LLAMA_STACK_TEST_COLLECTOR_PORT", "4318")
+    print(f"Starting OTLP HTTP Test Collector on port {collector_port}...")
+
+    collector = OtlpHttpTestCollector()
+    print(f"OTLP Collector started at {collector.endpoint}")
+
+    # Keep the collector running
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        print("Stopping OTLP Collector...")
+        collector.shutdown()

--- a/src/llama_stack/log.py
+++ b/src/llama_stack/log.py
@@ -51,6 +51,7 @@ CATEGORIES = [
     "post_training",
     "scoring",
     "tests",
+    "telemetry",
 ]
 UNCATEGORIZED = "uncategorized"
 

--- a/src/llama_stack/telemetry/__init__.py
+++ b/src/llama_stack/telemetry/__init__.py
@@ -3,3 +3,64 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
+
+"""OpenTelemetry initialization for llama-stack.
+
+This module configures OpenTelemetry metrics export based on environment variables.
+If OTEL_EXPORTER_OTLP_ENDPOINT is set, metrics will be exported to that endpoint.
+"""
+
+import os
+
+from llama_stack.log import get_logger
+
+logger = get_logger(__name__, category="telemetry")
+
+
+def setup_telemetry():
+    """Initialize OpenTelemetry metrics exporter if configured via environment.
+
+    This function checks for OTEL_EXPORTER_OTLP_ENDPOINT and configures the
+    MeterProvider to export metrics to the specified endpoint.
+    """
+    otlp_endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+
+    if not otlp_endpoint:
+        logger.debug("OTEL_EXPORTER_OTLP_ENDPOINT not set, metrics will not be exported")
+        return
+
+    try:
+        from opentelemetry import metrics
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+            OTLPMetricExporter,
+        )
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+        from opentelemetry.sdk.resources import Resource
+
+        # Get export interval from environment (default 200ms for tests, 60s otherwise)
+        export_interval_ms = int(os.environ.get("OTEL_METRIC_EXPORT_INTERVAL", "60000"))
+        export_interval_s = export_interval_ms / 1000.0
+
+        # Create OTLP exporter
+        exporter = OTLPMetricExporter(endpoint=f"{otlp_endpoint}/v1/metrics")
+
+        # Create metric reader with periodic export
+        reader = PeriodicExportingMetricReader(exporter, export_interval_millis=export_interval_ms)
+
+        # Create resource with service name
+        service_name = os.environ.get("OTEL_SERVICE_NAME", "llama-stack")
+        resource = Resource(attributes={"service.name": service_name})
+
+        # Create and set global MeterProvider
+        provider = MeterProvider(resource=resource, metric_readers=[reader])
+        metrics.set_meter_provider(provider)
+
+        logger.info(f"OpenTelemetry metrics exporter configured: {otlp_endpoint} (interval: {export_interval_s}s)")
+
+    except Exception as e:
+        logger.warning(f"Failed to configure OpenTelemetry metrics exporter: {e}")
+
+
+# Initialize telemetry when module is imported
+setup_telemetry()

--- a/src/llama_stack/telemetry/constants.py
+++ b/src/llama_stack/telemetry/constants.py
@@ -25,3 +25,16 @@ SAFETY_RESPONSE_PREFIX = f"{llama_stack_prefix}.safety.response"
 SAFETY_RESPONSE_METADATA_ATTRIBUTE = f"{SAFETY_RESPONSE_PREFIX}.metadata"
 SAFETY_RESPONSE_VIOLATION_LEVEL_ATTRIBUTE = f"{SAFETY_RESPONSE_PREFIX}.violation.level"
 SAFETY_RESPONSE_USER_MESSAGE_ATTRIBUTE = f"{SAFETY_RESPONSE_PREFIX}.violation.user_message"
+
+# Inference Metrics
+# These constants define the names for OpenTelemetry metrics tracking inference operations
+INFERENCE_PREFIX = f"{llama_stack_prefix}.inference"
+
+# Request-level metrics
+REQUESTS_TOTAL = f"{INFERENCE_PREFIX}.requests_total"
+REQUEST_DURATION = f"{INFERENCE_PREFIX}.request_duration_seconds"
+CONCURRENT_REQUESTS = f"{INFERENCE_PREFIX}.concurrent_requests"
+
+# Token-level metrics
+INFERENCE_DURATION = f"{INFERENCE_PREFIX}.inference_duration_seconds"
+TIME_TO_FIRST_TOKEN = f"{INFERENCE_PREFIX}.time_to_first_token_seconds"

--- a/src/llama_stack/telemetry/metrics.py
+++ b/src/llama_stack/telemetry/metrics.py
@@ -1,0 +1,108 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""
+OpenTelemetry metrics for llama-stack inference operations.
+
+This module provides centralized metric definitions for tracking:
+- Request-level metrics (total requests, duration, concurrency)
+- Token-level metrics (tokens/second, inference duration, time to first token)
+
+All metrics follow OpenTelemetry semantic conventions and use the llama_stack prefix
+for consistent naming across the telemetry stack.
+"""
+
+# Import telemetry setup first to ensure OTLP exporter is configured
+from opentelemetry import metrics
+from opentelemetry.metrics import Counter, Histogram, UpDownCounter
+
+from . import setup_telemetry  # noqa: F401
+from .constants import (
+    CONCURRENT_REQUESTS,
+    INFERENCE_DURATION,
+    REQUEST_DURATION,
+    REQUESTS_TOTAL,
+    TIME_TO_FIRST_TOKEN,
+)
+
+# Get or create meter for llama_stack.inference
+# This uses the global MeterProvider configured by OTEL auto-instrumentation
+# or set explicitly via metrics.set_meter_provider()
+meter = metrics.get_meter("llama_stack.inference", version="1.0.0")
+
+
+# Request-level metrics
+# These track overall request patterns and server load
+
+requests_total: Counter = meter.create_counter(
+    name=REQUESTS_TOTAL,
+    description="Total number of inference requests processed by the server",
+    unit="1",
+)
+
+request_duration: Histogram = meter.create_histogram(
+    name=REQUEST_DURATION,
+    description="Duration of inference requests from start to completion",
+    unit="s",
+)
+
+concurrent_requests: UpDownCounter = meter.create_up_down_counter(
+    name=CONCURRENT_REQUESTS,
+    description="Number of concurrent inference requests currently being processed",
+    unit="1",
+)
+
+
+# Token-level metrics
+# These track model inference performance and token generation rates
+
+inference_duration: Histogram = meter.create_histogram(
+    name=INFERENCE_DURATION,
+    description="Time spent in model inference (excludes preprocessing/postprocessing)",
+    unit="s",
+)
+
+time_to_first_token: Histogram = meter.create_histogram(
+    name=TIME_TO_FIRST_TOKEN,
+    description="Time from request start until first token is generated (streaming only)",
+    unit="s",
+)
+
+
+# Utility function for creating metric attributes
+def create_metric_attributes(
+    model: str | None = None,
+    provider: str | None = None,
+    endpoint_type: str | None = None,
+    stream: bool | None = None,
+    status: str | None = None,
+) -> dict[str, str | bool]:
+    """Create a consistent attribute dictionary for metrics.
+
+    Args:
+        model: Model identifier (e.g., "meta-llama/Llama-3.2-3B-Instruct")
+        provider: Provider ID (e.g., "inline::meta-reference")
+        endpoint_type: Type of endpoint ("chat_completion", "completion", "embeddings")
+        stream: Whether request is streaming
+        status: Request outcome ("success", "error")
+
+    Returns:
+        Dictionary of attributes with non-None values
+    """
+    attributes: dict[str, str | bool] = {}
+
+    if model is not None:
+        attributes["model"] = model
+    if provider is not None:
+        attributes["provider"] = provider
+    if endpoint_type is not None:
+        attributes["endpoint_type"] = endpoint_type
+    if stream is not None:
+        attributes["stream"] = stream
+    if status is not None:
+        attributes["status"] = status
+
+    return attributes

--- a/tests/integration/telemetry/collectors/base.py
+++ b/tests/integration/telemetry/collectors/base.py
@@ -266,9 +266,7 @@ class BaseTelemetryCollector:
     ) -> None:
         """Accumulate a metric, preferring those matching expected model_id."""
         metric_name = metric.name
-        matches_model_id = (
-            expect_model_id and metric.attributes and metric.attributes.get("model_id") == expect_model_id
-        )
+        matches_model_id = expect_model_id and metric.attributes and metric.attributes.get("model") == expect_model_id
 
         if metric_name not in accumulated:
             accumulated[metric_name] = metric
@@ -278,7 +276,7 @@ class BaseTelemetryCollector:
 
         existing = accumulated[metric_name]
         existing_matches = (
-            expect_model_id and existing.attributes and existing.attributes.get("model_id") == expect_model_id
+            expect_model_id and existing.attributes and existing.attributes.get("model") == expect_model_id
         )
 
         if matches_model_id and not existing_matches:

--- a/tests/integration/telemetry/conftest.py
+++ b/tests/integration/telemetry/conftest.py
@@ -12,35 +12,171 @@ import pytest
 
 from llama_stack.testing.api_recorder import patch_httpx_for_test_id
 from tests.integration.fixtures.common import instantiate_llama_stack_client
-from tests.integration.telemetry.collectors import InMemoryTelemetryManager, OtlpHttpTestCollector
+from tests.integration.telemetry.collectors import InMemoryTelemetryManager
 
 
-# TODO: Fix this to work with Automatic Instrumentation
 @pytest.fixture(scope="session")
 def telemetry_test_collector():
+    """Provide telemetry collector for capturing metrics and traces.
+
+    In server mode, connects to the OTLP HTTP collector started by the integration test script.
+    In library_client mode, creates an in-memory collector via manual MeterProvider setup.
+
+    The server must be started with OTEL_EXPORTER_OTLP_ENDPOINT pointing to this collector.
+    """
     stack_mode = os.environ.get("LLAMA_STACK_TEST_STACK_CONFIG_TYPE", "library_client")
 
     if stack_mode == "server":
-        # In server mode, the collector must be started and the server is already running.
-        # The integration test script (scripts/integration-tests.sh) should have set
-        # LLAMA_STACK_TEST_COLLECTOR_PORT and OTEL_EXPORTER_OTLP_ENDPOINT before starting the server.
-        try:
-            collector = OtlpHttpTestCollector()
-        except RuntimeError as exc:
-            pytest.skip(str(exc))
+        # In server mode, the collector is already running (started by scripts/integration-tests.sh).
+        # We just need to create a client connection to it.
+        # The collector port is set by LLAMA_STACK_TEST_COLLECTOR_PORT.
+        import http.client
+        import time
 
-        # Verify the collector is listening on the expected endpoint
-        expected_endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
-        if expected_endpoint and collector.endpoint != expected_endpoint:
-            pytest.skip(
-                f"Collector endpoint mismatch: expected {expected_endpoint}, got {collector.endpoint}. "
-                "Server was likely started before collector."
-            )
+        collector_port = int(os.environ.get("LLAMA_STACK_TEST_COLLECTOR_PORT", "4318"))
+        endpoint = f"http://127.0.0.1:{collector_port}"
 
-        try:
-            yield collector
-        finally:
-            collector.shutdown()
+        # Verify the collector is responding
+        max_attempts = 30
+        for attempt in range(max_attempts):
+            try:
+                conn = http.client.HTTPConnection("127.0.0.1", collector_port, timeout=1)
+                conn.request("GET", "/")
+                conn.getresponse()
+                conn.close()
+                break
+            except Exception:
+                if attempt == max_attempts - 1:
+                    pytest.skip(f"OTLP collector not responding at {endpoint}")
+                time.sleep(0.1)
+
+        # Create a simple collector wrapper that connects to the running collector
+        # We can't use OtlpHttpTestCollector directly as it would try to start a new server
+
+        class ExistingCollectorWrapper:
+            """Wrapper for accessing an already-running OTLP collector."""
+
+            def __init__(self, endpoint: str):
+                self.endpoint = endpoint
+                # We'll access the collector's data via HTTP requests
+                # The actual collector is running in a separate process
+
+            def get_spans(self, **kwargs):
+                """Query spans from the running collector via HTTP."""
+                import http.client
+                import json
+
+                try:
+                    conn = http.client.HTTPConnection("127.0.0.1", collector_port, timeout=5)
+                    conn.request("GET", "/query/spans")
+                    response = conn.getresponse()
+                    if response.status == 200:
+                        data = json.loads(response.read().decode())
+                        from tests.integration.telemetry.collectors.base import SpanStub
+
+                        spans = [
+                            SpanStub(
+                                name=s["name"],
+                                attributes=s.get("attributes"),
+                                resource_attributes=s.get("resource_attributes"),
+                                trace_id=s.get("trace_id"),
+                                span_id=s.get("span_id"),
+                            )
+                            for s in data.get("spans", [])
+                        ]
+                        return tuple(spans)
+                    conn.close()
+                except Exception:
+                    pass
+                return tuple()
+
+            def get_metrics(self, **kwargs):
+                """Query metrics from the running collector via HTTP."""
+                import http.client
+                import json
+                import time
+
+                # Support polling similar to base class
+                timeout = kwargs.get("timeout", 5.0)
+                poll_interval = kwargs.get("poll_interval", 0.05)
+                deadline = time.time() + timeout
+
+                while time.time() < deadline:
+                    try:
+                        conn = http.client.HTTPConnection("127.0.0.1", collector_port, timeout=5)
+                        conn.request("GET", "/query/metrics")
+                        response = conn.getresponse()
+                        if response.status == 200:
+                            data = json.loads(response.read().decode())
+                            from tests.integration.telemetry.collectors.base import (
+                                MetricStub,
+                            )
+
+                            metrics_dict = {}
+                            for m in data.get("metrics", []):
+                                metric = MetricStub(
+                                    name=m["name"],
+                                    value=m["value"],
+                                    attributes=m.get("attributes"),
+                                )
+                                # Use the same accumulation logic - keep latest/highest value
+                                if m["name"] not in metrics_dict or metric.value > metrics_dict[m["name"]].value:
+                                    metrics_dict[m["name"]] = metric
+
+                            conn.close()
+
+                            # Check if we have enough metrics
+                            expected_count = kwargs.get("expected_count")
+                            if expected_count is None or len(metrics_dict) >= expected_count:
+                                return metrics_dict
+
+                    except Exception:
+                        pass
+
+                    time.sleep(poll_interval)
+
+                # Return whatever we collected even if timeout
+                try:
+                    conn = http.client.HTTPConnection("127.0.0.1", collector_port, timeout=5)
+                    conn.request("GET", "/query/metrics")
+                    response = conn.getresponse()
+                    if response.status == 200:
+                        data = json.loads(response.read().decode())
+                        from tests.integration.telemetry.collectors.base import (
+                            MetricStub,
+                        )
+
+                        metrics_dict = {}
+                        for m in data.get("metrics", []):
+                            metric = MetricStub(
+                                name=m["name"],
+                                value=m["value"],
+                                attributes=m.get("attributes"),
+                            )
+                            if m["name"] not in metrics_dict or metric.value > metrics_dict[m["name"]].value:
+                                metrics_dict[m["name"]] = metric
+                        conn.close()
+                        return metrics_dict
+                except Exception:
+                    pass
+
+                return {}
+
+            def clear(self):
+                """Clear the external collector via HTTP POST."""
+                import http.client
+
+                try:
+                    conn = http.client.HTTPConnection("127.0.0.1", collector_port, timeout=5)
+                    conn.request("POST", "/clear")
+                    conn.getresponse()
+                    conn.close()
+                except Exception:
+                    pass
+
+        # Return a wrapper that points to the running collector
+        wrapper = ExistingCollectorWrapper(endpoint)
+        yield wrapper
     else:
         manager = InMemoryTelemetryManager()
         try:
@@ -49,10 +185,13 @@ def telemetry_test_collector():
             manager.shutdown()
 
 
-# TODO: Fix this to work with Automatic Instrumentation
 @pytest.fixture(scope="session")
 def llama_stack_client(telemetry_test_collector, request):
-    """Ensure telemetry collector is ready before initializing the stack client."""
+    """Ensure telemetry collector is ready before initializing the stack client.
+
+    This guarantees the collector is listening before any requests are made,
+    preventing telemetry data from being lost.
+    """
     patch_httpx_for_test_id()
     client = instantiate_llama_stack_client(request.session)
     return client

--- a/tests/integration/telemetry/recordings/2e913c0d1687c0dbface6ae6905259303e34c27411da8965e1a3ea1c465e0fa7.json
+++ b/tests/integration/telemetry/recordings/2e913c0d1687c0dbface6ae6905259303e34c27411da8965e1a3ea1c465e0fa7.json
@@ -1,0 +1,58 @@
+{
+  "test_id": "tests/integration/telemetry/test_inference_metrics.py::test_chat_completion_nonstreaming_metrics[txt=ollama/llama3.2:3b-instruct-fp16]",
+  "request": {
+    "method": "POST",
+    "url": "http://0.0.0.0:11434/v1/v1/chat/completions",
+    "headers": {},
+    "body": {
+      "model": "llama3.2:3b-instruct-fp16",
+      "messages": [
+        {
+          "role": "user",
+          "content": "What is 2+2?"
+        }
+      ],
+      "stream": false
+    },
+    "endpoint": "/v1/chat/completions",
+    "model": "llama3.2:3b-instruct-fp16"
+  },
+  "response": {
+    "body": {
+      "__type__": "openai.types.chat.chat_completion.ChatCompletion",
+      "__data__": {
+        "id": "rec-2e913c0d1687",
+        "choices": [
+          {
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "content": "2 + 2 = 4.",
+              "refusal": null,
+              "role": "assistant",
+              "annotations": null,
+              "audio": null,
+              "function_call": null,
+              "tool_calls": null
+            }
+          }
+        ],
+        "created": 0,
+        "model": "llama3.2:3b-instruct-fp16",
+        "object": "chat.completion",
+        "service_tier": null,
+        "system_fingerprint": "fp_ollama",
+        "usage": {
+          "completion_tokens": 9,
+          "prompt_tokens": 32,
+          "total_tokens": 41,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        }
+      }
+    },
+    "is_streaming": false
+  },
+  "id_normalization_mapping": {}
+}

--- a/tests/integration/telemetry/recordings/30c53ea73f0b969ec3a4eece1fb101e235f862d0cc9ce5fd7f0b9da7acab4f14.json
+++ b/tests/integration/telemetry/recordings/30c53ea73f0b969ec3a4eece1fb101e235f862d0cc9ce5fd7f0b9da7acab4f14.json
@@ -1,0 +1,416 @@
+{
+  "test_id": "tests/integration/telemetry/test_inference_metrics.py::test_chat_completion_streaming_metrics[txt=ollama/llama3.2:3b-instruct-fp16]",
+  "request": {
+    "method": "POST",
+    "url": "http://0.0.0.0:11434/v1/v1/chat/completions",
+    "headers": {},
+    "body": {
+      "model": "llama3.2:3b-instruct-fp16",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Count to 5"
+        }
+      ],
+      "stream": true
+    },
+    "endpoint": "/v1/chat/completions",
+    "model": "llama3.2:3b-instruct-fp16"
+  },
+  "response": {
+    "body": [
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30c53ea73f0b",
+          "choices": [
+            {
+              "delta": {
+                "content": "1",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30c53ea73f0b",
+          "choices": [
+            {
+              "delta": {
+                "content": ",",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30c53ea73f0b",
+          "choices": [
+            {
+              "delta": {
+                "content": " ",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30c53ea73f0b",
+          "choices": [
+            {
+              "delta": {
+                "content": "2",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30c53ea73f0b",
+          "choices": [
+            {
+              "delta": {
+                "content": ",",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30c53ea73f0b",
+          "choices": [
+            {
+              "delta": {
+                "content": " ",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30c53ea73f0b",
+          "choices": [
+            {
+              "delta": {
+                "content": "3",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30c53ea73f0b",
+          "choices": [
+            {
+              "delta": {
+                "content": ",",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30c53ea73f0b",
+          "choices": [
+            {
+              "delta": {
+                "content": " ",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30c53ea73f0b",
+          "choices": [
+            {
+              "delta": {
+                "content": "4",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30c53ea73f0b",
+          "choices": [
+            {
+              "delta": {
+                "content": ",",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30c53ea73f0b",
+          "choices": [
+            {
+              "delta": {
+                "content": " ",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30c53ea73f0b",
+          "choices": [
+            {
+              "delta": {
+                "content": "5",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30c53ea73f0b",
+          "choices": [
+            {
+              "delta": {
+                "content": ".",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30c53ea73f0b",
+          "choices": [
+            {
+              "delta": {
+                "content": "",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": "stop",
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": null
+        }
+      }
+    ],
+    "is_streaming": true
+  },
+  "id_normalization_mapping": {}
+}

--- a/tests/integration/telemetry/recordings/3c034967313cc54db25b238dfe394d9e9d96869ba4466611cb12c158e86cc381.json
+++ b/tests/integration/telemetry/recordings/3c034967313cc54db25b238dfe394d9e9d96869ba4466611cb12c158e86cc381.json
@@ -1,0 +1,45 @@
+{
+  "test_id": "tests/integration/telemetry/test_inference_metrics.py::test_completion_nonstreaming_metrics[txt=ollama/llama3.2:3b-instruct-fp16]",
+  "request": {
+    "method": "POST",
+    "url": "http://0.0.0.0:11434/v1/v1/completions",
+    "headers": {},
+    "body": {
+      "model": "llama3.2:3b-instruct-fp16",
+      "prompt": "Once upon a time",
+      "max_tokens": 50,
+      "stream": false
+    },
+    "endpoint": "/v1/completions",
+    "model": "llama3.2:3b-instruct-fp16"
+  },
+  "response": {
+    "body": {
+      "__type__": "openai.types.completion.Completion",
+      "__data__": {
+        "id": "rec-3c034967313c",
+        "choices": [
+          {
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "text": "...in a land far, far away..."
+          }
+        ],
+        "created": 0,
+        "model": "llama3.2:3b-instruct-fp16",
+        "object": "text_completion",
+        "system_fingerprint": "fp_ollama",
+        "usage": {
+          "completion_tokens": 10,
+          "prompt_tokens": 29,
+          "total_tokens": 39,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        }
+      }
+    },
+    "is_streaming": false
+  },
+  "id_normalization_mapping": {}
+}

--- a/tests/integration/telemetry/recordings/62d7c479bfd96d96174aa3231e84649f0d5d8a0ee87871598dcec279694942c6.json
+++ b/tests/integration/telemetry/recordings/62d7c479bfd96d96174aa3231e84649f0d5d8a0ee87871598dcec279694942c6.json
@@ -1,0 +1,57 @@
+{
+  "test_id": "tests/integration/telemetry/test_inference_metrics.py::test_multiple_requests_increment_metrics[txt=ollama/llama3.2:3b-instruct-fp16]",
+  "request": {
+    "method": "POST",
+    "url": "http://0.0.0.0:11434/v1/v1/chat/completions",
+    "headers": {},
+    "body": {
+      "model": "llama3.2:3b-instruct-fp16",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Request 1"
+        }
+      ]
+    },
+    "endpoint": "/v1/chat/completions",
+    "model": "llama3.2:3b-instruct-fp16"
+  },
+  "response": {
+    "body": {
+      "__type__": "openai.types.chat.chat_completion.ChatCompletion",
+      "__data__": {
+        "id": "rec-62d7c479bfd9",
+        "choices": [
+          {
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "content": "I'm happy to help, but I don't see a request from you. Could you please provide the details of your request?",
+              "refusal": null,
+              "role": "assistant",
+              "annotations": null,
+              "audio": null,
+              "function_call": null,
+              "tool_calls": null
+            }
+          }
+        ],
+        "created": 0,
+        "model": "llama3.2:3b-instruct-fp16",
+        "object": "chat.completion",
+        "service_tier": null,
+        "system_fingerprint": "fp_ollama",
+        "usage": {
+          "completion_tokens": 27,
+          "prompt_tokens": 28,
+          "total_tokens": 55,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        }
+      }
+    },
+    "is_streaming": false
+  },
+  "id_normalization_mapping": {}
+}

--- a/tests/integration/telemetry/recordings/a6ab3ea292d293e25d4a566d1bd9007277edffa633939e5fbe3c220db0a1a1bb.json
+++ b/tests/integration/telemetry/recordings/a6ab3ea292d293e25d4a566d1bd9007277edffa633939e5fbe3c220db0a1a1bb.json
@@ -1,0 +1,57 @@
+{
+  "test_id": "tests/integration/telemetry/test_inference_metrics.py::test_multiple_requests_increment_metrics[txt=ollama/llama3.2:3b-instruct-fp16]",
+  "request": {
+    "method": "POST",
+    "url": "http://0.0.0.0:11434/v1/v1/chat/completions",
+    "headers": {},
+    "body": {
+      "model": "llama3.2:3b-instruct-fp16",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Request 2"
+        }
+      ]
+    },
+    "endpoint": "/v1/chat/completions",
+    "model": "llama3.2:3b-instruct-fp16"
+  },
+  "response": {
+    "body": {
+      "__type__": "openai.types.chat.chat_completion.ChatCompletion",
+      "__data__": {
+        "id": "rec-a6ab3ea292d2",
+        "choices": [
+          {
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "content": "You've requested something, but you haven't specified what it is. Can you please provide more context or clarify what you would like me to assist with? I'm here to help!",
+              "refusal": null,
+              "role": "assistant",
+              "annotations": null,
+              "audio": null,
+              "function_call": null,
+              "tool_calls": null
+            }
+          }
+        ],
+        "created": 0,
+        "model": "llama3.2:3b-instruct-fp16",
+        "object": "chat.completion",
+        "service_tier": null,
+        "system_fingerprint": "fp_ollama",
+        "usage": {
+          "completion_tokens": 38,
+          "prompt_tokens": 28,
+          "total_tokens": 66,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        }
+      }
+    },
+    "is_streaming": false
+  },
+  "id_normalization_mapping": {}
+}

--- a/tests/integration/telemetry/recordings/ac3ef4b070eca1ca66744a147b0f811366d870731313322f19b05a42b953a74c.json
+++ b/tests/integration/telemetry/recordings/ac3ef4b070eca1ca66744a147b0f811366d870731313322f19b05a42b953a74c.json
@@ -1,0 +1,57 @@
+{
+  "test_id": "tests/integration/telemetry/test_inference_metrics.py::test_multiple_requests_increment_metrics[txt=ollama/llama3.2:3b-instruct-fp16]",
+  "request": {
+    "method": "POST",
+    "url": "http://0.0.0.0:11434/v1/v1/chat/completions",
+    "headers": {},
+    "body": {
+      "model": "llama3.2:3b-instruct-fp16",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Request 3"
+        }
+      ]
+    },
+    "endpoint": "/v1/chat/completions",
+    "model": "llama3.2:3b-instruct-fp16"
+  },
+  "response": {
+    "body": {
+      "__type__": "openai.types.chat.chat_completion.ChatCompletion",
+      "__data__": {
+        "id": "rec-ac3ef4b070ec",
+        "choices": [
+          {
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "content": "You're requesting the third thing, but I don't see what you've asked for yet. Could you please clarify or provide more context so I can assist you better?",
+              "refusal": null,
+              "role": "assistant",
+              "annotations": null,
+              "audio": null,
+              "function_call": null,
+              "tool_calls": null
+            }
+          }
+        ],
+        "created": 0,
+        "model": "llama3.2:3b-instruct-fp16",
+        "object": "chat.completion",
+        "service_tier": null,
+        "system_fingerprint": "fp_ollama",
+        "usage": {
+          "completion_tokens": 35,
+          "prompt_tokens": 28,
+          "total_tokens": 63,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        }
+      }
+    },
+    "is_streaming": false
+  },
+  "id_normalization_mapping": {}
+}

--- a/tests/integration/telemetry/recordings/dc7294818b41b04bbdbde9d6aec8ca3005d06a127ee37cac1808477446010cdd.json
+++ b/tests/integration/telemetry/recordings/dc7294818b41b04bbdbde9d6aec8ca3005d06a127ee37cac1808477446010cdd.json
@@ -1,0 +1,58 @@
+{
+  "test_id": "tests/integration/telemetry/test_inference_metrics.py::test_metric_attributes_are_consistent[txt=ollama/llama3.2:3b-instruct-fp16]",
+  "request": {
+    "method": "POST",
+    "url": "http://0.0.0.0:11434/v1/v1/chat/completions",
+    "headers": {},
+    "body": {
+      "model": "llama3.2:3b-instruct-fp16",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Test attributes"
+        }
+      ],
+      "stream": false
+    },
+    "endpoint": "/v1/chat/completions",
+    "model": "llama3.2:3b-instruct-fp16"
+  },
+  "response": {
+    "body": {
+      "__type__": "openai.types.chat.chat_completion.ChatCompletion",
+      "__data__": {
+        "id": "rec-dc7294818b41",
+        "choices": [
+          {
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "content": "Attribute Testing\n================\n\nAttributes allow you to provide metadata about an object, such as its name, description, or other relevant information. Here are some common use cases for testing attributes:\n\n### 1. Basic Attribute Tests\n\nYou can test whether an attribute is present on a class or instance using the `hasattr()` function.\n\n```python\nimport unittest\n\nclass TestClass:\n    def __init__(self):\n        self.name = \"Test Class\"\n\ndef test_has_attribute():\n    obj = TestClass()\n    assert hasattr(obj, \"name\")\n\ndef test_no_attribute():\n    obj = object()\n    assert not hasattr(obj, \"name\")\n```\n\n### 2. Attribute Getters\n\nYou can write tests to verify that attribute getters are working correctly.\n\n```python\nimport unittest\n\nclassTestClass:\n    def __init__(self):\n        self._name = \"Test Class\"\n\n    @property\n    def name(self):\n        return self._name\n\ndef test_attribute_getter():\n    obj = TestClass()\n    assert obj.name == \"Test Class\"\n```\n\n### 3. Attribute Setters\n\nSimilarly, you can write tests to verify that attribute setters are working correctly.\n\n```python\nimport unittest\n\nclassTestClass:\n    def __init__(self):\n        self._name = \"Test Class\"\n\n    @name.setter\n    def name(self, value):\n        self._name = value\n\ndef test_attribute_setter():\n    obj = TestClass()\n    obj.name = \"New Name\"\n    assert obj.name == \"New Name\"\n```\n\n### 4. Type Checking with `assert isinstance()`\n\nYou can use the `isinstance()` function to test whether an attribute has a specific type.\n\n```python\nimport unittest\n\nclass TestClass:\n    def __init__(self):\n        self.number = 10\n\ndef test_type_checking():\n    obj = TestClass()\n    assert isinstance(obj.number, int)\n```\n\n### 5. Attribute Validation with `@validator`\n\nYou can use the `@validator` decorator from the `pydantic` library to validate attributes.\n\n```python\nfrom pydantic import validator\nimport unittest\n\nclass TestClass:\n    @validator(\"name\")\n    def name_must_not_be_empty(cls, v):\n        if not v:\n            raise ValueError(\"Name must not be empty\")\n        return v\n\ndef test_attribute_validation():\n    obj = TestClass(name=\"Test Value\")\n    assert obj.name == \"Test Value\"\n```\n\nBest Practices\n--------------\n\n*   Use meaningful and descriptive names for your tests.\n*   Keep each test focused on a specific use case or scenario.\n*   Use assertions to verify the expected behavior of your code.\n*   Consider using mocking libraries to isolate dependencies in your unit tests.",
+              "refusal": null,
+              "role": "assistant",
+              "annotations": null,
+              "audio": null,
+              "function_call": null,
+              "tool_calls": null
+            }
+          }
+        ],
+        "created": 0,
+        "model": "llama3.2:3b-instruct-fp16",
+        "object": "chat.completion",
+        "service_tier": null,
+        "system_fingerprint": "fp_ollama",
+        "usage": {
+          "completion_tokens": 560,
+          "prompt_tokens": 27,
+          "total_tokens": 587,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        }
+      }
+    },
+    "is_streaming": false
+  },
+  "id_normalization_mapping": {}
+}

--- a/tests/integration/telemetry/recordings/ee3a978055fdf1a934a8526fb8eb4947d8ed91dc96bf4cafcba47b8bb492694d.json
+++ b/tests/integration/telemetry/recordings/ee3a978055fdf1a934a8526fb8eb4947d8ed91dc96bf4cafcba47b8bb492694d.json
@@ -1,0 +1,57 @@
+{
+  "test_id": "tests/integration/telemetry/test_inference_metrics.py::test_concurrent_requests_metric_exists[txt=ollama/llama3.2:3b-instruct-fp16]",
+  "request": {
+    "method": "POST",
+    "url": "http://0.0.0.0:11434/v1/v1/chat/completions",
+    "headers": {},
+    "body": {
+      "model": "llama3.2:3b-instruct-fp16",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Hello"
+        }
+      ]
+    },
+    "endpoint": "/v1/chat/completions",
+    "model": "llama3.2:3b-instruct-fp16"
+  },
+  "response": {
+    "body": {
+      "__type__": "openai.types.chat.chat_completion.ChatCompletion",
+      "__data__": {
+        "id": "rec-ee3a978055fd",
+        "choices": [
+          {
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "content": "Hello! It's nice to meet you. Is there something I can help you with, or would you like to chat?",
+              "refusal": null,
+              "role": "assistant",
+              "annotations": null,
+              "audio": null,
+              "function_call": null,
+              "tool_calls": null
+            }
+          }
+        ],
+        "created": 0,
+        "model": "llama3.2:3b-instruct-fp16",
+        "object": "chat.completion",
+        "service_tier": null,
+        "system_fingerprint": "fp_ollama",
+        "usage": {
+          "completion_tokens": 26,
+          "prompt_tokens": 26,
+          "total_tokens": 52,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        }
+      }
+    },
+    "is_streaming": false
+  },
+  "id_normalization_mapping": {}
+}

--- a/tests/integration/telemetry/test_inference_metrics.py
+++ b/tests/integration/telemetry/test_inference_metrics.py
@@ -1,0 +1,253 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Integration tests for inference metrics tracking.
+
+These tests verify that the metrics implemented in Phase 1 & 2 are being
+correctly recorded for inference requests.
+"""
+
+import pytest
+
+
+def test_chat_completion_nonstreaming_metrics(mock_otlp_collector, llama_stack_client, text_model_id):
+    """Verify metrics are recorded for non-streaming chat completions."""
+    # Clear any existing metrics
+    mock_otlp_collector.clear()
+
+    # Make a non-streaming request
+    response = llama_stack_client.chat.completions.create(
+        model=text_model_id,
+        messages=[{"role": "user", "content": "What is 2+2?"}],
+        stream=False,
+    )
+
+    assert response is not None
+    assert response.choices is not None
+    assert len(response.choices) > 0
+
+    # Get metrics with appropriate timeout
+    metrics = mock_otlp_collector.get_metrics(
+        expected_count=3,  # requests_total, request_duration, inference_duration
+        expect_model_id=text_model_id,
+        timeout=10.0,
+    )
+
+    # Verify request-level metrics exist
+    assert "llama_stack.inference.requests_total" in metrics, "requests_total metric not found"
+    assert "llama_stack.inference.request_duration_seconds" in metrics, "request_duration metric not found"
+
+    # Verify token-level metrics exist (if usage data is available)
+    if response.usage and response.usage.total_tokens:
+        assert "llama_stack.inference.inference_duration_seconds" in metrics, "inference_duration metric not found"
+
+    # Verify metric attributes
+    requests_metric = metrics["llama_stack.inference.requests_total"]
+    assert requests_metric.attributes.get("model") == text_model_id
+    assert requests_metric.attributes.get("endpoint_type") == "chat_completion"
+    assert requests_metric.attributes.get("stream") is False
+    assert requests_metric.attributes.get("status") == "success"
+
+    # Verify request was counted
+    assert requests_metric.value >= 1, "Should have at least 1 request counted"
+
+
+def test_chat_completion_streaming_metrics(mock_otlp_collector, llama_stack_client, text_model_id):
+    """Verify metrics are recorded for streaming chat completions including TTFT."""
+    mock_otlp_collector.clear()
+
+    # Make a streaming request
+    stream = llama_stack_client.chat.completions.create(
+        model=text_model_id,
+        messages=[{"role": "user", "content": "Count to 5"}],
+        stream=True,
+    )
+
+    # Consume the stream
+    chunks = list(stream)
+    assert len(chunks) > 0, "Should receive at least one chunk"
+
+    # Get metrics - streaming should have additional TTFT metric
+    metrics = mock_otlp_collector.get_metrics(
+        expected_count=5,  # All previous + time_to_first_token
+        expect_model_id=text_model_id,
+        timeout=10.0,
+    )
+
+    # Verify all metrics exist
+    assert "llama_stack.inference.requests_total" in metrics
+    assert "llama_stack.inference.request_duration_seconds" in metrics
+    assert "llama_stack.inference.inference_duration_seconds" in metrics
+    assert "llama_stack.inference.time_to_first_token_seconds" in metrics, "TTFT metric not found for streaming request"
+
+    # Verify TTFT metric attributes
+    ttft_metric = metrics["llama_stack.inference.time_to_first_token_seconds"]
+    assert ttft_metric.attributes.get("stream") is True
+    assert ttft_metric.attributes.get("model") == text_model_id
+
+    # Verify TTFT value is reasonable (should be > 0 and < total duration)
+    assert ttft_metric.value > 0, "TTFT should be positive"
+
+    # Verify streaming attributes
+    requests_metric = metrics["llama_stack.inference.requests_total"]
+    assert requests_metric.attributes.get("stream") is True
+    assert requests_metric.attributes.get("status") == "success"
+
+
+def test_completion_nonstreaming_metrics(mock_otlp_collector, llama_stack_client, text_model_id):
+    """Verify metrics are recorded for non-streaming completions endpoint."""
+    mock_otlp_collector.clear()
+
+    # Make a non-streaming completion request
+    response = llama_stack_client.completions.create(
+        model=text_model_id,
+        prompt="Once upon a time",
+        stream=False,
+        max_tokens=50,
+    )
+
+    assert response is not None
+
+    # Get metrics
+    metrics = mock_otlp_collector.get_metrics(
+        expected_count=4,
+        expect_model_id=text_model_id,
+        timeout=10.0,
+    )
+
+    # Verify basic metrics
+    assert "llama_stack.inference.requests_total" in metrics
+    assert "llama_stack.inference.request_duration_seconds" in metrics
+
+    # Verify endpoint type is correct
+    requests_metric = metrics["llama_stack.inference.requests_total"]
+    assert requests_metric.attributes.get("endpoint_type") == "completion", "endpoint_type should be 'completion'"
+    assert requests_metric.attributes.get("model") == text_model_id
+
+
+def test_error_metrics_recorded(mock_otlp_collector, llama_stack_client):
+    """Verify metrics are recorded for failed requests with error status."""
+    mock_otlp_collector.clear()
+
+    # Make a request with invalid model
+    # Expecting an error - could be ModelNotFoundError or similar
+    with pytest.raises(Exception) as exc_info:  # noqa: B017
+        llama_stack_client.chat.completions.create(
+            model="nonexistent-model-12345",
+            messages=[{"role": "user", "content": "Test"}],
+        )
+    assert exc_info.value is not None
+
+    # Get metrics - should have at least request count and duration
+    metrics = mock_otlp_collector.get_metrics(
+        expected_count=2,
+        timeout=10.0,
+    )
+
+    # Verify error metrics were recorded
+    assert "llama_stack.inference.requests_total" in metrics, "Should record request count even on error"
+    assert "llama_stack.inference.request_duration_seconds" in metrics, "Should record duration even on error"
+
+    # Verify status is error
+    requests_metric = metrics["llama_stack.inference.requests_total"]
+    assert requests_metric.attributes.get("status") == "error", "Status should be 'error' for failed requests"
+
+
+def test_concurrent_requests_metric_exists(mock_otlp_collector, llama_stack_client, text_model_id):
+    """Verify concurrent_requests metric is being tracked."""
+    mock_otlp_collector.clear()
+
+    # Make a request
+    response = llama_stack_client.chat.completions.create(
+        model=text_model_id,
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+
+    assert response is not None
+
+    # Get all metrics - wait for at least 3 metrics to ensure all are exported
+    metrics = mock_otlp_collector.get_metrics(expected_count=3, timeout=10.0)
+
+    # Note: concurrent_requests will likely be 0 by the time we check
+    # since the request completed. This is expected behavior.
+    # We're just verifying the metric exists and was used.
+
+    # The metric should exist even if it's 0
+    # If it was never incremented/decremented, it wouldn't appear in metrics
+    # So its presence in the metrics dict indicates it was used
+
+    # We can't reliably assert on concurrent_requests value in sequential tests
+    # but we can verify the other metrics prove the tracking happened
+    assert "llama_stack.inference.requests_total" in metrics
+    assert "llama_stack.inference.request_duration_seconds" in metrics
+
+
+def test_metric_attributes_are_consistent(mock_otlp_collector, llama_stack_client, text_model_id):
+    """Verify all metrics have consistent attributes."""
+    mock_otlp_collector.clear()
+
+    # Make a request
+    response = llama_stack_client.chat.completions.create(
+        model=text_model_id,
+        messages=[{"role": "user", "content": "Test attributes"}],
+        stream=False,
+    )
+
+    assert response is not None
+
+    # Get metrics
+    metrics = mock_otlp_collector.get_metrics(expect_model_id=text_model_id, timeout=10.0)
+
+    # Collect all model IDs from all metrics
+    model_ids = set()
+    endpoint_types = set()
+    stream_values = set()
+
+    for _, metric in metrics.items():
+        if metric.attributes:
+            if "model" in metric.attributes:
+                model_ids.add(metric.attributes["model"])
+            if "endpoint_type" in metric.attributes:
+                endpoint_types.add(metric.attributes["endpoint_type"])
+            if "stream" in metric.attributes:
+                stream_values.add(metric.attributes["stream"])
+
+    # Verify attributes are consistent across metrics
+    assert text_model_id in model_ids, f"Expected model {text_model_id} in metrics, got {model_ids}"
+    assert "chat_completion" in endpoint_types, f"Expected chat_completion endpoint_type, got {endpoint_types}"
+    assert False in stream_values, f"Expected stream=False, got {stream_values}"
+
+
+def test_multiple_requests_increment_metrics(mock_otlp_collector, llama_stack_client, text_model_id):
+    """Verify metrics accumulate across multiple requests."""
+    mock_otlp_collector.clear()
+
+    # Make multiple requests
+    num_requests = 3
+    for i in range(num_requests):
+        response = llama_stack_client.chat.completions.create(
+            model=text_model_id,
+            messages=[{"role": "user", "content": f"Request {i + 1}"}],
+        )
+        assert response is not None
+
+    # Get metrics - wait for at least 3 metrics to ensure all are exported
+    metrics = mock_otlp_collector.get_metrics(expected_count=3, expect_model_id=text_model_id, timeout=10.0)
+
+    # Verify requests_total accumulated
+    assert "llama_stack.inference.requests_total" in metrics
+    requests_metric = metrics["llama_stack.inference.requests_total"]
+    assert requests_metric.value >= num_requests, (
+        f"Should have at least {num_requests} requests, got {requests_metric.value}"
+    )
+
+    # Verify request_duration recorded multiple values
+    assert "llama_stack.inference.request_duration_seconds" in metrics
+    duration_metric = metrics["llama_stack.inference.request_duration_seconds"]
+
+    # Histogram should have recorded multiple samples
+    # The value represents the sum or count depending on the metric type
+    assert duration_metric.value > 0, "Duration metric should have recorded values"


### PR DESCRIPTION
# What does this PR do?

Add comprehensive OTEL metrics tracking for inference requests with automatic export to OTLP collectors.

Metrics implemented:
 - llama_stack.inference.requests_total (counter)
 - llama_stack.inference.request_duration_seconds (histogram)
 - llama_stack.inference.concurrent_requests (up-down counter)
 - llama_stack.inference.inference_duration_seconds (histogram)
 - llama_stack.inference.time_to_first_token_seconds (histogram)

Key components:
 - Create metrics module with 5 OTEL instruments
 - Integrate metrics into chat/completions inference routers
 - Add OTLP HTTP exporter with auto-configuration via env vars
 - Implement integration tests with OTLP test collector
 - Fix test infrastructure to support metrics export in server mode

 All metrics include attributes for model, provider, endpoint_type,
 stream, and status for flexible filtering and aggregation.

## Test Plan

new telemetry integration tests should pass.