### PR TITLE
feat: Add endpoint authorization with YAML config

### DIFF
--- a/docs/docs/distributions/configuration.mdx
+++ b/docs/docs/distributions/configuration.mdx
@@ -595,6 +595,205 @@ created by users sharing a team with them:
       description: any user has read access to any resource created by a user with the same team
 ```
 
+### Route-Level Authorization
+
+Route-level authorization provides infrastructure-level access control for Llama Stack API routes. This feature allows administrators to restrict which API routes can be accessed based on user attributes (when authentication is enabled) or to globally block/allow specific routes (without authentication).
+
+#### Key Features
+
+1. **API Surface Control**: Restrict the available API surface without authentication by blocking specific routes
+2. **Role-Based Route Access**: Control which users or teams can access specific API routes based on their roles, teams, or other attributes
+3. **Works With or Without Authentication**: Route authorization can be configured independently of authentication
+4. **Two-Level Access Control**: When both route-level and resource-level authorization are configured:
+   - Route authorization is checked first (infrastructure level)
+   - Resource authorization is checked second (data level)
+   - Both checks must pass for access to be granted
+
+#### Configuration
+
+Route authorization is configured in the server's authentication section under `route_policy`:
+
+```yaml
+server:
+  auth:
+    provider_config: # Optional - only needed if using user-based conditions
+      type: "oauth2_token"
+      # ... authentication provider configuration ...
+
+    # Route-level access control (infrastructure)
+    route_policy:
+      - permit:
+          paths: "<path or list of paths>"
+        when: "<optional user condition>"
+        description: "<optional description>"
+
+      - forbid:
+          paths: "<path or list of paths>"
+        unless: "<optional user condition>"
+        description: "<optional description>"
+```
+
+#### Path Matching
+
+Route paths support three matching patterns:
+
+1. **Exact Match**: `/v1/chat/completions` - matches only this specific path
+2. **Prefix Wildcard**: `/v1/files*` - matches `/v1/files` and all paths starting with `/v1/files` (e.g., `/v1/files/upload`, `/v1/files/list`)
+3. **Full Wildcard**: `*` - matches all routes
+
+**Path Normalization**: Trailing slashes are automatically removed during matching (e.g., `/v1/files/` is treated as `/v1/files`).
+
+Multiple paths can be specified in a single rule using a list:
+```yaml
+paths: ["/v1/files*", "/v1/models*"]
+```
+
+#### Rule Evaluation
+
+- **Permit Rules**: Grant access to specified routes
+- **Forbid Rules**: Deny access to specified routes
+- Rules are evaluated in order of definition
+- First matching rule determines access (permit or forbid)
+- If no rule matches, access is denied by default
+- If no `route_policy` is configured, all routes are allowed (backward compatible)
+
+#### User Conditions
+
+When authentication is enabled, rules can include conditions based on user attributes:
+
+- `when: user with <value> in <attribute>` - Require user has specific attribute value
+- `unless: user with <value> in <attribute>` - Apply rule unless user has specific attribute value
+
+Multiple conditions can be specified as a list (all must match):
+```yaml
+when:
+  - user with admin in roles
+  - user with platform in teams
+```
+
+Rules with user conditions are skipped when authentication is not configured. Rules without conditions apply regardless of authentication status.
+
+#### Examples
+
+**Example 1: Route Blocking Without Authentication**
+
+Block unused routes while allowing public access to others:
+
+```yaml
+server:
+  auth:
+    route_policy:
+      - permit:
+          paths: ["/v1/health", "/v1/version"]
+        description: "Public monitoring routes"
+
+      - permit:
+          paths: "/v1/chat/completions"
+        description: "Allow inference"
+```
+
+Result:
+- `/v1/health` and `/v1/version` are accessible
+- `/v1/chat/completions` is accessible
+- All other routes are blocked (no matching permit rule)
+
+**Example 2: Role-Based Route Access**
+
+Different roles have access to different API surfaces:
+
+```yaml
+server:
+  auth:
+    provider_config:
+      type: "oauth2_token"
+      # ... provider configuration ...
+
+    route_policy:
+      - permit:
+          paths: "/v1/chat/completions"
+        when: user with developer in roles
+        description: "Developers can use inference"
+
+      - permit:
+          paths: ["/v1/files*", "/v1/models*"]
+        when: user with user in roles
+        description: "Users can manage files and models"
+
+      - permit:
+          paths: "*"
+        when: user with admin in roles
+        description: "Admins have full access"
+```
+
+Result:
+- Users with `developer` role can only access `/v1/chat/completions`
+- Users with `user` role can access file and model routes
+- Users with `admin` role can access all routes
+- Users without matching roles are denied access
+
+**Example 3: Mixed Public and Protected Routes**
+
+Combine public routes with role-based access:
+
+```yaml
+server:
+  auth:
+    provider_config:
+      type: "oauth2_token"
+      # ... provider configuration ...
+
+    route_policy:
+      - permit:
+          paths: ["/v1/health", "/v1/version"]
+        description: "Public routes (no authentication required)"
+
+      - permit:
+          paths: "/v1/admin*"
+        when: user with admin in roles
+        description: "Admin routes require admin role"
+
+      - permit:
+          paths: "/v1/chat/completions"
+        when: user with developer in roles
+        description: "Inference requires developer role"
+```
+
+Result:
+- Anyone can access `/v1/health` and `/v1/version` (no authentication needed)
+- Only authenticated users with `admin` role can access `/v1/admin*` routes
+- Only authenticated users with `developer` role can access `/v1/chat/completions`
+- All other routes are denied
+
+**Example 4: Integration with Resource-Level Authorization**
+
+Route authorization works seamlessly with resource-level authorization:
+
+```yaml
+server:
+  auth:
+    provider_config:
+      type: "oauth2_token"
+      # ... provider configuration ...
+
+    # Route-level: Controls which API routes are accessible
+    route_policy:
+      - permit:
+          paths: "/v1/chat/completions"
+        when: user with developer in roles
+
+    # Resource-level: Controls which specific resources are accessible
+    access_policy:
+      - permit:
+          actions: [read]
+          resource: model::llama-3-2-3b
+        when: user with developer in roles
+```
+
+For a request to succeed:
+1. User must pass route authorization (can access `/v1/chat/completions`)
+2. User must pass resource authorization (can read `model::llama-3-2-3b`)
+3. Both checks must pass
+
 #### API Endpoint Authorization with Scopes
 
 In addition to resource-based access control, Llama Stack supports endpoint-level authorization using OAuth 2.0 style scopes. When authentication is enabled, specific API endpoints require users to have particular scopes in their authentication token.

--- a/src/llama_stack/core/datatypes.py
+++ b/src/llama_stack/core/datatypes.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from llama_stack.core.access_control.datatypes import AccessRule
+from llama_stack.core.access_control.datatypes import AccessRule, RouteAccessRule
 from llama_stack.core.storage.datatypes import (
     KVStoreReference,
     StorageBackendType,
@@ -329,13 +329,17 @@ AuthProviderConfig = Annotated[
 class AuthenticationConfig(BaseModel):
     """Top-level authentication configuration."""
 
-    provider_config: AuthProviderConfig = Field(
-        ...,
-        description="Authentication provider configuration",
+    provider_config: AuthProviderConfig | None = Field(
+        default=None,
+        description="Authentication provider configuration (optional if only using route_policy)",
+    )
+    route_policy: list[RouteAccessRule] = Field(
+        default=[],
+        description="Rules for determining access to API routes (infrastructure-level)",
     )
     access_policy: list[AccessRule] = Field(
         default=[],
-        description="Rules for determining access to resources",
+        description="Rules for determining access to resources (data-level)",
     )
 
 

--- a/src/llama_stack/core/server/auth.py
+++ b/src/llama_stack/core/server/auth.py
@@ -9,6 +9,8 @@ import json
 import httpx
 from aiohttp import hdrs
 
+from llama_stack.core.access_control.conditions import parse_conditions
+from llama_stack.core.access_control.datatypes import RouteAccessRule
 from llama_stack.core.datatypes import AuthenticationConfig, User
 from llama_stack.core.request_headers import user_from_scope
 from llama_stack.core.server.auth_providers import create_auth_provider
@@ -187,3 +189,198 @@ def _has_required_scope(required_scope: str, user: User | None) -> bool:
 
     user_scopes = user.attributes.get("scopes", [])
     return required_scope in user_scopes
+
+
+class RouteAuthorizationMiddleware:
+    """Middleware that enforces route-level access control.
+
+    This middleware runs after authentication and checks if the authenticated user
+    has permission to access the requested API route based on route_policy rules.
+
+    """
+
+    def __init__(self, app, route_policy: list[RouteAccessRule]):
+        self.app = app
+        self.route_policy = route_policy
+
+    async def __call__(self, scope, receive, send):
+        # Only process HTTP requests
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        # If no route policy configured, allow all routes (backward compatible)
+        if not self.route_policy:
+            return await self.app(scope, receive, send)
+
+        route = scope.get("path", "")
+        # Normalize route: remove trailing slash (except for root "/")
+        if route != "/" and route.endswith("/"):
+            route = route.rstrip("/")
+
+        # Get authenticated user from scope (set by AuthenticationMiddleware if present)
+        user = user_from_scope(scope)
+
+        # Check if user has permission to access this route
+        if not self._is_route_allowed(route, user):
+            return await self._send_error(
+                send, f"Access denied: insufficient permissions for route {route}", status=403
+            )
+
+        return await self.app(scope, receive, send)
+
+    def _is_route_allowed(self, route: str, user: User | None) -> bool:
+        """Check if the user is allowed to access the given route.
+
+        Rules are evaluated in order. First matching rule determines access.
+        If no rule matches, access is denied.
+
+        Args:
+            route: The route being accessed
+            user: The authenticated user, or None if no authentication is configured
+        """
+        user_str = user.principal if user else "anonymous"
+
+        for index, rule in enumerate(self.route_policy):
+            if self._rule_matches(rule, route, user):
+                # Check if this is a permit or forbid rule
+                if rule.permit:
+                    decision = "APPROVED"
+                    reason = rule.description or ""
+                    logger.debug(
+                        f"ROUTE_AUTHZ,decision={decision},user={user_str},"
+                        f"route={route},rule_index={index},reason={reason!r}"
+                    )
+                    return True
+                else:  # forbid
+                    decision = "DENIED"
+                    reason = rule.description or ""
+                    logger.debug(
+                        f"ROUTE_AUTHZ,decision={decision},user={user_str},"
+                        f"route={route},rule_index={index},reason={reason!r}"
+                    )
+                    return False
+
+        # No matching rule found - deny by default
+        decision = "DENIED"
+        reason = "no matching rule"
+        logger.debug(f"ROUTE_AUTHZ,decision={decision},user={user_str},route={route},rule_index=-1,reason={reason!r}")
+        return False
+
+    def _rule_matches(self, rule: RouteAccessRule, route: str, user: User | None) -> bool:
+        """Check if a rule matches the given route and user.
+
+        Args:
+            rule: The rule to evaluate
+            route: The route being accessed
+            user: The authenticated user, or None if no authentication is configured
+        """
+        # Get the scope (permit or forbid)
+        scope = rule.permit if rule.permit else rule.forbid
+        if not scope:
+            return False
+
+        # Check if route matches
+        if not self._route_matches(route, scope.paths):
+            return False
+
+        # Evaluate conditions
+        return self._evaluate_conditions(rule, user)
+
+    def _route_matches(self, request_route: str, rule_patterns: str | list[str]) -> bool:
+        """Check if request route matches any of the rule patterns.
+
+        Supports:
+        - Exact match: "/v1/chat/completions"
+        - Prefix wildcard: "/v1/files*" matches "/v1/files", "/v1/files/upload", "/v1/files/list", etc.
+        - Full wildcard: "*" matches all routes
+        """
+        patterns = [rule_patterns] if isinstance(rule_patterns, str) else rule_patterns
+
+        for pattern in patterns:
+            if pattern == "*":
+                # Full wildcard matches everything
+                return True
+            elif pattern.endswith("*"):
+                # Prefix wildcard: check if request route starts with the prefix
+                prefix = pattern[:-1]  # Remove "*"
+                if request_route.startswith(prefix):
+                    return True
+            elif pattern == request_route:
+                # Exact match
+                return True
+
+        return False
+
+    def _evaluate_conditions(self, rule: RouteAccessRule, user: User | None) -> bool:
+        """Evaluate when/unless conditions for the rule.
+
+        Reuses the existing condition parsing from access_control.conditions.
+
+        Args:
+            rule: The rule whose conditions to evaluate
+            user: The authenticated user, or None if no authentication is configured
+
+        Returns:
+            True if conditions are met (or no conditions exist), False otherwise
+        """
+        # If rule has conditions but no user is available, conditions cannot be met
+        if (rule.when or rule.unless) and not user:
+            return False
+
+        if rule.when:
+            # At this point, if rule.when exists and we got past the check above,
+            # user is guaranteed to be non-None
+            assert user is not None
+            conditions_list = rule.when if isinstance(rule.when, list) else [rule.when]
+            conditions = parse_conditions(conditions_list)
+            # For 'when', all conditions must match (AND logic)
+            # Note: Since we're checking route access, we don't have a resource,
+            # so we create a context object to satisfy the interface
+            route_context = _RouteContext()
+            for condition in conditions:
+                if not condition.matches(route_context, user):
+                    return False
+            return True
+
+        if rule.unless:
+            # At this point, if rule.unless exists and we got past the check above,
+            # user is guaranteed to be non-None
+            assert user is not None
+            conditions_list = rule.unless if isinstance(rule.unless, list) else [rule.unless]
+            conditions = parse_conditions(conditions_list)
+            # For 'unless', no conditions should match (NOT logic)
+            route_context = _RouteContext()
+            for condition in conditions:
+                if condition.matches(route_context, user):
+                    return False
+            return True
+
+        # No conditions specified - rule applies regardless of user
+        return True
+
+    async def _send_error(self, send, message: str, status: int = 403):
+        """Send an error response."""
+        await send(
+            {
+                "type": "http.response.start",
+                "status": status,
+                "headers": [[b"content-type", b"application/json"]],
+            }
+        )
+        error_key = "message" if status == 401 else "detail"
+        error_msg = json.dumps({"error": {error_key: message}}).encode()
+        await send({"type": "http.response.body", "body": error_msg})
+
+
+class _RouteContext:
+    """Placeholder resource for route-level condition evaluation.
+
+    Route rules don't operate on actual resources, so we use this context object
+    to satisfy the condition.matches() interface. Route conditions typically check
+    user attributes (e.g., "user with admin in roles") and don't require resource properties.
+    """
+
+    def __init__(self):
+        self.type = "route"
+        self.identifier = "route"
+        self.owner = None

--- a/tests/unit/server/test_route_auth.py
+++ b/tests/unit/server/test_route_auth.py
@@ -1,0 +1,495 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from unittest.mock import Mock
+
+import pytest
+from fastapi import FastAPI
+
+from llama_stack.core.access_control.datatypes import RouteAccessRule, RouteScope
+from llama_stack.core.datatypes import (
+    AuthenticationConfig,
+    AuthProviderType,
+    CustomAuthConfig,
+    User,
+)
+from llama_stack.core.server.auth import (
+    AuthenticationMiddleware,
+    RouteAuthorizationMiddleware,
+)
+
+
+@pytest.fixture
+def admin_user():
+    return User(
+        principal="admin@example.com",
+        attributes={
+            "roles": ["admin"],
+            "teams": ["platform"],
+        },
+    )
+
+
+@pytest.fixture
+def developer_user():
+    return User(
+        principal="dev@example.com",
+        attributes={
+            "roles": ["developer"],
+            "teams": ["ml-team"],
+        },
+    )
+
+
+@pytest.fixture
+def regular_user():
+    return User(
+        principal="user@example.com",
+        attributes={
+            "roles": ["user"],
+            "teams": ["ml-team"],
+        },
+    )
+
+
+def create_mock_auth_provider(user: User):
+    """Create a mock auth provider that returns the specified user"""
+    mock_provider = Mock()
+    mock_provider.validate_token = Mock(return_value=user)
+    return mock_provider
+
+
+def create_app_with_route_policy(route_policy: list[RouteAccessRule], user: User):
+    """Create a FastAPI app with route authorization middleware"""
+    app = FastAPI()
+
+    # Create auth config
+    auth_config = AuthenticationConfig(
+        provider_config=CustomAuthConfig(
+            type=AuthProviderType.CUSTOM,
+            endpoint="http://mock-auth/validate",
+        ),
+        route_policy=route_policy,
+        access_policy=[],
+    )
+
+    # Add authentication middleware
+    auth_middleware = AuthenticationMiddleware(app, auth_config, {})
+    # Mock the auth provider to return our test user
+    auth_middleware.auth_provider = create_mock_auth_provider(user)
+
+    # Create the middleware stack
+    app.add_middleware(RouteAuthorizationMiddleware, route_policy=route_policy)
+
+    # Replace the app in the auth middleware
+    async def app_with_auth(scope, receive, send):
+        return await auth_middleware(scope, receive, send)
+
+    # Add test endpoints
+    @app.get("/v1/chat/completions")
+    def chat_completions():
+        return {"message": "chat completions"}
+
+    @app.get("/v1/models/list")
+    def models_list():
+        return {"message": "models list"}
+
+    @app.post("/v1/files/upload")
+    def files_upload():
+        return {"message": "file uploaded"}
+
+    @app.delete("/v1/admin/reset")
+    def admin_reset():
+        return {"message": "admin reset"}
+
+    return app, app_with_auth
+
+
+async def test_no_route_policy_allows_all(regular_user):
+    """Test backward compatibility: empty route_policy allows all routes"""
+    app = FastAPI()
+
+    # No route policy
+    route_policy = []
+
+    middleware = RouteAuthorizationMiddleware(app, route_policy)
+
+    # Mock scope with any path
+    scope = {
+        "type": "http",
+        "path": "/v1/chat/completions",
+        "method": "GET",
+        "principal": regular_user.principal,
+        "user_attributes": regular_user.attributes,
+    }
+
+    # Track if next middleware was called
+    called = False
+
+    async def mock_app(scope, receive, send):
+        nonlocal called
+        called = True
+
+    async def receive():
+        return {}
+
+    async def send(msg):
+        pass
+
+    middleware.app = mock_app
+    await middleware(scope, receive, send)
+
+    # Should pass through without blocking
+    assert called
+
+
+async def test_exact_path_match(developer_user):
+    """Test exact path matching"""
+    route_policy = [
+        RouteAccessRule(
+            permit=RouteScope(paths="/v1/chat/completions"),
+            when="user with developer in roles",
+        )
+    ]
+
+    middleware = RouteAuthorizationMiddleware(None, route_policy)
+
+    # Should match
+    assert middleware._route_matches("/v1/chat/completions", "/v1/chat/completions")
+
+    # Should not match
+    assert not middleware._route_matches("/v1/chat/completions/stream", "/v1/chat/completions")
+    assert not middleware._route_matches("/v1/models/list", "/v1/chat/completions")
+
+
+async def test_wildcard_prefix_match():
+    """Test wildcard prefix matching"""
+    route_policy = []
+    middleware = RouteAuthorizationMiddleware(None, route_policy)
+
+    # Test prefix wildcard
+    assert middleware._route_matches("/v1/files/upload", "/v1/files*")
+    assert middleware._route_matches("/v1/files/delete", "/v1/files*")
+    assert middleware._route_matches("/v1/files/list/all", "/v1/files*")
+    # Should also match the exact prefix
+    assert middleware._route_matches("/v1/files", "/v1/files*")
+
+    # Should not match different prefix
+    assert not middleware._route_matches("/v1/models/list", "/v1/files*")
+
+
+async def test_full_wildcard_match():
+    """Test full wildcard matching"""
+    route_policy = []
+    middleware = RouteAuthorizationMiddleware(None, route_policy)
+
+    # Full wildcard should match everything
+    assert middleware._route_matches("/v1/chat/completions", "*")
+    assert middleware._route_matches("/v1/files/upload", "*")
+    assert middleware._route_matches("/admin/reset", "*")
+    assert middleware._route_matches("/anything/goes", "*")
+
+
+async def test_multiple_paths_in_rule(regular_user):
+    """Test rule with multiple paths"""
+    route_policy = [
+        RouteAccessRule(
+            permit=RouteScope(paths=["/v1/files*", "/v1/models*"]),
+            when="user with user in roles",
+        )
+    ]
+
+    middleware = RouteAuthorizationMiddleware(None, route_policy)
+
+    # Test that the policy allows these paths for regular_user
+    assert middleware._is_route_allowed("/v1/files/upload", regular_user)
+    assert middleware._is_route_allowed("/v1/models/list", regular_user)
+
+    # Should not match other paths
+    assert not middleware._is_route_allowed("/v1/chat/completions", regular_user)
+
+
+async def test_condition_evaluation_with_roles(developer_user, regular_user):
+    """Test condition evaluation with role attributes"""
+    route_policy = [
+        RouteAccessRule(
+            permit=RouteScope(paths="/v1/chat/completions"),
+            when="user with developer in roles",
+        )
+    ]
+
+    middleware = RouteAuthorizationMiddleware(None, route_policy)
+
+    # Developer should pass
+    assert middleware._is_route_allowed("/v1/chat/completions", developer_user)
+
+    # Regular user should not pass
+    assert not middleware._is_route_allowed("/v1/chat/completions", regular_user)
+
+
+async def test_admin_full_wildcard_access(admin_user, developer_user):
+    """Test admin with full wildcard access"""
+    route_policy = [
+        RouteAccessRule(
+            permit=RouteScope(paths="/v1/chat/completions"),
+            when="user with developer in roles",
+        ),
+        RouteAccessRule(
+            permit=RouteScope(paths="*"),
+            when="user with admin in roles",
+        ),
+    ]
+
+    middleware = RouteAuthorizationMiddleware(None, route_policy)
+
+    # Admin should access everything
+    assert middleware._is_route_allowed("/v1/chat/completions", admin_user)
+    assert middleware._is_route_allowed("/v1/files/upload", admin_user)
+    assert middleware._is_route_allowed("/v1/admin/reset", admin_user)
+
+    # Developer should only access chat completions
+    assert middleware._is_route_allowed("/v1/chat/completions", developer_user)
+    assert not middleware._is_route_allowed("/v1/files/upload", developer_user)
+
+
+async def test_forbid_rule(admin_user, developer_user):
+    """Test forbid rules with unless conditions"""
+    route_policy = [
+        RouteAccessRule(
+            forbid=RouteScope(paths="/v1/admin*"),
+            unless="user with admin in roles",
+        ),
+        RouteAccessRule(
+            permit=RouteScope(paths="*"),
+            when="user with admin in roles",
+            description="Admins can access everything",
+        ),
+        RouteAccessRule(
+            permit=RouteScope(paths="*"),
+            when="user with developer in roles",
+            description="Developers can access everything except what's forbidden",
+        ),
+    ]
+
+    middleware = RouteAuthorizationMiddleware(None, route_policy)
+
+    # Developer is forbidden from admin routes by the first forbid rule
+    assert not middleware._is_route_allowed("/v1/admin/reset", developer_user)
+
+    # Admin bypasses the forbid rule (due to 'unless' condition) and matches the permit rule
+    assert middleware._is_route_allowed("/v1/admin/reset", admin_user)
+
+    # Developer can access non-admin routes
+    assert middleware._is_route_allowed("/v1/chat/completions", developer_user)
+
+
+async def test_no_matching_rule_denies_access(regular_user):
+    """Test that no matching rule results in denied access"""
+    route_policy = [
+        RouteAccessRule(
+            permit=RouteScope(paths="/v1/chat/completions"),
+            when="user with developer in roles",
+        )
+    ]
+
+    middleware = RouteAuthorizationMiddleware(None, route_policy)
+
+    # Regular user should be denied (doesn't have developer role)
+    assert not middleware._is_route_allowed("/v1/chat/completions", regular_user)
+
+    # Any user should be denied for non-matching path
+    assert not middleware._is_route_allowed("/v1/models/list", regular_user)
+
+
+async def test_multiple_conditions(admin_user):
+    """Test multiple conditions in a rule"""
+    route_policy = [
+        RouteAccessRule(
+            permit=RouteScope(paths="*"),
+            when=["user with admin in roles", "user with platform in teams"],
+        )
+    ]
+
+    middleware = RouteAuthorizationMiddleware(None, route_policy)
+
+    # Admin with platform team should pass
+    assert middleware._is_route_allowed("/v1/anything", admin_user)
+
+
+async def test_rule_order_matters(developer_user):
+    """Test that rules are evaluated in order"""
+    route_policy = [
+        # First rule: developers can access chat
+        RouteAccessRule(
+            permit=RouteScope(paths="/v1/chat/completions"),
+            when="user with developer in roles",
+        ),
+        # Second rule: deny all developers from everything (should not apply to chat)
+        RouteAccessRule(
+            forbid=RouteScope(paths="*"),
+            when="user with developer in roles",
+        ),
+    ]
+
+    middleware = RouteAuthorizationMiddleware(None, route_policy)
+
+    # First matching rule should win
+    assert middleware._is_route_allowed("/v1/chat/completions", developer_user)
+
+    # Second rule should match for other paths
+    assert not middleware._is_route_allowed("/v1/models/list", developer_user)
+
+
+async def test_websocket_passthrough():
+    """Test that websocket requests pass through without blocking"""
+    route_policy = [
+        RouteAccessRule(
+            permit=RouteScope(paths="/v1/chat/completions"),
+            when="user with developer in roles",
+        )
+    ]
+
+    app = FastAPI()
+    middleware = RouteAuthorizationMiddleware(app, route_policy)
+
+    # Mock websocket scope
+    scope = {
+        "type": "websocket",
+        "path": "/ws",
+    }
+
+    # Track if next middleware was called
+    called = False
+
+    async def mock_app(scope, receive, send):
+        nonlocal called
+        called = True
+
+    async def receive():
+        return {}
+
+    async def send(msg):
+        pass
+
+    middleware.app = mock_app
+    await middleware(scope, receive, send)
+
+    # Websocket requests should pass through
+    assert called
+
+
+async def test_route_blocking_without_auth():
+    """Test that route policy can block routes without authentication configured"""
+    route_policy = [
+        RouteAccessRule(
+            permit=RouteScope(paths="/v1/health"),
+            description="Allow health check route",
+        ),
+        RouteAccessRule(
+            permit=RouteScope(paths="/v1/models*"),
+            description="Allow model routes",
+        ),
+        # All other routes denied by default (no matching rule)
+    ]
+
+    app = FastAPI()
+    middleware = RouteAuthorizationMiddleware(app, route_policy)
+
+    # No user (no authentication)
+    user = None
+
+    # Should allow health check
+    assert middleware._is_route_allowed("/v1/health", user)
+
+    # Should allow model routes
+    assert middleware._is_route_allowed("/v1/models/list", user)
+
+    # Should deny other routes (no matching rule)
+    assert not middleware._is_route_allowed("/v1/chat/completions", user)
+    assert not middleware._is_route_allowed("/v1/admin/reset", user)
+
+
+async def test_forbid_rule_without_auth():
+    """Test forbid rules work without authentication"""
+    route_policy = [
+        RouteAccessRule(
+            forbid=RouteScope(paths="/v1/admin*"),
+            description="Block admin routes",
+        ),
+        RouteAccessRule(
+            permit=RouteScope(paths="*"),
+            description="Allow all other routes",
+        ),
+    ]
+
+    middleware = RouteAuthorizationMiddleware(None, route_policy)
+
+    # No user (no authentication)
+    user = None
+
+    # Should forbid admin routes
+    assert not middleware._is_route_allowed("/v1/admin/reset", user)
+    assert not middleware._is_route_allowed("/v1/admin/users", user)
+
+    # Should allow other routes
+    assert middleware._is_route_allowed("/v1/chat/completions", user)
+    assert middleware._is_route_allowed("/v1/models/list", user)
+
+
+async def test_rule_with_condition_requires_user():
+    """Test that rules with user conditions require authentication"""
+    route_policy = [
+        RouteAccessRule(
+            permit=RouteScope(paths="*"),
+            when="user with admin in roles",
+        )
+    ]
+
+    middleware = RouteAuthorizationMiddleware(None, route_policy)
+
+    # No user (no authentication)
+    user = None
+
+    # Should be denied because rule has condition but no user available
+    assert not middleware._is_route_allowed("/v1/chat/completions", user)
+
+
+async def test_mixed_rules_with_and_without_conditions(admin_user, regular_user):
+    """Test mixing rules with and without user conditions"""
+    route_policy = [
+        # Public routes (no condition)
+        RouteAccessRule(
+            permit=RouteScope(paths=["/v1/health", "/v1/version"]),
+            description="Public routes",
+        ),
+        # Admin-only routes (requires user)
+        RouteAccessRule(
+            permit=RouteScope(paths="/v1/admin*"),
+            when="user with admin in roles",
+            description="Admin routes require admin role",
+        ),
+        # Default: deny everything else
+    ]
+
+    middleware = RouteAuthorizationMiddleware(None, route_policy)
+
+    # No user can access public routes
+    assert middleware._is_route_allowed("/v1/health", None)
+    assert middleware._is_route_allowed("/v1/version", None)
+
+    # No user cannot access admin routes (condition requires user)
+    assert not middleware._is_route_allowed("/v1/admin/reset", None)
+
+    # Admin can access admin routes
+    assert middleware._is_route_allowed("/v1/admin/reset", admin_user)
+
+    # Regular user cannot access admin routes (lacks admin role)
+    assert not middleware._is_route_allowed("/v1/admin/reset", regular_user)
+
+    # No one can access other routes (no matching rule)
+    assert not middleware._is_route_allowed("/v1/chat/completions", None)
+    assert not middleware._is_route_allowed("/v1/chat/completions", admin_user)
+    assert not middleware._is_route_allowed("/v1/chat/completions", regular_user)


### PR DESCRIPTION
Implements infrastructure-level access control for API endpoints, allowing administrators to restrict endpoint access based on user attributes or globally block/allow specific endpoints without authentication.

Key Features:
- YAML-based endpoint_policy configuration in server.auth section
- Wildcard path matching: exact (/v1/health), prefix (/v1/files*), full (*)
- User condition support: role/team-based access control
- Works independently of authentication (can block endpoints without auth)
- Two-level security: endpoint authorization → resource authorization
- backward compatible (no policy = all endpoints allowed)

Related: #4365

# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->
