### PR TITLE
fix: skip resources with empty IDs from conditional env vars in config processing

### DIFF
--- a/tests/unit/server/test_replace_env_vars.py
+++ b/tests/unit/server/test_replace_env_vars.py
@@ -8,7 +8,7 @@ import os
 
 import pytest
 
-from llama_stack.core.stack import replace_env_vars
+from llama_stack.core.stack import EnvVarError, replace_env_vars
 
 
 @pytest.fixture
@@ -33,6 +33,13 @@ def setup_env_vars():
 
 def test_simple_replacement(setup_env_vars):
     assert replace_env_vars("${env.TEST_VAR}") == "test_value"
+
+
+def test_simple_replacement_raises_when_not_set(setup_env_vars):
+    """Test that ${env.VAR} without operators raises EnvVarError when env var is not set."""
+    with pytest.raises(EnvVarError) as exc_info:
+        replace_env_vars("${env.NOT_SET}")
+    assert exc_info.value.var_name == "NOT_SET"
 
 
 def test_default_value_when_not_set(setup_env_vars):
@@ -95,3 +102,86 @@ def test_explicit_strings_preserved(setup_env_vars):
     data = {"port": "8080", "enabled": "true", "count": "123", "ratio": "3.14"}
     expected = {"port": "8080", "enabled": "true", "count": "123", "ratio": "3.14"}
     assert replace_env_vars(data) == expected
+
+
+def test_resource_with_empty_benchmark_id_skipped(setup_env_vars):
+    """Test that resources with empty benchmark_id from conditional env vars are skipped."""
+    data = {
+        "benchmarks": [
+            {"benchmark_id": "${env.BENCHMARK_ID:+my-benchmark}", "dataset_id": "test-dataset"},
+            {"benchmark_id": "always-present", "dataset_id": "another-dataset"},
+        ]
+    }
+    # BENCHMARK_ID is not set, so first benchmark should be skipped
+    result = replace_env_vars(data)
+    assert len(result["benchmarks"]) == 1
+    assert result["benchmarks"][0]["benchmark_id"] == "always-present"
+
+
+def test_resource_with_set_benchmark_id_not_skipped(setup_env_vars):
+    """Test that resources with set benchmark_id are not skipped."""
+    os.environ["BENCHMARK_ID"] = "enabled"
+    try:
+        data = {
+            "benchmarks": [
+                {"benchmark_id": "${env.BENCHMARK_ID:+my-benchmark}", "dataset_id": "test-dataset"},
+                {"benchmark_id": "always-present", "dataset_id": "another-dataset"},
+            ]
+        }
+        result = replace_env_vars(data)
+        assert len(result["benchmarks"]) == 2
+        assert result["benchmarks"][0]["benchmark_id"] == "my-benchmark"
+        assert result["benchmarks"][1]["benchmark_id"] == "always-present"
+    finally:
+        del os.environ["BENCHMARK_ID"]
+
+
+def test_resource_with_empty_model_id_skipped(setup_env_vars):
+    """Test that resources with empty model_id from conditional env vars are skipped."""
+    data = {
+        "models": [
+            {"model_id": "${env.MODEL_ID:+my-model}", "provider_id": "test-provider"},
+            {"model_id": "always-present", "provider_id": "another-provider"},
+        ]
+    }
+    # MODEL_ID is not set, so first model should be skipped
+    result = replace_env_vars(data)
+    assert len(result["models"]) == 1
+    assert result["models"][0]["model_id"] == "always-present"
+
+
+def test_resource_with_empty_shield_id_skipped(setup_env_vars):
+    """Test that resources with empty shield_id from conditional env vars are skipped."""
+    data = {
+        "shields": [
+            {"shield_id": "${env.SHIELD_ID:+my-shield}", "provider_id": "test-provider"},
+            {"shield_id": "always-present", "provider_id": "another-provider"},
+        ]
+    }
+    # SHIELD_ID is not set, so first shield should be skipped
+    result = replace_env_vars(data)
+    assert len(result["shields"]) == 1
+    assert result["shields"][0]["shield_id"] == "always-present"
+
+
+def test_multiple_resources_with_conditional_ids(setup_env_vars):
+    """Test that multiple resource types with conditional IDs are handled correctly."""
+    os.environ["INCLUDE_BENCHMARK"] = "yes"
+    try:
+        data = {
+            "benchmarks": [
+                {"benchmark_id": "${env.INCLUDE_BENCHMARK:+included-benchmark}", "dataset_id": "ds1"},
+                {"benchmark_id": "${env.EXCLUDE_BENCHMARK:+excluded-benchmark}", "dataset_id": "ds2"},
+            ],
+            "models": [
+                {"model_id": "${env.EXCLUDE_MODEL:+excluded-model}", "provider_id": "p1"},
+            ],
+        }
+        result = replace_env_vars(data)
+        # Only the benchmark with INCLUDE_BENCHMARK set should remain
+        assert len(result["benchmarks"]) == 1
+        assert result["benchmarks"][0]["benchmark_id"] == "included-benchmark"
+        # Model with unset env var should be skipped
+        assert len(result["models"]) == 0
+    finally:
+        del os.environ["INCLUDE_BENCHMARK"]


### PR DESCRIPTION
## What does this PR do?

This PR fixes config processing to skip registered resources when their ID fields resolve to empty/None from conditional environment variable syntax (e.g., `${env.VAR:+value}`).

### Changes

- Added `RESOURCE_ID_FIELDS` constant listing all resource ID fields: `model_id`, `shield_id`, `dataset_id`, `scoring_fn_id`, `benchmark_id`, `toolgroup_id`
- Modified `replace_env_vars()` to check if any resource ID field resolves to empty/None and skip the entire resource entry early during config processing
- Added unit tests for the new functionality

### Why is this needed?

When using conditional env var syntax like `${env.ENABLE_BENCHMARK:+my-benchmark}`, if the env var is not set, the `benchmark_id` (or other resource ID) resolves to empty/None. Previously this would cause validation errors. Now these entries are gracefully skipped during config processing.

Fixes #4453