### PR TITLE
refactor: Part 1 - Introduce rerankers and fix tests for existing search modes 

### DIFF
--- a/client-sdks/stainless/openapi.yml
+++ b/client-sdks/stainless/openapi.yml
@@ -13546,9 +13546,52 @@ components:
           - type: number
           - type: 'null'
           default: 0.0
+        alpha:
+          anyOf:
+          - type: number
+            maximum: 1.0
+            minimum: 0.0
+          - type: 'null'
+          description: Weight factor for weighted ranker
+        impact_factor:
+          anyOf:
+          - type: number
+            minimum: 0.0
+          - type: 'null'
+          description: Impact factor for RRF algorithm
+        weights:
+          anyOf:
+          - additionalProperties:
+              type: number
+            type: object
+          - type: 'null'
+          description: "Weights for combining vector, keyword, and neural scores. Keys: 'vector', 'keyword', 'neural'"
+        model:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Model identifier for neural reranker
       type: object
       title: SearchRankingOptions
-      description: Options for ranking and filtering search results.
+      description: |-
+        Options for ranking and filtering search results.
+
+        This class configures how search results are ranked and filtered. You can use algorithm-based
+        rerankers (weighted, RRF) or neural rerankers. Defaults from VectorStoresConfig are
+        used when parameters are not provided.
+
+        Examples:
+            # Weighted ranker with custom alpha
+            SearchRankingOptions(ranker="weighted", alpha=0.7)
+
+            # RRF ranker with custom impact factor
+            SearchRankingOptions(ranker="rrf", impact_factor=50.0)
+
+            # Use config defaults (just specify ranker type)
+            SearchRankingOptions(ranker="weighted")  # Uses alpha from VectorStoresConfig
+
+            # Score threshold filtering
+            SearchRankingOptions(ranker="weighted", score_threshold=0.5)
     SetDefaultVersionBodyRequest:
       properties:
         version:

--- a/docs/docs/concepts/file_operations_vector_stores.mdx
+++ b/docs/docs/concepts/file_operations_vector_stores.mdx
@@ -44,16 +44,81 @@ For hybrid search, Llama Stack offers configurable ranking strategies:
 
 - **RRF (Reciprocal Rank Fusion)**: Combines rankings with configurable impact factor
 - **Weighted Ranker**: Linear combination of vector and keyword scores with adjustable weights
+- **Neural Reranker**: Uses neural models for reranking (requires model parameter)
 
+**Elasticsearch note**: Elasticsearch hybrid search uses the retriever API and maps the
+`weighted` ranker to its `linear` retriever under the hood. RRF parameters are translated
+to Elasticsearch equivalents when possible.
+
+#### Algorithm-Based Rerankers
+
+**Weighted Ranker:**
 ```python
-# Custom ranking configuration
+from llama_stack_api import SearchRankingOptions
+
+# Weighted ranker with custom alpha (0 = keyword only, 1 = vector only)
 results = await client.vector_stores.search(
     vector_store_id=vector_store.id,
     query="neural networks",
     search_mode="hybrid",
-    ranking_options={
-        "ranker": {"type": "weighted", "alpha": 0.7}  # 70% vector, 30% keyword
-    },
+    ranking_options=SearchRankingOptions(
+        ranker="weighted",
+        alpha=0.7  # 70% vector, 30% keyword
+    ),
+)
+```
+
+**RRF Ranker:**
+```python
+# RRF ranker with custom impact factor
+results = await client.vector_stores.search(
+    vector_store_id=vector_store.id,
+    query="machine learning",
+    search_mode="hybrid",
+    ranking_options=SearchRankingOptions(
+        ranker="rrf",
+        impact_factor=50.0  # Lower values give more weight to higher-ranked results
+    ),
+)
+```
+
+#### Using VectorStoresConfig Defaults
+
+You can set default reranker parameters in your stack configuration:
+
+```yaml
+vector_stores:
+  chunk_retrieval_params:
+    default_reranker_strategy: "weighted"  # or "rrf"
+    weighted_search_alpha: 0.7
+    rrf_impact_factor: 50.0
+```
+
+Then use them without specifying parameters:
+
+```python
+# Uses defaults from VectorStoresConfig
+results = await client.vector_stores.search(
+    vector_store_id=vector_store.id,
+    query="your query",
+    search_mode="hybrid",
+    ranking_options=SearchRankingOptions(ranker="weighted"),  # Uses alpha=0.7 from config
+)
+```
+
+#### Neural Reranking (TODO: implement inference endpoint)
+
+
+```python
+# Neural reranker
+results = await client.vector_stores.search(
+    vector_store_id=vector_store.id,
+    query="your query",
+    search_mode="hybrid",
+    ranking_options=SearchRankingOptions(
+        ranker="neural",
+        model="vllm/Qwen3-Reranker-0.6B"  # Required for neural reranking
+    ),
 )
 ```
 

--- a/docs/docs/concepts/vector_stores_configuration.mdx
+++ b/docs/docs/concepts/vector_stores_configuration.mdx
@@ -113,6 +113,67 @@ chunk_retrieval_params:
 - **RRF (Reciprocal Rank Fusion)**: Combines vector and keyword rankings with configurable impact factor
 - **Weighted**: Linear combination with adjustable alpha (0=keyword only, 1=vector only)
 - **Normalized**: Normalizes scores before combination
+- **Neural**: Neural reranking using inference models (requires model parameter, Part II)
+
+### Using Ranking Options in Search
+
+You can override the default reranker strategy and parameters per-request using `SearchRankingOptions`:
+
+#### Weighted Ranker
+
+```python
+from llama_stack_api import SearchRankingOptions
+
+results = await client.vector_stores.search(
+    vector_store_id=vector_store.id,
+    query="your query",
+    search_mode="hybrid",
+    ranking_options=SearchRankingOptions(
+        ranker="weighted",
+        alpha=0.8  # 80% vector, 20% keyword (overrides config default)
+    ),
+)
+```
+
+**Alpha Parameter:**
+- `alpha=0.0`: Use only keyword scores
+- `alpha=0.5`: Equal weight to vector and keyword (default)
+- `alpha=1.0`: Use only vector scores
+
+#### RRF Ranker
+
+```python
+results = await client.vector_stores.search(
+    vector_store_id=vector_store.id,
+    query="your query",
+    search_mode="hybrid",
+    ranking_options=SearchRankingOptions(
+        ranker="rrf",
+        impact_factor=42.0  # Overrides config default of 60.0
+    ),
+)
+```
+
+**Impact Factor:**
+- Lower values (20-40): More emphasis on higher-ranked results
+- Default (60.0): Balanced approach (from RRF research)
+- Higher values (80-100): More uniform distribution across ranks
+
+#### Score Threshold
+
+Filter results by minimum relevance score:
+
+```python
+results = await client.vector_stores.search(
+    vector_store_id=vector_store.id,
+    query="your query",
+    ranking_options=SearchRankingOptions(
+        ranker="weighted",
+        alpha=0.7,
+        score_threshold=0.5  # Only return results with score >= 0.5
+    ),
+)
+```
 
 ### File Batch Parameters
 

--- a/docs/static/deprecated-llama-stack-spec.yaml
+++ b/docs/static/deprecated-llama-stack-spec.yaml
@@ -10129,9 +10129,52 @@ components:
           - type: number
           - type: 'null'
           default: 0.0
+        alpha:
+          anyOf:
+          - type: number
+            maximum: 1.0
+            minimum: 0.0
+          - type: 'null'
+          description: Weight factor for weighted ranker
+        impact_factor:
+          anyOf:
+          - type: number
+            minimum: 0.0
+          - type: 'null'
+          description: Impact factor for RRF algorithm
+        weights:
+          anyOf:
+          - additionalProperties:
+              type: number
+            type: object
+          - type: 'null'
+          description: "Weights for combining vector, keyword, and neural scores. Keys: 'vector', 'keyword', 'neural'"
+        model:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Model identifier for neural reranker
       type: object
       title: SearchRankingOptions
-      description: Options for ranking and filtering search results.
+      description: |-
+        Options for ranking and filtering search results.
+
+        This class configures how search results are ranked and filtered. You can use algorithm-based
+        rerankers (weighted, RRF) or neural rerankers. Defaults from VectorStoresConfig are
+        used when parameters are not provided.
+
+        Examples:
+            # Weighted ranker with custom alpha
+            SearchRankingOptions(ranker="weighted", alpha=0.7)
+
+            # RRF ranker with custom impact factor
+            SearchRankingOptions(ranker="rrf", impact_factor=50.0)
+
+            # Use config defaults (just specify ranker type)
+            SearchRankingOptions(ranker="weighted")  # Uses alpha from VectorStoresConfig
+
+            # Score threshold filtering
+            SearchRankingOptions(ranker="weighted", score_threshold=0.5)
     SetDefaultVersionBodyRequest:
       properties:
         version:

--- a/docs/static/experimental-llama-stack-spec.yaml
+++ b/docs/static/experimental-llama-stack-spec.yaml
@@ -9653,9 +9653,52 @@ components:
           - type: number
           - type: 'null'
           default: 0.0
+        alpha:
+          anyOf:
+          - type: number
+            maximum: 1.0
+            minimum: 0.0
+          - type: 'null'
+          description: Weight factor for weighted ranker
+        impact_factor:
+          anyOf:
+          - type: number
+            minimum: 0.0
+          - type: 'null'
+          description: Impact factor for RRF algorithm
+        weights:
+          anyOf:
+          - additionalProperties:
+              type: number
+            type: object
+          - type: 'null'
+          description: "Weights for combining vector, keyword, and neural scores. Keys: 'vector', 'keyword', 'neural'"
+        model:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Model identifier for neural reranker
       type: object
       title: SearchRankingOptions
-      description: Options for ranking and filtering search results.
+      description: |-
+        Options for ranking and filtering search results.
+
+        This class configures how search results are ranked and filtered. You can use algorithm-based
+        rerankers (weighted, RRF) or neural rerankers. Defaults from VectorStoresConfig are
+        used when parameters are not provided.
+
+        Examples:
+            # Weighted ranker with custom alpha
+            SearchRankingOptions(ranker="weighted", alpha=0.7)
+
+            # RRF ranker with custom impact factor
+            SearchRankingOptions(ranker="rrf", impact_factor=50.0)
+
+            # Use config defaults (just specify ranker type)
+            SearchRankingOptions(ranker="weighted")  # Uses alpha from VectorStoresConfig
+
+            # Score threshold filtering
+            SearchRankingOptions(ranker="weighted", score_threshold=0.5)
     SetDefaultVersionBodyRequest:
       properties:
         version:

--- a/docs/static/llama-stack-spec.yaml
+++ b/docs/static/llama-stack-spec.yaml
@@ -11958,9 +11958,52 @@ components:
           - type: number
           - type: 'null'
           default: 0.0
+        alpha:
+          anyOf:
+          - type: number
+            maximum: 1.0
+            minimum: 0.0
+          - type: 'null'
+          description: Weight factor for weighted ranker
+        impact_factor:
+          anyOf:
+          - type: number
+            minimum: 0.0
+          - type: 'null'
+          description: Impact factor for RRF algorithm
+        weights:
+          anyOf:
+          - additionalProperties:
+              type: number
+            type: object
+          - type: 'null'
+          description: "Weights for combining vector, keyword, and neural scores. Keys: 'vector', 'keyword', 'neural'"
+        model:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Model identifier for neural reranker
       type: object
       title: SearchRankingOptions
-      description: Options for ranking and filtering search results.
+      description: |-
+        Options for ranking and filtering search results.
+
+        This class configures how search results are ranked and filtered. You can use algorithm-based
+        rerankers (weighted, RRF) or neural rerankers. Defaults from VectorStoresConfig are
+        used when parameters are not provided.
+
+        Examples:
+            # Weighted ranker with custom alpha
+            SearchRankingOptions(ranker="weighted", alpha=0.7)
+
+            # RRF ranker with custom impact factor
+            SearchRankingOptions(ranker="rrf", impact_factor=50.0)
+
+            # Use config defaults (just specify ranker type)
+            SearchRankingOptions(ranker="weighted")  # Uses alpha from VectorStoresConfig
+
+            # Score threshold filtering
+            SearchRankingOptions(ranker="weighted", score_threshold=0.5)
     SetDefaultVersionBodyRequest:
       properties:
         version:

--- a/docs/static/stainless-llama-stack-spec.yaml
+++ b/docs/static/stainless-llama-stack-spec.yaml
@@ -13546,9 +13546,52 @@ components:
           - type: number
           - type: 'null'
           default: 0.0
+        alpha:
+          anyOf:
+          - type: number
+            maximum: 1.0
+            minimum: 0.0
+          - type: 'null'
+          description: Weight factor for weighted ranker
+        impact_factor:
+          anyOf:
+          - type: number
+            minimum: 0.0
+          - type: 'null'
+          description: Impact factor for RRF algorithm
+        weights:
+          anyOf:
+          - additionalProperties:
+              type: number
+            type: object
+          - type: 'null'
+          description: "Weights for combining vector, keyword, and neural scores. Keys: 'vector', 'keyword', 'neural'"
+        model:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Model identifier for neural reranker
       type: object
       title: SearchRankingOptions
-      description: Options for ranking and filtering search results.
+      description: |-
+        Options for ranking and filtering search results.
+
+        This class configures how search results are ranked and filtered. You can use algorithm-based
+        rerankers (weighted, RRF) or neural rerankers. Defaults from VectorStoresConfig are
+        used when parameters are not provided.
+
+        Examples:
+            # Weighted ranker with custom alpha
+            SearchRankingOptions(ranker="weighted", alpha=0.7)
+
+            # RRF ranker with custom impact factor
+            SearchRankingOptions(ranker="rrf", impact_factor=50.0)
+
+            # Use config defaults (just specify ranker type)
+            SearchRankingOptions(ranker="weighted")  # Uses alpha from VectorStoresConfig
+
+            # Score threshold filtering
+            SearchRankingOptions(ranker="weighted", score_threshold=0.5)
     SetDefaultVersionBodyRequest:
       properties:
         version:

--- a/src/llama_stack_api/vector_io/models.py
+++ b/src/llama_stack_api/vector_io/models.py
@@ -351,8 +351,45 @@ register_schema(VectorStoreChunkingStrategy, name="VectorStoreChunkingStrategy")
 class SearchRankingOptions(BaseModel):
     """Options for ranking and filtering search results.
 
-    :param ranker: (Optional) Name of the ranking algorithm to use
-    :param score_threshold: (Optional) Minimum relevance score threshold for results
+    This class configures how search results are ranked and filtered. You can use algorithm-based
+    rerankers (weighted, RRF) or neural rerankers. Defaults from VectorStoresConfig are
+    used when parameters are not provided.
+
+    Examples:
+        # Weighted ranker with custom alpha
+        SearchRankingOptions(ranker="weighted", alpha=0.7)
+
+        # RRF ranker with custom impact factor
+        SearchRankingOptions(ranker="rrf", impact_factor=50.0)
+
+        # Use config defaults (just specify ranker type)
+        SearchRankingOptions(ranker="weighted")  # Uses alpha from VectorStoresConfig
+
+        # Score threshold filtering
+        SearchRankingOptions(ranker="weighted", score_threshold=0.5)
+
+    :param ranker: (Optional) Name of the ranking algorithm to use. Supported values:
+        - "weighted": Weighted combination of vector and keyword scores
+        - "rrf": Reciprocal Rank Fusion algorithm
+        - "neural": Neural reranking model (requires model parameter, Part II)
+        Note: For OpenAI API compatibility, any string value is accepted, but only the above values are supported.
+    :param score_threshold: (Optional) Minimum relevance score threshold for results. Default: 0.0
+    :param alpha: (Optional) Weight factor for weighted ranker (0-1).
+        - 0.0 = keyword only
+        - 0.5 = equal weight (default)
+        - 1.0 = vector only
+        Only used when ranker="weighted" and weights is not provided.
+        Falls back to VectorStoresConfig.chunk_retrieval_params.weighted_search_alpha if not provided.
+    :param impact_factor: (Optional) Impact factor (k) for RRF algorithm.
+        Lower values emphasize higher-ranked results. Default: 60.0 (optimal from research).
+        Only used when ranker="rrf".
+        Falls back to VectorStoresConfig.chunk_retrieval_params.rrf_impact_factor if not provided.
+    :param weights: (Optional) Dictionary of weights for combining different signal types.
+        Keys can be "vector", "keyword", "neural". Values should sum to 1.0.
+        Used when combining algorithm-based reranking with neural reranking (Part II).
+        Example: {"vector": 0.3, "keyword": 0.3, "neural": 0.4}
+    :param model: (Optional) Model identifier for neural reranker (e.g., "vllm/Qwen3-Reranker-0.6B").
+        Required when ranker="neural" or when weights contains "neural" (Part II).
     """
 
     ranker: str | None = None
@@ -360,6 +397,25 @@ class SearchRankingOptions(BaseModel):
     # we don't guarantee that the score is between 0 and 1, so will leave this unconstrained
     # and let the provider handle it
     score_threshold: float | None = Field(default=0.0)
+    alpha: float | None = Field(default=None, ge=0.0, le=1.0, description="Weight factor for weighted ranker")
+    impact_factor: float | None = Field(default=None, gt=0.0, description="Impact factor for RRF algorithm")
+    weights: dict[str, float] | None = Field(
+        default=None,
+        description="Weights for combining vector, keyword, and neural scores. Keys: 'vector', 'keyword', 'neural'",
+    )
+    model: str | None = Field(default=None, description="Model identifier for neural reranker")
+
+    @field_validator("weights")
+    @classmethod
+    def validate_weights(cls, v: dict[str, float] | None) -> dict[str, float] | None:
+        if v is None:
+            return v
+        allowed_keys = {"vector", "keyword", "neural"}
+        if not all(key in allowed_keys for key in v.keys()):
+            raise ValueError(f"weights keys must be from {allowed_keys}")
+        if abs(sum(v.values()) - 1.0) > 0.001:
+            raise ValueError("weights must sum to 1.0")
+        return v
 
 
 @json_schema_type


### PR DESCRIPTION
# What does this PR do?
Reranker support:
- query_hybrid accepts reranker_type and reranker_params parameters for API compatibility with the reranking system.
    
Fixes:
- Fixed Qdrant keyword and hybrid search implementations to correctly find documents by splitting queries into words and matching any of them, rather than requiring exact phrase matches.
    
Tests:
- Add reranker tests for all the providers and ensure they pass.

## Test Plan
`PYTHONPATH=/Users/vnarsing/go/src/github/meta-llama/llama-stack/src:$PYTHONPATH python3 -m pytest tests/integration/vector_io/test_openai_vector_stores.py --stack-config=starter -v --embedding-model=sentence-transformers/nomic-ai/nomic-embed-text-v1.5`