### PR TITLE
feat(ci): added codeql scanning workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,6 +6,7 @@ Llama Stack uses GitHub Actions for Continuous Integration (CI). Below is a tabl
 | ---- | ---- | ------- |
 | Backward Compatibility Check | [backward-compat.yml](backward-compat.yml) | Check backward compatibility for config.yaml files |
 | Build Distribution Images | [build-distributions.yml](build-distributions.yml) | Build Distribution Images |
+| CodeQL Workflow Security Scan | [codeql.yml](codeql.yml) | CodeQL Workflow Security Scan |
 | API Conformance Tests | [conformance.yml](conformance.yml) | Run the API Conformance test suite on the changes. |
 | Installer CI | [install-script-ci.yml](install-script-ci.yml) | Test the installation script |
 | Integration Auth Tests | [integration-auth-tests.yml](integration-auth-tests.yml) | Run the integration test suite with Kubernetes authentication |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: "CodeQL Workflow Security Scan"
+
+on:
+  push:
+    # Running on push for workflows not going through PRs
+    branches: [ "main" ]
+    # Limit scans to changes in the .github directory, bash scripts are not scanned anyway
+    paths:
+      - '.github/**'
+  pull_request:
+    # PRs are checked for new issues
+    branches: [ "main" ]
+    # Limit scans to changes in the .github directory, bash scripts are not scanned anyway
+    paths:
+      - '.github/**'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # actions is the most specific language option for
+        # codeql does NOT support Bash
+        # In case javascript is used in workflows, that should be added or replace
+        language: [ 'actions' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+    # Initializes CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@45c373516f557556c15d420e3f5e0aa3d64366bc # v3
+      with:
+        languages: ${{ matrix.language }}
+        # "security-extended" is recommended for higher severity coverage - not necessary can be removed to speed up
+        queries: security-extended
+
+    # Scans the code and uploads results to GitHub Security tab.
+    # The "Fail on High" logic is handled by Branch Protection Rules in Settings
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@45c373516f557556c15d420e3f5e0aa3d64366bc # v3
+      with:
+        category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Codeql to run on pull_requests and push to cover both normal and unusual changes

# What does this PR do?
Adding codeql scans to avoid command injection and [pwn request](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) issues
Design:

- Runs only `actions` language checks for speed, extendable in case javascript type actions need to be scanned
- Runs only if workflow files are changed 
- Only runs the tests on main branch pushes/PRs

Having issues will not fail the runs, only updates security findings, it is possible to make this specifically gating to merge through a Branch Protection Rule with the following option:
<img width="1744" height="522" alt="image" src="https://github.com/user-attachments/assets/cf5f5abe-fddf-4590-9eca-fd325b54f070" />
<img width="1758" height="192" alt="image" src="https://github.com/user-attachments/assets/d5e9835d-5e5e-4e72-9087-b3434ef7c260" />

Appx 1m to run faster than the current slowest job

## Test Plan
See [test pr](https://github.com/gmatuz/llama-stack/pull/1 )
