### PR TITLE
chore(benchmark): add vertical scaling benchmark

### DIFF
--- a/benchmarking/vertical-scaling/README.md
+++ b/benchmarking/vertical-scaling/README.md
@@ -1,0 +1,122 @@
+# Llama Stack Vertical Scaling Benchmark
+
+A simple benchmark suite for measuring the vertical scaling performance of the Llama Stack inference API using a mocked OpenAI-compatible backend.
+
+## Overview
+
+This benchmark measures how well the Llama Stack server scales with increasing worker counts. It uses:
+
+- **Python Mock Server** - Lightweight HTTP server returning fixed OpenAI-compatible responses
+- **Locust** - Load testing tool to generate concurrent requests
+- **Llama Stack Server** - The inference API under test with `remote::openai` provider
+
+The benchmark runs twice:
+1. **Baseline**: Tests the mock server directly to establish maximum throughput
+2. **Stack**: Tests the stack server to measure routing overhead
+
+This helps identify bottlenecks in the stack routing layer and measure the impact of vertical scaling (adding more workers) on throughput and latency.
+
+## Prerequisites
+
+### Python (for mock server)
+
+The mock server is a simple Python script with no dependencies beyond the standard library.
+
+```bash
+python --version
+```
+
+### Locust (Load Testing)
+
+Verify installation:
+```bash
+uv run --group benchmark locust --version
+```
+
+## Quick Start
+
+Run a benchmark with default settings (1 worker, 1 user, 60 seconds):
+
+```bash
+cd benchmarking/vertical-scaling
+./run-benchmark.sh
+```
+
+This will:
+1. Check port availability (8080, 8321)
+2. Start Python mock server on port 8080
+3. Start Llama Stack server on port 8321 with 1 worker
+4. Run baseline benchmark against mock server (60 seconds)
+5. Run stack benchmark against stack server (60 seconds)
+6. Generate HTML reports in `results/`
+7. Clean up all services
+
+## Usage
+
+**Server Options:**
+- `--workers NUMBER` - Number of uvicorn workers (default: 1)
+- `--mock-port NUMBER` - Port for mock server (default: 8080)
+- `--stack-port NUMBER` - Port for Llama Stack server (default: 8321)
+
+**Benchmark Options:**
+- `--users NUMBER` - Concurrent users (default: 1)
+- `--run-time SECONDS` - Test duration (default: 60)
+
+## Interpreting Results
+
+### Output Files
+
+Results are saved to `results/` directory:
+- `baseline.html` - Interactive HTML report for mock server baseline
+- `baseline_stats.csv` - Baseline summary statistics
+- `baseline_stats_history.csv` - Baseline time-series data
+- `baseline_failures.csv` - Baseline failed requests
+- `stack.html` - Interactive HTML report for stack server
+- `stack_stats.csv` - Stack summary statistics
+- `stack_stats_history.csv` - Stack time-series data
+- `stack_failures.csv` - Stack failed requests
+
+Additional files in the benchmark directory:
+- `stack.log` - Llama Stack server logs
+
+Compare the baseline and stack HTML reports to see the routing overhead.
+
+### Key Metrics
+
+Open the HTML report to view:
+
+1. **Requests/s (RPS)** - Throughput metric
+   - Higher is better
+   - Should increase with more workers (up to a point)
+
+2. **Response Times** - Latency metrics
+   - **p50 (median)** - Typical user experience
+   - **p95** - 95th percentile, catches slower requests
+   - **p99** - 99th percentile, catches outliers
+   - Lower is better
+
+3. **Failure Rate** - Error percentage
+   - Should be 0% for healthy setup
+   - High failure rate indicates overload
+
+### Identifying Bottlenecks
+
+**Good vertical scaling:**
+- RPS increases linearly with workers (2x workers ≈ 2x RPS)
+- Latency remains stable or improves
+- No failures
+
+**CPU-bound bottleneck:**
+- RPS increases but plateaus at high worker counts
+- Latency increases with more workers
+- System CPU usage at 100%
+
+**I/O-bound bottleneck:**
+- RPS doesn't increase much with workers
+- Latency increases significantly
+- Network or disk I/O saturated
+
+**GIL bottleneck (Python):**
+- RPS plateaus around 2-4 workers
+- Adding more workers doesn't help
+- Consider using multiple processes

--- a/benchmarking/vertical-scaling/locustfile.py
+++ b/benchmarking/vertical-scaling/locustfile.py
@@ -1,0 +1,57 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import json
+
+from locust import HttpUser, task
+
+
+class ChatCompletionUser(HttpUser):
+    """
+    Locust user for straightline performance testing of the Llama Stack server.
+
+    Sends chat completion requests continuously without delays to measure
+    maximum throughput and minimal latency of the inference API.
+    """
+
+    def on_start(self):
+        """Initialize user with model ID."""
+        self.model_id = "openai/mock-chat-model"
+        self.headers = {
+            "Content-Type": "application/json",
+        }
+
+    @task
+    def chat_completion(self):
+        """Send a non-streaming chat completion request."""
+        payload = {
+            "model": self.model_id,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Hello, how are you?",
+                },
+            ],
+            "max_tokens": 50,
+        }
+
+        with self.client.post(
+            "/v1/chat/completions",
+            data=json.dumps(payload),
+            headers=self.headers,
+            catch_response=True,
+        ) as response:
+            if response.status_code == 200:
+                try:
+                    data = response.json()
+                    if "choices" in data and len(data["choices"]) > 0:
+                        response.success()
+                    else:
+                        response.failure("Invalid response format: missing choices")
+                except json.JSONDecodeError:
+                    response.failure("Invalid JSON response")
+            else:
+                response.failure(f"HTTP {response.status_code}: {response.text}")

--- a/benchmarking/vertical-scaling/mock-server.py
+++ b/benchmarking/vertical-scaling/mock-server.py
@@ -1,0 +1,67 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import json
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+MOCK_RESPONSE = {
+    "id": "chatcmpl-mock123",
+    "object": "chat.completion",
+    "created": int(time.time()),
+    "model": "openai/mock-chat-model",
+    "choices": [
+        {
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "This is a mock response from the benchmark server.",
+            },
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {
+        "prompt_tokens": 10,
+        "completion_tokens": 20,
+        "total_tokens": 30,
+    },
+}
+
+
+class MockHandler(BaseHTTPRequestHandler):
+    def do_POST(self):  # noqa: N802
+        if self.path == "/v1/chat/completions":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            response = MOCK_RESPONSE.copy()
+            response["created"] = int(time.time())
+            self.wfile.write(json.dumps(response).encode())
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_GET(self):  # noqa: N802
+        if self.path == "/v1/health":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"status":"ok"}')
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format, *args):
+        pass
+
+
+if __name__ == "__main__":
+    import sys
+
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8080
+    server = HTTPServer(("0.0.0.0", port), MockHandler)
+    print(f"Mock server listening on port {port}")
+    server.serve_forever()

--- a/benchmarking/vertical-scaling/run-benchmark.sh
+++ b/benchmarking/vertical-scaling/run-benchmark.sh
@@ -1,0 +1,256 @@
+#!/bin/bash
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PIDS_FILE="$SCRIPT_DIR/.pids"
+
+MOCK_PORT=8080
+STACK_PORT=8321
+WORKERS=1
+LOCUST_ARGS=()
+RESULTS_DIR="$SCRIPT_DIR/results"
+USERS=1
+SPAWN_RATE=10
+RUN_TIME=60
+
+usage() {
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+Runs complete vertical scaling benchmark: starts services, runs load test, cleans up.
+
+Server Options:
+    --workers NUMBER         Number of uvicorn workers (default: 1)
+    --mock-port NUMBER       Port for mock server (default: 8080)
+    --stack-port NUMBER      Port for Llama Stack server (default: 8321)
+
+Benchmark Options:
+    --users NUMBER          Number of concurrent users (default: 1)
+    --run-time SECONDS      Duration of test in seconds (default: 60)
+
+Common Options:
+    --help                  Show this help message
+
+Examples:
+    # Run with defaults (1 worker, 1 user, 60s)
+    $0
+
+    # Test vertical scaling with 8 workers
+    $0 --workers 8
+
+    # Longer test with more users
+    $0 --workers 16 --users 200 --run-time 120
+EOF
+}
+
+cleanup() {
+    echo ""
+    echo "=== Cleaning up ==="
+
+    if [[ -f "$PIDS_FILE" ]]; then
+        while read -r pid; do
+            if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+                echo "Stopping process: $pid"
+                kill "$pid" 2>/dev/null || true
+            fi
+        done < "$PIDS_FILE"
+        rm -f "$PIDS_FILE"
+    fi
+
+    echo "✅ Cleanup complete"
+}
+
+trap cleanup EXIT ERR INT TERM
+
+check_port_available() {
+    local port=$1
+    if lsof -Pi :$port -sTCP:LISTEN -t >/dev/null 2>&1; then
+        return 1
+    fi
+    return 0
+}
+
+wait_for_url() {
+    local url=$1
+    local max_attempts=30
+    local attempt=0
+
+    echo "Waiting for $url to be ready..."
+    while [ $attempt -lt $max_attempts ]; do
+        if curl -s "$url" >/dev/null 2>&1; then
+            echo "✅ Service ready"
+            return 0
+        fi
+        attempt=$((attempt + 1))
+        sleep 1
+    done
+
+    echo "❌ Service failed to start after $max_attempts seconds"
+    return 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --workers)
+            WORKERS="$2"
+            shift 2
+            ;;
+        --mock-port)
+            MOCK_PORT="$2"
+            shift 2
+            ;;
+        --stack-port)
+            STACK_PORT="$2"
+            shift 2
+            ;;
+        --users)
+            USERS="$2"
+            shift 2
+            ;;
+        --spawn-rate)
+            SPAWN_RATE="$2"
+            shift 2
+            ;;
+        --run-time)
+            RUN_TIME="$2"
+            shift 2
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+echo "==================================================================="
+echo "  Llama Stack Vertical Scaling Benchmark"
+echo "==================================================================="
+echo ""
+
+if ! check_port_available $MOCK_PORT; then
+    echo "❌ Port $MOCK_PORT is already in use"
+    exit 1
+fi
+
+if ! check_port_available $STACK_PORT; then
+    echo "❌ Port $STACK_PORT is already in use"
+    exit 1
+fi
+
+echo "✅ Ports $MOCK_PORT and $STACK_PORT are available"
+echo ""
+
+echo "Step 1/3: Starting mock server..."
+echo "Port: $MOCK_PORT"
+echo ""
+
+python "$SCRIPT_DIR/mock-server.py" $MOCK_PORT > /dev/null 2>&1 &
+MOCK_PID=$!
+echo "$MOCK_PID" > "$PIDS_FILE"
+echo "Mock Server PID: $MOCK_PID"
+
+MOCK_URL="http://localhost:$MOCK_PORT"
+if ! wait_for_url "$MOCK_URL/v1/health"; then
+    echo "Failed to start mock server"
+    exit 1
+fi
+
+echo ""
+echo "Step 2/3: Starting stack server..."
+echo "Port: $STACK_PORT"
+echo "Workers: $WORKERS"
+echo "Backend: $MOCK_URL"
+echo ""
+
+OPENAI_BASE_URL="$MOCK_URL/v1" OPENAI_API_KEY="fake-token" uv run llama stack run --providers inference=remote::openai --port $STACK_PORT > "$SCRIPT_DIR/stack.log" 2>&1 &
+STACK_PID=$!
+echo "$STACK_PID" >> "$PIDS_FILE"
+echo "Stack Server PID: $STACK_PID"
+
+STACK_URL="http://localhost:$STACK_PORT"
+if ! wait_for_url "$STACK_URL/v1/health"; then
+    echo "Failed to start stack server. Check $SCRIPT_DIR/stack.log"
+    exit 1
+fi
+
+echo ""
+echo "Step 3/3: Running benchmarks..."
+echo ""
+
+mkdir -p "$RESULTS_DIR"
+
+# Baseline benchmark - mock server
+echo "Benchmarking mock server (baseline)..."
+echo "Host: $MOCK_URL"
+echo "Users: $USERS"
+echo "Spawn rate: $SPAWN_RATE users/sec"
+echo "Run time: ${RUN_TIME}s"
+echo ""
+
+uv run --with locust locust \
+    --locustfile "$SCRIPT_DIR/locustfile.py" \
+    --host "$MOCK_URL" \
+    --users $USERS \
+    --spawn-rate $SPAWN_RATE \
+    --run-time ${RUN_TIME}s \
+    --headless \
+    --html "$RESULTS_DIR/baseline.html" \
+    --csv "$RESULTS_DIR/baseline" \
+    --only-summary
+
+if [ $? -ne 0 ]; then
+    echo "❌ Baseline benchmark failed"
+    exit 1
+fi
+
+echo ""
+echo "Benchmarking stack server..."
+echo "Host: $STACK_URL"
+echo "Users: $USERS"
+echo "Spawn rate: $SPAWN_RATE users/sec"
+echo "Run time: ${RUN_TIME}s"
+echo ""
+
+uv run --with locust locust \
+    --locustfile "$SCRIPT_DIR/locustfile.py" \
+    --host "$STACK_URL" \
+    --users $USERS \
+    --spawn-rate $SPAWN_RATE \
+    --run-time ${RUN_TIME}s \
+    --headless \
+    --html "$RESULTS_DIR/stack.html" \
+    --csv "$RESULTS_DIR/stack" \
+    --only-summary
+
+if [ $? -ne 0 ]; then
+    echo "❌ Stack benchmark failed"
+    exit 1
+fi
+
+echo ""
+echo "==================================================================="
+echo "  Benchmark Complete"
+echo "==================================================================="
+echo ""
+echo "Results:"
+echo "  Baseline (Mock): $RESULTS_DIR/baseline.html"
+echo "  Stack Server:    $RESULTS_DIR/stack.html"
+echo ""
+echo "Open reports:"
+echo "  open $RESULTS_DIR/baseline.html  # macOS"
+echo "  open $RESULTS_DIR/stack.html  # macOS"
+echo "  xdg-open $RESULTS_DIR/baseline.html  # Linux"
+echo "  xdg-open $RESULTS_DIR/stack.html  # Linux"
+echo ""


### PR DESCRIPTION
# What does this PR do?

adds a vertical scaling benchmark 

## Test Plan

```
$ ./run-benchmark.sh 
===================================================================
  Llama Stack Vertical Scaling Benchmark
===================================================================

✅ Ports 8080 and 8321 are available

Step 1/3: Starting mock server...
Port: 8080

Mock Server PID: 3147727
Waiting for http://localhost:8080/v1/health to be ready...
✅ Service ready

Step 2/3: Starting stack server...
Port: 8321
Workers: 1
Backend: http://localhost:8080

Stack Server PID: 3147735
Waiting for http://localhost:8321/v1/health to be ready...
✅ Service ready

Step 3/3: Running benchmarks...

Benchmarking mock server (baseline)...
Host: http://localhost:8080
Users: 1
Spawn rate: 10 users/sec
Run time: 60s

[2026-01-09 06:41:09,806] fedora/INFO/locust.main: Starting Locust 2.40.1
[2026-01-09 06:41:09,807] fedora/INFO/locust.main: Run time limit set to 60 seconds
[2026-01-09 06:41:09,809] fedora/INFO/locust.runners: Ramping to 1 users at a rate of 10.00 per second
[2026-01-09 06:41:09,810] fedora/INFO/locust.runners: All users spawned: {"ChatCompletionUser": 1} (1 total users)
[2026-01-09 06:42:08,949] fedora/INFO/locust.main: --run-time limit reached, shutting down
[2026-01-09 06:42:09,223] fedora/INFO/locust.main: writing html report to file: .../llama-stack/benchmarking/vertical-scaling/results/baseline.html
[2026-01-09 06:42:09,231] fedora/INFO/locust.main: Shutting down (exit code 0)
Type     Name                  # reqs      # fails |    Avg     Min     Max    Med |   req/s  failures/s
--------|--------------------|-------|-------------|-------|-------|-------|-------|--------|-----------
POST     /v1/chat/completions   18928     0(0.00%) |      2       2      34      3 |  320.06        0.00
--------|--------------------|-------|-------------|-------|-------|-------|-------|--------|-----------
         Aggregated             18928     0(0.00%) |      2       2      34      3 |  320.06        0.00

Response time percentiles (approximated)
Type     Name                          50%    66%    75%    80%    90%    95%    98%    99%  99.9% 99.99%   100% # reqs
--------|------------------------|--------|------|------|------|------|------|------|------|------|------|------|------
POST     /v1/chat/completions            3      3      3      3      3      4      4      4      7     16     35  18928
--------|------------------------|--------|------|------|------|------|------|------|------|------|------|------|------
         Aggregated                      3      3      3      3      3      4      4      4      7     16     35  18928


Benchmarking stack server...
Host: http://localhost:8321
Users: 1
Spawn rate: 10 users/sec
Run time: 60s

[2026-01-09 06:42:11,596] fedora/INFO/locust.main: Starting Locust 2.40.1
[2026-01-09 06:42:11,597] fedora/INFO/locust.main: Run time limit set to 60 seconds
[2026-01-09 06:42:11,599] fedora/INFO/locust.runners: Ramping to 1 users at a rate of 10.00 per second
[2026-01-09 06:42:11,600] fedora/INFO/locust.runners: All users spawned: {"ChatCompletionUser": 1} (1 total users)
[2026-01-09 06:43:10,716] fedora/INFO/locust.main: --run-time limit reached, shutting down
[2026-01-09 06:43:11,010] fedora/INFO/locust.main: writing html report to file: .../llama-stack/benchmarking/vertical-scaling/results/stack.html
[2026-01-09 06:43:11,017] fedora/INFO/locust.main: Shutting down (exit code 0)
Type     Name                  # reqs      # fails |    Avg     Min     Max    Med |   req/s  failures/s
--------|--------------------|-------|-------------|-------|-------|-------|-------|--------|-----------
POST     /v1/chat/completions    3284     0(0.00%) |     17      13     156     17 |   55.41        0.00
--------|--------------------|-------|-------------|-------|-------|-------|-------|--------|-----------
         Aggregated              3284     0(0.00%) |     17      13     156     17 |   55.41        0.00

Response time percentiles (approximated)
Type     Name                          50%    66%    75%    80%    90%    95%    98%    99%  99.9% 99.99%   100% # reqs
--------|------------------------|--------|------|------|------|------|------|------|------|------|------|------|------
POST     /v1/chat/completions           17     18     18     19     20     21     22     24    120    160    160   3284
--------|------------------------|--------|------|------|------|------|------|------|------|------|------|------|------
         Aggregated                     17     18     18     19     20     21     22     24    120    160    160   3284


===================================================================
  Benchmark Complete
===================================================================

Results:
  Baseline (Mock): .../llama-stack/benchmarking/vertical-scaling/results/baseline.html
  Stack Server:    .../llama-stack/benchmarking/vertical-scaling/results/stack.html

Open reports:
  open .../llama-stack/benchmarking/vertical-scaling/results/baseline.html  # macOS
  open .../llama-stack/benchmarking/vertical-scaling/results/stack.html  # macOS
  xdg-open .../llama-stack/benchmarking/vertical-scaling/results/baseline.html  # Linux
  xdg-open .../llama-stack/benchmarking/vertical-scaling/results/stack.html  # Linux


=== Cleaning up ===
Stopping process: 3147727
Stopping process: 3147735
✅ Cleanup complete
```
