### PR TITLE
ci: run ARM64 builds on nightly schedule only

### DIFF
--- a/.github/workflows/providers-build.yml
+++ b/.github/workflows/providers-build.yml
@@ -29,6 +29,9 @@ on:
       - 'containers/Containerfile'
       - '.dockerignore'
 
+  schedule:
+    - cron: '0 0 * * *'  # Daily at 12 AM UTC
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}
   cancel-in-progress: true
@@ -89,6 +92,7 @@ jobs:
             --tag llama-stack:${{ matrix.distro }}-ci
 
   build-arm64:
+    if: github.event_name == 'schedule'
     needs: generate-matrix
     runs-on: ubuntu-latest
     strategy:
@@ -229,6 +233,7 @@ jobs:
               || { echo "Base image is not UBI 9!"; exit 1; }
 
   build-starter-ubi9-arm64-container:
+    if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
# What does this PR do?
Follows up on #4474 and #4290, making the ARM64 builds only run on a nightly cadence, instead of on every PR. This was done because the ARM64 builds take significantly longer to complete than the others.

@leseb for awareness

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan
Commit hooks pass and builds complete without error on a PR in my fork.