### PR TITLE
docs: Update RAG Agent Documentation using vector_stores

### DIFF
--- a/docs/docs/getting_started/detailed_tutorial.mdx
+++ b/docs/docs/getting_started/detailed_tutorial.mdx
@@ -505,7 +505,7 @@ vector_store = client.vector_stores.create(
     "embedding_dimension": 768,
     "provider_id": "faiss"
   },
-  # This isn't working ... defaults to using `auto`
+  # Not yet implemented... defaults to using `auto`
   chunking_strategy={
       "type": "static",
       "static": {


### PR DESCRIPTION
# What does this PR do?
This PR updates the faulty docs  in `docs/getting_started/detailed_tutorial.mdx` to remove references to the deprecated `vector_db` APIs and `Document` types and use  `vector_stores` instead.
<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

