### PR TITLE
fix: fonttools security advisory

### DIFF
--- a/src/llama_stack/providers/registry/agents.py
+++ b/src/llama_stack/providers/registry/agents.py
@@ -20,6 +20,7 @@ def available_providers() -> list[ProviderSpec]:
             provider_type="inline::meta-reference",
             pip_packages=[
                 "matplotlib",
+                "fonttools>=4.60.2",
                 "pillow",
                 "pandas",
                 "scikit-learn",


### PR DESCRIPTION
# What does this PR do?

https://github.com/fonttools/fonttools/security/advisories/GHSA-768j-98cg-p3fv
