### PR TITLE
feat: add scheduled CI workflow for release branches

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -18,6 +18,7 @@ Llama Stack uses GitHub Actions for Continuous Integration (CI). Below is a tabl
 | Test llama stack list-deps | [providers-list-deps.yml](providers-list-deps.yml) | Test llama stack list-deps |
 | Python Package Build Test | [python-build-test.yml](python-build-test.yml) | Test building the llama-stack PyPI project |
 | Integration Tests (Record) | [record-integration-tests.yml](record-integration-tests.yml) | Run the integration test suite from tests/integration |
+| Release Branch Scheduled CI | [release-branch-scheduled-ci.yml](release-branch-scheduled-ci.yml) | Scheduled CI checks for active release branches |
 | Check semantic PR titles | [semantic-pr.yml](semantic-pr.yml) | Ensure that PR titles follow the conventional commit spec |
 | Stainless SDK Builds | [stainless-builds.yml](stainless-builds.yml) | Build Stainless SDK from OpenAPI spec changes |
 | Close stale issues and PRs | [stale_bot.yml](stale_bot.yml) | Run the Stale Bot action |

--- a/.github/workflows/release-branch-scheduled-ci.yml
+++ b/.github/workflows/release-branch-scheduled-ci.yml
@@ -1,0 +1,220 @@
+name: Release Branch Scheduled CI
+
+run-name: Scheduled CI checks for active release branches
+
+on:
+  schedule:
+    # Run twice weekly (Monday and Thursday) at 2 AM UTC
+    - cron: '0 2 * * 1,4'
+  workflow_dispatch:
+    inputs:
+      branches:
+        description: 'Comma-separated list of release branches to test (leave empty for auto-discovery)'
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  discover-branches:
+    name: Discover active release branches
+    runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.set-branches.outputs.branches }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0  # Fetch all branches
+
+      - name: Discover release branches
+        id: set-branches
+        run: |
+          if [ -n "${{ github.event.inputs.branches }}" ]; then
+            # Manual input: use provided branches
+            branches=$(echo "${{ github.event.inputs.branches }}" | tr ',' '\n' | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          else
+            # Auto-discovery: find active release branches (*.x pattern)
+            # These are the long-lived release branches that should be tested regularly
+            branches=$(git branch -r | \
+              grep 'origin/release-[0-9]' | \
+              grep '\.x$' | \
+              sed 's|origin/||' | \
+              sort -V | \
+              tail -2 | \
+              jq -R -s -c 'split("\n") | map(select(length > 0))')
+          fi
+
+          echo "branches=$branches" >> $GITHUB_OUTPUT
+          echo "Testing branches: $branches"
+
+  unit-tests:
+    name: Unit tests on ${{ matrix.branch }}
+    needs: discover-branches
+    if: needs.discover-branches.outputs.branches != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJSON(needs.discover-branches.outputs.branches) }}
+        python: ["3.12", "3.13"]
+    steps:
+      - name: Checkout ${{ matrix.branch }}
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Install dependencies
+        uses: ./.github/actions/setup-runner
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Run unit tests
+        run: |
+          PYTHON_VERSION=${{ matrix.python }} ./scripts/unit-tests.sh --junitxml=pytest-report-${{ matrix.python }}.xml
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: unit-test-results-${{ matrix.branch }}-${{ matrix.python }}
+          path: |
+            .pytest_cache/
+            pytest-report-${{ matrix.python }}.xml
+            htmlcov-${{ matrix.python }}/
+          retention-days: 7
+
+  integration-tests:
+    name: Integration tests on ${{ matrix.branch }}
+    needs: discover-branches
+    if: needs.discover-branches.outputs.branches != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJSON(needs.discover-branches.outputs.branches) }}
+        client: [library, docker, server]
+        python-version: ["3.12"]
+        node-version: [22]
+        client-version: ["latest"]
+    steps:
+      - name: Checkout ${{ matrix.branch }}
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Setup test environment
+        uses: ./.github/actions/setup-test-environment
+        with:
+          python-version: ${{ matrix.python-version }}
+          client-version: ${{ matrix.client-version }}
+          setup: 'ollama'
+          suite: 'integration'
+          inference-mode: 'replay'
+
+      - name: Setup Node.js for TypeScript client tests
+        if: matrix.client == 'server'
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+          cache-dependency-path: tests/integration/client-typescript/package-lock.json
+
+      - name: Setup TypeScript client
+        if: matrix.client == 'server'
+        id: setup-ts-client
+        uses: ./.github/actions/setup-typescript-client
+        with:
+          client-version: ${{ matrix.client-version }}
+
+      - name: Run tests
+        uses: ./.github/actions/run-and-record-tests
+        env:
+          OPENAI_API_KEY: dummy
+          TS_CLIENT_PATH: ${{ steps.setup-ts-client.outputs.ts-client-path || '' }}
+        with:
+          stack-config: >-
+            ${{ matrix.client == 'library' && 'ci-tests'
+                || (matrix.client == 'server' && 'server:ci-tests')
+                || 'docker:ci-tests' }}
+          setup: 'ollama'
+          inference-mode: 'replay'
+          suite: 'integration'
+          target-branch: ''
+          is-fork-pr: 'false'
+
+  build-verification:
+    name: Build verification on ${{ matrix.branch }}
+    needs: discover-branches
+    if: needs.discover-branches.outputs.branches != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJSON(needs.discover-branches.outputs.branches) }}
+        python-version: ['3.12', '3.13']
+    steps:
+      - name: Checkout ${{ matrix.branch }}
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          activate-environment: true
+
+      - name: Build Llama Stack API package
+        working-directory: src/llama_stack_api
+        run: uv build
+
+      - name: Build Llama Stack package
+        run: uv build
+
+      - name: Install Llama Stack package (with api stubs from local build)
+        run: |
+          uv pip install --find-links src/llama_stack_api/dist dist/*.whl
+
+      - name: Verify Llama Stack package
+        run: |
+          uv pip list
+          uv pip show llama-stack
+          command -v llama
+          llama stack list-apis
+          llama stack list-providers inference
+          llama stack list-deps starter
+
+  summary:
+    name: Scheduled CI Summary
+    runs-on: ubuntu-latest
+    needs: [discover-branches, unit-tests, integration-tests, build-verification]
+    if: always()
+    steps:
+      - name: Check results
+        run: |
+          branches="${{ needs.discover-branches.outputs.branches }}"
+
+          if [ "$branches" = "[]" ] || [ -z "$branches" ]; then
+            echo "::warning::No release branches found to test"
+            exit 0
+          fi
+
+          if [ "${{ needs.unit-tests.result }}" != "success" ]; then
+            echo "::error::Unit tests failed on one or more branches"
+            exit 1
+          fi
+
+          if [ "${{ needs.integration-tests.result }}" != "success" ]; then
+            echo "::error::Integration tests failed on one or more branches"
+            exit 1
+          fi
+
+          if [ "${{ needs.build-verification.result }}" != "success" ]; then
+            echo "::error::Build verification failed on one or more branches"
+            exit 1
+          fi
+
+          echo "✅ All scheduled CI checks passed for release branches!"


### PR DESCRIPTION
# What does this PR do?

Implements daily testing of active release branches to ensure they remain healthy even when not actively developed. This complements existing push/PR workflows by catching issues from external dependency changes over time.

- Auto-discovers active release branches (*.x pattern) and tests the 2 most recent
- Runs comprehensive test suite: unit tests, integration tests, and build verification
- Tests across Python 3.12 and 3.13 with multiple client configurations
- Scheduled daily at 2 AM UTC (offset from main branch tests at midnight)
- Supports manual dispatch with custom branch selection
- Provides summary job for overall health status

Scheduled triggers only run on the default branch in GitHub Actions, so this workflow checks out each release branch and runs tests in a matrix strategy for parallel execution.

resolves #4509 

## Test Plan

run the new tests!
