### PR TITLE
fix: uvicorn log ambiguity

### DIFF
--- a/src/llama_stack/log.py
+++ b/src/llama_stack/log.py
@@ -209,6 +209,14 @@ def setup_logging(category_levels: dict[str, int] | None = None, log_file: str |
                 record.category = UNCATEGORIZED  # Default to 'uncategorized' if no category found
             return True
 
+    class UvicornCategoryFilter(logging.Filter):
+        """Assign uvicorn logs to 'server' category."""
+
+        def filter(self, record):
+            if not hasattr(record, "category"):
+                record.category = "server"
+            return True
+
     # Determine the root logger's level (default to WARNING if not specified)
     root_level = category_levels.get("root", logging.WARNING)
 
@@ -246,7 +254,10 @@ def setup_logging(category_levels: dict[str, int] | None = None, log_file: str |
         "filters": {
             "category_filter": {
                 "()": CategoryFilter,
-            }
+            },
+            "uvicorn_category_filter": {
+                "()": UvicornCategoryFilter,
+            },
         },
         "loggers": {
             **{
@@ -262,16 +273,19 @@ def setup_logging(category_levels: dict[str, int] | None = None, log_file: str |
                 "handlers": list(handlers.keys()),
                 "level": logging.INFO,
                 "propagate": False,
+                "filters": ["uvicorn_category_filter"],
             },
             "uvicorn.error": {
                 "handlers": list(handlers.keys()),
                 "level": logging.INFO,
                 "propagate": False,
+                "filters": ["uvicorn_category_filter"],
             },
             "uvicorn.access": {
                 "handlers": list(handlers.keys()),
                 "level": logging.INFO,
                 "propagate": False,
+                "filters": ["uvicorn_category_filter"],
             },
         },
         "root": {


### PR DESCRIPTION
# What does this PR do?

uvicorn is logging as "uncategorized" which has been bugging me, add a handler for setting the category for all uvicorn logs to server

before:

```
INFO     2026-01-13 11:53:18,371 uvicorn.error:84 uncategorized: Started server process [64907]
INFO     2026-01-13 11:53:18,371 uvicorn.error:48 uncategorized: Waiting for application startup.
```
after:

```
INFO     2026-01-13 11:53:18,371 uvicorn.error:84 server: Started server process [64907]
INFO     2026-01-13 11:53:18,371 uvicorn.error:48 server: Waiting for application startup.
```

