### PR TITLE
fix: Enabled check-init-py.sh to work with sh/bash/zsh

### DIFF
--- a/scripts/check-init-py.sh
+++ b/scripts/check-init-py.sh
@@ -27,7 +27,7 @@ find "$PACKAGE_DIR" \
     -name "*.py" ! -name "__init__.py" \
     ! -path "*/.venv/*" \
     ! -path "*/node_modules/*" \
-    -exec dirname {} \; | sort -u | while IFS= read -r dir; do
+    -exec dirname {} + | sort -u | while IFS= read -r dir; do
     if [ ! -f "$dir/__init__.py" ]; then
         echo "ERROR: Missing __init__.py in directory: $dir"
         echo "This directory contains Python files but no __init__.py, which may cause packaging issues."


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->

- Problem:
  - The script failed when run with sh because it used mapfile (Bash 4.0+), which isn't available in older shells or when executed via sh.
- Solution:
  - Removed Bash 4.0+ dependency: deleted the version check and mapfile usage.
  - Replaced with a portable while read loop that works with sh, bash, and zsh.
  - Fixed subshell variable scope: used a temporary file to track errors since the pipe creates a subshell where variable changes don't persist.
- Result:
  - The script now works when run with sh scripts/check-init-py.sh, bash scripts/check-init-py.sh, or ./scripts/check-init-py.sh, while maintaining the same functionality of checking for missing __init__.py files in Python packages.

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->

### Before fix
```console
(llama-stack) gualiu@gualiu-mac llama-stack % sh scripts/check-init-py.sh
This script requires Bash 4.0 or higher for mapfile support.
```
```console
(llama-stack) gualiu@gualiu-mac llama-stack % echo $SHELL
/bin/zsh
```

### After fix

```console
(llama-stack) gualiu@gualiu-mac llama-stack % rm -rf src/llama_stack/core/__init__.py
```
```console
(llama-stack) gualiu@gualiu-mac llama-stack % sh scripts/check-init-py.sh
ERROR: Missing __init__.py in directory: src/llama_stack/core
This directory contains Python files but no __init__.py, which may cause packaging issues.
```


