### PR TITLE
docs: add Bedrock inference example notebook

### DIFF
--- a/docs/notebooks/bedrock_inference_example.ipynb
+++ b/docs/notebooks/bedrock_inference_example.ipynb
@@ -51,41 +51,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Bedrock provider config: add/ensure the following\n",
-      "- providers.inference includes provider_id='bedrock' and provider_type='remote::bedrock'\n",
-      "- providers.inference[bedrock].config.api_key uses env AWS_BEARER_TOKEN_BEDROCK\n",
-      "- providers.inference[bedrock].config.region_name = AWS_DEFAULT_REGION (typically us-west-2)\n",
-      "\n",
-      "Model registration: add/ensure the following\n",
-      "- registered model_id: openai.gpt-oss-20b-1:0\n",
-      "- provider_id: bedrock\n",
-      "- provider_resource_id (or provider_model_id, depending on config schema): openai.gpt-oss-20b-1:0\n",
-      "- model_type: llm\n"
-     ]
-    }
-   ],
-   "source": [
-    "# What to add to your server config (high-level checklist)\n",
-    "# (No YAML output here; just the key fields.)\n",
-    "\n",
-    "print(\"Bedrock provider config: add/ensure the following\")\n",
-    "print(\"- providers.inference includes provider_id='bedrock' and provider_type='remote::bedrock'\")\n",
-    "print(\"- providers.inference[bedrock].config.api_key uses env AWS_BEARER_TOKEN_BEDROCK\")\n",
-    "print(\"- providers.inference[bedrock].config.region_name = AWS_DEFAULT_REGION (typically us-west-2)\")\n",
-    "print(\"\")\n",
-    "print(\"Model registration: add/ensure the following\")\n",
-    "print(\"- registered model_id: openai.gpt-oss-20b-1:0\")\n",
-    "print(\"- provider_id: bedrock\")\n",
-    "print(\"- provider_resource_id (or provider_model_id, depending on config schema): openai.gpt-oss-20b-1:0\")\n",
-    "print(\"- model_type: llm\")"
-   ]
+   "outputs": [],
+   "source": "# Minimal config.yaml example for Bedrock\n# Copy this and save as your-config.yaml\n\nminimal_config = \"\"\"\nversion: 2\nproviders:\n  inference:\n    - provider_id: bedrock\n      provider_type: remote::bedrock\n      config:\n        api_key: ${env.AWS_BEARER_TOKEN_BEDROCK:=}\n        region_name: ${env.AWS_DEFAULT_REGION:=us-west-2}\n\nregistered_resources:\n  models:\n    - metadata: {}\n      model_id: bedrock/openai.gpt-oss-20b-1:0\n      provider_id: bedrock\n      provider_model_id: openai.gpt-oss-20b-1:0\n      model_type: llm\n\"\"\".strip()\n\nprint(\"=\" * 60)\nprint(\"MINIMAL CONFIG.YAML FOR BEDROCK\")\nprint(\"=\" * 60)\nprint(minimal_config)\nprint(\"=\" * 60)\nprint(\"\\nSave this as 'config.yaml' and run:\")\nprint(\"  export AWS_BEARER_TOKEN_BEDROCK='your-token'\")\nprint(\"  export AWS_DEFAULT_REGION=us-west-2\")\nprint(\"  uv run llama stack run ./config.yaml\")"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary

Add an interactive Jupyter notebook demonstrating AWS Bedrock provider inference via Llama Stack's OpenAI-compatible API.

**Notebook covers:**
- Simple chat completion (non-streaming)
- Streaming responses with SSE
- Multi-turn conversations (client-side context)
- System messages for role-based prompting
- Sampling parameters (temperature, top_p, max_tokens)
- Error handling patterns
- Batch processing multiple prompts
- Equivalent cURL commands for reference

**Also includes:**
- Prerequisites and server setup instructions
- API support matrix (what works/doesn't with Bedrock)
- Troubleshooting guide for common errors
- Bearer token refresh instructions

## Test plan
- [ ] Verified notebook renders correctly on GitHub
- [ ] Ran notebook cells with a live Bedrock server
- [ ] Confirmed all examples execute without errors