### PR TITLE
fix!: align chat completions API with OpenAI spec

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -58,7 +58,6 @@ jobs:
       # Checkout the base branch to compare against (usually main)
       # This allows us to diff the current changes against the previous state
       - name: Checkout Base Branch
-        if: steps.skip-check.outputs.skip != 'true'
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           ref: ${{ github.event.pull_request.base.ref }}
@@ -67,7 +66,6 @@ jobs:
 
       # Cache oasdiff to avoid checksum failures and speed up builds
       - name: Cache oasdiff
-        if: steps.skip-check.outputs.skip != 'true'
         id: cache-oasdiff
         uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7
         with:
@@ -76,14 +74,14 @@ jobs:
 
       # Install oasdiff: https://github.com/oasdiff/oasdiff, a tool for detecting breaking changes in OpenAPI specs.
       - name: Install oasdiff
-        if: steps.skip-check.outputs.skip != 'true' && steps.cache-oasdiff.outputs.cache-hit != 'true'
+        if: steps.cache-oasdiff.outputs.cache-hit != 'true'
         run: |
           curl -fsSL https://raw.githubusercontent.com/oasdiff/oasdiff/main/install.sh | sh
           cp /usr/local/bin/oasdiff ~/oasdiff
 
       # Setup cached oasdiff
       - name: Setup cached oasdiff
-        if: steps.skip-check.outputs.skip != 'true' && steps.cache-oasdiff.outputs.cache-hit == 'true'
+        if: steps.cache-oasdiff.outputs.cache-hit == 'true'
         run: |
           sudo cp ~/oasdiff /usr/local/bin/oasdiff
           sudo chmod +x /usr/local/bin/oasdiff
@@ -96,7 +94,6 @@ jobs:
 
       # Verify API specs exist for conformance testing
       - name: Check API Specs
-        if: steps.skip-check.outputs.skip != 'true'
         run: |
           echo "Checking for API specification files..."
 
@@ -133,13 +130,14 @@ jobs:
       # Run oasdiff to detect breaking changes in the API specification
       # This step will fail if incompatible changes are detected, preventing breaking changes from being merged
       - name: Run OpenAPI Breaking Change Diff
-        if: steps.skip-check.outputs.skip != 'true'
+        id: breaking-change-diff
+        continue-on-error: true
         run: |
           oasdiff breaking --fail-on ERR $BASE_SPEC $CURRENT_SPEC --match-path '^/v1/'
 
       # Run oasdiff to detect breaking changes in the API specification when compared to the OpenAI openAPI spec
       - name: Run OpenAPI Breaking Change Diff Against OpenAI API
-        if: steps.skip-check.outputs.skip != 'true'
+        id: openai-breaking-change-diff
         continue-on-error: true
         shell: bash
         run: |
@@ -154,8 +152,16 @@ jobs:
             "$OPENAI_SPEC" \
             --strip-prefix-base "/v1"
 
-      # Report when test is skipped
-      - name: Report skip reason
-        if: steps.skip-check.outputs.skip == 'true'
+      # Report when breaking changes are allowed
+      - name: Report breaking changes allowed
+        if: steps.skip-check.outputs.skip == 'true' && (steps.breaking-change-diff.outcome == 'failure' || steps.openai-breaking-change-diff.outcome == 'failure')
         run: |
-          echo "Conformance test skipped due to breaking change indicator"
+          echo "Breaking changes detected but allowed due to breaking change indicator in PR"
+          echo "The diff checks ran but failures are being ignored for this PR"
+
+      # Fail the job if the breaking change diff failed and skip is not set
+      - name: Check Breaking Change Diff Result
+        if: steps.skip-check.outputs.skip != 'true' && steps.breaking-change-diff.outcome == 'failure'
+        run: |
+          echo "Breaking change diff detected incompatible API changes"
+          exit 1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,6 +24,7 @@ on:
       - '.github/actions/run-and-record-tests/action.yml'
       - 'scripts/integration-tests.sh'
       - 'scripts/generate_ci_matrix.py'
+      - 'docs/static/llama-stack-spec.yaml'
   schedule:
     # If changing the cron schedule, update the provider in the test-matrix job
     - cron: '0 0 * * *'  # (test latest client) Daily at 12 AM UTC

--- a/client-sdks/stainless/openapi.yml
+++ b/client-sdks/stainless/openapi.yml
@@ -194,35 +194,30 @@ paths:
         in: query
         required: false
         schema:
-          anyOf:
-          - type: string
-          - type: 'null'
+          type: string
           title: After
       - name: limit
         in: query
         required: false
         schema:
-          anyOf:
-          - type: integer
-          - type: 'null'
+          type: integer
           default: 20
           title: Limit
       - name: model
         in: query
         required: false
         schema:
-          anyOf:
-          - type: string
-          - type: 'null'
+          type: string
           title: Model
       - name: order
         in: query
         required: false
         schema:
-          anyOf:
-          - $ref: '#/components/schemas/Order'
-          - type: 'null'
-          default: desc
+          enum:
+          - asc
+          - desc
+          type: string
+          default: asc
           title: Order
     post:
       responses:
@@ -4655,8 +4650,9 @@ components:
               tool: '#/components/schemas/OpenAIToolMessageParam'
               user: '#/components/schemas/OpenAIUserMessageParam-Output'
         finish_reason:
-          type: string
-          title: Finish Reason
+          anyOf:
+          - type: string
+          - type: 'null'
         index:
           type: integer
           title: Index
@@ -5255,8 +5251,9 @@ components:
         delta:
           $ref: '#/components/schemas/OpenAIChoiceDelta'
         finish_reason:
-          title: Finish Reason
-          type: string
+          anyOf:
+          - type: string
+          - type: 'null'
         index:
           title: Index
           type: integer
@@ -5301,36 +5298,36 @@ components:
           - type: 'null'
           title: OpenAIChatCompletionUsage
         input_messages:
-          items:
-            oneOf:
-            - $ref: '#/components/schemas/OpenAIUserMessageParam-Output'
-              title: OpenAIUserMessageParam-Output
-            - $ref: '#/components/schemas/OpenAISystemMessageParam'
-              title: OpenAISystemMessageParam
-            - $ref: '#/components/schemas/OpenAIAssistantMessageParam-Output'
-              title: OpenAIAssistantMessageParam-Output
-            - $ref: '#/components/schemas/OpenAIToolMessageParam'
-              title: OpenAIToolMessageParam
-            - $ref: '#/components/schemas/OpenAIDeveloperMessageParam'
-              title: OpenAIDeveloperMessageParam
-            discriminator:
-              propertyName: role
-              mapping:
-                assistant: '#/components/schemas/OpenAIAssistantMessageParam-Output'
-                developer: '#/components/schemas/OpenAIDeveloperMessageParam'
-                system: '#/components/schemas/OpenAISystemMessageParam'
-                tool: '#/components/schemas/OpenAIToolMessageParam'
-                user: '#/components/schemas/OpenAIUserMessageParam-Output'
-            title: OpenAIUserMessageParam-Output | ... (5 variants)
-          type: array
-          title: Input Messages
+          anyOf:
+          - items:
+              oneOf:
+              - $ref: '#/components/schemas/OpenAIUserMessageParam-Output'
+                title: OpenAIUserMessageParam-Output
+              - $ref: '#/components/schemas/OpenAISystemMessageParam'
+                title: OpenAISystemMessageParam
+              - $ref: '#/components/schemas/OpenAIAssistantMessageParam-Output'
+                title: OpenAIAssistantMessageParam-Output
+              - $ref: '#/components/schemas/OpenAIToolMessageParam'
+                title: OpenAIToolMessageParam
+              - $ref: '#/components/schemas/OpenAIDeveloperMessageParam'
+                title: OpenAIDeveloperMessageParam
+              discriminator:
+                propertyName: role
+                mapping:
+                  assistant: '#/components/schemas/OpenAIAssistantMessageParam-Output'
+                  developer: '#/components/schemas/OpenAIDeveloperMessageParam'
+                  system: '#/components/schemas/OpenAISystemMessageParam'
+                  tool: '#/components/schemas/OpenAIToolMessageParam'
+                  user: '#/components/schemas/OpenAIUserMessageParam-Output'
+              title: OpenAIUserMessageParam-Output | ... (5 variants)
+            type: array
+          - type: 'null'
       type: object
       required:
       - id
       - choices
       - created
       - model
-      - input_messages
       title: OpenAICompletionWithInputMessages
     OpenAICompletionRequestWithExtraBody:
       properties:

--- a/docs/static/deprecated-llama-stack-spec.yaml
+++ b/docs/static/deprecated-llama-stack-spec.yaml
@@ -1301,8 +1301,9 @@ components:
               tool: '#/components/schemas/OpenAIToolMessageParam'
               user: '#/components/schemas/OpenAIUserMessageParam-Output'
         finish_reason:
-          type: string
-          title: Finish Reason
+          anyOf:
+          - type: string
+          - type: 'null'
         index:
           type: integer
           title: Index
@@ -1901,8 +1902,9 @@ components:
         delta:
           $ref: '#/components/schemas/OpenAIChoiceDelta'
         finish_reason:
-          title: Finish Reason
-          type: string
+          anyOf:
+          - type: string
+          - type: 'null'
         index:
           title: Index
           type: integer
@@ -1947,36 +1949,36 @@ components:
           - type: 'null'
           title: OpenAIChatCompletionUsage
         input_messages:
-          items:
-            oneOf:
-            - $ref: '#/components/schemas/OpenAIUserMessageParam-Output'
-              title: OpenAIUserMessageParam-Output
-            - $ref: '#/components/schemas/OpenAISystemMessageParam'
-              title: OpenAISystemMessageParam
-            - $ref: '#/components/schemas/OpenAIAssistantMessageParam-Output'
-              title: OpenAIAssistantMessageParam-Output
-            - $ref: '#/components/schemas/OpenAIToolMessageParam'
-              title: OpenAIToolMessageParam
-            - $ref: '#/components/schemas/OpenAIDeveloperMessageParam'
-              title: OpenAIDeveloperMessageParam
-            discriminator:
-              propertyName: role
-              mapping:
-                assistant: '#/components/schemas/OpenAIAssistantMessageParam-Output'
-                developer: '#/components/schemas/OpenAIDeveloperMessageParam'
-                system: '#/components/schemas/OpenAISystemMessageParam'
-                tool: '#/components/schemas/OpenAIToolMessageParam'
-                user: '#/components/schemas/OpenAIUserMessageParam-Output'
-            title: OpenAIUserMessageParam-Output | ... (5 variants)
-          type: array
-          title: Input Messages
+          anyOf:
+          - items:
+              oneOf:
+              - $ref: '#/components/schemas/OpenAIUserMessageParam-Output'
+                title: OpenAIUserMessageParam-Output
+              - $ref: '#/components/schemas/OpenAISystemMessageParam'
+                title: OpenAISystemMessageParam
+              - $ref: '#/components/schemas/OpenAIAssistantMessageParam-Output'
+                title: OpenAIAssistantMessageParam-Output
+              - $ref: '#/components/schemas/OpenAIToolMessageParam'
+                title: OpenAIToolMessageParam
+              - $ref: '#/components/schemas/OpenAIDeveloperMessageParam'
+                title: OpenAIDeveloperMessageParam
+              discriminator:
+                propertyName: role
+                mapping:
+                  assistant: '#/components/schemas/OpenAIAssistantMessageParam-Output'
+                  developer: '#/components/schemas/OpenAIDeveloperMessageParam'
+                  system: '#/components/schemas/OpenAISystemMessageParam'
+                  tool: '#/components/schemas/OpenAIToolMessageParam'
+                  user: '#/components/schemas/OpenAIUserMessageParam-Output'
+              title: OpenAIUserMessageParam-Output | ... (5 variants)
+            type: array
+          - type: 'null'
       type: object
       required:
       - id
       - choices
       - created
       - model
-      - input_messages
       title: OpenAICompletionWithInputMessages
     OpenAICompletionRequestWithExtraBody:
       properties:

--- a/docs/static/experimental-llama-stack-spec.yaml
+++ b/docs/static/experimental-llama-stack-spec.yaml
@@ -1372,8 +1372,9 @@ components:
               tool: '#/components/schemas/OpenAIToolMessageParam'
               user: '#/components/schemas/OpenAIUserMessageParam-Output'
         finish_reason:
-          type: string
-          title: Finish Reason
+          anyOf:
+          - type: string
+          - type: 'null'
         index:
           type: integer
           title: Index
@@ -1972,8 +1973,9 @@ components:
         delta:
           $ref: '#/components/schemas/OpenAIChoiceDelta'
         finish_reason:
-          title: Finish Reason
-          type: string
+          anyOf:
+          - type: string
+          - type: 'null'
         index:
           title: Index
           type: integer
@@ -2018,36 +2020,36 @@ components:
           - type: 'null'
           title: OpenAIChatCompletionUsage
         input_messages:
-          items:
-            oneOf:
-            - $ref: '#/components/schemas/OpenAIUserMessageParam-Output'
-              title: OpenAIUserMessageParam-Output
-            - $ref: '#/components/schemas/OpenAISystemMessageParam'
-              title: OpenAISystemMessageParam
-            - $ref: '#/components/schemas/OpenAIAssistantMessageParam-Output'
-              title: OpenAIAssistantMessageParam-Output
-            - $ref: '#/components/schemas/OpenAIToolMessageParam'
-              title: OpenAIToolMessageParam
-            - $ref: '#/components/schemas/OpenAIDeveloperMessageParam'
-              title: OpenAIDeveloperMessageParam
-            discriminator:
-              propertyName: role
-              mapping:
-                assistant: '#/components/schemas/OpenAIAssistantMessageParam-Output'
-                developer: '#/components/schemas/OpenAIDeveloperMessageParam'
-                system: '#/components/schemas/OpenAISystemMessageParam'
-                tool: '#/components/schemas/OpenAIToolMessageParam'
-                user: '#/components/schemas/OpenAIUserMessageParam-Output'
-            title: OpenAIUserMessageParam-Output | ... (5 variants)
-          type: array
-          title: Input Messages
+          anyOf:
+          - items:
+              oneOf:
+              - $ref: '#/components/schemas/OpenAIUserMessageParam-Output'
+                title: OpenAIUserMessageParam-Output
+              - $ref: '#/components/schemas/OpenAISystemMessageParam'
+                title: OpenAISystemMessageParam
+              - $ref: '#/components/schemas/OpenAIAssistantMessageParam-Output'
+                title: OpenAIAssistantMessageParam-Output
+              - $ref: '#/components/schemas/OpenAIToolMessageParam'
+                title: OpenAIToolMessageParam
+              - $ref: '#/components/schemas/OpenAIDeveloperMessageParam'
+                title: OpenAIDeveloperMessageParam
+              discriminator:
+                propertyName: role
+                mapping:
+                  assistant: '#/components/schemas/OpenAIAssistantMessageParam-Output'
+                  developer: '#/components/schemas/OpenAIDeveloperMessageParam'
+                  system: '#/components/schemas/OpenAISystemMessageParam'
+                  tool: '#/components/schemas/OpenAIToolMessageParam'
+                  user: '#/components/schemas/OpenAIUserMessageParam-Output'
+              title: OpenAIUserMessageParam-Output | ... (5 variants)
+            type: array
+          - type: 'null'
       type: object
       required:
       - id
       - choices
       - created
       - model
-      - input_messages
       title: OpenAICompletionWithInputMessages
     OpenAICompletionRequestWithExtraBody:
       properties:

--- a/docs/static/llama-stack-spec.yaml
+++ b/docs/static/llama-stack-spec.yaml
@@ -192,35 +192,30 @@ paths:
         in: query
         required: false
         schema:
-          anyOf:
-          - type: string
-          - type: 'null'
+          type: string
           title: After
       - name: limit
         in: query
         required: false
         schema:
-          anyOf:
-          - type: integer
-          - type: 'null'
+          type: integer
           default: 20
           title: Limit
       - name: model
         in: query
         required: false
         schema:
-          anyOf:
-          - type: string
-          - type: 'null'
+          type: string
           title: Model
       - name: order
         in: query
         required: false
         schema:
-          anyOf:
-          - $ref: '#/components/schemas/Order'
-          - type: 'null'
-          default: desc
+          enum:
+          - asc
+          - desc
+          type: string
+          default: asc
           title: Order
     post:
       responses:
@@ -3123,8 +3118,9 @@ components:
               tool: '#/components/schemas/OpenAIToolMessageParam'
               user: '#/components/schemas/OpenAIUserMessageParam-Output'
         finish_reason:
-          type: string
-          title: Finish Reason
+          anyOf:
+          - type: string
+          - type: 'null'
         index:
           type: integer
           title: Index
@@ -3723,8 +3719,9 @@ components:
         delta:
           $ref: '#/components/schemas/OpenAIChoiceDelta'
         finish_reason:
-          title: Finish Reason
-          type: string
+          anyOf:
+          - type: string
+          - type: 'null'
         index:
           title: Index
           type: integer
@@ -3769,36 +3766,36 @@ components:
           - type: 'null'
           title: OpenAIChatCompletionUsage
         input_messages:
-          items:
-            oneOf:
-            - $ref: '#/components/schemas/OpenAIUserMessageParam-Output'
-              title: OpenAIUserMessageParam-Output
-            - $ref: '#/components/schemas/OpenAISystemMessageParam'
-              title: OpenAISystemMessageParam
-            - $ref: '#/components/schemas/OpenAIAssistantMessageParam-Output'
-              title: OpenAIAssistantMessageParam-Output
-            - $ref: '#/components/schemas/OpenAIToolMessageParam'
-              title: OpenAIToolMessageParam
-            - $ref: '#/components/schemas/OpenAIDeveloperMessageParam'
-              title: OpenAIDeveloperMessageParam
-            discriminator:
-              propertyName: role
-              mapping:
-                assistant: '#/components/schemas/OpenAIAssistantMessageParam-Output'
-                developer: '#/components/schemas/OpenAIDeveloperMessageParam'
-                system: '#/components/schemas/OpenAISystemMessageParam'
-                tool: '#/components/schemas/OpenAIToolMessageParam'
-                user: '#/components/schemas/OpenAIUserMessageParam-Output'
-            title: OpenAIUserMessageParam-Output | ... (5 variants)
-          type: array
-          title: Input Messages
+          anyOf:
+          - items:
+              oneOf:
+              - $ref: '#/components/schemas/OpenAIUserMessageParam-Output'
+                title: OpenAIUserMessageParam-Output
+              - $ref: '#/components/schemas/OpenAISystemMessageParam'
+                title: OpenAISystemMessageParam
+              - $ref: '#/components/schemas/OpenAIAssistantMessageParam-Output'
+                title: OpenAIAssistantMessageParam-Output
+              - $ref: '#/components/schemas/OpenAIToolMessageParam'
+                title: OpenAIToolMessageParam
+              - $ref: '#/components/schemas/OpenAIDeveloperMessageParam'
+                title: OpenAIDeveloperMessageParam
+              discriminator:
+                propertyName: role
+                mapping:
+                  assistant: '#/components/schemas/OpenAIAssistantMessageParam-Output'
+                  developer: '#/components/schemas/OpenAIDeveloperMessageParam'
+                  system: '#/components/schemas/OpenAISystemMessageParam'
+                  tool: '#/components/schemas/OpenAIToolMessageParam'
+                  user: '#/components/schemas/OpenAIUserMessageParam-Output'
+              title: OpenAIUserMessageParam-Output | ... (5 variants)
+            type: array
+          - type: 'null'
       type: object
       required:
       - id
       - choices
       - created
       - model
-      - input_messages
       title: OpenAICompletionWithInputMessages
     OpenAICompletionRequestWithExtraBody:
       properties:

--- a/docs/static/stainless-llama-stack-spec.yaml
+++ b/docs/static/stainless-llama-stack-spec.yaml
@@ -194,35 +194,30 @@ paths:
         in: query
         required: false
         schema:
-          anyOf:
-          - type: string
-          - type: 'null'
+          type: string
           title: After
       - name: limit
         in: query
         required: false
         schema:
-          anyOf:
-          - type: integer
-          - type: 'null'
+          type: integer
           default: 20
           title: Limit
       - name: model
         in: query
         required: false
         schema:
-          anyOf:
-          - type: string
-          - type: 'null'
+          type: string
           title: Model
       - name: order
         in: query
         required: false
         schema:
-          anyOf:
-          - $ref: '#/components/schemas/Order'
-          - type: 'null'
-          default: desc
+          enum:
+          - asc
+          - desc
+          type: string
+          default: asc
           title: Order
     post:
       responses:
@@ -4655,8 +4650,9 @@ components:
               tool: '#/components/schemas/OpenAIToolMessageParam'
               user: '#/components/schemas/OpenAIUserMessageParam-Output'
         finish_reason:
-          type: string
-          title: Finish Reason
+          anyOf:
+          - type: string
+          - type: 'null'
         index:
           type: integer
           title: Index
@@ -5255,8 +5251,9 @@ components:
         delta:
           $ref: '#/components/schemas/OpenAIChoiceDelta'
         finish_reason:
-          title: Finish Reason
-          type: string
+          anyOf:
+          - type: string
+          - type: 'null'
         index:
           title: Index
           type: integer
@@ -5301,36 +5298,36 @@ components:
           - type: 'null'
           title: OpenAIChatCompletionUsage
         input_messages:
-          items:
-            oneOf:
-            - $ref: '#/components/schemas/OpenAIUserMessageParam-Output'
-              title: OpenAIUserMessageParam-Output
-            - $ref: '#/components/schemas/OpenAISystemMessageParam'
-              title: OpenAISystemMessageParam
-            - $ref: '#/components/schemas/OpenAIAssistantMessageParam-Output'
-              title: OpenAIAssistantMessageParam-Output
-            - $ref: '#/components/schemas/OpenAIToolMessageParam'
-              title: OpenAIToolMessageParam
-            - $ref: '#/components/schemas/OpenAIDeveloperMessageParam'
-              title: OpenAIDeveloperMessageParam
-            discriminator:
-              propertyName: role
-              mapping:
-                assistant: '#/components/schemas/OpenAIAssistantMessageParam-Output'
-                developer: '#/components/schemas/OpenAIDeveloperMessageParam'
-                system: '#/components/schemas/OpenAISystemMessageParam'
-                tool: '#/components/schemas/OpenAIToolMessageParam'
-                user: '#/components/schemas/OpenAIUserMessageParam-Output'
-            title: OpenAIUserMessageParam-Output | ... (5 variants)
-          type: array
-          title: Input Messages
+          anyOf:
+          - items:
+              oneOf:
+              - $ref: '#/components/schemas/OpenAIUserMessageParam-Output'
+                title: OpenAIUserMessageParam-Output
+              - $ref: '#/components/schemas/OpenAISystemMessageParam'
+                title: OpenAISystemMessageParam
+              - $ref: '#/components/schemas/OpenAIAssistantMessageParam-Output'
+                title: OpenAIAssistantMessageParam-Output
+              - $ref: '#/components/schemas/OpenAIToolMessageParam'
+                title: OpenAIToolMessageParam
+              - $ref: '#/components/schemas/OpenAIDeveloperMessageParam'
+                title: OpenAIDeveloperMessageParam
+              discriminator:
+                propertyName: role
+                mapping:
+                  assistant: '#/components/schemas/OpenAIAssistantMessageParam-Output'
+                  developer: '#/components/schemas/OpenAIDeveloperMessageParam'
+                  system: '#/components/schemas/OpenAISystemMessageParam'
+                  tool: '#/components/schemas/OpenAIToolMessageParam'
+                  user: '#/components/schemas/OpenAIUserMessageParam-Output'
+              title: OpenAIUserMessageParam-Output | ... (5 variants)
+            type: array
+          - type: 'null'
       type: object
       required:
       - id
       - choices
       - created
       - model
-      - input_messages
       title: OpenAICompletionWithInputMessages
     OpenAICompletionRequestWithExtraBody:
       properties:

--- a/src/llama_stack_api/inference.py
+++ b/src/llama_stack_api/inference.py
@@ -19,9 +19,6 @@ from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
 from llama_stack_api.common.content_types import InterleavedContent
-from llama_stack_api.common.responses import (
-    Order,
-)
 from llama_stack_api.models import Model
 from llama_stack_api.schema_utils import json_schema_type, register_schema, webmethod
 from llama_stack_api.version import LLAMA_STACK_API_V1, LLAMA_STACK_API_V1ALPHA
@@ -701,7 +698,7 @@ class OpenAIChunkChoice(BaseModel):
     """
 
     delta: OpenAIChoiceDelta
-    finish_reason: str
+    finish_reason: str | None
     index: int
     logprobs: OpenAIChoiceLogprobs | None = None
 
@@ -717,7 +714,7 @@ class OpenAIChoice(BaseModel):
     """
 
     message: OpenAIMessageParam
-    finish_reason: str
+    finish_reason: str | None
     index: int
     logprobs: OpenAIChoiceLogprobs | None = None
 
@@ -920,7 +917,7 @@ class EmbeddingTaskType(Enum):
 
 
 class OpenAICompletionWithInputMessages(OpenAIChatCompletion):
-    input_messages: list[OpenAIMessageParam]
+    input_messages: list[OpenAIMessageParam] | None = None
 
 
 @json_schema_type
@@ -1142,10 +1139,10 @@ class Inference(InferenceProvider):
     @webmethod(route="/chat/completions", method="GET", level=LLAMA_STACK_API_V1)
     async def list_chat_completions(
         self,
-        after: str | None = None,
-        limit: int | None = 20,
-        model: str | None = None,
-        order: Order | None = Order.desc,
+        after: str = None,  # type: ignore[assignment]
+        limit: int = 20,
+        model: str = None,  # type: ignore[assignment]
+        order: Literal["asc", "desc"] = "asc",
     ) -> ListOpenAIChatCompletionResponse:
         """List chat completions.
 


### PR DESCRIPTION
# What does this PR do?

 - Fix GET /chat/completions query parameters to match OpenAI:
    - Remove nullable types from after, limit, model, order
    - Add enum constraint to order parameter (asc, desc)
    - Set correct default values
- Make finish_reason nullable in OpenAIChoice and OpenAIChunkChoice to match OpenAI streaming response spec
- Make input_messages optional in OpenAICompletionWithInputMessages since it's not part of standard OpenAI response Fixed errors:

```
  error    [request-parameter-became-enum] at docs/static/openai-spec-2.3.0.yml
      in API GET /chat/completions
          the 'query' request parameter 'order' was restricted to a list of enum values

  error    [request-parameter-default-value-changed] at docs/static/openai-spec-2.3.0.yml
      in API GET /chat/completions
          for the 'query' request parameter 'order', default value was changed from 'desc' to 'asc'

  error    [request-parameter-list-of-types-narrowed] at docs/static/openai-spec-2.3.0.yml
      in API GET /chat/completions
          'query' request parameter 'after' list-of-types was narrowed by removing types 'null'

  error    [request-parameter-list-of-types-narrowed] at docs/static/openai-spec-2.3.0.yml
      in API GET /chat/completions
          'query' request parameter 'limit' list-of-types was narrowed by removing types 'null'

  error    [request-parameter-list-of-types-narrowed] at docs/static/openai-spec-2.3.0.yml
      in API GET /chat/completions
          'query' request parameter 'model' list-of-types was narrowed by removing types 'null'

  error    [request-parameter-list-of-types-narrowed] at docs/static/openai-spec-2.3.0.yml
      in API GET /chat/completions
          'query' request parameter 'order' list-of-types was narrowed by removing types 'null'

  error    [request-parameter-type-changed] at docs/static/openai-spec-2.3.0.yml
      in API GET /chat/completions
          for the 'query' request parameter 'limit', the type/format was changed from ''/'' to 'integer'/''

  error    [response-required-property-removed] at docs/static/openai-spec-2.3.0.yml
      in API GET /chat/completions
          removed the required property 'data/items/input_messages' from the response with the '200' status

  error    [response-required-property-removed] at docs/static/openai-spec-2.3.0.yml
      in API GET /chat/completions/{completion_id}
          removed the required property 'input_messages' from the response with the '200' status
```

The changes here align the GET /chat/completions endpoint with OpenAI's API spec.                                                                                             
                                                                                                                                                                                
  When you write after: str | None = None, the schema generator produces:           
  
  ```                                                                                            
  anyOf:                                                                                                                                                                        
    - type: string                                                                                                                                                              
    - type: 'null'                                                                                                                                                              
  ```                                                                                                             
                                                                   
  But OpenAI's spec has these parameters as optional but not nullable — you can omit them, but you can't explicitly pass null.                                                  
                                                                                                                                                                                
  Using `after: str = None` produces the correct schema:                                                                                                                          
  `type: string`                                                                                                                                                                  
                                                                                                                                                                                
  The # type: ignore[assignment] silences mypy since None isn't technically a valid str, but the schema generator only sees str and outputs the correct OpenAPI spec.           
                                                                                                                                                                                
  I looked at adopting the `_remove_null_from_anyof` approach from #4644, but that works for Pydantic model fields (like the embeddings request body), not for query parameters on @webmethod decorated methods. The custom schema generator doesn't process Query(json_schema_extra=...) metadata. Once Inference is converted to a FastAPI router, we could revisit this.     

resolves #4622 

## Test Plan

conformance diff between LLS spec and openAI spec should not have these errors anymore.