### PR TITLE
fix(telemetry): Allow None/empty service_name in TelemetryConfig

### DIFF
--- a/docs/source/distributions/k8s-benchmark/stack-configmap.yaml
+++ b/docs/source/distributions/k8s-benchmark/stack-configmap.yaml
@@ -68,7 +68,7 @@ data:
       - provider_id: meta-reference
         provider_type: inline::meta-reference
         config:
-          service_name: "${env.OTEL_SERVICE_NAME:=\u200B}"
+          service_name: "${env.OTEL_SERVICE_NAME:=}"
           sinks: ${env.TELEMETRY_SINKS:=console}
       tool_runtime:
       - provider_id: brave-search

--- a/docs/source/distributions/k8s-benchmark/stack_run_config.yaml
+++ b/docs/source/distributions/k8s-benchmark/stack_run_config.yaml
@@ -52,7 +52,7 @@ providers:
   - provider_id: meta-reference
     provider_type: inline::meta-reference
     config:
-      service_name: "${env.OTEL_SERVICE_NAME:=\u200B}"
+      service_name: "${env.OTEL_SERVICE_NAME:=}"
       sinks: ${env.TELEMETRY_SINKS:=console}
   tool_runtime:
   - provider_id: brave-search

--- a/docs/source/distributions/k8s/stack-configmap.yaml
+++ b/docs/source/distributions/k8s/stack-configmap.yaml
@@ -68,7 +68,7 @@ data:
       - provider_id: meta-reference
         provider_type: inline::meta-reference
         config:
-          service_name: "${env.OTEL_SERVICE_NAME:=\u200B}"
+          service_name: "${env.OTEL_SERVICE_NAME:=}"
           sinks: ${env.TELEMETRY_SINKS:=console}
       tool_runtime:
       - provider_id: brave-search

--- a/docs/source/distributions/k8s/stack_run_config.yaml
+++ b/docs/source/distributions/k8s/stack_run_config.yaml
@@ -65,7 +65,7 @@ providers:
   - provider_id: meta-reference
     provider_type: inline::meta-reference
     config:
-      service_name: "${env.OTEL_SERVICE_NAME:=\u200B}"
+      service_name: "${env.OTEL_SERVICE_NAME:=}"
       sinks: ${env.TELEMETRY_SINKS:=console}
   tool_runtime:
   - provider_id: brave-search

--- a/llama_stack/distributions/ci-tests/run.yaml
+++ b/llama_stack/distributions/ci-tests/run.yaml
@@ -151,7 +151,7 @@ providers:
   - provider_id: meta-reference
     provider_type: inline::meta-reference
     config:
-      service_name: "${env.OTEL_SERVICE_NAME:=\u200B}"
+      service_name: "${env.OTEL_SERVICE_NAME:=}"
       sinks: ${env.TELEMETRY_SINKS:=console,sqlite}
       sqlite_db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/ci-tests}/trace_store.db
       otel_exporter_otlp_endpoint: ${env.OTEL_EXPORTER_OTLP_ENDPOINT:=}

--- a/llama_stack/distributions/dell/run-with-safety.yaml
+++ b/llama_stack/distributions/dell/run-with-safety.yaml
@@ -49,7 +49,7 @@ providers:
   - provider_id: meta-reference
     provider_type: inline::meta-reference
     config:
-      service_name: "${env.OTEL_SERVICE_NAME:=\u200B}"
+      service_name: "${env.OTEL_SERVICE_NAME:=}"
       sinks: ${env.TELEMETRY_SINKS:=console,sqlite}
       sqlite_db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/dell}/trace_store.db
       otel_exporter_otlp_endpoint: ${env.OTEL_EXPORTER_OTLP_ENDPOINT:=}

--- a/llama_stack/distributions/dell/run.yaml
+++ b/llama_stack/distributions/dell/run.yaml
@@ -45,7 +45,7 @@ providers:
   - provider_id: meta-reference
     provider_type: inline::meta-reference
     config:
-      service_name: "${env.OTEL_SERVICE_NAME:=\u200B}"
+      service_name: "${env.OTEL_SERVICE_NAME:=}"
       sinks: ${env.TELEMETRY_SINKS:=console,sqlite}
       sqlite_db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/dell}/trace_store.db
       otel_exporter_otlp_endpoint: ${env.OTEL_EXPORTER_OTLP_ENDPOINT:=}

--- a/llama_stack/distributions/meta-reference-gpu/run-with-safety.yaml
+++ b/llama_stack/distributions/meta-reference-gpu/run-with-safety.yaml
@@ -60,7 +60,7 @@ providers:
   - provider_id: meta-reference
     provider_type: inline::meta-reference
     config:
-      service_name: "${env.OTEL_SERVICE_NAME:=\u200B}"
+      service_name: "${env.OTEL_SERVICE_NAME:=}"
       sinks: ${env.TELEMETRY_SINKS:=console,sqlite}
       sqlite_db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/meta-reference-gpu}/trace_store.db
       otel_exporter_otlp_endpoint: ${env.OTEL_EXPORTER_OTLP_ENDPOINT:=}

--- a/llama_stack/distributions/meta-reference-gpu/run.yaml
+++ b/llama_stack/distributions/meta-reference-gpu/run.yaml
@@ -50,7 +50,7 @@ providers:
   - provider_id: meta-reference
     provider_type: inline::meta-reference
     config:
-      service_name: "${env.OTEL_SERVICE_NAME:=\u200B}"
+      service_name: "${env.OTEL_SERVICE_NAME:=}"
       sinks: ${env.TELEMETRY_SINKS:=console,sqlite}
       sqlite_db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/meta-reference-gpu}/trace_store.db
       otel_exporter_otlp_endpoint: ${env.OTEL_EXPORTER_OTLP_ENDPOINT:=}

--- a/llama_stack/distributions/nvidia/run-with-safety.yaml
+++ b/llama_stack/distributions/nvidia/run-with-safety.yaml
@@ -51,7 +51,7 @@ providers:
   - provider_id: meta-reference
     provider_type: inline::meta-reference
     config:
-      service_name: "${env.OTEL_SERVICE_NAME:=\u200B}"
+      service_name: "${env.OTEL_SERVICE_NAME:=}"
       sinks: ${env.TELEMETRY_SINKS:=console,sqlite}
       sqlite_db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/nvidia}/trace_store.db
       otel_exporter_otlp_endpoint: ${env.OTEL_EXPORTER_OTLP_ENDPOINT:=}

--- a/llama_stack/distributions/nvidia/run.yaml
+++ b/llama_stack/distributions/nvidia/run.yaml
@@ -46,7 +46,7 @@ providers:
   - provider_id: meta-reference
     provider_type: inline::meta-reference
     config:
-      service_name: "${env.OTEL_SERVICE_NAME:=\u200B}"
+      service_name: "${env.OTEL_SERVICE_NAME:=}"
       sinks: ${env.TELEMETRY_SINKS:=console,sqlite}
       sqlite_db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/nvidia}/trace_store.db
       otel_exporter_otlp_endpoint: ${env.OTEL_EXPORTER_OTLP_ENDPOINT:=}

--- a/llama_stack/distributions/open-benchmark/run.yaml
+++ b/llama_stack/distributions/open-benchmark/run.yaml
@@ -80,7 +80,7 @@ providers:
   - provider_id: meta-reference
     provider_type: inline::meta-reference
     config:
-      service_name: "${env.OTEL_SERVICE_NAME:=\u200B}"
+      service_name: "${env.OTEL_SERVICE_NAME:=}"
       sinks: ${env.TELEMETRY_SINKS:=console,sqlite}
       sqlite_db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/open-benchmark}/trace_store.db
       otel_exporter_otlp_endpoint: ${env.OTEL_EXPORTER_OTLP_ENDPOINT:=}

--- a/llama_stack/distributions/postgres-demo/run.yaml
+++ b/llama_stack/distributions/postgres-demo/run.yaml
@@ -53,7 +53,7 @@ providers:
   - provider_id: meta-reference
     provider_type: inline::meta-reference
     config:
-      service_name: "${env.OTEL_SERVICE_NAME:=\u200B}"
+      service_name: "${env.OTEL_SERVICE_NAME:=}"
       sinks: ${env.TELEMETRY_SINKS:=console,otel_trace}
       otel_exporter_otlp_endpoint: ${env.OTEL_EXPORTER_OTLP_ENDPOINT:=http://localhost:4318/v1/traces}
   tool_runtime:

--- a/llama_stack/distributions/starter-gpu/run.yaml
+++ b/llama_stack/distributions/starter-gpu/run.yaml
@@ -151,7 +151,7 @@ providers:
   - provider_id: meta-reference
     provider_type: inline::meta-reference
     config:
-      service_name: "${env.OTEL_SERVICE_NAME:=\u200B}"
+      service_name: "${env.OTEL_SERVICE_NAME:=}"
       sinks: ${env.TELEMETRY_SINKS:=console,sqlite}
       sqlite_db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/starter-gpu}/trace_store.db
       otel_exporter_otlp_endpoint: ${env.OTEL_EXPORTER_OTLP_ENDPOINT:=}

--- a/llama_stack/distributions/starter/run.yaml
+++ b/llama_stack/distributions/starter/run.yaml
@@ -151,7 +151,7 @@ providers:
   - provider_id: meta-reference
     provider_type: inline::meta-reference
     config:
-      service_name: "${env.OTEL_SERVICE_NAME:=\u200B}"
+      service_name: "${env.OTEL_SERVICE_NAME:=}"
       sinks: ${env.TELEMETRY_SINKS:=console,sqlite}
       sqlite_db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/starter}/trace_store.db
       otel_exporter_otlp_endpoint: ${env.OTEL_EXPORTER_OTLP_ENDPOINT:=}

--- a/llama_stack/distributions/watsonx/run.yaml
+++ b/llama_stack/distributions/watsonx/run.yaml
@@ -46,7 +46,7 @@ providers:
   - provider_id: meta-reference
     provider_type: inline::meta-reference
     config:
-      service_name: "${env.OTEL_SERVICE_NAME:=\u200B}"
+      service_name: "${env.OTEL_SERVICE_NAME:=}"
       sinks: ${env.TELEMETRY_SINKS:=console,sqlite}
       sqlite_db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/watsonx}/trace_store.db
       otel_exporter_otlp_endpoint: ${env.OTEL_EXPORTER_OTLP_ENDPOINT:=}

--- a/llama_stack/providers/inline/telemetry/meta_reference/config.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/config.py
@@ -24,10 +24,9 @@ class TelemetryConfig(BaseModel):
         default=None,
         description="The OpenTelemetry collector endpoint URL (base URL for traces, metrics, and logs). If not set, the SDK will use OTEL_EXPORTER_OTLP_ENDPOINT environment variable.",
     )
-    service_name: str = Field(
-        # service name is always the same, use zero-width space to avoid clutter
-        default="\u200b",
-        description="The service name to use for telemetry",
+    service_name: str | None = Field(
+        default=None,
+        description="The service name to use for telemetry. Defaults to 'llama-stack' if not set.",
     )
     sinks: list[TelemetrySink] = Field(
         default=[TelemetrySink.CONSOLE, TelemetrySink.SQLITE],
@@ -48,7 +47,7 @@ class TelemetryConfig(BaseModel):
     @classmethod
     def sample_run_config(cls, __distro_dir__: str, db_name: str = "trace_store.db") -> dict[str, Any]:
         return {
-            "service_name": "${env.OTEL_SERVICE_NAME:=\u200b}",
+            "service_name": "${env.OTEL_SERVICE_NAME:=}",
             "sinks": "${env.TELEMETRY_SINKS:=console,sqlite}",
             "sqlite_db_path": "${env.SQLITE_STORE_DIR:=" + __distro_dir__ + "}/" + db_name,
             "otel_exporter_otlp_endpoint": "${env.OTEL_EXPORTER_OTLP_ENDPOINT:=}",

--- a/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
@@ -51,6 +51,9 @@ from llama_stack.providers.utils.telemetry.tracing import ROOT_SPAN_MARKERS
 
 from .config import TelemetryConfig, TelemetrySink
 
+# Default service name when not explicitly configured
+DEFAULT_SERVICE_NAME = "llama-stack"
+
 _GLOBAL_STORAGE: dict[str, dict[str | int, Any]] = {
     "active_spans": {},
     "counters": {},
@@ -74,9 +77,12 @@ class TelemetryAdapter(TelemetryDatasetMixin, Telemetry):
         self.datasetio_api = deps.get(Api.datasetio)
         self.meter = None
 
+        # Use configured service name or default to "llama-stack"
+        effective_service_name = self.config.service_name or DEFAULT_SERVICE_NAME
+
         resource = Resource.create(
             {
-                ResourceAttributes.SERVICE_NAME: self.config.service_name,
+                ResourceAttributes.SERVICE_NAME: effective_service_name,
             }
         )
 

--- a/tests/unit/providers/telemetry/__init__.py
+++ b/tests/unit/providers/telemetry/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.

--- a/tests/unit/providers/telemetry/test_telemetry_config.py
+++ b/tests/unit/providers/telemetry/test_telemetry_config.py
@@ -1,0 +1,134 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Tests for TelemetryConfig handling of empty/None service_name.
+
+This test suite validates the fix for the empty env var default issue
+(https://github.com/meta-llama/llama-stack/issues/4611), ensuring that
+TelemetryConfig accepts None/empty service_name values and the
+TelemetryAdapter handles them gracefully with a default value.
+"""
+
+import pytest
+
+from llama_stack.providers.inline.telemetry.meta_reference.config import TelemetryConfig
+
+
+class TestTelemetryConfigServiceName:
+    """Test TelemetryConfig handling of service_name field."""
+
+    def test_service_name_accepts_none(self):
+        """Test that TelemetryConfig accepts None for service_name."""
+        config = TelemetryConfig(service_name=None)
+        assert config.service_name is None
+
+    def test_service_name_accepts_empty_string(self):
+        """Test that TelemetryConfig accepts empty string for service_name."""
+        config = TelemetryConfig(service_name="")
+        assert config.service_name == ""
+
+    def test_service_name_accepts_valid_string(self):
+        """Test that TelemetryConfig accepts valid string for service_name."""
+        config = TelemetryConfig(service_name="my-service")
+        assert config.service_name == "my-service"
+
+    def test_service_name_default_is_none(self):
+        """Test that service_name defaults to None when not specified."""
+        config = TelemetryConfig()
+        assert config.service_name is None
+
+    def test_sample_run_config_has_service_name(self):
+        """Test that sample_run_config includes service_name field."""
+        sample = TelemetryConfig.sample_run_config(__distro_dir__="/tmp/test")
+        assert "service_name" in sample
+        # Should use env var syntax with empty default (no zero-width space)
+        assert sample["service_name"] == "${env.OTEL_SERVICE_NAME:=}"
+
+    def test_sample_run_config_no_zero_width_space(self):
+        """Test that sample_run_config does not use zero-width space character.
+
+        The previous implementation used a zero-width space (\\u200b) as a workaround
+        to pass Pydantic validation while appearing empty. This is problematic because:
+        1. Invisible characters cause debugging difficulties
+        2. Copy-paste can lose or duplicate these characters
+        3. Most editors don't show them, hiding the actual value
+        """
+        sample = TelemetryConfig.sample_run_config(__distro_dir__="/tmp/test")
+        # Ensure no zero-width space in service_name template
+        assert "\u200b" not in sample["service_name"]
+
+
+class TestTelemetryAdapterServiceName:
+    """Test TelemetryAdapter handling of None/empty service_name."""
+
+    def test_default_service_name_constant_exists(self):
+        """Test that DEFAULT_SERVICE_NAME constant is defined."""
+        from llama_stack.providers.inline.telemetry.meta_reference.telemetry import (
+            DEFAULT_SERVICE_NAME,
+        )
+
+        assert DEFAULT_SERVICE_NAME == "llama-stack"
+
+    def test_adapter_handles_none_service_name(self):
+        """Test that TelemetryAdapter handles None service_name without error.
+
+        When service_name is None, the adapter should use the default "llama-stack".
+        """
+        from unittest.mock import MagicMock, patch
+
+        from llama_stack.providers.inline.telemetry.meta_reference.telemetry import (
+            DEFAULT_SERVICE_NAME,
+        )
+
+        # Reset global state to ensure clean test
+        import llama_stack.providers.inline.telemetry.meta_reference.telemetry as telemetry_module
+
+        original_provider = telemetry_module._TRACER_PROVIDER
+        telemetry_module._TRACER_PROVIDER = None
+
+        try:
+            config = TelemetryConfig(service_name=None)
+
+            # Mock the trace module to capture the Resource creation
+            with patch.object(telemetry_module, "trace") as mock_trace:
+                mock_trace.get_tracer_provider.return_value = MagicMock()
+
+                # Import and instantiate adapter
+                from llama_stack.providers.inline.telemetry.meta_reference.telemetry import (
+                    TelemetryAdapter,
+                )
+
+                adapter = TelemetryAdapter(config, deps={})
+
+                # The adapter should have been created without error
+                assert adapter is not None
+        finally:
+            # Restore original state
+            telemetry_module._TRACER_PROVIDER = original_provider
+
+    def test_adapter_uses_custom_service_name(self):
+        """Test that TelemetryAdapter uses custom service_name when provided."""
+        from unittest.mock import MagicMock, patch
+
+        import llama_stack.providers.inline.telemetry.meta_reference.telemetry as telemetry_module
+
+        original_provider = telemetry_module._TRACER_PROVIDER
+        telemetry_module._TRACER_PROVIDER = None
+
+        try:
+            config = TelemetryConfig(service_name="custom-service")
+
+            with patch.object(telemetry_module, "trace") as mock_trace:
+                mock_trace.get_tracer_provider.return_value = MagicMock()
+
+                from llama_stack.providers.inline.telemetry.meta_reference.telemetry import (
+                    TelemetryAdapter,
+                )
+
+                adapter = TelemetryAdapter(config, deps={})
+                assert adapter is not None
+        finally:
+            telemetry_module._TRACER_PROVIDER = original_provider


### PR DESCRIPTION
## Summary

- Makes `TelemetryConfig.service_name` accept `None` by changing type from `str` to `str | None`
- Adds default "llama-stack" in `TelemetryAdapter` when `service_name` is None/empty
- Removes zero-width space (`\u200B`) from all distribution run.yaml files

## Problem

When `${env.OTEL_SERVICE_NAME:=}` resolves to empty string, `_convert_string_to_proper_type()` converts it to `None`. However, `TelemetryConfig.service_name` is typed as `str`, causing Pydantic `ValidationError`:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for TelemetryConfig
service_name
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
```

This prevented the server from starting when `OTEL_SERVICE_NAME` environment variable was not set.

## Solution

1. **config.py**: Changed `service_name` type to `str | None` with default `None`
2. **telemetry.py**: Added `DEFAULT_SERVICE_NAME = "llama-stack"` constant and fallback logic
3. **Distribution templates**: Removed zero-width space workaround from all YAML files

## Test plan

- [ ] Unit tests pass: `pytest tests/unit/providers/telemetry/test_telemetry_config.py -v`
- [ ] Start server without `OTEL_SERVICE_NAME` set - should use "llama-stack" default
- [ ] Start server with `OTEL_SERVICE_NAME=my-service` - should use "my-service"

## Note on invisible characters in config files

The previous implementation used a zero-width space character (`\u200B`) as the default value to work around Pydantic validation while keeping the service name "empty". This pattern of using invisible Unicode characters (zero-width spaces, tabs, etc.) as configuration markers is problematic because:

1. **Debugging difficulty** - Values appear empty but aren't, causing confusing behavior
2. **Copy-paste issues** - Invisible characters can be lost or duplicated when copying config
3. **Editor display** - Most editors don't show these characters, hiding the actual value
4. **YAML parsing** - Some YAML parsers may handle these characters inconsistently

The fix properly uses `None` to represent "not set" rather than invisible character workarounds.

Fixes #4611

🤖 Generated with [Claude Code](https://claude.com/claude-code)