### PR TITLE
fix: Removed unused para for test score

### DIFF
--- a/tests/integration/scoring/test_scoring.py
+++ b/tests/integration/scoring/test_scoring.py
@@ -184,7 +184,6 @@ def test_scoring_score_with_aggregation_functions(
     sample_judge_prompt_template,
     judge_model_id,
     provider_id,
-    rag_dataset_for_test,
 ):
     df = pd.read_csv(Path(__file__).parent.parent / "datasets" / "test_dataset.csv")
     rows = df.to_dict(orient="records")


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

`rag_dataset_for_test` is not defined and not used in test.

```
====================================================================================================== ERRORS ======================================================================================================
__________________________________________________ ERROR at setup of test_scoring_score_with_aggregation_functions[judge=ollama/llama3.2:3b-instruct-fp16-basic] ___________________________________________________
file /Users/gualiu/go/src/github.com/llamastack/llama-stack/tests/integration/scoring/test_scoring.py, line 174
  @pytest.mark.parametrize(
      "provider_id",
      [
          "basic",
          "llm-as-judge",
          "braintrust",
      ],
  )
  def test_scoring_score_with_aggregation_functions(
E       fixture 'rag_dataset_for_test' not found
>       available fixtures: _class_scoped_runner, _function_scoped_runner, _module_scoped_runner, _package_scoped_runner, _session_scoped_runner, _track_test_context, anyio_backend, anyio_backend_name, anyio_backend_options, available_shields, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, capteesys, cleanup_server_process, client_with_models, compat_client, cov, doctest_namespace, event_loop_policy, extra, extras, free_tcp_port, free_tcp_port_factory, free_udp_port, free_udp_port_factory, include_metadata_in_junit_xml, inference_provider_type, json_metadata, llama_stack_client, metadata, model_providers, monkeypatch, no_cover, openai_client, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, require_server, sample_judge_prompt_template, sample_scoring_fn_id, skip_if_no_model, socket_disabled, socket_enabled, suppress_httpx_logs, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory, unused_tcp_port, unused_tcp_port_factory, unused_udp_port, unused_udp_port_factory, vector_io_provider_id
>       use 'pytest --fixtures [testpath]' for help on them.

/Users/gualiu/go/src/github.com/llamastack/llama-stack/tests/integration/scoring/test_scoring.py:174
_______________________________________________ ERROR at setup of test_scoring_score_with_aggregation_functions[judge=ollama/llama3.2:3b-instruct-fp16-llm-as-judge] _______________________________________________
file /Users/gualiu/go/src/github.com/llamastack/llama-stack/tests/integration/scoring/test_scoring.py, line 174
  @pytest.mark.parametrize(
      "provider_id",
      [
          "basic",
          "llm-as-judge",
          "braintrust",
      ],
  )
  def test_scoring_score_with_aggregation_functions(
E       fixture 'rag_dataset_for_test' not found
>       available fixtures: _class_scoped_runner, _function_scoped_runner, _module_scoped_runner, _package_scoped_runner, _session_scoped_runner, _track_test_context, anyio_backend, anyio_backend_name, anyio_backend_options, available_shields, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, capteesys, cleanup_server_process, client_with_models, compat_client, cov, doctest_namespace, event_loop_policy, extra, extras, free_tcp_port, free_tcp_port_factory, free_udp_port, free_udp_port_factory, include_metadata_in_junit_xml, inference_provider_type, json_metadata, llama_stack_client, metadata, model_providers, monkeypatch, no_cover, openai_client, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, require_server, sample_judge_prompt_template, sample_scoring_fn_id, skip_if_no_model, socket_disabled, socket_enabled, suppress_httpx_logs, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory, unused_tcp_port, unused_tcp_port_factory, unused_udp_port, unused_udp_port_factory, vector_io_provider_id
>       use 'pytest --fixtures [testpath]' for help on them.

/Users/gualiu/go/src/github.com/llamastack/llama-stack/tests/integration/scoring/test_scoring.py:174
________________________________________________ ERROR at setup of test_scoring_score_with_aggregation_functions[judge=ollama/llama3.2:3b-instruct-fp16-braintrust] ________________________________________________
file /Users/gualiu/go/src/github.com/llamastack/llama-stack/tests/integration/scoring/test_scoring.py, line 174
  @pytest.mark.parametrize(
      "provider_id",
      [
          "basic",
          "llm-as-judge",
          "braintrust",
      ],
  )
  def test_scoring_score_with_aggregation_functions(
E       fixture 'rag_dataset_for_test' not found
>       available fixtures: _class_scoped_runner, _function_scoped_runner, _module_scoped_runner, _package_scoped_runner, _session_scoped_runner, _track_test_context, anyio_backend, anyio_backend_name, anyio_backend_options, available_shields, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, capteesys, cleanup_server_process, client_with_models, compat_client, cov, doctest_namespace, event_loop_policy, extra, extras, free_tcp_port, free_tcp_port_factory, free_udp_port, free_udp_port_factory, include_metadata_in_junit_xml, inference_provider_type, json_metadata, llama_stack_client, metadata, model_providers, monkeypatch, no_cover, openai_client, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, require_server, sample_judge_prompt_template, sample_scoring_fn_id, skip_if_no_model, socket_disabled, socket_enabled, suppress_httpx_logs, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory, unused_tcp_port, unused_tcp_port_factory, unused_udp_port, unused_udp_port_factory, vector_io_provider_id
>       use 'pytest --fixtures [testpath]' for help on them.


```

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->
