### PR TITLE
fix!: align chat completions POST API with OpenAI spec

### DIFF
--- a/client-sdks/stainless/openapi.yml
+++ b/client-sdks/stainless/openapi.yml
@@ -4654,9 +4654,11 @@ components:
               system: '#/components/schemas/OpenAISystemMessageParam'
               tool: '#/components/schemas/OpenAIToolMessageParam'
               user: '#/components/schemas/OpenAIUserMessageParam-Output'
+          type: object
         finish_reason:
-          type: string
           title: Finish Reason
+          type: string
+          nullable: true
         index:
           type: integer
           title: Index
@@ -5172,6 +5174,7 @@ components:
           - $ref: '#/components/schemas/OpenAIChatCompletionUsage'
             title: OpenAIChatCompletionUsage
           - type: 'null'
+          type: object
           title: OpenAIChatCompletionUsage
       type: object
       required:
@@ -5257,6 +5260,7 @@ components:
         finish_reason:
           title: Finish Reason
           type: string
+          nullable: true
         index:
           title: Index
           type: integer
@@ -5473,8 +5477,9 @@ components:
     OpenAICompletionChoice:
       properties:
         finish_reason:
-          type: string
-          title: Finish Reason
+          anyOf:
+          - type: string
+          - type: 'null'
         text:
           type: string
           title: Text

--- a/docs/static/deprecated-llama-stack-spec.yaml
+++ b/docs/static/deprecated-llama-stack-spec.yaml
@@ -1300,9 +1300,11 @@ components:
               system: '#/components/schemas/OpenAISystemMessageParam'
               tool: '#/components/schemas/OpenAIToolMessageParam'
               user: '#/components/schemas/OpenAIUserMessageParam-Output'
+          type: object
         finish_reason:
-          type: string
           title: Finish Reason
+          type: string
+          nullable: true
         index:
           type: integer
           title: Index
@@ -1818,6 +1820,7 @@ components:
           - $ref: '#/components/schemas/OpenAIChatCompletionUsage'
             title: OpenAIChatCompletionUsage
           - type: 'null'
+          type: object
           title: OpenAIChatCompletionUsage
       type: object
       required:
@@ -1903,6 +1906,7 @@ components:
         finish_reason:
           title: Finish Reason
           type: string
+          nullable: true
         index:
           title: Index
           type: integer
@@ -2119,8 +2123,9 @@ components:
     OpenAICompletionChoice:
       properties:
         finish_reason:
-          type: string
-          title: Finish Reason
+          anyOf:
+          - type: string
+          - type: 'null'
         text:
           type: string
           title: Text

--- a/docs/static/experimental-llama-stack-spec.yaml
+++ b/docs/static/experimental-llama-stack-spec.yaml
@@ -1371,9 +1371,11 @@ components:
               system: '#/components/schemas/OpenAISystemMessageParam'
               tool: '#/components/schemas/OpenAIToolMessageParam'
               user: '#/components/schemas/OpenAIUserMessageParam-Output'
+          type: object
         finish_reason:
-          type: string
           title: Finish Reason
+          type: string
+          nullable: true
         index:
           type: integer
           title: Index
@@ -1889,6 +1891,7 @@ components:
           - $ref: '#/components/schemas/OpenAIChatCompletionUsage'
             title: OpenAIChatCompletionUsage
           - type: 'null'
+          type: object
           title: OpenAIChatCompletionUsage
       type: object
       required:
@@ -1974,6 +1977,7 @@ components:
         finish_reason:
           title: Finish Reason
           type: string
+          nullable: true
         index:
           title: Index
           type: integer
@@ -2190,8 +2194,9 @@ components:
     OpenAICompletionChoice:
       properties:
         finish_reason:
-          type: string
-          title: Finish Reason
+          anyOf:
+          - type: string
+          - type: 'null'
         text:
           type: string
           title: Text

--- a/docs/static/llama-stack-spec.yaml
+++ b/docs/static/llama-stack-spec.yaml
@@ -3122,9 +3122,11 @@ components:
               system: '#/components/schemas/OpenAISystemMessageParam'
               tool: '#/components/schemas/OpenAIToolMessageParam'
               user: '#/components/schemas/OpenAIUserMessageParam-Output'
+          type: object
         finish_reason:
-          type: string
           title: Finish Reason
+          type: string
+          nullable: true
         index:
           type: integer
           title: Index
@@ -3640,6 +3642,7 @@ components:
           - $ref: '#/components/schemas/OpenAIChatCompletionUsage'
             title: OpenAIChatCompletionUsage
           - type: 'null'
+          type: object
           title: OpenAIChatCompletionUsage
       type: object
       required:
@@ -3725,6 +3728,7 @@ components:
         finish_reason:
           title: Finish Reason
           type: string
+          nullable: true
         index:
           title: Index
           type: integer
@@ -3941,8 +3945,9 @@ components:
     OpenAICompletionChoice:
       properties:
         finish_reason:
-          type: string
-          title: Finish Reason
+          anyOf:
+          - type: string
+          - type: 'null'
         text:
           type: string
           title: Text

--- a/docs/static/stainless-llama-stack-spec.yaml
+++ b/docs/static/stainless-llama-stack-spec.yaml
@@ -4654,9 +4654,11 @@ components:
               system: '#/components/schemas/OpenAISystemMessageParam'
               tool: '#/components/schemas/OpenAIToolMessageParam'
               user: '#/components/schemas/OpenAIUserMessageParam-Output'
+          type: object
         finish_reason:
-          type: string
           title: Finish Reason
+          type: string
+          nullable: true
         index:
           type: integer
           title: Index
@@ -5172,6 +5174,7 @@ components:
           - $ref: '#/components/schemas/OpenAIChatCompletionUsage'
             title: OpenAIChatCompletionUsage
           - type: 'null'
+          type: object
           title: OpenAIChatCompletionUsage
       type: object
       required:
@@ -5257,6 +5260,7 @@ components:
         finish_reason:
           title: Finish Reason
           type: string
+          nullable: true
         index:
           title: Index
           type: integer
@@ -5473,8 +5477,9 @@ components:
     OpenAICompletionChoice:
       properties:
         finish_reason:
-          type: string
-          title: Finish Reason
+          anyOf:
+          - type: string
+          - type: 'null'
         text:
           type: string
           title: Text

--- a/scripts/openapi_generator/schema_transforms.py
+++ b/scripts/openapi_generator/schema_transforms.py
@@ -924,10 +924,101 @@ def _apply_legacy_sorting(openapi_schema: dict[str, Any]) -> dict[str, Any]:
     return openapi_schema
 
 
+def _convert_anyof_null_to_nullable(prop: dict[str, Any]) -> None:
+    """Convert anyOf with null type to nullable: true format (OpenAPI 3.0 style).
+
+    This converts patterns like:
+        anyOf:
+          - type: string
+          - type: 'null'
+    To:
+        type: string
+        nullable: true
+    """
+    if "anyOf" not in prop:
+        return
+
+    any_of = prop["anyOf"]
+    if not isinstance(any_of, list) or len(any_of) != 2:
+        return
+
+    # Find the null type and the actual type
+    null_item = None
+    actual_item = None
+    for item in any_of:
+        if isinstance(item, dict):
+            if item.get("type") == "null" or item.get("type") == "'null'":
+                null_item = item
+            else:
+                actual_item = item
+
+    if null_item is not None and actual_item is not None:
+        # Remove anyOf and add nullable: true with the actual type
+        del prop["anyOf"]
+        if "type" in actual_item:
+            prop["type"] = actual_item["type"]
+        if "$ref" in actual_item:
+            prop["$ref"] = actual_item["$ref"]
+        prop["nullable"] = True
+
+
+def _fix_openai_chat_completions_compatibility(openapi_schema: dict[str, Any]) -> dict[str, Any]:
+    """Fix OpenAI chat completions schema for oasdiff compatibility.
+
+    This addresses several breaking change errors when comparing against OpenAI's spec:
+    - Converts finish_reason from anyOf null to nullable: true format
+    - Adds type: object to OpenAIChoice.message (oneOf without explicit type)
+    - Adds type: object to OpenAIChatCompletion.usage (anyOf without explicit type)
+    - Adds type: object to OpenAIChatCompletionRequestWithExtraBody request body
+    """
+    schemas = openapi_schema.get("components", {}).get("schemas", {})
+
+    # Fix OpenAIChoice schema
+    if "OpenAIChoice" in schemas:
+        choice_schema = schemas["OpenAIChoice"]
+        if "properties" in choice_schema:
+            # Fix message - add type: object to the oneOf wrapper
+            if "message" in choice_schema["properties"]:
+                message_prop = choice_schema["properties"]["message"]
+                if "oneOf" in message_prop and "type" not in message_prop:
+                    message_prop["type"] = "object"
+
+            # Fix finish_reason - convert anyOf null to nullable: true
+            if "finish_reason" in choice_schema["properties"]:
+                _convert_anyof_null_to_nullable(choice_schema["properties"]["finish_reason"])
+
+    # Fix OpenAIChunkChoice schema (streaming response)
+    if "OpenAIChunkChoice" in schemas:
+        chunk_choice_schema = schemas["OpenAIChunkChoice"]
+        if "properties" in chunk_choice_schema:
+            # Fix finish_reason - convert anyOf null to nullable: true
+            if "finish_reason" in chunk_choice_schema["properties"]:
+                _convert_anyof_null_to_nullable(chunk_choice_schema["properties"]["finish_reason"])
+
+    # Fix OpenAIChatCompletion.usage - add type: object to the anyOf wrapper
+    if "OpenAIChatCompletion" in schemas:
+        completion_schema = schemas["OpenAIChatCompletion"]
+        if "properties" in completion_schema and "usage" in completion_schema["properties"]:
+            usage_prop = completion_schema["properties"]["usage"]
+            if "anyOf" in usage_prop and "type" not in usage_prop:
+                usage_prop["type"] = "object"
+
+    # Fix OpenAIChatCompletionRequestWithExtraBody - ensure type: object is present
+    if "OpenAIChatCompletionRequestWithExtraBody" in schemas:
+        request_schema = schemas["OpenAIChatCompletionRequestWithExtraBody"]
+        if "type" not in request_schema:
+            request_schema["type"] = "object"
+
+    return openapi_schema
+
+
 def _fix_schema_issues(openapi_schema: dict[str, Any]) -> dict[str, Any]:
     """Fix common schema issues: exclusiveMinimum, null defaults, and add titles to unions."""
     # Convert anyOf with const values to enums across the entire schema
     _convert_anyof_const_to_enum(openapi_schema)
+
+    # Fix OpenAI chat completions compatibility issues
+    _fix_openai_chat_completions_compatibility(openapi_schema)
 
     # Fix other schema issues and add titles to unions
     if "components" in openapi_schema and "schemas" in openapi_schema["components"]:

--- a/src/llama_stack_api/inference.py
+++ b/src/llama_stack_api/inference.py
@@ -701,7 +701,7 @@ class OpenAIChunkChoice(BaseModel):
     """
 
     delta: OpenAIChoiceDelta
-    finish_reason: str
+    finish_reason: str | None
     index: int
     logprobs: OpenAIChoiceLogprobs | None = None
 
@@ -717,7 +717,7 @@ class OpenAIChoice(BaseModel):
     """
 
     message: OpenAIMessageParam
-    finish_reason: str
+    finish_reason: str | None
     index: int
     logprobs: OpenAIChoiceLogprobs | None = None
 
@@ -824,7 +824,7 @@ class OpenAICompletionChoice(BaseModel):
     :logprobs: (Optional) The log probabilities for the tokens in the choice
     """
 
-    finish_reason: str
+    finish_reason: str | None
     text: str
     index: int
     logprobs: OpenAIChoiceLogprobs | None = None


### PR DESCRIPTION
# What does this PR do?

Fix oasdiff breaking change errors for POST /chat/completions:
- Make OpenAIChoice.finish_reason nullable to match OpenAI streaming response
- Add schema transform to convert anyOf null to nullable: true format
- Add type: object to OpenAIChoice.message (oneOf wrapper)
- Add type: object to OpenAIChatCompletion.usage (anyOf wrapper)

This resolves 3 of 5 oasdiff errors:
- response-property-became-nullable (finish_reason)
- response-property-type-changed (message)
- response-property-type-changed (usage)

Remaining errors (request-body-all-of-added, request-body-type-changed)
are due to structural differences in how OpenAI composes their request
schema using allOf with CreateModelResponseProperties.

this fixes the majority of the following errors in the `API Conformance` test:

```
error	[request-body-all-of-added] at docs/static/openai-spec-2.3.0.yml
	in API POST /chat/completions
		added '#/components/schemas/CreateModelResponseProperties, subschema #2' to the request body 'allOf' list

error	[request-body-type-changed] at docs/static/openai-spec-2.3.0.yml
	in API POST /chat/completions
		the request's body type/format changed from 'object'/'' to ''/''

error	[response-property-became-nullable] at docs/static/openai-spec-2.3.0.yml
	in API POST /chat/completions
		the response property 'choices/items/finish_reason' became nullable for the status '200'

error	[response-property-type-changed] at docs/static/openai-spec-2.3.0.yml
	in API POST /chat/completions
		the 'choices/items/message' response's property type/format changed from ''/'' to 'object'/'' for status '200'

error	[response-property-type-changed] at docs/static/openai-spec-2.3.0.yml
	in API POST /chat/completions
		the 'usage' response's property type/format changed from ''/'' to 'object'/'' for status '200'
```

 Closes #4621 

## Test Plan

errs should be gone from conformance test. 

depends on #4598 