### PR TITLE
fix: fix list-deps quoting in deps-only output

### DIFF
--- a/src/llama_stack/cli/stack/_list_deps.py
+++ b/src/llama_stack/cli/stack/_list_deps.py
@@ -47,16 +47,20 @@ def format_output_deps_only(
     uv_str = ""
     if uv:
         uv_str = "uv pip install "
-
-    # Quote deps with commas
-    quoted_normal_deps = [quote_if_needed(dep) for dep in normal_deps]
-    lines.append(f"{uv_str}{' '.join(quoted_normal_deps)}")
+        # Only quote when emitting a shell command. In deps-only mode, keep raw
+        # specs so they can be safely consumed via command substitution.
+        formatted_normal_deps = [quote_if_needed(dep) for dep in normal_deps]
+    else:
+        formatted_normal_deps = normal_deps
+    lines.append(f"{uv_str}{' '.join(formatted_normal_deps)}")
 
     for special_dep in special_deps:
-        lines.append(f"{uv_str}{quote_special_dep(special_dep)}")
+        formatted = quote_special_dep(special_dep) if uv else special_dep
+        lines.append(f"{uv_str}{formatted}")
 
     for external_dep in external_deps:
-        lines.append(f"{uv_str}{quote_special_dep(external_dep)}")
+        formatted = quote_special_dep(external_dep) if uv else external_dep
+        lines.append(f"{uv_str}{formatted}")
 
     return "\n".join(lines)
 

--- a/tests/unit/distribution/test_stack_list_deps.py
+++ b/tests/unit/distribution/test_stack_list_deps.py
@@ -9,6 +9,7 @@ from io import StringIO
 from unittest.mock import patch
 
 from llama_stack.cli.stack._list_deps import (
+    format_output_deps_only,
     run_stack_list_deps_command,
 )
 
@@ -48,3 +49,11 @@ def test_stack_list_deps_with_distro_uv():
         output = mock_stdout.getvalue()
 
         assert "uv pip install" in output
+
+
+def test_list_deps_formatting_quotes_only_for_uv():
+    deps_only = format_output_deps_only(["mcp>=1.23.0"], [], [], uv=False)
+    assert deps_only.strip() == "mcp>=1.23.0"
+
+    uv_format = format_output_deps_only(["mcp>=1.23.0"], [], [], uv=True)
+    assert uv_format.strip() == "uv pip install 'mcp>=1.23.0'"


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

Fixed #4614 

- Stop quoting version specs in deps-only output so command substitution works with uv pip install $(...).
- Keep quoting only for --format uv, which emits a full shell command.
- Add unit test covering deps-only vs uv formatting.

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->

```console
(llama-stack) gualiu@gualiu-mac llama-stack % uv pip install $(uv run llama stack list-deps --providers agents=inline::meta-reference)
Audited 17 packages in 13ms
```
```console
(llama-stack) gualiu@gualiu-mac llama-stack % uv run llama stack list-deps --providers agents=inline::meta-reference
fonttools>=4.60.2 matplotlib scikit-learn mcp>=1.23.0 psycopg2-binary pillow aiosqlite pymongo redis pandas aiosqlite fastapi fire httpx uvicorn opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
```
