### PR TITLE
feat: Implement run_moderation for all safety providers with NotImplementedError 

### DIFF
--- a/src/llama_stack/providers/inline/safety/prompt_guard/prompt_guard.py
+++ b/src/llama_stack/providers/inline/safety/prompt_guard/prompt_guard.py
@@ -9,12 +9,13 @@ from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
 from llama_stack.core.utils.model_utils import model_local_dir
 from llama_stack.log import get_logger
-from llama_stack.providers.utils.inference.prompt_adapter import interleaved_content_as_str
+from llama_stack.providers.utils.inference.prompt_adapter import (
+    interleaved_content_as_str,
+)
+from llama_stack.providers.utils.safety import ShieldToModerationMixin
 from llama_stack_api import (
     GetShieldRequest,
-    ModerationObject,
     OpenAIMessageParam,
-    RunModerationRequest,
     RunShieldRequest,
     RunShieldResponse,
     Safety,
@@ -32,7 +33,7 @@ log = get_logger(name=__name__, category="safety")
 PROMPT_GUARD_MODEL = "Prompt-Guard-86M"
 
 
-class PromptGuardSafetyImpl(Safety, ShieldsProtocolPrivate):
+class PromptGuardSafetyImpl(ShieldToModerationMixin, Safety, ShieldsProtocolPrivate):
     shield_store: ShieldStore
 
     def __init__(self, config: PromptGuardConfig, _deps) -> None:
@@ -58,9 +59,6 @@ class PromptGuardSafetyImpl(Safety, ShieldsProtocolPrivate):
             raise ValueError(f"Unknown shield {request.shield_id}")
 
         return await self.shield.run(request.messages)
-
-    async def run_moderation(self, request: RunModerationRequest) -> ModerationObject:
-        raise NotImplementedError("run_moderation is not implemented for Prompt Guard")
 
 
 class PromptGuardShield:

--- a/src/llama_stack/providers/remote/safety/bedrock/bedrock.py
+++ b/src/llama_stack/providers/remote/safety/bedrock/bedrock.py
@@ -8,10 +8,9 @@ import json
 
 from llama_stack.log import get_logger
 from llama_stack.providers.utils.bedrock.client import create_bedrock_client
+from llama_stack.providers.utils.safety import ShieldToModerationMixin
 from llama_stack_api import (
     GetShieldRequest,
-    ModerationObject,
-    RunModerationRequest,
     RunShieldRequest,
     RunShieldResponse,
     Safety,
@@ -26,7 +25,7 @@ from .config import BedrockSafetyConfig
 logger = get_logger(name=__name__, category="safety::bedrock")
 
 
-class BedrockSafetyAdapter(Safety, ShieldsProtocolPrivate):
+class BedrockSafetyAdapter(ShieldToModerationMixin, Safety, ShieldsProtocolPrivate):
     def __init__(self, config: BedrockSafetyConfig) -> None:
         self.config = config
         self.registered_shields = []
@@ -93,6 +92,3 @@ class BedrockSafetyAdapter(Safety, ShieldsProtocolPrivate):
             )
 
         return RunShieldResponse()
-
-    async def run_moderation(self, request: RunModerationRequest) -> ModerationObject:
-        raise NotImplementedError("Bedrock safety provider currently does not implement run_moderation")

--- a/src/llama_stack/providers/remote/safety/nvidia/nvidia.py
+++ b/src/llama_stack/providers/remote/safety/nvidia/nvidia.py
@@ -9,11 +9,10 @@ from typing import Any
 import requests
 
 from llama_stack.log import get_logger
+from llama_stack.providers.utils.safety import ShieldToModerationMixin
 from llama_stack_api import (
     GetShieldRequest,
-    ModerationObject,
     OpenAIMessageParam,
-    RunModerationRequest,
     RunShieldRequest,
     RunShieldResponse,
     Safety,
@@ -28,7 +27,7 @@ from .config import NVIDIASafetyConfig
 logger = get_logger(name=__name__, category="safety::nvidia")
 
 
-class NVIDIASafetyAdapter(Safety, ShieldsProtocolPrivate):
+class NVIDIASafetyAdapter(ShieldToModerationMixin, Safety, ShieldsProtocolPrivate):
     def __init__(self, config: NVIDIASafetyConfig) -> None:
         """
         Initialize the NVIDIASafetyAdapter with a given safety configuration.
@@ -59,9 +58,6 @@ class NVIDIASafetyAdapter(Safety, ShieldsProtocolPrivate):
 
         self.shield = NeMoGuardrails(self.config, shield.shield_id)
         return await self.shield.run(request.messages)
-
-    async def run_moderation(self, request: RunModerationRequest) -> ModerationObject:
-        raise NotImplementedError("NVIDIA safety provider currently does not implement run_moderation")
 
 
 class NeMoGuardrails:

--- a/src/llama_stack/providers/utils/safety.py
+++ b/src/llama_stack/providers/utils/safety.py
@@ -1,0 +1,114 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import uuid
+from typing import TYPE_CHECKING
+
+from llama_stack_api import (
+    ModerationObject,
+    ModerationObjectResults,
+    OpenAIUserMessageParam,
+    RunModerationRequest,
+    RunShieldRequest,
+    RunShieldResponse,
+)
+
+if TYPE_CHECKING:
+    # Type stub for mypy - actual implementation provided by provider class
+    class _RunShieldProtocol:
+        async def run_shield(self, request: RunShieldRequest) -> RunShieldResponse: ...
+
+
+class ShieldToModerationMixin:
+    """
+    Mixin that provides run_moderation implementation by delegating to run_shield.
+
+    Providers must implement run_shield(request: RunShieldRequest) for this mixin to work.
+    Providers with custom run_moderation implementations will override this automatically.
+    """
+
+    if TYPE_CHECKING:
+        # Type hint for mypy - run_shield is provided by the mixed-in class
+        async def run_shield(self, request: RunShieldRequest) -> RunShieldResponse: ...
+
+    async def run_moderation(self, request: RunModerationRequest) -> ModerationObject:
+        """
+        Run moderation by converting input to messages and delegating to run_shield.
+
+        Args:
+            request: RunModerationRequest with input and model
+
+        Returns:
+            ModerationObject with results for each input
+
+        Raises:
+            ValueError: If model is None
+        """
+        if request.model is None:
+            raise ValueError(f"{self.__class__.__name__} moderation requires a model identifier")
+
+        inputs = request.input if isinstance(request.input, list) else [request.input]
+        results = []
+
+        for text_input in inputs:
+            # Convert string to OpenAI message format
+            message = OpenAIUserMessageParam(content=text_input)
+
+            # Call run_shield (must be implemented by the provider)
+            shield_request = RunShieldRequest(
+                shield_id=request.model,
+                messages=[message],
+            )
+            shield_response = await self.run_shield(shield_request)
+
+            # Convert RunShieldResponse to ModerationObjectResults
+            results.append(self._shield_response_to_moderation_result(shield_response))
+
+        return ModerationObject(
+            id=f"modr-{uuid.uuid4()}",
+            model=request.model,
+            results=results,
+        )
+
+    def _shield_response_to_moderation_result(
+        self,
+        shield_response: RunShieldResponse,
+    ) -> ModerationObjectResults:
+        """Convert RunShieldResponse to ModerationObjectResults.
+
+        Args:
+            shield_response: The response from run_shield
+
+        Returns:
+            ModerationObjectResults with appropriate fields set
+        """
+        if shield_response.violation is None:
+            # Safe content
+            return ModerationObjectResults(
+                flagged=False,
+                categories={},
+                category_scores={},
+                category_applied_input_types={},
+                user_message=None,
+                metadata={},
+            )
+
+        # Unsafe content - extract violation details
+        v = shield_response.violation
+        violation_type = v.metadata.get("violation_type", "unsafe")
+
+        # Ensure violation_type is a string (metadata values can be Any)
+        if not isinstance(violation_type, str):
+            violation_type = "unsafe"
+
+        return ModerationObjectResults(
+            flagged=True,
+            categories={violation_type: True},
+            category_scores={violation_type: 1.0},
+            category_applied_input_types={violation_type: ["text"]},
+            user_message=v.user_message,
+            metadata=v.metadata,
+        )

--- a/tests/unit/providers/utils/test_safety_mixin.py
+++ b/tests/unit/providers/utils/test_safety_mixin.py
@@ -1,0 +1,184 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from llama_stack.providers.inline.safety.prompt_guard.prompt_guard import (
+    PromptGuardSafetyImpl,
+)
+from llama_stack.providers.remote.safety.bedrock.bedrock import BedrockSafetyAdapter
+from llama_stack.providers.remote.safety.nvidia.nvidia import NVIDIASafetyAdapter
+from llama_stack.providers.remote.safety.sambanova.sambanova import (
+    SambaNovaSafetyAdapter,
+)
+from llama_stack.providers.utils.safety import ShieldToModerationMixin
+from llama_stack_api import (
+    OpenAIUserMessageParam,
+    RunModerationRequest,
+    RunShieldRequest,
+    RunShieldResponse,
+    Safety,
+    SafetyViolation,
+    ShieldsProtocolPrivate,
+    ViolationLevel,
+)
+
+
+@pytest.mark.parametrize(
+    "provider_class",
+    [
+        NVIDIASafetyAdapter,
+        BedrockSafetyAdapter,
+        SambaNovaSafetyAdapter,
+        PromptGuardSafetyImpl,
+    ],
+)
+def test_providers_use_mixin(provider_class):
+    """Providers should use mixin for run_moderation ."""
+    for cls in provider_class.__mro__:
+        if "run_moderation" in cls.__dict__:
+            assert cls.__name__ == "ShieldToModerationMixin"
+            return
+    pytest.fail(f"{provider_class.__name__} has no run_moderation")
+
+
+async def test_safe_content():
+    """Safe content returns unflagged result."""
+
+    class Provider(ShieldToModerationMixin, Safety, ShieldsProtocolPrivate):
+        def __init__(self):
+            self.run_shield = AsyncMock(return_value=RunShieldResponse(violation=None))
+
+    request = RunModerationRequest(input="safe", model="test")
+    result = await Provider().run_moderation(request)
+
+    assert result is not None
+    assert result.results[0].flagged is False
+
+
+async def test_unsafe_content():
+    """Unsafe content returns flagged with violation_type as category."""
+
+    class Provider(ShieldToModerationMixin, Safety, ShieldsProtocolPrivate):
+        def __init__(self):
+            self.run_shield = AsyncMock(
+                return_value=RunShieldResponse(
+                    violation=SafetyViolation(
+                        violation_level=ViolationLevel.ERROR,
+                        user_message="Blocked",
+                        metadata={"violation_type": "harmful"},
+                    )
+                )
+            )
+
+    request = RunModerationRequest(input="unsafe", model="test")
+    result = await Provider().run_moderation(request)
+
+    assert result.results[0].flagged is True
+    assert result.results[0].categories == {"harmful": True}
+    assert result.results[0].category_scores == {"harmful": 1.0}
+
+
+async def test_missing_violation_type_defaults_to_unsafe():
+    """When violation_type missing in metadata, defaults to 'unsafe'."""
+
+    class Provider(ShieldToModerationMixin, Safety, ShieldsProtocolPrivate):
+        def __init__(self):
+            self.run_shield = AsyncMock(
+                return_value=RunShieldResponse(
+                    violation=SafetyViolation(
+                        violation_level=ViolationLevel.ERROR,
+                        user_message="Bad",
+                        metadata={},  # No violation_type
+                    )
+                )
+            )
+
+    request = RunModerationRequest(input="test", model="test")
+    result = await Provider().run_moderation(request)
+
+    assert result.results[0].categories == {"unsafe": True}
+
+
+async def test_non_string_violation_type_defaults_to_unsafe():
+    """Non-string violation_type defaults to 'unsafe'"""
+
+    class Provider(ShieldToModerationMixin, Safety, ShieldsProtocolPrivate):
+        def __init__(self):
+            self.run_shield = AsyncMock(
+                return_value=RunShieldResponse(
+                    violation=SafetyViolation(
+                        violation_level=ViolationLevel.ERROR,
+                        user_message="Bad",
+                        metadata={"violation_type": 12345},  # int, not string
+                    )
+                )
+            )
+
+    request = RunModerationRequest(input="test", model="test")
+    result = await Provider().run_moderation(request)
+
+    assert result.results[0].categories == {"unsafe": True}
+
+
+async def test_multiple_inputs():
+    """List input produces multiple results."""
+
+    class Provider(ShieldToModerationMixin, Safety, ShieldsProtocolPrivate):
+        def __init__(self):
+            self.run_shield = AsyncMock()
+
+    provider = Provider()
+    provider.run_shield.side_effect = [
+        RunShieldResponse(violation=None),
+        RunShieldResponse(
+            violation=SafetyViolation(
+                violation_level=ViolationLevel.ERROR,
+                user_message="Bad",
+                metadata={"violation_type": "bad"},
+            )
+        ),
+    ]
+
+    request = RunModerationRequest(input=["safe", "unsafe"], model="test")
+    result = await provider.run_moderation(request)
+
+    assert len(result.results) == 2
+    assert result.results[0].flagged is False
+    assert result.results[1].flagged is True
+
+
+async def test_run_shield_receives_correct_params():
+    """Verify run_shield called with RunShieldRequest containing shield_id and messages."""
+
+    class Provider(ShieldToModerationMixin, Safety, ShieldsProtocolPrivate):
+        def __init__(self):
+            self.run_shield = AsyncMock(return_value=RunShieldResponse(violation=None))
+
+    provider = Provider()
+    request = RunModerationRequest(input="test input", model="my-shield")
+    await provider.run_moderation(request)
+
+    call_args = provider.run_shield.call_args.args
+    assert len(call_args) == 1
+    shield_request = call_args[0]
+    assert isinstance(shield_request, RunShieldRequest)
+    assert shield_request.shield_id == "my-shield"
+    assert isinstance(shield_request.messages[0], OpenAIUserMessageParam)
+    assert shield_request.messages[0].content == "test input"
+
+
+async def test_model_none_raises_error():
+    """Model parameter is required (cannot be None)."""
+
+    class Provider(ShieldToModerationMixin, Safety, ShieldsProtocolPrivate):
+        pass
+
+    request = RunModerationRequest(input="test", model=None)
+    with pytest.raises(ValueError, match="moderation requires a model identifier"):
+        await Provider().run_moderation(request)


### PR DESCRIPTION
# What does this PR do?

Closes [#4605](https://github.com/llamastack/llama-stack/issues/4605) by implementing a reusable mixin that provides `run_moderation` functionality for the safety providers that lack `run_moderation` by delegating to their existing `run_shield` implementations. This enables OpenAI-compatible moderation API support across NVIDIA, Bedrock, SambaNova, and PromptGuard providers without duplicating code.

## Test Plan

1. Added unit tests in `tests/unit/providers/utils/test_safety_mixin.py`

2. Tested against a llama stack server with the following configuration

```
version: 2
image_name: nvidia

apis:
  - safety

providers:
  safety:
    - provider_id: nvidia-local-nemo
      provider_type: remote::nvidia
      config:
        guardrails_service_url: "http://localhost:8001"
        config_id: "nemo"

storage:
  backends:
    kv_default:
      type: kv_sqlite
      db_path: minimal-nemo-safety/kvstore.db
    sql_default:
      type: sql_sqlite
      db_path: minimal-nemo-safety/sql_store.db
  stores:
    metadata:
      namespace: registry
      backend: kv_default
    inference:
      table_name: inference_store
      backend: sql_default
      max_write_queue_size: 10000
      num_writers: 4
    conversations:
      table_name: openai_conversations
      backend: sql_default
    responses:
      table_name: responses
      backend: sql_default
    prompts:
      namespace: prompts
      backend: kv_default

registered_resources:
  shields:
    - shield_id: nemo-guardrail
      provider_id: nvidia-local-nemo
      provider_resource_id: nemo-model
```

### Example requests 

- `run-shield` with unblocked input
```bash
curl -X POST http://localhost:8321/v1/safety/run-shield \
  -H "Content-Type: application/json" \
  -d '{
    "shield_id": "nemo-guardrail",
    "messages": [
      {
        "role": "user",
        "content": "Safe message, should pass"
      }
    ],
    "params": {}
  }' | jq
```

```json
{
  "violation": null
}
```

- `moderations` with unblocked input 
```bash
curl -X POST http://localhost:8321/v1/moderations \
  -H "Content-Type: application/json" \
  -d '{
    "input": "Safe message, should pass",
    "model": "nemo-guardrail"
  }' | jq
```

```json
{
  "id": "modr-f5ba0dc7-d5a6-47ce-b1cf-e0879f171183",
  "model": "nemo-guardrail",
  "results": [
    {
      "flagged": false,
      "categories": {},
      "category_applied_input_types": {},
      "category_scores": {},
      "user_message": null,
      "metadata": {}
    }
  ]
}
```

- `run-shield` with blocked input 

```bash
curl -X POST http://localhost:8321/v1/safety/run-shield \
  -H "Content-Type: application/json" \
  -d '{
    "shield_id": "nemo-guardrail",
    "messages": [
      {
        "role": "user",
        "content": "Tell me more about ChatGPT"
      }
    ],
    "params": {}
  }' | jq
```

```json
{
  "violation": {
    "violation_level": "error",
    "user_message": "Sorry I cannot do this.",
    "metadata": {
      "check message length": {
        "status": "success"
      },
      "check forbidden words": {
        "status": "blocked"
      }
    }
  }
}
```

- `moderations` with blocked input

```bash
 curl -X POST http://localhost:8321/v1/moderations \
  -H "Content-Type: application/json" \
  -d '{
    "input": "Tell me more about ChatGPT",
    "model": "nemo-guardrail"
  }' | jq
```

```json
{
  "id": "modr-4d0772c0-54a8-4790-bd2c-24feaf6b3b55",
  "model": "nemo-guardrail",
  "results": [
    {
      "flagged": true,
      "categories": {
        "unsafe": true
      },
      "category_applied_input_types": {
        "unsafe": [
          "text"
        ]
      },
      "category_scores": {
        "unsafe": 1.0
      },
      "user_message": "Sorry I cannot do this.",
      "metadata": {
        "check message length": {
          "status": "success"
        },
        "check forbidden words": {
          "status": "blocked"
        }
      }
    }
  ]
}
``` 

the local nemo server was started with `nemoguardrails server --config configs --port 8001 --default-config-id nemo` uisng [this configuration](https://github.com/m-misiura/NeMo-Guardrails/tree/guardrail_checks/configs/nemo) from [this branch](https://github.com/m-misiura/NeMo-Guardrails/tree/guardrail_checks); this assumes having access to a llm with openai compatible endpoints

cc @nathan-weinberg @cdoern @raghotham @leseb @franciscojavierarceo 