### PR TITLE
fix: Make check-init-py hook compatible with Bash 3.2 (macOS)

### DIFF
--- a/scripts/check-init-py.sh
+++ b/scripts/check-init-py.sh
@@ -10,12 +10,6 @@
 
 set -euo pipefail
 
-# Use mapfile to get a faster way to iterate over directories
-if (( BASH_VERSINFO[0] < 4 )); then
-    echo "This script requires Bash 4.0 or higher for mapfile support."
-    exit 1
-fi
-
 PACKAGE_DIR="${1:-src/llama_stack}"
 
 if [ ! -d "$PACKAGE_DIR" ]; then
@@ -23,8 +17,17 @@ if [ ! -d "$PACKAGE_DIR" ]; then
     exit 1
 fi
 
+missing_init_files=0
+
 # Get all directories with Python files (excluding __init__.py)
-mapfile -t py_dirs < <(
+# Use process substitution with while loop for Bash 3.2 compatibility
+while IFS= read -r dir; do
+    if [ ! -f "$dir/__init__.py" ]; then
+        echo "ERROR: Missing __init__.py in directory: $dir"
+        echo "This directory contains Python files but no __init__.py, which may cause packaging issues."
+        missing_init_files=1
+    fi
+done < <(
     find "$PACKAGE_DIR" \
         -type f \
         -name "*.py" ! -name "__init__.py" \
@@ -32,15 +35,5 @@ mapfile -t py_dirs < <(
         ! -path "*/node_modules/*" \
         -exec dirname {} \; | sort -u
 )
-
-missing_init_files=0
-
-for dir in "${py_dirs[@]}"; do
-    if [ ! -f "$dir/__init__.py" ]; then
-        echo "ERROR: Missing __init__.py in directory: $dir"
-        echo "This directory contains Python files but no __init__.py, which may cause packaging issues."
-        missing_init_files=1
-    fi
-done
 
 exit $missing_init_files


### PR DESCRIPTION
The `check-init-py` pre-commit hook was failing on macOS with the default Bash 3.2:

```
This script requires Bash 4.0 or higher for mapfile support.
```

## Changes:

Replaced mapfile (Bash 4.0+) with while read loop (Bash 3.2+)
Removed Bash version check
Maintained identical functionality and acceptable performance (~0.67s to check all files)

## Testing:

Manually verified that the change...
- Detects missing __init__.py files
- Passes when __init__.py exists
- Works on macOS with Bash 3.2