### PR TITLE
fix: use `SecretStr` for AWS credentials

### DIFF
--- a/docs/docs/providers/files/remote_s3.mdx
+++ b/docs/docs/providers/files/remote_s3.mdx
@@ -16,8 +16,8 @@ AWS S3-based file storage provider for scalable cloud file management with metad
 |-------|------|----------|---------|-------------|
 | `bucket_name` | `str` | No |  | S3 bucket name to store files |
 | `region` | `str` | No | us-east-1 | AWS region where the bucket is located |
-| `aws_access_key_id` | `str \| None` | No |  | AWS access key ID (optional if using IAM roles) |
-| `aws_secret_access_key` | `str \| None` | No |  | AWS secret access key (optional if using IAM roles) |
+| `aws_access_key_id` | `SecretStr \| None` | No |  | AWS access key ID (optional if using IAM roles) |
+| `aws_secret_access_key` | `SecretStr \| None` | No |  | AWS secret access key (optional if using IAM roles) |
 | `endpoint_url` | `str \| None` | No |  | Custom S3 endpoint URL (for MinIO, LocalStack, etc.) |
 | `auto_create_bucket` | `bool` | No | False | Automatically create the S3 bucket if it doesn't exist |
 | `metadata_store` | `SqlStoreReference` | No |  | SQL store configuration for file metadata |

--- a/docs/docs/providers/safety/remote_bedrock.mdx
+++ b/docs/docs/providers/safety/remote_bedrock.mdx
@@ -16,9 +16,9 @@ AWS Bedrock safety provider for content moderation using AWS's safety services.
 |-------|------|----------|---------|-------------|
 | `allowed_models` | `list[str] \| None` | No |  | List of models that should be registered with the model registry. If None, all models are allowed. |
 | `refresh_models` | `bool` | No | False | Whether to refresh models periodically from the provider |
-| `aws_access_key_id` | `str \| None` | No |  | The AWS access key to use. Default use environment variable: AWS_ACCESS_KEY_ID |
-| `aws_secret_access_key` | `str \| None` | No |  | The AWS secret access key to use. Default use environment variable: AWS_SECRET_ACCESS_KEY |
-| `aws_session_token` | `str \| None` | No |  | The AWS session token to use. Default use environment variable: AWS_SESSION_TOKEN |
+| `aws_access_key_id` | `SecretStr \| None` | No |  | The AWS access key to use. Default use environment variable: AWS_ACCESS_KEY_ID |
+| `aws_secret_access_key` | `SecretStr \| None` | No |  | The AWS secret access key to use. Default use environment variable: AWS_SECRET_ACCESS_KEY |
+| `aws_session_token` | `SecretStr \| None` | No |  | The AWS session token to use. Default use environment variable: AWS_SESSION_TOKEN |
 | `region_name` | `str \| None` | No |  | The default AWS Region to use, for example, us-west-1 or us-west-2.Default use environment variable: AWS_DEFAULT_REGION |
 | `profile_name` | `str \| None` | No |  | The profile name that contains credentials to use.Default use environment variable: AWS_PROFILE |
 | `total_max_attempts` | `int \| None` | No |  | An integer representing the maximum number of attempts that will be made for a single request, including the initial attempt. Default use environment variable: AWS_MAX_ATTEMPTS |

--- a/src/llama_stack/providers/remote/files/s3/config.py
+++ b/src/llama_stack/providers/remote/files/s3/config.py
@@ -6,7 +6,7 @@
 
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, SecretStr
 
 from llama_stack.core.storage.datatypes import SqlStoreReference
 
@@ -16,8 +16,10 @@ class S3FilesImplConfig(BaseModel):
 
     bucket_name: str = Field(description="S3 bucket name to store files")
     region: str = Field(default="us-east-1", description="AWS region where the bucket is located")
-    aws_access_key_id: str | None = Field(default=None, description="AWS access key ID (optional if using IAM roles)")
-    aws_secret_access_key: str | None = Field(
+    aws_access_key_id: SecretStr | None = Field(
+        default=None, description="AWS access key ID (optional if using IAM roles)"
+    )
+    aws_secret_access_key: SecretStr | None = Field(
         default=None, description="AWS secret access key (optional if using IAM roles)"
     )
     endpoint_url: str | None = Field(default=None, description="Custom S3 endpoint URL (for MinIO, LocalStack, etc.)")

--- a/src/llama_stack/providers/remote/files/s3/files.py
+++ b/src/llama_stack/providers/remote/files/s3/files.py
@@ -57,8 +57,8 @@ def _create_s3_client(config: S3FilesImplConfig) -> "S3Client":
         if config.aws_access_key_id and config.aws_secret_access_key:
             s3_config.update(
                 {
-                    "aws_access_key_id": config.aws_access_key_id,
-                    "aws_secret_access_key": config.aws_secret_access_key,
+                    "aws_access_key_id": config.aws_access_key_id.get_secret_value(),
+                    "aws_secret_access_key": config.aws_secret_access_key.get_secret_value(),
                 }
             )
 

--- a/src/llama_stack/providers/utils/bedrock/client.py
+++ b/src/llama_stack/providers/utils/bedrock/client.py
@@ -49,9 +49,9 @@ def create_bedrock_client(config: BedrockBaseConfig, service_name: str = "bedroc
         boto3_config = Config(**config_args)
 
         session_args = {
-            "aws_access_key_id": config.aws_access_key_id,
-            "aws_secret_access_key": config.aws_secret_access_key,
-            "aws_session_token": config.aws_session_token,
+            "aws_access_key_id": config.aws_access_key_id.get_secret_value(),
+            "aws_secret_access_key": config.aws_secret_access_key.get_secret_value(),
+            "aws_session_token": config.aws_session_token.get_secret_value() if config.aws_session_token else None,
             "region_name": config.region_name,
             "profile_name": config.profile_name,
             "session_ttl": config.session_ttl,

--- a/src/llama_stack/providers/utils/bedrock/config.py
+++ b/src/llama_stack/providers/utils/bedrock/config.py
@@ -6,23 +6,23 @@
 
 import os
 
-from pydantic import Field
+from pydantic import Field, SecretStr
 
 from llama_stack.providers.utils.inference.model_registry import RemoteInferenceProviderConfig
 
 
 class BedrockBaseConfig(RemoteInferenceProviderConfig):
     auth_credential: None = Field(default=None, exclude=True)
-    aws_access_key_id: str | None = Field(
-        default_factory=lambda: os.getenv("AWS_ACCESS_KEY_ID"),
+    aws_access_key_id: SecretStr | None = Field(
+        default_factory=lambda: SecretStr(val) if (val := os.getenv("AWS_ACCESS_KEY_ID")) else None,
         description="The AWS access key to use. Default use environment variable: AWS_ACCESS_KEY_ID",
     )
-    aws_secret_access_key: str | None = Field(
-        default_factory=lambda: os.getenv("AWS_SECRET_ACCESS_KEY"),
+    aws_secret_access_key: SecretStr | None = Field(
+        default_factory=lambda: SecretStr(val) if (val := os.getenv("AWS_SECRET_ACCESS_KEY")) else None,
         description="The AWS secret access key to use. Default use environment variable: AWS_SECRET_ACCESS_KEY",
     )
-    aws_session_token: str | None = Field(
-        default_factory=lambda: os.getenv("AWS_SESSION_TOKEN"),
+    aws_session_token: SecretStr | None = Field(
+        default_factory=lambda: SecretStr(val) if (val := os.getenv("AWS_SESSION_TOKEN")) else None,
         description="The AWS session token to use. Default use environment variable: AWS_SESSION_TOKEN",
     )
     region_name: str | None = Field(

--- a/tests/unit/providers/inference/bedrock/test_config.py
+++ b/tests/unit/providers/inference/bedrock/test_config.py
@@ -38,8 +38,8 @@ class TestBedrockBaseConfig:
         with patch.dict(os.environ, env_vars, clear=True):
             config = BedrockBaseConfig()
 
-            assert config.aws_access_key_id == "AKIATEST123"
-            assert config.aws_secret_access_key == "secret123"
+            assert config.aws_access_key_id.get_secret_value() == "AKIATEST123"
+            assert config.aws_secret_access_key.get_secret_value() == "secret123"
             assert config.region_name == "us-west-2"
             assert config.total_max_attempts == 5
             assert config.retry_mode == "adaptive"


### PR DESCRIPTION
## Summary

Converts AWS credential fields to use Pydantic's `SecretStr` type in Bedrock and S3 providers to prevent accidental exposure of sensitive data.

## Changes

- **Config files**: Changed `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token` from `str | None` to `SecretStr | None`
  - `src/llama_stack/providers/utils/bedrock/config.py`
  - `src/llama_stack/providers/remote/files/s3/config.py`

- **Client code**: Added `.get_secret_value()` calls when passing credentials to boto3
  - `src/llama_stack/providers/utils/bedrock/client.py`
  - `src/llama_stack/providers/remote/files/s3/files.py`

- **Tests**: Updated assertions to use `.get_secret_value()`
  - `tests/unit/providers/inference/bedrock/test_config.py`

## Security Benefits

- Credentials are redacted when printed/logged (show as `**********`)
- Makes it explicit that fields contain sensitive data
- Follows Pydantic best practices for handling secrets
- Prevents accidental credential exposure in error messages, logs, docs, or debug output

## Testing

All Bedrock config tests pass (4/4)
All S3 files tests pass (27/27)
Documentation correctly shows `SecretStr` types
