### PR TITLE
fix: Remove unused scope-based endpoint authorization feature

### DIFF
--- a/docs/docs/distributions/configuration.mdx
+++ b/docs/docs/distributions/configuration.mdx
@@ -794,36 +794,6 @@ For a request to succeed:
 2. User must pass resource authorization (can read `model::llama-3-2-3b`)
 3. Both checks must pass
 
-#### API Endpoint Authorization with Scopes
-
-In addition to resource-based access control, Llama Stack supports endpoint-level authorization using OAuth 2.0 style scopes. When authentication is enabled, specific API endpoints require users to have particular scopes in their authentication token.
-
-**Authentication Configuration:**
-
-For **JWT/OAuth2 providers**, scopes should be included in the JWT's claims:
-```json
-{
-  "sub": "user123",
-  "scope": "<scope>",
-  "aud": "llama-stack"
-}
-```
-
-For **custom authentication providers**, the endpoint must return user attributes including the `scopes` array:
-```json
-{
-  "principal": "user123",
-  "attributes": {
-    "scopes": ["<scope>"]
-  }
-}
-```
-
-**Behavior:**
-- Users without the required scope receive a 403 Forbidden response
-- When authentication is disabled, scope checks are bypassed
-- Endpoints without `required_scope` work normally for all authenticated users
-
 ### Quota Configuration
 
 The `quota` section allows you to enable server-side request throttling for both

--- a/src/llama_stack_api/schema_utils.py
+++ b/src/llama_stack_api/schema_utils.py
@@ -149,7 +149,6 @@ class WebMethod:
     raw_bytes_request_body: bool | None = False
     # A descriptive name of the corresponding span created by tracing
     descriptive_name: str | None = None
-    required_scope: str | None = None
     deprecated: bool | None = False
     require_authentication: bool | None = True
 
@@ -166,7 +165,6 @@ def webmethod(
     response_examples: list[Any] | None = None,
     raw_bytes_request_body: bool | None = False,
     descriptive_name: str | None = None,
-    required_scope: str | None = None,
     deprecated: bool | None = False,
     require_authentication: bool | None = True,
 ) -> Callable[[CallableT], CallableT]:
@@ -177,7 +175,6 @@ def webmethod(
     :param public: True if the operation can be invoked without prior authentication.
     :param request_examples: Sample requests that the operation might take. Pass a list of objects, not JSON.
     :param response_examples: Sample responses that the operation might produce. Pass a list of objects, not JSON.
-    :param required_scope: Required scope for this endpoint (e.g., 'monitoring.viewer').
     :param require_authentication: Whether this endpoint requires authentication (default True).
     """
 
@@ -191,7 +188,6 @@ def webmethod(
             response_examples=response_examples,
             raw_bytes_request_body=raw_bytes_request_body,
             descriptive_name=descriptive_name,
-            required_scope=required_scope,
             deprecated=deprecated,
             require_authentication=require_authentication if require_authentication is not None else True,
         )


### PR DESCRIPTION
The scope-based authorization feature was only used by the telemetry API endpoints which were removed in commit 866c13cd. Since no endpoints currently use this feature, remove it entirely.

Changes:
o Remove required_scope parameter from WebMethod dataclass and webmethod decorator o Remove scope checking logic from AuthenticationMiddleware o Remove _has_required_scope helper function
o Remove scope authorization documentation
o Remove scope-related tests and fixtures

--
This code is unused since https://github.com/llamastack/llama-stack/pull/3740