### PR TITLE
fix: prevent MDX build failure in OpenAI conformance report

### DIFF
--- a/docs/docs/api-openai/conformance.mdx
+++ b/docs/docs/api-openai/conformance.mdx
@@ -180,7 +180,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **POST**
 
-<details><summary>Missing Properties (39)</summary>
+<details>
+<summary>Missing Properties (39)</summary>
 
 - `responses.200.content.application/json.properties.results.items.properties.categories.properties.harassment`
 - `responses.200.content.application/json.properties.results.items.properties.categories.properties.harassment/threatening`
@@ -224,7 +225,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 </details>
 
-<details><summary>Schema Issues (5)</summary>
+<details>
+<summary>Schema Issues (5)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -244,7 +246,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **GET**
 
-<details><summary>Missing Properties (10)</summary>
+<details>
+<summary>Missing Properties (10)</summary>
 
 - `responses.200.content.application/json.properties.data.items.properties.errors.properties.data`
 - `responses.200.content.application/json.properties.data.items.properties.errors.properties.object`
@@ -259,7 +262,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 </details>
 
-<details><summary>Schema Issues (19)</summary>
+<details>
+<summary>Schema Issues (19)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -287,7 +291,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **POST**
 
-<details><summary>Missing Properties (11)</summary>
+<details>
+<summary>Missing Properties (11)</summary>
 
 - `requestBody.content.application/json.properties.output_expires_after`
 - `responses.200.content.application/json.properties.errors.properties.data`
@@ -303,7 +308,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 </details>
 
-<details><summary>Schema Issues (17)</summary>
+<details>
+<summary>Schema Issues (17)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -331,7 +337,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **GET**
 
-<details><summary>Missing Properties (10)</summary>
+<details>
+<summary>Missing Properties (10)</summary>
 
 - `responses.200.content.application/json.properties.errors.properties.data`
 - `responses.200.content.application/json.properties.errors.properties.object`
@@ -346,7 +353,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 </details>
 
-<details><summary>Schema Issues (15)</summary>
+<details>
+<summary>Schema Issues (15)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -372,7 +380,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **POST**
 
-<details><summary>Missing Properties (10)</summary>
+<details>
+<summary>Missing Properties (10)</summary>
 
 - `responses.200.content.application/json.properties.errors.properties.data`
 - `responses.200.content.application/json.properties.errors.properties.object`
@@ -387,7 +396,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 </details>
 
-<details><summary>Schema Issues (15)</summary>
+<details>
+<summary>Schema Issues (15)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -417,13 +427,15 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **GET**
 
-<details><summary>Missing Properties (1)</summary>
+<details>
+<summary>Missing Properties (1)</summary>
 
 - `responses.200.content.application/json.properties.object`
 
 </details>
 
-<details><summary>Schema Issues (2)</summary>
+<details>
+<summary>Schema Issues (2)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -436,7 +448,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **GET**
 
-<details><summary>Missing Properties (4)</summary>
+<details>
+<summary>Missing Properties (4)</summary>
 
 - `responses.200.content.application/json.properties.created`
 - `responses.200.content.application/json.properties.id`
@@ -453,14 +466,16 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **POST**
 
-<details><summary>Missing Properties (2)</summary>
+<details>
+<summary>Missing Properties (2)</summary>
 
 - `responses.200.content.application/json.properties.system_fingerprint`
 - `responses.200.content.application/json.properties.usage`
 
 </details>
 
-<details><summary>Schema Issues (19)</summary>
+<details>
+<summary>Schema Issues (19)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -494,14 +509,16 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **GET**
 
-<details><summary>Missing Properties (2)</summary>
+<details>
+<summary>Missing Properties (2)</summary>
 
 - `responses.200.content.application/json.properties.data.items.properties.status`
 - `responses.200.content.application/json.properties.data.items.properties.status_details`
 
 </details>
 
-<details><summary>Schema Issues (4)</summary>
+<details>
+<summary>Schema Issues (4)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -514,7 +531,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **POST**
 
-<details><summary>Missing Properties (4)</summary>
+<details>
+<summary>Missing Properties (4)</summary>
 
 - `requestBody.content.multipart/form-data.properties.expires_after.properties.anchor`
 - `requestBody.content.multipart/form-data.properties.expires_after.properties.seconds`
@@ -523,7 +541,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 </details>
 
-<details><summary>Schema Issues (4)</summary>
+<details>
+<summary>Schema Issues (4)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -538,7 +557,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **DELETE**
 
-<details><summary>Schema Issues (1)</summary>
+<details>
+<summary>Schema Issues (1)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -548,14 +568,16 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **GET**
 
-<details><summary>Missing Properties (2)</summary>
+<details>
+<summary>Missing Properties (2)</summary>
 
 - `responses.200.content.application/json.properties.status`
 - `responses.200.content.application/json.properties.status_details`
 
 </details>
 
-<details><summary>Schema Issues (2)</summary>
+<details>
+<summary>Schema Issues (2)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -572,14 +594,16 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **GET**
 
-<details><summary>Missing Properties (2)</summary>
+<details>
+<summary>Missing Properties (2)</summary>
 
 - `responses.200.content.application/json.properties.data.items.properties.expires_after.properties.anchor`
 - `responses.200.content.application/json.properties.data.items.properties.expires_after.properties.days`
 
 </details>
 
-<details><summary>Schema Issues (10)</summary>
+<details>
+<summary>Schema Issues (10)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -598,7 +622,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **POST**
 
-<details><summary>Missing Properties (5)</summary>
+<details>
+<summary>Missing Properties (5)</summary>
 
 - `requestBody.content.application/json.properties.description`
 - `requestBody.content.application/json.properties.expires_after.properties.anchor`
@@ -608,7 +633,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 </details>
 
-<details><summary>Schema Issues (10)</summary>
+<details>
+<summary>Schema Issues (10)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -629,7 +655,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **DELETE**
 
-<details><summary>Schema Issues (2)</summary>
+<details>
+<summary>Schema Issues (2)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -640,14 +667,16 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **GET**
 
-<details><summary>Missing Properties (2)</summary>
+<details>
+<summary>Missing Properties (2)</summary>
 
 - `responses.200.content.application/json.properties.expires_after.properties.anchor`
 - `responses.200.content.application/json.properties.expires_after.properties.days`
 
 </details>
 
-<details><summary>Schema Issues (6)</summary>
+<details>
+<summary>Schema Issues (6)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -662,14 +691,16 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **POST**
 
-<details><summary>Missing Properties (2)</summary>
+<details>
+<summary>Missing Properties (2)</summary>
 
 - `responses.200.content.application/json.properties.expires_after.properties.anchor`
 - `responses.200.content.application/json.properties.expires_after.properties.days`
 
 </details>
 
-<details><summary>Schema Issues (8)</summary>
+<details>
+<summary>Schema Issues (8)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -688,13 +719,15 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **POST**
 
-<details><summary>Missing Properties (1)</summary>
+<details>
+<summary>Missing Properties (1)</summary>
 
 - `requestBody.content.application/json.properties.files`
 
 </details>
 
-<details><summary>Schema Issues (3)</summary>
+<details>
+<summary>Schema Issues (3)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -708,7 +741,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **GET**
 
-<details><summary>Schema Issues (2)</summary>
+<details>
+<summary>Schema Issues (2)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -721,7 +755,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **POST**
 
-<details><summary>Schema Issues (2)</summary>
+<details>
+<summary>Schema Issues (2)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -734,7 +769,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **GET**
 
-<details><summary>Schema Issues (10)</summary>
+<details>
+<summary>Schema Issues (10)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -755,7 +791,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **GET**
 
-<details><summary>Schema Issues (10)</summary>
+<details>
+<summary>Schema Issues (10)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -774,7 +811,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **POST**
 
-<details><summary>Schema Issues (7)</summary>
+<details>
+<summary>Schema Issues (7)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -792,7 +830,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **DELETE**
 
-<details><summary>Schema Issues (2)</summary>
+<details>
+<summary>Schema Issues (2)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -803,7 +842,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **GET**
 
-<details><summary>Schema Issues (6)</summary>
+<details>
+<summary>Schema Issues (6)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -818,7 +858,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **POST**
 
-<details><summary>Schema Issues (7)</summary>
+<details>
+<summary>Schema Issues (7)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -836,7 +877,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **GET**
 
-<details><summary>Schema Issues (2)</summary>
+<details>
+<summary>Schema Issues (2)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -849,14 +891,16 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **POST**
 
-<details><summary>Missing Properties (2)</summary>
+<details>
+<summary>Missing Properties (2)</summary>
 
 - `requestBody.content.application/json.properties.ranking_options.properties.ranker`
 - `requestBody.content.application/json.properties.ranking_options.properties.score_threshold`
 
 </details>
 
-<details><summary>Schema Issues (7)</summary>
+<details>
+<summary>Schema Issues (7)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -878,7 +922,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **POST**
 
-<details><summary>Schema Issues (4)</summary>
+<details>
+<summary>Schema Issues (4)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -897,7 +942,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **POST**
 
-<details><summary>Missing Properties (19)</summary>
+<details>
+<summary>Missing Properties (19)</summary>
 
 - `requestBody.content.application/json.properties.background`
 - `requestBody.content.application/json.properties.frequency_penalty`
@@ -921,7 +967,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 </details>
 
-<details><summary>Schema Issues (22)</summary>
+<details>
+<summary>Schema Issues (22)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -958,7 +1005,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **GET**
 
-<details><summary>Missing Properties (13)</summary>
+<details>
+<summary>Missing Properties (13)</summary>
 
 - `parameters.query.metadata`
 - `responses.200.content.application/json.properties.data.items.properties.choices.items.properties.message.properties.annotations`
@@ -976,7 +1024,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 </details>
 
-<details><summary>Schema Issues (5)</summary>
+<details>
+<summary>Schema Issues (5)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -990,7 +1039,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **POST**
 
-<details><summary>Missing Properties (23)</summary>
+<details>
+<summary>Missing Properties (23)</summary>
 
 - `responses.200.content.application/json.properties.choices.items.properties.message.properties.annotations`
 - `responses.200.content.application/json.properties.choices.items.properties.message.properties.audio`
@@ -1018,7 +1068,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 </details>
 
-<details><summary>Schema Issues (9)</summary>
+<details>
+<summary>Schema Issues (9)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -1038,7 +1089,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **GET**
 
-<details><summary>Missing Properties (14)</summary>
+<details>
+<summary>Missing Properties (14)</summary>
 
 - `responses.200.content.application/json.properties.choices.items.properties.message.properties.annotations`
 - `responses.200.content.application/json.properties.choices.items.properties.message.properties.audio`
@@ -1057,7 +1109,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 </details>
 
-<details><summary>Schema Issues (4)</summary>
+<details>
+<summary>Schema Issues (4)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -1076,7 +1129,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **POST**
 
-<details><summary>Schema Issues (3)</summary>
+<details>
+<summary>Schema Issues (3)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -1090,7 +1144,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **DELETE**
 
-<details><summary>Schema Issues (2)</summary>
+<details>
+<summary>Schema Issues (2)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -1101,7 +1156,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **GET**
 
-<details><summary>Schema Issues (2)</summary>
+<details>
+<summary>Schema Issues (2)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -1112,7 +1168,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **POST**
 
-<details><summary>Schema Issues (3)</summary>
+<details>
+<summary>Schema Issues (3)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -1126,7 +1183,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **GET**
 
-<details><summary>Schema Issues (5)</summary>
+<details>
+<summary>Schema Issues (5)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -1140,13 +1198,15 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **POST**
 
-<details><summary>Missing Properties (1)</summary>
+<details>
+<summary>Missing Properties (1)</summary>
 
 - `parameters.query.include`
 
 </details>
 
-<details><summary>Schema Issues (6)</summary>
+<details>
+<summary>Schema Issues (6)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -1163,14 +1223,16 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **DELETE**
 
-<details><summary>Missing Properties (2)</summary>
+<details>
+<summary>Missing Properties (2)</summary>
 
 - `responses.200.content.application/json.properties.created_at`
 - `responses.200.content.application/json.properties.metadata`
 
 </details>
 
-<details><summary>Schema Issues (1)</summary>
+<details>
+<summary>Schema Issues (1)</summary>
 
 | Property | Issues |
 |----------|--------|
@@ -1180,7 +1242,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 **GET**
 
-<details><summary>Missing Properties (1)</summary>
+<details>
+<summary>Missing Properties (1)</summary>
 
 - `parameters.query.include`
 

--- a/scripts/generate_openai_coverage_docs.py
+++ b/scripts/generate_openai_coverage_docs.py
@@ -148,7 +148,8 @@ def generate_docs(coverage_path: Path, output_path: Path) -> None:
                 lines.append("")
 
                 if op["missing_properties"]:
-                    lines.append(f"<details><summary>Missing Properties ({op['missing_count']})</summary>")
+                    lines.append("<details>")
+                    lines.append(f"<summary>Missing Properties ({op['missing_count']})</summary>")
                     lines.append("")
                     for prop in op["missing_properties"]:
                         # Clean up the property path for readability
@@ -159,7 +160,8 @@ def generate_docs(coverage_path: Path, output_path: Path) -> None:
                     lines.append("")
 
                 if op["conformance_issues"]:
-                    lines.append(f"<details><summary>Schema Issues ({op['issues_count']})</summary>")
+                    lines.append("<details>")
+                    lines.append(f"<summary>Schema Issues ({op['issues_count']})</summary>")
                     lines.append("")
                     lines.append("| Property | Issues |")
                     lines.append("|----------|--------|")


### PR DESCRIPTION

# What does this PR do?
- Issue
  - Docusaurus build fails when rendering `docs/docs/api-openai/conformance.mdx` because the generated MDX uses inline `<details><summary>` tags, which MDX treats as an inline paragraph and throws an end-tag mismatch error.

- Solution
  - Update `scripts/generate_openai_coverage_docs.py` to emit `<details>` and `<summary>` on separate lines (block-level), then regenerate `conformance.mdx` with the new formatting so MDX parses correctly.

Fixed https://github.com/llamastack/llama-stack/issues/4736

@leseb 

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->

<!-- For API changes, include:
1. A testing script (Python, curl, etc.) that exercises the new/modified endpoints
2. The output from running your script

Example:
```python
...
...
```

Output:
```
<paste actual output here>
```
-->
