### PR TITLE
feat: add support for /responses background parameter

### DIFF
--- a/client-sdks/stainless/openapi.yml
+++ b/client-sdks/stainless/openapi.yml
@@ -4150,6 +4150,41 @@ paths:
       summary: Get service version
       description: Get the version of the service.
       operationId: version_v1alpha_admin_version_get
+  /v1/responses/{response_id}/cancel:
+    post:
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OpenAIResponseObject'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+          description: Bad Request
+        '429':
+          $ref: '#/components/responses/TooManyRequests429'
+          description: Too Many Requests
+        '500':
+          $ref: '#/components/responses/InternalServerError500'
+          description: Internal Server Error
+        default:
+          $ref: '#/components/responses/DefaultError'
+          description: Default Response
+      tags:
+      - Agents
+      summary: Cancel a background response.
+      description: Cancel a background response. Only responses created with background=true can be cancelled.
+      operationId: cancel_openai_response_v1_responses__response_id__cancel_post
+      parameters:
+      - name: response_id
+        in: path
+        required: true
+        schema:
+          type: string
+          description: The ID of the response to cancel.
+          title: Response Id
+        description: The ID of the response to cancel.
   /v1alpha/connectors/{connector_id}:
     get:
       responses:
@@ -7218,6 +7253,9 @@ components:
       description: Web search tool configuration for OpenAI response inputs.
     OpenAIResponseObjectWithInput:
       properties:
+        background:
+          type: boolean
+          title: Background
         created_at:
           type: integer
           title: Created At
@@ -7669,6 +7707,9 @@ components:
       description: Model Context Protocol (MCP) tool configuration for OpenAI response inputs.
     OpenAIResponseObject:
       properties:
+        background:
+          type: boolean
+          title: Background
         created_at:
           type: integer
           title: Created At
@@ -12132,6 +12173,10 @@ components:
           type: string
           title: Model
           description: The underlying LLM used for completions.
+        background:
+          type: boolean
+          title: Background
+          description: Whether to run the model response in the background. When true, returns immediately with status 'queued'.
         prompt:
           anyOf:
           - $ref: '#/components/schemas/OpenAIResponsePrompt'

--- a/docs/docs/api-openai/conformance.mdx
+++ b/docs/docs/api-openai/conformance.mdx
@@ -18,12 +18,12 @@ This documentation is auto-generated from the OpenAI API specification compariso
 
 | Metric | Value |
 |--------|-------|
-| **Overall Conformance Score** | 82.8% |
+| **Overall Conformance Score** | 82.9% |
 | **Endpoints Implemented** | 28/114 |
 | **Total Properties Checked** | 2598 |
 | **Schema/Type Issues** | 263 |
-| **Missing Properties** | 184 |
-| **Total Issues to Fix** | 447 |
+| **Missing Properties** | 182 |
+| **Total Issues to Fix** | 445 |
 
 ## Category Scores
 
@@ -38,7 +38,7 @@ Categories are sorted by conformance score (lowest first, needing most attention
 | Files | 54.8% | 42 | 11 | 8 |
 | Vector stores | 65.2% | 310 | 94 | 14 |
 | Embeddings | 71.4% | 14 | 4 | 0 |
-| Responses | 80.9% | 225 | 22 | 21 |
+| Responses | 81.8% | 225 | 22 | 19 |
 | Chat | 83.1% | 402 | 18 | 50 |
 | Conversations | 98.0% | 1323 | 22 | 4 |
 
@@ -891,15 +891,14 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 ### Responses
 
-**Score:** 80.9% · **Issues:** 22 · **Missing:** 21
+**Score:** 81.8% · **Issues:** 22 · **Missing:** 19
 
 #### `/responses`
 
 **POST**
 
-<details><summary>Missing Properties (21)</summary>
+<details><summary>Missing Properties (19)</summary>
 
-- `requestBody.content.application/json.properties.background`
 - `requestBody.content.application/json.properties.frequency_penalty`
 - `requestBody.content.application/json.properties.max_output_tokens`
 - `requestBody.content.application/json.properties.presence_penalty`
@@ -911,7 +910,6 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 - `requestBody.content.application/json.properties.top_p`
 - `requestBody.content.application/json.properties.truncation`
 - `requestBody.content.application/x-www-form-urlencoded`
-- `responses.200.content.application/json.properties.background`
 - `responses.200.content.application/json.properties.frequency_penalty`
 - `responses.200.content.application/json.properties.incomplete_details`
 - `responses.200.content.application/json.properties.max_output_tokens`

--- a/docs/docs/providers/openai_responses_limitations.mdx
+++ b/docs/docs/providers/openai_responses_limitations.mdx
@@ -130,11 +130,17 @@ The return object from a call to Responses includes a field for indicating why a
 
 ### Background
 
-**Status:** Not Implemented
+**Status:** ✅ Resolved
 
-**Issue:** [#3568](https://github.com/llamastack/llama-stack/issues/3568)
+**Issue:** [#3568](https://github.com/llamastack/llama-stack/issues/3568), [#4701](https://github.com/llamastack/llama-stack/issues/4701)
 
-[Background mode](https://platform.openai.com/docs/guides/background) in OpenAI Responses lets you start a response generation job and then check back in on it later.  This is useful if you might lose a connection during a generation and want to reconnect later and get the response back (for example if the client is running in a mobile app).  It is not implemented in Llama Stack.
+[Background mode](https://platform.openai.com/docs/guides/background) in OpenAI Responses lets you start a response generation job and then check back in on it later. This is useful if you might lose a connection during a generation and want to reconnect later and get the response back (for example if the client is running in a mobile app).
+
+Background mode is now implemented in Llama Stack:
+- Set `background=true` in the request to queue a response for background processing
+- The API returns immediately with status `queued`
+- Poll `GET /v1/responses/{response_id}` to check status (`in_progress`, `completed`, `failed`, `cancelled`)
+- Use `POST /v1/responses/{response_id}/cancel` to cancel a background response
 
 ---
 

--- a/docs/static/deprecated-llama-stack-spec.yaml
+++ b/docs/static/deprecated-llama-stack-spec.yaml
@@ -3811,6 +3811,9 @@ components:
       description: Web search tool configuration for OpenAI response inputs.
     OpenAIResponseObjectWithInput:
       properties:
+        background:
+          type: boolean
+          title: Background
         created_at:
           type: integer
           title: Created At
@@ -4262,6 +4265,9 @@ components:
       description: Model Context Protocol (MCP) tool configuration for OpenAI response inputs.
     OpenAIResponseObject:
       properties:
+        background:
+          type: boolean
+          title: Background
         created_at:
           type: integer
           title: Created At
@@ -8727,6 +8733,10 @@ components:
           type: string
           title: Model
           description: The underlying LLM used for completions.
+        background:
+          type: boolean
+          title: Background
+          description: Whether to run the model response in the background. When true, returns immediately with status 'queued'.
         prompt:
           anyOf:
           - $ref: '#/components/schemas/OpenAIResponsePrompt'

--- a/docs/static/experimental-llama-stack-spec.yaml
+++ b/docs/static/experimental-llama-stack-spec.yaml
@@ -3875,6 +3875,9 @@ components:
       description: Web search tool configuration for OpenAI response inputs.
     OpenAIResponseObjectWithInput:
       properties:
+        background:
+          type: boolean
+          title: Background
         created_at:
           type: integer
           title: Created At
@@ -4315,6 +4318,9 @@ components:
       description: Model Context Protocol (MCP) tool configuration for OpenAI response inputs.
     OpenAIResponseObject:
       properties:
+        background:
+          type: boolean
+          title: Background
         created_at:
           type: integer
           title: Created At

--- a/docs/static/llama-stack-spec.yaml
+++ b/docs/static/llama-stack-spec.yaml
@@ -2771,6 +2771,41 @@ paths:
       description: Get the version of the service.
       operationId: version_v1_version_get
       x-public: true
+  /v1/responses/{response_id}/cancel:
+    post:
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OpenAIResponseObject'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+          description: Bad Request
+        '429':
+          $ref: '#/components/responses/TooManyRequests429'
+          description: Too Many Requests
+        '500':
+          $ref: '#/components/responses/InternalServerError500'
+          description: Internal Server Error
+        default:
+          $ref: '#/components/responses/DefaultError'
+          description: Default Response
+      tags:
+      - Agents
+      summary: Cancel a background response.
+      description: Cancel a background response. Only responses created with background=true can be cancelled.
+      operationId: cancel_openai_response_v1_responses__response_id__cancel_post
+      parameters:
+      - name: response_id
+        in: path
+        required: true
+        schema:
+          type: string
+          description: The ID of the response to cancel.
+          title: Response Id
+        description: The ID of the response to cancel.
 components:
   schemas:
     Error:
@@ -5684,6 +5719,9 @@ components:
       description: Web search tool configuration for OpenAI response inputs.
     OpenAIResponseObjectWithInput:
       properties:
+        background:
+          type: boolean
+          title: Background
         created_at:
           type: integer
           title: Created At
@@ -6135,6 +6173,9 @@ components:
       description: Model Context Protocol (MCP) tool configuration for OpenAI response inputs.
     OpenAIResponseObject:
       properties:
+        background:
+          type: boolean
+          title: Background
         created_at:
           type: integer
           title: Created At
@@ -10524,6 +10565,10 @@ components:
           type: string
           title: Model
           description: The underlying LLM used for completions.
+        background:
+          type: boolean
+          title: Background
+          description: Whether to run the model response in the background. When true, returns immediately with status 'queued'.
         prompt:
           anyOf:
           - $ref: '#/components/schemas/OpenAIResponsePrompt'

--- a/docs/static/openai-coverage.json
+++ b/docs/static/openai-coverage.json
@@ -96,10 +96,10 @@
       ]
     },
     "conformance": {
-      "score": 82.8,
+      "score": 82.9,
       "issues": 263,
-      "missing_properties": 184,
-      "total_problems": 447,
+      "missing_properties": 182,
+      "total_problems": 445,
       "total_properties": 2598
     }
   },
@@ -1695,9 +1695,9 @@
       ]
     },
     "Responses": {
-      "score": 80.9,
+      "score": 81.8,
       "issues": 22,
-      "missing_properties": 21,
+      "missing_properties": 19,
       "total_properties": 225,
       "endpoints": [
         {
@@ -1706,7 +1706,6 @@
             {
               "method": "POST",
               "missing_properties": [
-                "POST.requestBody.content.application/json.properties.background",
                 "POST.requestBody.content.application/json.properties.frequency_penalty",
                 "POST.requestBody.content.application/json.properties.max_output_tokens",
                 "POST.requestBody.content.application/json.properties.presence_penalty",
@@ -1718,7 +1717,6 @@
                 "POST.requestBody.content.application/json.properties.top_p",
                 "POST.requestBody.content.application/json.properties.truncation",
                 "POST.requestBody.content.application/x-www-form-urlencoded",
-                "POST.responses.200.content.application/json.properties.background",
                 "POST.responses.200.content.application/json.properties.frequency_penalty",
                 "POST.responses.200.content.application/json.properties.incomplete_details",
                 "POST.responses.200.content.application/json.properties.max_output_tokens",
@@ -1889,7 +1887,7 @@
                   ]
                 }
               ],
-              "missing_count": 21,
+              "missing_count": 19,
               "issues_count": 22
             }
           ]

--- a/docs/static/stainless-llama-stack-spec.yaml
+++ b/docs/static/stainless-llama-stack-spec.yaml
@@ -4150,6 +4150,41 @@ paths:
       summary: Get service version
       description: Get the version of the service.
       operationId: version_v1alpha_admin_version_get
+  /v1/responses/{response_id}/cancel:
+    post:
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OpenAIResponseObject'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+          description: Bad Request
+        '429':
+          $ref: '#/components/responses/TooManyRequests429'
+          description: Too Many Requests
+        '500':
+          $ref: '#/components/responses/InternalServerError500'
+          description: Internal Server Error
+        default:
+          $ref: '#/components/responses/DefaultError'
+          description: Default Response
+      tags:
+      - Agents
+      summary: Cancel a background response.
+      description: Cancel a background response. Only responses created with background=true can be cancelled.
+      operationId: cancel_openai_response_v1_responses__response_id__cancel_post
+      parameters:
+      - name: response_id
+        in: path
+        required: true
+        schema:
+          type: string
+          description: The ID of the response to cancel.
+          title: Response Id
+        description: The ID of the response to cancel.
   /v1alpha/connectors/{connector_id}:
     get:
       responses:
@@ -7218,6 +7253,9 @@ components:
       description: Web search tool configuration for OpenAI response inputs.
     OpenAIResponseObjectWithInput:
       properties:
+        background:
+          type: boolean
+          title: Background
         created_at:
           type: integer
           title: Created At
@@ -7669,6 +7707,9 @@ components:
       description: Model Context Protocol (MCP) tool configuration for OpenAI response inputs.
     OpenAIResponseObject:
       properties:
+        background:
+          type: boolean
+          title: Background
         created_at:
           type: integer
           title: Created At
@@ -12132,6 +12173,10 @@ components:
           type: string
           title: Model
           description: The underlying LLM used for completions.
+        background:
+          type: boolean
+          title: Background
+          description: Whether to run the model response in the background. When true, returns immediately with status 'queued'.
         prompt:
           anyOf:
           - $ref: '#/components/schemas/OpenAIResponsePrompt'

--- a/src/llama_stack/providers/inline/agents/meta_reference/agents.py
+++ b/src/llama_stack/providers/inline/agents/meta_reference/agents.py
@@ -12,6 +12,7 @@ from llama_stack.log import get_logger
 from llama_stack.providers.utils.responses.responses_store import ResponsesStore
 from llama_stack_api import (
     Agents,
+    CancelResponseRequest,
     Connectors,
     Conversations,
     CreateResponseRequest,
@@ -110,6 +111,7 @@ class MetaReferenceAgentsImpl(Agents):
         result = await self.openai_responses_impl.create_openai_response(
             request.input,
             request.model,
+            request.background,
             request.prompt,
             request.instructions,
             request.previous_response_id,
@@ -159,3 +161,10 @@ class MetaReferenceAgentsImpl(Agents):
     ) -> OpenAIDeleteResponseObject:
         assert self.openai_responses_impl is not None, "OpenAI responses not initialized"
         return await self.openai_responses_impl.delete_openai_response(request.response_id)
+
+    async def cancel_openai_response(
+        self,
+        request: CancelResponseRequest,
+    ) -> OpenAIResponseObject:
+        assert self.openai_responses_impl is not None, "OpenAI responses not initialized"
+        return await self.openai_responses_impl.cancel_openai_response(request.response_id)

--- a/src/llama_stack/providers/inline/agents/meta_reference/responses/openai_responses.py
+++ b/src/llama_stack/providers/inline/agents/meta_reference/responses/openai_responses.py
@@ -32,6 +32,7 @@ from llama_stack_api import (
     OpenAIChatCompletionContentPartParam,
     OpenAIDeleteResponseObject,
     OpenAIMessageParam,
+    OpenAIResponseError,
     OpenAIResponseInput,
     OpenAIResponseInputMessageContentFile,
     OpenAIResponseInputMessageContentImage,
@@ -455,6 +456,7 @@ class OpenAIResponsesImpl:
         self,
         input: str | list[OpenAIResponseInput],
         model: str,
+        background: bool | None = False,
         prompt: OpenAIResponsePrompt | None = None,
         instructions: str | None = None,
         previous_response_id: str | None = None,
@@ -474,7 +476,15 @@ class OpenAIResponsesImpl:
         metadata: dict[str, str] | None = None,
     ):
         stream = bool(stream)
+        background = bool(background)
         text = OpenAIResponseText(format=OpenAIResponseTextFormat(type="text")) if text is None else text
+
+        # Validate that stream and background are mutually exclusive
+        if stream and background:
+            raise ValueError(
+                "Cannot use 'stream' and 'background' together. "
+                "Background mode returns immediately with a queued response."
+            )
 
         # Validate MCP tools: ensure Authorization header is not passed via headers dict
         if tools:
@@ -510,6 +520,29 @@ class OpenAIResponsesImpl:
 
         if max_tool_calls is not None and max_tool_calls < 1:
             raise ValueError(f"Invalid {max_tool_calls=}; should be >= 1")
+
+        # Handle background mode
+        if background:
+            return await self._create_background_response(
+                input=input,
+                model=model,
+                prompt=prompt,
+                instructions=instructions,
+                previous_response_id=previous_response_id,
+                conversation=conversation,
+                store=store,
+                temperature=temperature,
+                text=text,
+                tool_choice=tool_choice,
+                tools=tools,
+                include=include,
+                max_infer_iters=max_infer_iters,
+                guardrail_ids=guardrail_ids,
+                parallel_tool_calls=parallel_tool_calls,
+                max_tool_calls=max_tool_calls,
+                reasoning=reasoning,
+                metadata=metadata,
+            )
 
         stream_gen = self._create_streaming_response(
             input=input,
@@ -565,6 +598,222 @@ class OpenAIResponsesImpl:
             if final_response is None:
                 raise ValueError("The response stream never reached a terminal state")
             return final_response
+
+    async def _create_background_response(
+        self,
+        input: str | list[OpenAIResponseInput],
+        model: str,
+        prompt: OpenAIResponsePrompt | None = None,
+        instructions: str | None = None,
+        previous_response_id: str | None = None,
+        conversation: str | None = None,
+        store: bool | None = True,
+        temperature: float | None = None,
+        text: OpenAIResponseText | None = None,
+        tool_choice: OpenAIResponseInputToolChoice | None = None,
+        tools: list[OpenAIResponseInputTool] | None = None,
+        include: list[ResponseItemInclude] | None = None,
+        max_infer_iters: int | None = 10,
+        guardrail_ids: list[str] | None = None,
+        parallel_tool_calls: bool | None = None,
+        max_tool_calls: int | None = None,
+        reasoning: OpenAIResponseReasoning | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> OpenAIResponseObject:
+        """Create a response that processes in the background.
+
+        Returns immediately with a queued response object.
+        """
+        response_id = f"resp_{uuid.uuid4()}"
+        created_at = int(time.time())
+
+        # Normalize input to list format for storage
+        input_items = [OpenAIResponseInput(input)] if isinstance(input, str) else input
+
+        # Create initial queued response
+        queued_response = OpenAIResponseObject(
+            id=response_id,
+            created_at=created_at,
+            model=model,
+            status="queued",
+            output=[],
+            background=True,
+            parallel_tool_calls=parallel_tool_calls if parallel_tool_calls is not None else True,
+            previous_response_id=previous_response_id,
+            prompt=prompt,
+            temperature=temperature,
+            text=text if text else OpenAIResponseText(format=OpenAIResponseTextFormat(type="text")),
+            tools=[],  # Will be populated when processing completes
+            tool_choice=tool_choice,
+            instructions=instructions,
+            max_tool_calls=max_tool_calls,
+            reasoning=reasoning,
+            metadata=metadata,
+            store=store if store is not None else True,
+        )
+
+        # Store the queued response
+        await self.responses_store.store_response_object(
+            response_object=queued_response,
+            input=input_items,
+            messages=[],
+        )
+
+        # Schedule background processing task
+        asyncio.create_task(
+            self._process_background_response(
+                response_id=response_id,
+                input=input,
+                model=model,
+                prompt=prompt,
+                instructions=instructions,
+                previous_response_id=previous_response_id,
+                conversation=conversation,
+                store=store,
+                temperature=temperature,
+                text=text,
+                tool_choice=tool_choice,
+                tools=tools,
+                include=include,
+                max_infer_iters=max_infer_iters,
+                guardrail_ids=guardrail_ids,
+                parallel_tool_calls=parallel_tool_calls,
+                max_tool_calls=max_tool_calls,
+                reasoning=reasoning,
+                metadata=metadata,
+            )
+        )
+
+        return queued_response
+
+    async def _process_background_response(
+        self,
+        response_id: str,
+        input: str | list[OpenAIResponseInput],
+        model: str,
+        prompt: OpenAIResponsePrompt | None = None,
+        instructions: str | None = None,
+        previous_response_id: str | None = None,
+        conversation: str | None = None,
+        store: bool | None = True,
+        temperature: float | None = None,
+        text: OpenAIResponseText | None = None,
+        tool_choice: OpenAIResponseInputToolChoice | None = None,
+        tools: list[OpenAIResponseInputTool] | None = None,
+        include: list[ResponseItemInclude] | None = None,
+        max_infer_iters: int | None = 10,
+        guardrail_ids: list[str] | None = None,
+        parallel_tool_calls: bool | None = None,
+        max_tool_calls: int | None = None,
+        reasoning: OpenAIResponseReasoning | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> None:
+        """Process a background response asynchronously."""
+        try:
+            # Check if response was cancelled before starting
+            existing = await self.responses_store.get_response_object(response_id)
+            if existing.status == "cancelled":
+                logger.info(f"Background response {response_id} was cancelled before processing started")
+                return
+
+            # Update status to in_progress
+            existing.status = "in_progress"
+            await self.responses_store.update_response_object(existing)
+
+            # Process the response using existing streaming logic
+            stream_gen = self._create_streaming_response(
+                input=input,
+                conversation=conversation,
+                model=model,
+                prompt=prompt,
+                instructions=instructions,
+                previous_response_id=previous_response_id,
+                store=store,
+                temperature=temperature,
+                text=text,
+                tools=tools,
+                tool_choice=tool_choice,
+                max_infer_iters=max_infer_iters,
+                guardrail_ids=guardrail_ids,
+                parallel_tool_calls=parallel_tool_calls,
+                max_tool_calls=max_tool_calls,
+                reasoning=reasoning,
+                metadata=metadata,
+                include=include,
+            )
+
+            final_response = None
+            failed_response = None
+
+            async for stream_chunk in stream_gen:
+                # Check for cancellation periodically
+                current = await self.responses_store.get_response_object(response_id)
+                if current.status == "cancelled":
+                    logger.info(f"Background response {response_id} was cancelled during processing")
+                    return
+
+                match stream_chunk.type:
+                    case "response.completed" | "response.incomplete":
+                        final_response = stream_chunk.response
+                    case "response.failed":
+                        failed_response = stream_chunk.response
+                    case _:
+                        pass
+
+            if failed_response is not None:
+                # Update with failed status
+                failed_response.background = True
+                failed_response.id = response_id  # Ensure we update the correct response
+                await self.responses_store.update_response_object(failed_response)
+            elif final_response is not None:
+                # Update with completed response
+                final_response.background = True
+                final_response.id = response_id  # Ensure we update the correct response
+                await self.responses_store.update_response_object(final_response)
+            else:
+                # Something went wrong - mark as failed
+                existing = await self.responses_store.get_response_object(response_id)
+                existing.status = "failed"
+                existing.error = OpenAIResponseError(
+                    code="processing_error",
+                    message="Response stream never reached a terminal state",
+                )
+                await self.responses_store.update_response_object(existing)
+
+        except Exception as e:
+            logger.exception(f"Error processing background response {response_id}: {e}")
+            try:
+                existing = await self.responses_store.get_response_object(response_id)
+                existing.status = "failed"
+                existing.error = OpenAIResponseError(
+                    code="processing_error",
+                    message=str(e),
+                )
+                await self.responses_store.update_response_object(existing)
+            except Exception as update_error:
+                logger.exception(f"Failed to update response {response_id} with error status: {update_error}")
+
+    async def cancel_openai_response(self, response_id: str) -> OpenAIResponseObject:
+        """Cancel a background response.
+
+        Only responses created with background=true can be cancelled.
+        """
+        response = await self.responses_store.get_response_object(response_id)
+
+        if not response.background:
+            raise ValueError(f"Response {response_id} was not created with background=true and cannot be cancelled")
+
+        if response.status not in ("queued", "in_progress"):
+            raise ValueError(
+                f"Response {response_id} has status '{response.status}' and cannot be cancelled. "
+                "Only responses with status 'queued' or 'in_progress' can be cancelled."
+            )
+
+        # Update status to cancelled
+        response.status = "cancelled"
+        await self.responses_store.update_response_object(response)
+
+        return response
 
     async def _create_streaming_response(
         self,

--- a/src/llama_stack_api/__init__.py
+++ b/src/llama_stack_api/__init__.py
@@ -53,6 +53,7 @@ from .admin import (
 # Import all public API symbols
 from .agents import (
     Agents,
+    CancelResponseRequest,
     CreateResponseRequest,
     DeleteResponseRequest,
     ListResponseInputItemsRequest,
@@ -522,6 +523,7 @@ from .tools import (
     ToolStore,
 )
 from .validators import validate_embeddings_input_is_text
+from .helpers import remove_null_from_anyof
 from .vector_io import (
     Chunk,
     ChunkMetadata,
@@ -576,6 +578,7 @@ __all__ = [
     "Agents",
     "AggregationFunctionType",
     # Agents Request Models
+    "CancelResponseRequest",
     "CreateResponseRequest",
     "DeleteResponseRequest",
     "ListResponseInputItemsRequest",
@@ -1075,4 +1078,6 @@ __all__ = [
     "WeightedRanker",
     # Validators
     "validate_embeddings_input_is_text",
+    # helpers
+    "remove_null_from_anyof",
 ]

--- a/src/llama_stack_api/agents/__init__.py
+++ b/src/llama_stack_api/agents/__init__.py
@@ -14,6 +14,7 @@ The FastAPI router is defined in llama_stack_api.agents.fastapi_routes.
 from . import fastapi_routes
 from .api import Agents
 from .models import (
+    CancelResponseRequest,
     CreateResponseRequest,
     DeleteResponseRequest,
     ListResponseInputItemsRequest,
@@ -26,6 +27,7 @@ from .models import (
 
 __all__ = [
     "Agents",
+    "CancelResponseRequest",
     "CreateResponseRequest",
     "DeleteResponseRequest",
     "ListResponseInputItemsRequest",

--- a/src/llama_stack_api/agents/api.py
+++ b/src/llama_stack_api/agents/api.py
@@ -16,6 +16,7 @@ from llama_stack_api.openai_responses import (
 )
 
 from .models import (
+    CancelResponseRequest,
     CreateResponseRequest,
     DeleteResponseRequest,
     ListResponseInputItemsRequest,
@@ -50,3 +51,8 @@ class Agents(Protocol):
         self,
         request: DeleteResponseRequest,
     ) -> OpenAIDeleteResponseObject: ...
+
+    async def cancel_openai_response(
+        self,
+        request: CancelResponseRequest,
+    ) -> OpenAIResponseObject: ...

--- a/src/llama_stack_api/agents/models.py
+++ b/src/llama_stack_api/agents/models.py
@@ -15,6 +15,7 @@ from enum import StrEnum
 from pydantic import BaseModel, ConfigDict, Field
 
 from llama_stack_api.common.responses import Order
+from llama_stack_api.helpers import remove_null_from_anyof
 from llama_stack_api.openai_responses import (
     OpenAIResponseInput,
     OpenAIResponseInputTool,
@@ -56,6 +57,11 @@ class CreateResponseRequest(BaseModel):
 
     input: str | list[OpenAIResponseInput] = Field(..., description="Input message(s) to create the response.")
     model: str = Field(..., description="The underlying LLM used for completions.")
+    background: bool | None = Field(
+        default=None,
+        description="Whether to run the model response in the background. When true, returns immediately with status 'queued'.",
+        json_schema_extra=remove_null_from_anyof,
+    )
     prompt: OpenAIResponsePrompt | None = Field(
         default=None, description="Prompt object with ID, version, and variables."
     )
@@ -173,3 +179,11 @@ class DeleteResponseRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     response_id: str = Field(..., min_length=1, description="The ID of the OpenAI response to delete.")
+
+
+class CancelResponseRequest(BaseModel):
+    """Request model for cancelling a background response."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    response_id: str = Field(..., min_length=1, description="The ID of the response to cancel.")

--- a/src/llama_stack_api/helpers.py
+++ b/src/llama_stack_api/helpers.py
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+
+def remove_null_from_anyof(schema: dict) -> None:
+    """Remove null type from anyOf if present in JSON schema.
+
+    This is used to make optional fields non-nullable in the OpenAPI spec,
+    matching OpenAI's API specification where optional fields can be omitted
+    but cannot be explicitly set to null.
+
+    Handles both OpenAPI 3.0 format (anyOf with null) and OpenAPI 3.1 format
+    (type as array with null).
+    """
+    # Handle anyOf format: anyOf: [{type: integer}, {type: null}]
+    if "anyOf" in schema:
+        schema["anyOf"] = [s for s in schema["anyOf"] if s.get("type") != "null"]
+        if len(schema["anyOf"]) == 1:
+            # If only one type left, flatten it
+            only_schema = schema["anyOf"][0]
+            schema.pop("anyOf")
+            schema.update(only_schema)
+
+    # Handle OpenAPI 3.1 format: type: ['integer', 'null']
+    elif isinstance(schema.get("type"), list) and "null" in schema["type"]:
+        schema["type"].remove("null")
+        if len(schema["type"]) == 1:
+            schema["type"] = schema["type"][0]
+
+
+__all__ = [
+    "remove_null_from_anyof",
+]

--- a/src/llama_stack_api/openai_responses.py
+++ b/src/llama_stack_api/openai_responses.py
@@ -15,6 +15,8 @@ from llama_stack_api.inference import OpenAITokenLogProb
 from llama_stack_api.schema_utils import json_schema_type, register_schema
 from llama_stack_api.vector_io import SearchRankingOptions as FileSearchRankingOptions
 
+from .helpers import remove_null_from_anyof
+
 # NOTE(ashwin): this file is literally a copy of the OpenAI responses API schema. We should probably
 # take their YAML and generate this file automatically. Their YAML is available.
 
@@ -702,6 +704,7 @@ class OpenAIResponseUsage(BaseModel):
 class OpenAIResponseObject(BaseModel):
     """Complete OpenAI response object containing generation results and metadata.
 
+    :param background: Whether this response was run in background mode
     :param created_at: Unix timestamp when the response was created
     :param error: (Optional) Error details if the response generation failed
     :param id: Unique identifier for this response
@@ -711,7 +714,7 @@ class OpenAIResponseObject(BaseModel):
     :param parallel_tool_calls: (Optional) Whether to allow more than one function tool call generated per turn.
     :param previous_response_id: (Optional) ID of the previous response in a conversation
     :param prompt: (Optional) Reference to a prompt template and its variables.
-    :param status: Current status of the response generation
+    :param status: Current status of the response generation (queued, in_progress, completed, failed, cancelled, incomplete)
     :param temperature: (Optional) Sampling temperature used for generation
     :param text: Text formatting configuration for the response
     :param top_p: (Optional) Nucleus sampling parameter used for generation
@@ -724,6 +727,7 @@ class OpenAIResponseObject(BaseModel):
     :param metadata: (Optional) Dictionary of metadata key-value pairs
     """
 
+    background: bool | None = Field(default=None, json_schema_extra=remove_null_from_anyof)
     created_at: int
     completed_at: int | None = None
     error: OpenAIResponseError | None = None

--- a/src/llama_stack_api/pyproject.toml
+++ b/src/llama_stack_api/pyproject.toml
@@ -83,6 +83,7 @@ py-modules = [
     "llama_stack_api.vector_stores",
     "llama_stack_api.version",
     "llama_stack_api.validators",
+    "llama_stack_api.helpers",
 ]
 
 [tool.setuptools.package-data]

--- a/tests/integration/responses/test_background_responses.py
+++ b/tests/integration/responses/test_background_responses.py
@@ -1,0 +1,156 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Integration tests for background mode in the Responses API."""
+
+import time
+
+import pytest
+
+
+class TestBackgroundResponses:
+    """Test background mode for response generation."""
+
+    def test_background_response_returns_queued(self, responses_client, text_model_id):
+        """Test that background=True returns immediately with queued status."""
+        response = responses_client.responses.create(
+            model=text_model_id,
+            input="What is 2+2?",
+            background=True,
+        )
+
+        # Should return immediately with queued status
+        assert response.status == "queued"
+        assert response.background is True
+        assert response.id.startswith("resp_")
+        # Output should be empty initially
+        assert len(response.output) == 0
+
+    def test_background_response_completes(self, responses_client, text_model_id):
+        """Test that a background response eventually completes."""
+        response = responses_client.responses.create(
+            model=text_model_id,
+            input="Say hello",
+            background=True,
+        )
+
+        assert response.status == "queued"
+        response_id = response.id
+
+        # Poll for completion (max 60 seconds)
+        max_wait = 60
+        poll_interval = 1
+        elapsed = 0
+
+        while elapsed < max_wait:
+            time.sleep(poll_interval)
+            elapsed += poll_interval
+
+            retrieved = responses_client.responses.retrieve(response_id=response_id)
+
+            if retrieved.status == "completed":
+                assert retrieved.background is True
+                assert len(retrieved.output) > 0
+                assert len(retrieved.output_text) > 0
+                return
+
+            if retrieved.status == "failed":
+                pytest.fail(f"Background response failed: {retrieved.error}")
+
+            # Status should be queued or in_progress while processing
+            assert retrieved.status in ("queued", "in_progress")
+
+        pytest.fail(f"Background response did not complete within {max_wait} seconds")
+
+    def test_cancel_background_response(self, responses_client, text_model_id):
+        """Test cancelling a background response."""
+        # Create a background response with a longer prompt to give time to cancel
+        response = responses_client.responses.create(
+            model=text_model_id,
+            input="Write a very long and detailed story about a dragon who learns to code. Include many chapters.",
+            background=True,
+        )
+
+        assert response.status == "queued"
+        response_id = response.id
+
+        # Cancel the response
+        cancelled = responses_client.responses.cancel(response_id=response_id)
+
+        assert cancelled.status == "cancelled"
+        assert cancelled.background is True
+        assert cancelled.id == response_id
+
+    def test_cannot_cancel_non_background_response(self, responses_client, text_model_id):
+        """Test that non-background responses cannot be cancelled."""
+        response = responses_client.responses.create(
+            model=text_model_id,
+            input="Hello",
+            background=False,
+        )
+
+        assert response.status == "completed"
+        assert response.background is False
+
+        # Attempting to cancel should raise an error
+        with pytest.raises(Exception) as exc_info:
+            responses_client.responses.cancel(response_id=response.id)
+
+        assert "cannot be cancelled" in str(exc_info.value).lower()
+
+    def test_cannot_cancel_completed_background_response(self, responses_client, text_model_id):
+        """Test that completed background responses cannot be cancelled."""
+        response = responses_client.responses.create(
+            model=text_model_id,
+            input="Say hi",
+            background=True,
+        )
+
+        response_id = response.id
+
+        # Wait for completion
+        max_wait = 60
+        poll_interval = 1
+        elapsed = 0
+
+        while elapsed < max_wait:
+            time.sleep(poll_interval)
+            elapsed += poll_interval
+
+            retrieved = responses_client.responses.retrieve(response_id=response_id)
+            if retrieved.status == "completed":
+                break
+
+        # Now try to cancel the completed response
+        with pytest.raises(Exception) as exc_info:
+            responses_client.responses.cancel(response_id=response_id)
+
+        assert "cannot be cancelled" in str(exc_info.value).lower()
+
+    def test_background_and_stream_mutually_exclusive(self, responses_client, text_model_id):
+        """Test that background=True and stream=True cannot be used together."""
+        with pytest.raises(Exception) as exc_info:
+            responses_client.responses.create(
+                model=text_model_id,
+                input="Hello",
+                background=True,
+                stream=True,
+            )
+
+        error_msg = str(exc_info.value).lower()
+        assert "background" in error_msg or "stream" in error_msg
+
+    def test_background_false_is_synchronous(self, responses_client, text_model_id):
+        """Test that background=False returns a completed response synchronously."""
+        response = responses_client.responses.create(
+            model=text_model_id,
+            input="What is 1+1?",
+            background=False,
+        )
+
+        assert response.status == "completed"
+        assert response.background is False
+        assert len(response.output) > 0

--- a/tests/unit/providers/agents/meta_reference/test_responses_background.py
+++ b/tests/unit/providers/agents/meta_reference/test_responses_background.py
@@ -1,0 +1,160 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Unit tests for background parameter support in Responses API."""
+
+import pytest
+
+from llama_stack_api import OpenAIResponseError, OpenAIResponseObject
+
+
+class TestBackgroundFieldInResponseObject:
+    """Test that the background field is properly defined in OpenAIResponseObject."""
+
+    def test_background_field_default_is_none(self):
+        """Verify background field defaults to None."""
+        response = OpenAIResponseObject(
+            id="resp_123",
+            created_at=1234567890,
+            model="test-model",
+            status="completed",
+            output=[],
+            store=True,
+        )
+        assert response.background is None
+
+    def test_background_field_can_be_true(self):
+        """Verify background field can be set to True."""
+        response = OpenAIResponseObject(
+            id="resp_123",
+            created_at=1234567890,
+            model="test-model",
+            status="queued",
+            output=[],
+            background=True,
+            store=True,
+        )
+        assert response.background is True
+
+    def test_background_field_can_be_false(self):
+        """Verify background field can be False."""
+        response = OpenAIResponseObject(
+            id="resp_123",
+            created_at=1234567890,
+            model="test-model",
+            status="completed",
+            output=[],
+            background=False,
+            store=True,
+        )
+        assert response.background is False
+
+
+class TestResponseStatus:
+    """Test that all expected status values work correctly."""
+
+    @pytest.mark.parametrize(
+        "status",
+        ["queued", "in_progress", "completed", "failed", "cancelled", "incomplete"],
+    )
+    def test_valid_status_values(self, status):
+        """Verify all OpenAI-compatible status values are accepted."""
+        response = OpenAIResponseObject(
+            id="resp_123",
+            created_at=1234567890,
+            model="test-model",
+            status=status,
+            output=[],
+            background=True if status in ("queued", "in_progress", "cancelled") else False,
+            store=True,
+        )
+        assert response.status == status
+
+    def test_queued_status_with_background(self):
+        """Verify queued status is typically used with background=True."""
+        response = OpenAIResponseObject(
+            id="resp_123",
+            created_at=1234567890,
+            model="test-model",
+            status="queued",
+            output=[],
+            background=True,
+            store=True,
+        )
+        assert response.status == "queued"
+        assert response.background is True
+
+    def test_cancelled_status_with_background(self):
+        """Verify cancelled status is typically used with background=True."""
+        response = OpenAIResponseObject(
+            id="resp_123",
+            created_at=1234567890,
+            model="test-model",
+            status="cancelled",
+            output=[],
+            background=True,
+            store=True,
+        )
+        assert response.status == "cancelled"
+        assert response.background is True
+
+
+class TestResponseObjectSerialization:
+    """Test that the response object serializes correctly with background field."""
+
+    def test_model_dump_includes_background(self):
+        """Verify model_dump includes the background field."""
+        response = OpenAIResponseObject(
+            id="resp_123",
+            created_at=1234567890,
+            model="test-model",
+            status="queued",
+            output=[],
+            background=True,
+            store=True,
+        )
+        data = response.model_dump()
+        assert "background" in data
+        assert data["background"] is True
+
+    def test_model_dump_json_includes_background(self):
+        """Verify JSON serialization includes the background field."""
+        response = OpenAIResponseObject(
+            id="resp_123",
+            created_at=1234567890,
+            model="test-model",
+            status="completed",
+            output=[],
+            background=False,
+            store=True,
+        )
+        json_str = response.model_dump_json()
+        assert '"background":false' in json_str or '"background": false' in json_str
+
+
+class TestResponseErrorForBackground:
+    """Test error responses for background processing failures."""
+
+    def test_error_response_with_background(self):
+        """Verify error responses can include background field."""
+        error = OpenAIResponseError(
+            code="processing_error",
+            message="Background processing failed",
+        )
+        response = OpenAIResponseObject(
+            id="resp_123",
+            created_at=1234567890,
+            model="test-model",
+            status="failed",
+            output=[],
+            background=True,
+            error=error,
+            store=True,
+        )
+        assert response.status == "failed"
+        assert response.background is True
+        assert response.error is not None
+        assert response.error.code == "processing_error"


### PR DESCRIPTION
# What does this PR do?

Add OpenAI-compatible background mode for the Responses API, allowing responses to be queued for asynchronous processing.

- Added `background` parameter (bool, default: false)
- When true, returns immediately with status "queued"

- Added `background` field to `OpenAIResponseObject`
- New status values: "queued", "in_progress", "cancelled"

- OpenAI-compatible endpoint for cancelling background responses
- Only works for responses created with background=true
- Only cancellable when status is "queued" or "in_progress"

- `agents/models.py`: Added `background` to `CreateResponseRequest`, new `CancelResponseRequest`
- `agents/api.py`: Added `cancel_openai_response` to Agents protocol
- `agents/fastapi_routes.py`: Added cancel route
- `openai_responses.py`: Added `background` field to response object

- `openai_responses.py`: Background processing with `_create_background_response` and `_process_background_response`
- `responses_store.py`: Added `update_response_object` for status updates

closes #4701

## Test Plan

new unit and integration tests (with stainless builds) should pass. The integration tests represent the testing for the new API changes. 