### PR TITLE
fix: pass branch explicitly to install-llama-stack-client action

### DIFF
--- a/.github/actions/install-llama-stack-client/action.yml
+++ b/.github/actions/install-llama-stack-client/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: 'URL to install Python SDK from (for testing preview builds). If provided, overrides client-version.'
     required: false
     default: ""
+  branch:
+    description: 'Explicit branch override (used by scheduled CI to pass the matrix branch)'
+    required: false
+    default: ""
 
 outputs:
   uv-extra-index-url:
@@ -38,8 +42,13 @@ runs:
         fi
 
         # Determine the branch we're working with
-        BRANCH="${{ github.base_ref || github.ref }}"
-        BRANCH="${BRANCH#refs/heads/}"
+        # Use explicit branch input if provided (for scheduled CI), otherwise detect from GitHub context
+        if [ -n "${{ inputs.branch }}" ]; then
+          BRANCH="${{ inputs.branch }}"
+        else
+          BRANCH="${{ github.base_ref || github.ref }}"
+          BRANCH="${BRANCH#refs/heads/}"
+        fi
 
         echo "Working with branch: $BRANCH"
 

--- a/.github/actions/setup-runner/action.yml
+++ b/.github/actions/setup-runner/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'URL to install Python SDK from (for testing preview builds). If provided, overrides client-version.'
     required: false
     default: ""
+  branch:
+    description: 'Explicit branch override (used by scheduled CI to pass the matrix branch)'
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -27,6 +31,7 @@ runs:
       with:
         client-version: ${{ inputs.client-version }}
         sdk_install_url: ${{ inputs.sdk_install_url }}
+        branch: ${{ inputs.branch }}
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -23,6 +23,10 @@ inputs:
   inference-mode:
     description: 'Inference mode (record or replay)'
     required: true
+  branch:
+    description: 'Explicit branch override (used by scheduled CI to pass the matrix branch)'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -33,6 +37,7 @@ runs:
         python-version: ${{ inputs.python-version }}
         client-version: ${{ inputs.client-version }}
         sdk_install_url: ${{ inputs.sdk_install_url }}
+        branch: ${{ inputs.branch }}
 
     - name: Setup ollama
       if: ${{ (inputs.setup == 'ollama' || inputs.setup == 'ollama-vision') && inputs.inference-mode == 'record' }}

--- a/.github/workflows/release-branch-scheduled-ci.yml
+++ b/.github/workflows/release-branch-scheduled-ci.yml
@@ -113,6 +113,7 @@ jobs:
           setup: 'ollama'
           suite: 'base'
           inference-mode: 'replay'
+          branch: ${{ matrix.branch }}
 
       - name: Check for TypeScript client tests
         id: check-ts-client


### PR DESCRIPTION
# What does this PR do?

The scheduled CI workflow runs on main but checks out release branches. The install-llama-stack-client action was using github.ref to detect the branch, which always resolves to main (the workflow's branch), not the checked-out release branch.

Add a branch input to the action chain (setup-test-environment → setup-runner → install-llama-stack-client) so the scheduled CI can pass matrix.branch explicitly. This ensures the correct client version is installed from the matching release branch in llama-stack-client-python.

see https://github.com/llamastack/llama-stack/actions/runs/21441736130/job/61746421583 for reference

## Test Plan

run using workflow dispatch when this merges