### PR TITLE
feat(storage): make responses table name configurable

### DIFF
--- a/src/llama_stack/core/storage/datatypes.py
+++ b/src/llama_stack/core/storage/datatypes.py
@@ -255,6 +255,11 @@ class InferenceStoreReference(SqlStoreReference):
 class ResponsesStoreReference(InferenceStoreReference):
     """Responses store configuration with queue tuning."""
 
+    table_name: str = Field(
+        default="openai_responses",
+        description="Name of the table to use for storing OpenAI responses",
+    )
+
 
 class ServerStoresConfig(BaseModel):
     metadata: KVStoreReference | None = Field(

--- a/src/llama_stack/providers/utils/responses/responses_store.py
+++ b/src/llama_stack/providers/utils/responses/responses_store.py
@@ -57,7 +57,7 @@ class ResponsesStore:
         self.sql_store = AuthorizedSqlStore(base_store, self.policy)
 
         await self.sql_store.create_table(
-            "openai_responses",
+            self.reference.table_name,
             {
                 "id": ColumnDefinition(type=ColumnType.STRING, primary_key=True),
                 "created_at": ColumnType.INTEGER,
@@ -112,7 +112,7 @@ class ResponsesStore:
         data["messages"] = [msg.model_dump() for msg in messages]
 
         await self.sql_store.upsert(
-            table="openai_responses",
+            table=self.reference.table_name,
             data={
                 "id": data["id"],
                 "created_at": data["created_at"],
@@ -137,7 +137,7 @@ class ResponsesStore:
         data["messages"] = [msg.model_dump() for msg in messages]
 
         await self.sql_store.insert(
-            "openai_responses",
+            self.reference.table_name,
             {
                 "id": data["id"],
                 "created_at": data["created_at"],
@@ -172,7 +172,7 @@ class ResponsesStore:
             where_conditions["model"] = model
 
         paginated_result = await self.sql_store.fetch_all(
-            table="openai_responses",
+            table=self.reference.table_name,
             where=where_conditions if where_conditions else None,
             order_by=[("created_at", order.value)],
             cursor=("id", after) if after else None,
@@ -195,7 +195,7 @@ class ResponsesStore:
             raise ValueError("Responses store is not initialized")
 
         row = await self.sql_store.fetch_one(
-            "openai_responses",
+            self.reference.table_name,
             where={"id": response_id},
         )
 
@@ -210,10 +210,10 @@ class ResponsesStore:
         if not self.sql_store:
             raise ValueError("Responses store is not initialized")
 
-        row = await self.sql_store.fetch_one("openai_responses", where={"id": response_id})
+        row = await self.sql_store.fetch_one(self.reference.table_name, where={"id": response_id})
         if not row:
             raise ValueError(f"Response with id {response_id} not found")
-        await self.sql_store.delete("openai_responses", where={"id": response_id})
+        await self.sql_store.delete(self.reference.table_name, where={"id": response_id})
         return OpenAIDeleteResponseObject(id=response_id)
 
     async def list_response_input_items(

--- a/tests/unit/utils/responses/test_responses_store.py
+++ b/tests/unit/utils/responses/test_responses_store.py
@@ -193,7 +193,7 @@ async def test_responses_store_pagination_invalid_after():
         await store.initialize()
 
         # Try to paginate with non-existent ID
-        with pytest.raises(ValueError, match="Record with id.*'non-existent' not found in table 'openai_responses'"):
+        with pytest.raises(ValueError, match="Record with id.*'non-existent' not found in table 'responses'"):
             await store.list_responses(after="non-existent", limit=2)
 
 


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
- Make responses table name configurable, which falls back to the name `openai-responses` if no name is provided.
- The changes in this PR have been generated by the use of `Spec-Kit` (Spec-Driven Development tools). After reviewing the changes, they are precise, follows codebase structure, and solve the problem at hand.
- Added spec-kit paths to `.gitignore`

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->
Closes #4746 

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->
0. Tests should continue to pass. To test manually follow steps below:

1. In the [config.yaml file](https://github.com/llamastack/llama-stack/blob/main/src/llama_stack/distributions/starter/config.yaml#L180) for the `starter` distribution, change the table name from `responses` to `chris_responses`.

2. Install uv and start Ollama:
`ollama run llama3.2:3b --keepalive 60m`

3. Install server dependencies:
`uv run --with llama-stack llama stack list-deps starter | xargs -L1 uv pip install`

4. Run Llama Stack server:
`OLLAMA_URL=http://localhost:11434/v1 uv run --with llama-stack llama stack run starter`

5. Curl:
```
curl -X POST http://localhost:8321/v1/responses \
  -H "Content-Type: application/json" \
  -d '{
    "model": "ollama/llama3.2:3b",
    "input": "Hello, what is 2+2?"
  }'
```

6. Check the `sql_store.db` normally found in this path: `.llama/distributions/starter/sql_store.db`.
  - Once in the starter directory you can run `sqlite3 sql_store.db`
  - Then run `.tables`, which will show the new `chris_responses` table.
  - Furthermore, you can run `SELECT * FROM chris_responses;`, to view all items from the table.


<!-- For API changes, include:
1. A testing script (Python, curl, etc.) that exercises the new/modified endpoints
2. The output from running your script

Example:
```python
...
...
```

Output:
```
<paste actual output here>
```
-->
