### PR TITLE
fix: trim whitespace from discovered branch names

### DIFF
--- a/.github/actions/install-llama-stack-client/action.yml
+++ b/.github/actions/install-llama-stack-client/action.yml
@@ -49,6 +49,8 @@ runs:
           BRANCH="${{ github.base_ref || github.ref }}"
           BRANCH="${BRANCH#refs/heads/}"
         fi
+        # Trim leading/trailing whitespace (git branch -r output includes padding)
+        BRANCH="$(echo "$BRANCH" | xargs)"
 
         echo "Working with branch: $BRANCH"
 

--- a/.github/workflows/release-branch-scheduled-ci.yml
+++ b/.github/workflows/release-branch-scheduled-ci.yml
@@ -41,10 +41,10 @@ jobs:
             branches=$(git branch -r | \
               grep 'origin/release-[0-9]' | \
               grep '\.x$' | \
-              sed 's|origin/||' | \
+              sed 's|^[[:space:]]*origin/||' | \
               sort -V | \
               tail -2 | \
-              jq -R -s -c 'split("\n") | map(select(length > 0))')
+              jq -R -s -c 'split("\n") | map(select(length > 0) | ltrimstr(" ") | rtrimstr(" "))')
           fi
 
           echo "branches=$branches" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# What does this PR do?

git branch -r outputs lines with leading spaces (e.g. '  origin/release-0.3.x'). The sed command stripped 'origin/' but not the whitespace, causing the release branch regex to fail and the wrong client version to be installed.

Trim whitespace in both the discover-branches step and the install-llama-stack-client action as a safety net.

## Test Plan

see https://github.com/llamastack/llama-stack/actions/runs/21453322655/job/61787508351 with a successful run!

