### PR TITLE
fix: install setuptools-scm in CI

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -190,7 +190,7 @@ jobs:
 
       - name: Install build dependencies
         if: steps.should-build.outputs.skip != 'true' && matrix.registry == 'pypi'
-        run: uv pip install --system setuptools wheel build
+        run: uv pip install --system setuptools setuptools-scm wheel build
 
       # === NODE SETUP (for npm packages) ===
       - name: Set up Node.js


### PR DESCRIPTION
# What does this PR do?

without setuptools-scm SETUPTOOLS_SCM_PRETEND_VERSION is ignored, 0.0.0 is used as a version to test.pypi and for all other pkgs.


## Test Plan

The build job should show a 0.4.4 version in the `Build Local Package` step
