### PR TITLE
fix: suppress tar pipe error in npm dry-run verification

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -644,6 +644,6 @@ jobs:
             ls -la dist/*.tgz
             # Verify the tarball is valid
             TARBALL=$(ls ./dist/*.tgz | head -1)
-            tar -tzf "$TARBALL" | head -20
+            tar -tzf "$TARBALL" 2>/dev/null | head -20 || true
             echo "... (truncated)"
           fi


### PR DESCRIPTION
# What does this PR do?

see error here: https://github.com/llamastack/llama-stack/actions/runs/21534920926