### PR TITLE
fix: unify version computation for all packages in pypi workflow

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -285,8 +285,11 @@ jobs:
         working-directory: external-repo
         run: |
           VERSION="${{ needs.compute-version.outputs.version }}"
-          echo "Setting version to $VERSION"
-          npm version "$VERSION" --no-git-tag-version
+          # Convert PEP 440 dev version to valid semver for npm
+          # e.g. 0.4.5.dev20260202 -> 0.4.5-dev.20260202
+          NPM_VERSION=$(echo "$VERSION" | sed 's/\.dev/-dev./')
+          echo "Setting version to $NPM_VERSION (from $VERSION)"
+          npm version "$NPM_VERSION" --no-git-tag-version
           npm install
           npm run build
 


### PR DESCRIPTION
# What does this PR do?

Extract version computation into a separate job so external packages (client-python, client-typescript) get the same version as local packages during nightly and manual workflow_dispatch runs.

see most recent run, the versioning of the clients is wrong: https://github.com/llamastack/llama-stack/actions/runs/21592880563/job/62217292870 