### PR TITLE
fix: bump fallback version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "setuptools-scm>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-fallback_version = "0.4.5.dev0"
+fallback_version = "0.5.0.dev0"
 
 [tool.uv]
 required-version = ">=0.7.0"

--- a/src/llama_stack_api/pyproject.toml
+++ b/src/llama_stack_api/pyproject.toml
@@ -90,7 +90,7 @@ llama_stack_api = ["py.typed", "**/*.json", "**/*.yaml"]
 
 [tool.setuptools_scm]
 root = "../.."
-fallback_version = "0.4.5.dev0"
+fallback_version = "0.5.0.dev0"
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
# What does this PR do?

since 0.5.0 is the next release, target a 0.5.0 fallback version. this also fixes CI which is failing due to pulling in a 0.5.0alpha client


## Test Plan
 ci passes, it fails on new PRs. 
