### PR TITLE
fix: remove params={} from safety integration tests

### DIFF
--- a/tests/integration/safety/test_llama_guard.py
+++ b/tests/integration/safety/test_llama_guard.py
@@ -56,9 +56,7 @@ def text_shield_id(client_with_models, safety_provider, text_model) -> Generator
     shield_id = f"test_llama_guard_{uuid.uuid4().hex[:8]}"
 
     # Register the shield with the verified model ID from text_model fixture
-    client_with_models.shields.register(
-        shield_id=shield_id, provider_id=safety_provider, provider_shield_id=text_model, params={}
-    )
+    client_with_models.shields.register(shield_id=shield_id, provider_id=safety_provider, provider_shield_id=text_model)
 
     # Return the shield ID for use in tests
     yield shield_id
@@ -94,7 +92,7 @@ def vision_shield_id(client_with_models, safety_provider, vision_model) -> Gener
     # Register the shield with the verified model ID from vision_model fixture
     try:
         client_with_models.shields.register(
-            shield_id=shield_id, provider_id=safety_provider, provider_shield_id=vision_model, params={}
+            shield_id=shield_id, provider_id=safety_provider, provider_shield_id=vision_model
         )
     except Exception as e:
         pytest.skip(reason=f"Unable to register Llama Guard Vision shield with model {vision_model}: {str(e)}")
@@ -147,7 +145,6 @@ def test_unsafe_text_examples(client_with_models, text_shield_id, example):
     response = client_with_models.safety.run_shield(
         messages=[message],
         shield_id=text_shield_id,
-        params={},
     )
     assert response.violation is not None
     assert response.violation.violation_level == ViolationLevel.ERROR.value
@@ -173,7 +170,6 @@ def test_safe_text_examples(client_with_models, text_shield_id, example):
     response = client_with_models.safety.run_shield(
         messages=[message],
         shield_id=text_shield_id,
-        params={},
     )
     assert response.violation is None
 
@@ -208,7 +204,6 @@ def test_llama_guard_for_code_interpreter_abuse(client_with_models, text_shield_
     response = client_with_models.safety.run_shield(
         messages=[message],
         shield_id=text_shield_id,
-        params={},
     )
     assert response is not None
     assert response.violation is not None
@@ -238,7 +233,6 @@ def test_llama_guard_with_conversation_history(client_with_models, text_shield_i
     response = client_with_models.safety.run_shield(
         messages=[message1, message2, message3],
         shield_id=text_shield_id,
-        params={},
     )
     assert response.violation is not None
     assert response.violation.violation_level == ViolationLevel.ERROR.value
@@ -290,7 +284,6 @@ def test_vision_safety_with_safe_image(client_with_models, vision_shield_id, saf
     response = client_with_models.safety.run_shield(
         messages=[message],
         shield_id=vision_shield_id,
-        params={},
     )
 
     # Safe image should not trigger a violation
@@ -313,7 +306,6 @@ def test_vision_safety_with_unsafe_image(client_with_models, vision_shield_id, u
     response = client_with_models.safety.run_shield(
         messages=[message],
         shield_id=vision_shield_id,
-        params={},
     )
 
     # Unsafe image should trigger a violation

--- a/tests/integration/safety/test_safety.py
+++ b/tests/integration/safety/test_safety.py
@@ -49,7 +49,6 @@ def test_unsafe_examples(client_with_models, shield_id):
         response = client_with_models.safety.run_shield(
             messages=[message],
             shield_id=shield_id,
-            params={},
         )
         assert response.violation is not None
         assert response.violation.violation_level == ViolationLevel.ERROR.value
@@ -117,7 +116,6 @@ def test_safe_examples(client_with_models, shield_id):
         response = client_with_models.safety.run_shield(
             messages=[message],
             shield_id=shield_id,
-            params={},
         )
         assert response.violation is None
 
@@ -153,7 +151,6 @@ def test_safety_with_code_scanner(client_with_models, code_scanner_shield_id, mo
     response = client_with_models.safety.run_shield(
         messages=[message],
         shield_id=code_scanner_shield_id,
-        params={},
     )
     assert response is not None
     assert response.violation is not None
@@ -235,7 +232,6 @@ def test_safety_with_code_interpreter_abuse(client_with_models, shield_id):
     response = client_with_models.safety.run_shield(
         messages=[message],
         shield_id=shield_id,
-        params={},
     )
     assert response is not None
     assert response.violation is not None

--- a/tests/integration/safety/test_vision_safety.py
+++ b/tests/integration/safety/test_vision_safety.py
@@ -58,7 +58,6 @@ def test_safety_with_image(llama_stack_client, model_providers):
         response = llama_stack_client.safety.run_shield(
             messages=[message],
             shield_id="meta-llama/Llama-Guard-3-11B-Vision",
-            params={},
         )
         assert response is not None
 


### PR DESCRIPTION


# What does this PR do?
The regenerated llama-stack-client removed the params parameter from SafetyResource.run_shield() and ShieldsResource.register().

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan

tests pass, they are broken on main 