### PR TITLE
fix: remove unsupported params argument from safety tests

### DIFF
--- a/tests/integration/safety/test_safety.py
+++ b/tests/integration/safety/test_safety.py
@@ -49,7 +49,6 @@ def test_unsafe_examples(client_with_models, shield_id):
         response = client_with_models.safety.run_shield(
             messages=[message],
             shield_id=shield_id,
-            params={},
         )
         assert response.violation is not None
         assert response.violation.violation_level == ViolationLevel.ERROR.value
@@ -117,7 +116,6 @@ def test_safe_examples(client_with_models, shield_id):
         response = client_with_models.safety.run_shield(
             messages=[message],
             shield_id=shield_id,
-            params={},
         )
         assert response.violation is None
 
@@ -153,7 +151,6 @@ def test_safety_with_code_scanner(client_with_models, code_scanner_shield_id, mo
     response = client_with_models.safety.run_shield(
         messages=[message],
         shield_id=code_scanner_shield_id,
-        params={},
     )
     assert response is not None
     assert response.violation is not None
@@ -235,7 +232,6 @@ def test_safety_with_code_interpreter_abuse(client_with_models, shield_id):
     response = client_with_models.safety.run_shield(
         messages=[message],
         shield_id=shield_id,
-        params={},
     )
     assert response is not None
     assert response.violation is not None


### PR DESCRIPTION
## Summary
- Remove `params={}` argument from `run_shield()` calls in safety tests

The `params` argument was [removed from `run_shield()`](https://github.com/llamastack/llama-stack-client-python/compare/75e3efa...9d4c603#diff-aa49f4bf60229751fd5599477ed66b61ea481195b397d8d17be8c59bd7645d07L84) in llama-stack-client 0.5.0a2, causing CI failures.

## Test plan
- CI should pass with this fix