### PR TITLE
chore: reduce uses of models.llama.datatypes

### DIFF
--- a/src/llama_stack/providers/inline/safety/llama_guard/llama_guard.py
+++ b/src/llama_stack/providers/inline/safety/llama_guard/llama_guard.py
@@ -10,7 +10,6 @@ from string import Template
 
 from llama_stack.core.datatypes import Api
 from llama_stack.log import get_logger
-from llama_stack.models.llama.datatypes import Role
 from llama_stack.providers.utils.inference.prompt_adapter import (
     interleaved_content_as_str,
 )
@@ -278,10 +277,10 @@ class LlamaGuardShield:
     def validate_messages(self, messages: list[OpenAIMessageParam]) -> list[OpenAIMessageParam]:
         if len(messages) == 0:
             raise ValueError("Messages must not be empty")
-        if messages[0].role != Role.user.value:
+        if messages[0].role != "user":
             raise ValueError("Messages must start with user")
 
-        if len(messages) >= 2 and (messages[0].role == Role.user.value and messages[1].role == Role.user.value):
+        if len(messages) >= 2 and (messages[0].role == "user" and messages[1].role == "user"):
             messages = messages[1:]
 
         return messages
@@ -316,7 +315,7 @@ class LlamaGuardShield:
             if isinstance(m.content, str) or isinstance(m.content, TextContentItem):
                 conversation.append(m)
             elif isinstance(m.content, ImageContentItem):
-                if most_recent_img is None and m.role == Role.user.value:
+                if most_recent_img is None and m.role == "user":
                     most_recent_img = m.content
                     conversation.append(m)
             elif isinstance(m.content, list):
@@ -325,7 +324,7 @@ class LlamaGuardShield:
                     if isinstance(c, str) or isinstance(c, TextContentItem):
                         content.append(c)
                     elif isinstance(c, ImageContentItem):
-                        if most_recent_img is None and m.role == Role.user.value:
+                        if most_recent_img is None and m.role == "user":
                             most_recent_img = c
                             content.append(c)
                     else:

--- a/src/llama_stack/providers/remote/tool_runtime/brave_search/brave_search.py
+++ b/src/llama_stack/providers/remote/tool_runtime/brave_search/brave_search.py
@@ -9,7 +9,6 @@ from typing import Any
 import httpx
 
 from llama_stack.core.request_headers import NeedsRequestProviderData
-from llama_stack.models.llama.datatypes import BuiltinTool
 from llama_stack_api import (
     URL,
     ListToolDefsResponse,
@@ -68,7 +67,6 @@ class BraveSearchToolRuntimeImpl(ToolGroupsProtocolPrivate, ToolRuntime, NeedsRe
                         },
                         "required": ["query"],
                     },
-                    built_in_type=BuiltinTool.brave_search,
                 )
             ]
         )

--- a/tests/integration/inference/test_tools_with_schemas.py
+++ b/tests/integration/inference/test_tools_with_schemas.py
@@ -12,7 +12,6 @@ Tests that tools pass through correctly to various LLM providers.
 import pytest
 
 from llama_stack.core.library_client import LlamaStackAsLibraryClient
-from llama_stack.models.llama.datatypes import ToolDefinition
 from tests.common.mcp import make_mcp_server
 
 AUTH_TOKEN = "test-token"
@@ -221,45 +220,6 @@ class TestMCPToolsInChatCompletion:
 
         # Schema should have been passed through correctly
         assert response is not None
-
-
-class TestProviderSpecificBehavior:
-    """Test provider-specific handling of schemas."""
-
-    def test_openai_provider_drops_output_schema(self, llama_stack_client, text_model_id):
-        """Test that OpenAI provider doesn't send output_schema (API limitation)."""
-        # This is more of a documentation test
-        # OpenAI API doesn't support output schemas, so we drop them
-
-        _tool = ToolDefinition(
-            tool_name="test",
-            input_schema={"type": "object", "properties": {"x": {"type": "string"}}},
-            output_schema={"type": "object", "properties": {"y": {"type": "number"}}},
-        )
-
-        # When this tool is sent to OpenAI provider, output_schema is dropped
-        # But input_schema is preserved
-        # This test documents the expected behavior
-
-        # We can't easily test this without mocking, but the unit tests cover it
-        pass
-
-    def test_gemini_array_support(self):
-        """Test that Gemini receives array schemas correctly (issue from commit 65f7b81e)."""
-        # This was the original bug that led to adding 'items' field
-        # Now with full JSON Schema pass-through, arrays should work
-
-        tool = ToolDefinition(
-            tool_name="tag_processor",
-            input_schema={
-                "type": "object",
-                "properties": {"tags": {"type": "array", "items": {"type": "string"}, "description": "List of tags"}},
-            },
-        )
-
-        # With new approach, the complete schema with items is preserved
-        assert tool.input_schema["properties"]["tags"]["type"] == "array"
-        assert tool.input_schema["properties"]["tags"]["items"]["type"] == "string"
 
 
 class TestStreamingWithTools:

--- a/tests/unit/tools/test_tools_json_schema.py
+++ b/tests/unit/tools/test_tools_json_schema.py
@@ -11,7 +11,6 @@ Tests the new input_schema and output_schema fields.
 
 from pydantic import ValidationError
 
-from llama_stack.models.llama.datatypes import BuiltinTool, ToolDefinition
 from llama_stack_api import ToolDef
 
 
@@ -178,56 +177,6 @@ class TestToolDefValidation:
             # For now this passes, but shouldn't after we add validation
         except ValidationError:
             pass  # Expected once validation is added
-
-
-class TestToolDefinitionValidation:
-    """Test ToolDefinition (internal) validation with JSON Schema."""
-
-    def test_simple_tool_definition(self):
-        """Test ToolDefinition with simple schema."""
-        tool = ToolDefinition(
-            tool_name="get_time",
-            description="Get current time",
-            input_schema={"type": "object", "properties": {"timezone": {"type": "string"}}},
-        )
-
-        assert tool.tool_name == "get_time"
-        assert tool.input_schema is not None
-
-    def test_builtin_tool_with_schema(self):
-        """Test ToolDefinition with BuiltinTool enum."""
-        tool = ToolDefinition(
-            tool_name=BuiltinTool.code_interpreter,
-            description="Run Python code",
-            input_schema={"type": "object", "properties": {"code": {"type": "string"}}, "required": ["code"]},
-            output_schema={"type": "object", "properties": {"output": {"type": "string"}, "error": {"type": "string"}}},
-        )
-
-        assert isinstance(tool.tool_name, BuiltinTool)
-        assert tool.input_schema is not None
-        assert tool.output_schema is not None
-
-    def test_tool_definition_with_refs(self):
-        """Test ToolDefinition preserves $ref/$defs."""
-        tool = ToolDefinition(
-            tool_name="process_data",
-            input_schema={
-                "type": "object",
-                "properties": {"data": {"$ref": "#/$defs/DataObject"}},
-                "$defs": {
-                    "DataObject": {
-                        "type": "object",
-                        "properties": {
-                            "id": {"type": "integer"},
-                            "values": {"type": "array", "items": {"type": "number"}},
-                        },
-                    }
-                },
-            },
-        )
-
-        assert "$defs" in tool.input_schema
-        assert tool.input_schema["properties"]["data"]["$ref"] == "#/$defs/DataObject"
 
 
 class TestSchemaEquivalence:


### PR DESCRIPTION
- inline Role.user.value
- remove unused built_in_type
- remove blind-pass: test_openai_provider_drops_output_schema
- remove trivial constructor test: test_gemini_array_support
- remove unused: TestToolDefinitionValidation
