### PR TITLE
fix: MCP CPU spike by using context manager for session cleanup

### DIFF
--- a/src/llama_stack/providers/inline/agents/meta_reference/responses/openai_responses.py
+++ b/src/llama_stack/providers/inline/agents/meta_reference/responses/openai_responses.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-import asyncio
 import re
 import time
 import uuid
@@ -612,46 +611,39 @@ class OpenAIResponsesImpl:
 
         # Create a per-request MCP session manager for session reuse (fix for #4452)
         # This avoids redundant tools/list calls when making multiple MCP tool invocations
-        mcp_session_manager = MCPSessionManager()
+        async with MCPSessionManager() as mcp_session_manager:
+            request_tool_executor = ToolExecutor(
+                tool_groups_api=self.tool_groups_api,
+                tool_runtime_api=self.tool_runtime_api,
+                vector_io_api=self.vector_io_api,
+                vector_stores_config=self.tool_executor.vector_stores_config,
+                mcp_session_manager=mcp_session_manager,
+            )
 
-        # Create a per-request ToolExecutor with the session manager
-        request_tool_executor = ToolExecutor(
-            tool_groups_api=self.tool_groups_api,
-            tool_runtime_api=self.tool_runtime_api,
-            vector_io_api=self.vector_io_api,
-            vector_stores_config=self.tool_executor.vector_stores_config,
-            mcp_session_manager=mcp_session_manager,
-        )
+            orchestrator = StreamingResponseOrchestrator(
+                inference_api=self.inference_api,
+                ctx=ctx,
+                response_id=response_id,
+                created_at=created_at,
+                prompt=prompt,
+                text=text,
+                max_infer_iters=max_infer_iters,
+                parallel_tool_calls=parallel_tool_calls,
+                tool_executor=request_tool_executor,
+                safety_api=self.safety_api,
+                guardrail_ids=guardrail_ids,
+                instructions=instructions,
+                max_tool_calls=max_tool_calls,
+                metadata=metadata,
+                include=include,
+            )
+            final_response = None
+            failed_response = None
 
-        orchestrator = StreamingResponseOrchestrator(
-            inference_api=self.inference_api,
-            ctx=ctx,
-            response_id=response_id,
-            created_at=created_at,
-            prompt=prompt,
-            text=text,
-            max_infer_iters=max_infer_iters,
-            parallel_tool_calls=parallel_tool_calls,
-            tool_executor=request_tool_executor,
-            safety_api=self.safety_api,
-            guardrail_ids=guardrail_ids,
-            instructions=instructions,
-            max_tool_calls=max_tool_calls,
-            metadata=metadata,
-            include=include,
-        )
+            output_items: list[ConversationItem] = []
 
-        # Stream the response
-        final_response = None
-        failed_response = None
+            input_items_for_storage = self._prepare_input_items_for_storage(all_input)
 
-        # Type as ConversationItem to avoid list invariance issues
-        output_items: list[ConversationItem] = []
-
-        # Prepare input items for storage once (used by all persistence calls)
-        input_items_for_storage = self._prepare_input_items_for_storage(all_input)
-
-        try:
             async for stream_chunk in orchestrator.create_response():
                 match stream_chunk.type:
                     case "response.completed" | "response.incomplete":
@@ -689,16 +681,6 @@ class OpenAIResponsesImpl:
                         await self.responses_store.store_conversation_messages(conversation, messages_to_store)
 
                 yield stream_chunk
-        finally:
-            # Clean up MCP sessions at the end of the request (fix for #4452)
-            # Use shield() to prevent cancellation from interrupting cleanup and leaking resources
-            # Wrap in try/except as cleanup errors should not mask the original response
-            try:
-                await asyncio.shield(mcp_session_manager.close_all())
-            except BaseException as e:
-                # Debug level - cleanup errors are expected in streaming scenarios where
-                # anyio cancel scopes may be in a different task context
-                logger.debug(f"Error during MCP session cleanup: {e}")
 
     async def delete_openai_response(self, response_id: str) -> OpenAIDeleteResponseObject:
         return await self.responses_store.delete_response_object(response_id)

--- a/src/llama_stack/providers/utils/tools/mcp.py
+++ b/src/llama_stack/providers/utils/tools/mcp.py
@@ -241,10 +241,12 @@ class MCPSessionManager:
             raise last_exception
         raise RuntimeError(f"Failed to create MCP session for {endpoint}")
 
-    async def close_all(self) -> None:
-        """Close all cached sessions.
+    async def __aenter__(self):
+        """Enter the async context manager."""
+        return self
 
-        Should be called at the end of a request to clean up resources.
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Exit the async context manager and cleanup all sessions.
 
         Note: We catch BaseException (not just Exception) because:
         1. CancelledError is a BaseException and can occur during cleanup
@@ -274,6 +276,8 @@ class MCPSessionManager:
 
         if errors:
             logger.debug(f"Encountered {len(errors)} errors while closing MCP sessions (expected in streaming)")
+
+        return False
 
 
 @asynccontextmanager


### PR DESCRIPTION
Cherry-picking https://github.com/llamastack/llama-stack/pull/4758 into 0.4.x

Conflicts:  
   src/llama_stack/providers/inline/agents/meta_reference/responses/openai_responses.py