### PR TITLE
fix: correct typo 'existance' to 'existence'

### DIFF
--- a/src/llama_stack/providers/inline/batches/reference/batches.py
+++ b/src/llama_stack/providers/inline/batches/reference/batches.py
@@ -347,7 +347,7 @@ class ReferenceBatchesImpl(Batches):
         Read & validate input, return errors and valid input.
 
         Validation of
-        - input_file_id existance
+        - input_file_id existence
         - valid json
         - custom_id, method, url, body presence and valid
         - no streaming


### PR DESCRIPTION
Fixes typo in batches.py docstring comment.