### PR TITLE
fix: update together to work with latest api.together.xyz service (circa feb 2026)

### DIFF
--- a/src/llama_stack/providers/registry/inference.py
+++ b/src/llama_stack/providers/registry/inference.py
@@ -119,7 +119,7 @@ def available_providers() -> list[ProviderSpec]:
             adapter_type="together",
             provider_type="remote::together",
             pip_packages=[
-                "together",
+                "together>=2",
             ],
             module="llama_stack.providers.remote.inference.together",
             config_class="llama_stack.providers.remote.inference.together.TogetherImplConfig",


### PR DESCRIPTION
as of feb 2026, api.together.xyz is incompatible with the together sdk <2.

```
$ uv run --with 'together<2' python -c 'import together; print(f"number of models: {len(together.Together().models.list())}")'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File ".../together/resources/models.py", line 70, in list
    models = [ModelObject(**model) for model in response.data]
              ^^^^^^^^^^^^^^^^^^^^
  File ".../pydantic/main.py", line 253, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for ModelObject
type
  Input should be 'chat', 'language', 'code', 'image', 'embedding', 'moderation', 'rerank', 'audio' or 'transcribe' [type=enum, input_value='video', input_type=str]
    For further information visit https://errors.pydantic.dev/2.11/v/enum
```

```
$ uv run --with 'together>=2' python -c 'import together; print(f"number of models: {len(together.Together().models.list())}")'
number of models: 120
```

inside stack this results in failure to list models and perform inference with together.

```
ERROR    2026-02-07 12:11:29,427 llama_stack.providers.utils.inference.openai_mixin:505 providers::utils:
         TogetherInferenceAdapter.list_provider_model_ids() failed with: 1 validation error for ModelObject type
           Input should be 'chat', 'language', 'code', 'image', 'embedding', 'moderation', 'rerank', 'audio' or 'transcribe'
             For further information visit https://errors.pydantic.dev/2.11/v/enum
```