### PR TITLE
fix: kvstore should call shutdown but not close

### DIFF
--- a/src/llama_stack/core/connectors/connectors.py
+++ b/src/llama_stack/core/connectors/connectors.py
@@ -159,4 +159,4 @@ class ConnectorServiceImpl(Connectors):
 
     async def shutdown(self):
         """Shutdown the connector service."""
-        await self.kvstore.close()
+        await self.kvstore.shutdown()


### PR DESCRIPTION
# What does this PR do?

When llama stack server start on a port that is in use, it will report some error as below:

```
ERROR    2026-02-09 13:07:54,609 llama_stack.core.stack:676 core: Failed to shutdown ConnectorServiceImpl:
           'SqliteKVStoreImpl' object has no attribute 'close'
           ╭───────────────────────────────────── Traceback (most recent call last) ─────────────────────────────────────╮
           │ /Users/gualiu/go/src/github.com/llamastack/llama-stack/src/llama_stack/core/stack.py:670 in shutdown        │
           │                                                                                                             │
           │   667 │   │   │   logger.debug(f"Shutting down {impl_name}")                                                │
           │   668 │   │   │   try:                                                                                      │
           │   669 │   │   │   │   if hasattr(impl, "shutdown"):                                                         │
           │ ❱ 670 │   │   │   │   │   await asyncio.wait_for(impl.shutdown(), timeout=5)                                │
           │   671 │   │   │   │   else:                                                                                 │
           │   672 │   │   │   │   │   logger.warning(f"No shutdown method for {impl_name}")                             │
           │   673 │   │   │   except TimeoutError:                                                                      │
           │                                                                                                             │
           │ /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/tasks.py:520 in wait_for          │
           │                                                                                                             │
           │    517 │   │   │   raise TimeoutError from exc                                                              │
           │    518 │                                                                                                    │
           │    519 │   async with timeouts.timeout(timeout):                                                            │
           │ ❱  520 │   │   return await fut                                                                             │
           │    521                                                                                                      │
           │    522 async def _wait(fs, timeout, return_when, loop):                                                     │
           │    523 │   """Internal helper for wait().                                                                   │
           │                                                                                                             │
           │ /Users/gualiu/go/src/github.com/llamastack/llama-stack/src/llama_stack/core/connectors/connectors.py:162 in │
           │ shutdown                                                                                                    │
           │                                                                                                             │
           │   159 │                                                                                                     │
           │   160 │   async def shutdown(self):                                                                         │
           │   161 │   │   """Shutdown the connector service."""                                                         │
           │ ❱ 162 │   │   await self.kvstore.close()                                                                    │
           │   163                                                                                                       │
           ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
           AttributeError: 'SqliteKVStoreImpl' object has no attribute 'close'
  INFO     2026-02-09 13:07:54,652 uvicorn.error:76 uncategorized: Application shutdown complete.
  ERROR    2026-02-09 13:07:54,653 llama_stack.core.stack:655 core: Model refresh task cancelled
  INFO     2026-02-09 13:07:54,653 llama_stack.cli.stack.run:222 cli: Received interrupt signal, shutting down
           gracefully...
```

After the fix, there is no `AttributeError: 'SqliteKVStoreImpl' object has no attribute 'close'`.

The new message is as below

```

ERROR    2026-02-09 13:11:29,323 uvicorn.error:172 uncategorized: [Errno 48] error while attempting to bind on address
         ('0.0.0.0', 8321):  address already in use
INFO     2026-02-09 13:11:29,323 uvicorn.error:67 uncategorized: Waiting for application shutdown.
INFO     2026-02-09 13:11:29,323 llama_stack.core.server.server:179 core::server: Shutting down
INFO     2026-02-09 13:11:29,324 uvicorn.error:76 uncategorized: Application shutdown complete.
ERROR    2026-02-09 13:11:29,325 llama_stack.core.stack:655 core: Model refresh task cancelled
INFO     2026-02-09 13:11:29,325 llama_stack.cli.stack.run:222 cli: Received interrupt signal, shutting down
         gracefully...
```

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->

<!-- For API changes, include:
1. A testing script (Python, curl, etc.) that exercises the new/modified endpoints
2. The output from running your script

Example:
```python
...
...
```

Output:
```
<paste actual output here>
```
-->
