### PR TITLE
refactor: use OpenAIErrorResponse model for consistent error responses

### DIFF
--- a/src/llama_stack/core/server/auth.py
+++ b/src/llama_stack/core/server/auth.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-import json
-
 import httpx
 from aiohttp import hdrs
 
@@ -16,6 +14,7 @@ from llama_stack.core.request_headers import user_from_scope
 from llama_stack.core.server.auth_providers import create_auth_provider
 from llama_stack.core.server.routes import find_matching_route, initialize_route_impls
 from llama_stack.log import get_logger
+from llama_stack_api.common.errors import OpenAIErrorResponse
 
 logger = get_logger(name=__name__, category="core::auth")
 
@@ -164,8 +163,7 @@ class AuthenticationMiddleware:
                 "headers": [[b"content-type", b"application/json"]],
             }
         )
-        error_key = "message" if status == 401 else "detail"
-        error_msg = json.dumps({"error": {error_key: message}}).encode()
+        error_msg = OpenAIErrorResponse.from_message(message).to_bytes()
         await send({"type": "http.response.body", "body": error_msg})
 
 
@@ -345,8 +343,7 @@ class RouteAuthorizationMiddleware:
                 "headers": [[b"content-type", b"application/json"]],
             }
         )
-        error_key = "message" if status == 401 else "detail"
-        error_msg = json.dumps({"error": {error_key: message}}).encode()
+        error_msg = OpenAIErrorResponse.from_message(message).to_bytes()
         await send({"type": "http.response.body", "body": error_msg})
 
 

--- a/src/llama_stack/core/server/quota.py
+++ b/src/llama_stack/core/server/quota.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-import json
 import time
 from datetime import UTC, datetime, timedelta
 
@@ -13,6 +12,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 from llama_stack.core.storage.datatypes import KVStoreReference, StorageBackendType
 from llama_stack.core.storage.kvstore.kvstore import _KVSTORE_BACKENDS, kvstore_impl
 from llama_stack.log import get_logger
+from llama_stack_api.common.errors import OpenAIErrorResponse
 from llama_stack_api.internal.kvstore import KVStore
 
 logger = get_logger(name=__name__, category="core::server")
@@ -106,5 +106,5 @@ class QuotaMiddleware:
                 "headers": [[b"content-type", b"application/json"]],
             }
         )
-        body = json.dumps({"error": {"message": message}}).encode()
+        body = OpenAIErrorResponse.from_message(message).to_bytes()
         await send({"type": "http.response.body", "body": body})

--- a/src/llama_stack_api/agents/fastapi_routes.py
+++ b/src/llama_stack_api/agents/fastapi_routes.py
@@ -22,6 +22,7 @@ from fastapi.responses import StreamingResponse
 from fastapi.routing import APIRoute
 from pydantic import BaseModel
 
+from llama_stack_api.common.errors import OpenAIErrorResponse
 from llama_stack_api.common.responses import Order
 from llama_stack_api.openai_responses import (
     ListOpenAIResponseInputItem,
@@ -76,7 +77,7 @@ async def sse_generator(event_gen):
         http_exc = _try_translate_to_http_exception(e)
         status_code = http_exc.status_code if http_exc else 500
         detail = http_exc.detail if http_exc else "Internal server error: An unexpected error occurred."
-        yield create_sse_event({"error": {"status_code": status_code, "message": detail}})
+        yield create_sse_event(OpenAIErrorResponse.from_message(detail, code=str(status_code)).to_dict())
 
 
 # Automatically generate dependency functions from Pydantic models

--- a/src/llama_stack_api/inference/fastapi_routes.py
+++ b/src/llama_stack_api/inference/fastapi_routes.py
@@ -22,6 +22,7 @@ from fastapi import APIRouter, Body, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
+from llama_stack_api.common.errors import OpenAIErrorResponse
 from llama_stack_api.router_utils import create_path_dependency, create_query_dependency, standard_responses
 from llama_stack_api.version import LLAMA_STACK_API_V1, LLAMA_STACK_API_V1ALPHA
 
@@ -65,7 +66,7 @@ async def _sse_generator(event_gen: AsyncIterator[Any], context: str = "inferenc
     except Exception as e:
         logger.exception(f"Error in SSE generator ({context})")
         exc = _http_exception_from_sse_error(e)
-        yield _create_sse_event({"error": {"status_code": exc.status_code, "message": exc.detail}})
+        yield _create_sse_event(OpenAIErrorResponse.from_message(exc.detail, code=str(exc.status_code)).to_dict())
 
 
 def _http_exception_from_value_error(exc: ValueError) -> HTTPException:

--- a/tests/unit/core/routers/test_agents_router.py
+++ b/tests/unit/core/routers/test_agents_router.py
@@ -237,7 +237,7 @@ async def test_sse_stream_reports_value_error_as_http_exception():
         break
 
     assert first_event is not None
-    assert '"status_code": 400' in first_event
+    assert '"code": "400"' in first_event
     assert '"message": "not found"' in first_event
 
 


### PR DESCRIPTION
## Summary

Removed incorrect and duplicated creation of OpenAI Error Response object by centralizing code to create it with a library call.

- Adds `OpenAIErrorResponse` Pydantic model in `llama_stack_api/common/errors.py` matching the [OpenAI error format](https://platform.openai.com/docs/guides/error-codes)
- Replaces hand-built `{"error": {...}}` dicts across 6 error response sites with `OpenAIErrorResponse.from_message()`
- Fixes inconsistency where some sites used `"detail"`, others `"message"`, and SSE generators included non-standard `"status_code"` fields

## Test plan

- Existing auth, quota, and integration tests pass (they assert on `["error"]["message"]`)
- Verify OpenAI SDK correctly parses error responses