### PR TITLE
fix(ci): disable uv cache cleanup when UV_NO_CACHE is set

### DIFF
--- a/.github/actions/setup-runner/action.yml
+++ b/.github/actions/setup-runner/action.yml
@@ -24,6 +24,7 @@ runs:
       uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # v7.1.4
       with:
         python-version: ${{ inputs.python-version }}
+        enable-cache: ${{ env.UV_NO_CACHE != 'true' }}
 
     - name: Configure client installation
       id: client-config


### PR DESCRIPTION
# What does this PR do?

When disable_cache is true (e.g., from stainless-builds.yml), UV_NO_CACHE=true is set as a job-level env. The setup-uv action's post-job cleanup runs "uv cache prune" which, under UV_NO_CACHE=true, targets an ephemeral temp directory that lacks the expected structure, causing the step to fail.

Pass enable-cache based on UV_NO_CACHE so setup-uv skips its cache prune post-step when caching is disabled.

see https://github.com/llamastack/llama-stack/actions/runs/21912319402/job/63270887740?pr=4824 for example failure.


## Test Plan

stainless integration tests should pass. as should all other integration tests. 
