### PR TITLE
feat(api): support extra_body pass-through in responses API

### DIFF
--- a/client-sdks/stainless/openapi.yml
+++ b/client-sdks/stainless/openapi.yml
@@ -12740,7 +12740,7 @@ components:
             minimum: -2.0
           - type: 'null'
           description: Penalizes new tokens based on whether they appear in the text so far.
-      additionalProperties: false
+      additionalProperties: true
       type: object
       required:
       - input

--- a/docs/static/deprecated-llama-stack-spec.yaml
+++ b/docs/static/deprecated-llama-stack-spec.yaml
@@ -9286,7 +9286,7 @@ components:
             minimum: -2.0
           - type: 'null'
           description: Penalizes new tokens based on whether they appear in the text so far.
-      additionalProperties: false
+      additionalProperties: true
       type: object
       required:
       - input

--- a/docs/static/llama-stack-spec.yaml
+++ b/docs/static/llama-stack-spec.yaml
@@ -11095,7 +11095,7 @@ components:
             minimum: -2.0
           - type: 'null'
           description: Penalizes new tokens based on whether they appear in the text so far.
-      additionalProperties: false
+      additionalProperties: true
       type: object
       required:
       - input

--- a/docs/static/stainless-llama-stack-spec.yaml
+++ b/docs/static/stainless-llama-stack-spec.yaml
@@ -12740,7 +12740,7 @@ components:
             minimum: -2.0
           - type: 'null'
           description: Penalizes new tokens based on whether they appear in the text so far.
-      additionalProperties: false
+      additionalProperties: true
       type: object
       required:
       - input

--- a/src/llama_stack/providers/inline/agents/meta_reference/agents.py
+++ b/src/llama_stack/providers/inline/agents/meta_reference/agents.py
@@ -141,6 +141,7 @@ class MetaReferenceAgentsImpl(Agents):
             truncation=request.truncation,
             top_logprobs=request.top_logprobs,
             presence_penalty=request.presence_penalty,
+            extra_body=request.model_extra,
         )
         return result
 

--- a/src/llama_stack/providers/inline/agents/meta_reference/responses/openai_responses.py
+++ b/src/llama_stack/providers/inline/agents/meta_reference/responses/openai_responses.py
@@ -570,6 +570,7 @@ class OpenAIResponsesImpl:
         truncation: ResponseTruncation | None = None,
         top_logprobs: int | None = None,
         presence_penalty: float | None = None,
+        extra_body: dict | None = None,
     ):
         stream = bool(stream)
         background = bool(background)
@@ -646,6 +647,7 @@ class OpenAIResponsesImpl:
                 metadata=metadata,
                 truncation=truncation,
                 presence_penalty=presence_penalty,
+                extra_body=extra_body,
             )
 
         stream_gen = self._create_streaming_response(
@@ -676,6 +678,7 @@ class OpenAIResponsesImpl:
             truncation=truncation,
             top_logprobs=top_logprobs,
             presence_penalty=presence_penalty,
+            extra_body=extra_body,
         )
 
         if stream:
@@ -759,6 +762,7 @@ class OpenAIResponsesImpl:
         metadata: dict[str, str] | None = None,
         truncation: ResponseTruncation | None = None,
         presence_penalty: float | None = None,
+        extra_body: dict | None = None,
     ) -> OpenAIResponseObject:
         """Create a response that processes in the background.
 
@@ -831,6 +835,7 @@ class OpenAIResponsesImpl:
                     metadata=metadata,
                     truncation=truncation,
                     presence_penalty=presence_penalty,
+                    extra_body=extra_body,
                 )
             )
         except asyncio.QueueFull:
@@ -867,6 +872,7 @@ class OpenAIResponsesImpl:
         metadata: dict[str, str] | None = None,
         truncation: ResponseTruncation | None = None,
         presence_penalty: float | None = None,
+        extra_body: dict | None = None,
     ) -> None:
         """Inner loop for background response processing, separated for timeout wrapping."""
         # Check if response was cancelled before starting
@@ -906,6 +912,7 @@ class OpenAIResponsesImpl:
             truncation=truncation,
             response_id=response_id,
             presence_penalty=presence_penalty,
+            extra_body=extra_body,
         )
 
         result_response = None
@@ -967,6 +974,7 @@ class OpenAIResponsesImpl:
         response_id: str | None = None,
         top_logprobs: int | None = None,
         presence_penalty: float | None = None,
+        extra_body: dict | None = None,
     ) -> AsyncIterator[OpenAIResponseObjectStream]:
         # These should never be None when called from create_openai_response (which sets defaults)
         # but we assert here to help mypy understand the types
@@ -998,6 +1006,7 @@ class OpenAIResponsesImpl:
             response_format=response_format,
             tool_context=tool_context,
             inputs=all_input,
+            extra_body=extra_body,
         )
 
         # Create orchestrator and delegate streaming logic
@@ -1042,6 +1051,7 @@ class OpenAIResponsesImpl:
                 truncation=truncation,
                 top_logprobs=top_logprobs,
                 presence_penalty=presence_penalty,
+                extra_body=extra_body,
             )
 
             final_response = None

--- a/src/llama_stack/providers/inline/agents/meta_reference/responses/streaming.py
+++ b/src/llama_stack/providers/inline/agents/meta_reference/responses/streaming.py
@@ -228,6 +228,7 @@ class StreamingResponseOrchestrator:
         truncation: ResponseTruncation | None = None,
         top_logprobs: int | None = None,
         presence_penalty: float | None = None,
+        extra_body: dict | None = None,
     ):
         self.inference_api = inference_api
         self.ctx = ctx
@@ -258,6 +259,7 @@ class StreamingResponseOrchestrator:
         self.truncation = truncation
         self.top_logprobs = top_logprobs
         self.include = include
+        self.extra_body = extra_body
         self.store = bool(store) if store is not None else True
         self.presence_penalty = presence_penalty
         self.sequence_number = 0
@@ -516,6 +518,7 @@ class StreamingResponseOrchestrator:
                     prompt_cache_key=self.prompt_cache_key,
                     top_logprobs=self.top_logprobs,
                     presence_penalty=self.presence_penalty,
+                    **(self.extra_body or {}),
                 )
                 completion_result = await self.inference_api.openai_chat_completion(params)
 

--- a/src/llama_stack/providers/inline/agents/meta_reference/responses/types.py
+++ b/src/llama_stack/providers/inline/agents/meta_reference/responses/types.py
@@ -168,6 +168,7 @@ class ChatCompletionContext(BaseModel):
     response_format: OpenAIResponseFormatParam
     tool_context: ToolContext | None
     tool_choice: OpenAIResponseInputToolChoice | None = None
+    extra_body: dict | None = None
     approval_requests: list[OpenAIResponseMCPApprovalRequest] = []
     approval_responses: dict[str, OpenAIResponseMCPApprovalResponse] = {}
 
@@ -183,6 +184,7 @@ class ChatCompletionContext(BaseModel):
         inputs: list[OpenAIResponseInput] | str,
         tool_choice: OpenAIResponseInputToolChoice | None = None,
         frequency_penalty: float | None = None,
+        extra_body: dict | None = None,
     ):
         super().__init__(
             model=model,
@@ -194,6 +196,7 @@ class ChatCompletionContext(BaseModel):
             response_format=response_format,
             tool_context=tool_context,
             tool_choice=tool_choice,
+            extra_body=extra_body,
         )
         if not isinstance(inputs, str):
             self.approval_requests = [input for input in inputs if input.type == "mcp_approval_request"]

--- a/src/llama_stack/providers/utils/inference/litellm_openai_mixin.py
+++ b/src/llama_stack/providers/utils/inference/litellm_openai_mixin.py
@@ -225,6 +225,8 @@ class LiteLLMOpenAIMixin(
             api_base=self.api_base,
             **self._litellm_extra_request_params(params),
         )
+        if extra_body := params.model_extra:
+            request_params["extra_body"] = extra_body
         # LiteLLM returns compatible type but mypy can't verify external library
         result = await litellm.atext_completion(**request_params)
 
@@ -282,6 +284,8 @@ class LiteLLMOpenAIMixin(
             api_base=self.api_base,
             **self._litellm_extra_request_params(params),
         )
+        if extra_body := params.model_extra:
+            request_params["extra_body"] = extra_body
         # LiteLLM returns compatible type but mypy can't verify external library
         result = await litellm.acompletion(**request_params)
 

--- a/src/llama_stack_api/agents/models.py
+++ b/src/llama_stack_api/agents/models.py
@@ -58,10 +58,11 @@ class ResponseGuardrailSpec(BaseModel):
 ResponseGuardrail = str | ResponseGuardrailSpec
 
 
+# extra_body can be accessed via .model_extra
 class CreateResponseRequest(BaseModel):
     """Request model for creating a response."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="allow")
 
     input: str | list[OpenAIResponseInput] = Field(..., description="Input message(s) to create the response.")
     model: str = Field(..., description="The underlying LLM used for completions.")

--- a/tests/integration/common/recordings/models-64a2277c90f0f42576f60c1030e3a020403d34a95f56931b792d5939f4cebc57-fb68f5a6.json
+++ b/tests/integration/common/recordings/models-64a2277c90f0f42576f60c1030e3a020403d34a95f56931b792d5939f4cebc57-fb68f5a6.json
@@ -14,17 +14,17 @@
         "__type__": "openai.types.model.Model",
         "__data__": {
           "id": "Qwen/Qwen3-0.6B",
-          "created": 1762374291,
+          "created": 1770865370,
           "object": "model",
           "owned_by": "vllm",
-          "root": "/root/.cache/Qwen3-0.6B",
+          "root": "Qwen/Qwen3-0.6B",
           "parent": null,
           "max_model_len": 8192,
           "permission": [
             {
-              "id": "modelperm-f70298e4ea3e4b4eb7f2cc2deb7a2b01",
+              "id": "modelperm-9d8b2db487d0e15f",
               "object": "model_permission",
-              "created": 1762374291,
+              "created": 1770865370,
               "allow_create_engine": false,
               "allow_sampling": true,
               "allow_logprobs": true,

--- a/tests/integration/inference/recordings/2367bed24bc3297a70b3c54a1c3e6267ef53986f8974b83364e43a41c06f76b5.json
+++ b/tests/integration/inference/recordings/2367bed24bc3297a70b3c54a1c3e6267ef53986f8974b83364e43a41c06f76b5.json
@@ -1,0 +1,58 @@
+{
+  "test_id": "tests/integration/inference/test_openai_completion.py::test_openai_completion_guided_choice[txt=vllm/Qwen/Qwen3-0.6B]",
+  "request": {
+    "method": "POST",
+    "url": "http://localhost:8000/v1/v1/completions",
+    "headers": {},
+    "body": {
+      "model": "Qwen/Qwen3-0.6B",
+      "prompt": "I am feeling really sad today.",
+      "stream": false,
+      "extra_body": {
+        "structured_outputs": {
+          "choice": [
+            "joy",
+            "sadness"
+          ]
+        }
+      }
+    },
+    "endpoint": "/v1/completions",
+    "model": "Qwen/Qwen3-0.6B"
+  },
+  "response": {
+    "body": {
+      "__type__": "openai.types.completion.Completion",
+      "__data__": {
+        "id": "rec-2367bed24bc3",
+        "choices": [
+          {
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "text": "joy",
+            "stop_reason": null,
+            "token_ids": null,
+            "prompt_logprobs": null,
+            "prompt_token_ids": null
+          }
+        ],
+        "created": 0,
+        "model": "Qwen/Qwen3-0.6B",
+        "object": "text_completion",
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 2,
+          "prompt_tokens": 7,
+          "total_tokens": 9,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "service_tier": null,
+        "kv_transfer_params": null
+      }
+    },
+    "is_streaming": false
+  },
+  "id_normalization_mapping": {}
+}

--- a/tests/integration/inference/recordings/models-2b9bac5da1a03c0b572bc019cc0c50904d49e6193990ca245908f4535bcaab43-fb68f5a6.json
+++ b/tests/integration/inference/recordings/models-2b9bac5da1a03c0b572bc019cc0c50904d49e6193990ca245908f4535bcaab43-fb68f5a6.json
@@ -14,17 +14,17 @@
         "__type__": "openai.types.model.Model",
         "__data__": {
           "id": "Qwen/Qwen3-0.6B",
-          "created": 1762374297,
+          "created": 1770865371,
           "object": "model",
           "owned_by": "vllm",
-          "root": "/root/.cache/Qwen3-0.6B",
+          "root": "Qwen/Qwen3-0.6B",
           "parent": null,
           "max_model_len": 8192,
           "permission": [
             {
-              "id": "modelperm-4bc93704559a4e1d8492aeec7222040c",
+              "id": "modelperm-83c9cf1d2b126a71",
               "object": "model_permission",
-              "created": 1762374297,
+              "created": 1770865371,
               "allow_create_engine": false,
               "allow_sampling": true,
               "allow_logprobs": true,

--- a/tests/integration/inference/test_openai_completion.py
+++ b/tests/integration/inference/test_openai_completion.py
@@ -235,7 +235,7 @@ def test_openai_completion_guided_choice(llama_stack_client, client_with_models,
         model=text_model_id,
         prompt=prompt,
         stream=False,
-        extra_body={"guided_choice": ["joy", "sadness"]},
+        extra_body={"structured_outputs": {"choice": ["joy", "sadness"]}},
     )
     assert len(response.choices) > 0
     choice = response.choices[0]

--- a/tests/unit/providers/agents/meta_reference/test_openai_responses.py
+++ b/tests/unit/providers/agents/meta_reference/test_openai_responses.py
@@ -2199,17 +2199,32 @@ async def test_create_openai_response_with_max_output_tokens_and_tools(openai_re
 @pytest.mark.parametrize("store", [False, True])
 @pytest.mark.parametrize("stream", [False, True])
 @pytest.mark.parametrize(
-    "param_name,param_value,backend_param_name,backend_expected_value,stored_expected_value",
+    "param_name,param_value,backend_param_name,backend_expected_value,response_expected_value,stored_expected_value",
     [
-        ("temperature", 1.5, "temperature", 1.5, 1.5),
-        ("safety_identifier", "user-123", "safety_identifier", "user-123", "user-123"),
-        ("max_output_tokens", 500, "max_completion_tokens", 500, 500),
-        ("prompt_cache_key", "geography-cache-001", "prompt_cache_key", "geography-cache-001", "geography-cache-001"),
-        ("service_tier", ServiceTier.flex, "service_tier", "flex", ServiceTier.default.value),
-        ("top_p", 0.9, "top_p", 0.9, 0.9),
-        ("frequency_penalty", 0.5, "frequency_penalty", 0.5, 0.5),
-        ("presence_penalty", 0.3, "presence_penalty", 0.3, 0.3),
-        ("top_logprobs", 5, "top_logprobs", 5, 5),
+        ("temperature", 1.5, "temperature", 1.5, 1.5, 1.5),
+        ("safety_identifier", "user-123", "safety_identifier", "user-123", "user-123", "user-123"),
+        ("max_output_tokens", 500, "max_completion_tokens", 500, 500, 500),
+        (
+            "prompt_cache_key",
+            "geography-cache-001",
+            "prompt_cache_key",
+            "geography-cache-001",
+            "geography-cache-001",
+            "geography-cache-001",
+        ),
+        ("service_tier", ServiceTier.flex, "service_tier", "flex", "flex", ServiceTier.default.value),
+        ("top_p", 0.9, "top_p", 0.9, 0.9, 0.9),
+        ("frequency_penalty", 0.5, "frequency_penalty", 0.5, 0.5, 0.5),
+        ("presence_penalty", 0.3, "presence_penalty", 0.3, 0.3, 0.3),
+        ("top_logprobs", 5, "top_logprobs", 5, 5, 5),
+        (
+            "extra_body",
+            {"chat_template_kwargs": {"thinking": True}},
+            "extra_body",
+            {"chat_template_kwargs": {"thinking": True}},
+            None,
+            None,
+        ),
     ],
 )
 async def test_params_passed_through_full_chain_to_backend_service(
@@ -2217,6 +2232,7 @@ async def test_params_passed_through_full_chain_to_backend_service(
     param_value,
     backend_param_name,
     backend_expected_value,
+    response_expected_value,
     stored_expected_value,
     stream,
     store,
@@ -2291,13 +2307,13 @@ async def test_params_passed_through_full_chain_to_backend_service(
             chunks = [chunk async for chunk in result]
             created_event = chunks[0]
             assert created_event.type == "response.created"
-            assert getattr(created_event.response, param_name) == backend_expected_value, (
-                f"Expected created {param_name}={backend_expected_value}, got {getattr(created_event.response, param_name)}"
+            assert getattr(created_event.response, param_name, None) == response_expected_value, (
+                f"Expected created {param_name}={response_expected_value}, got {getattr(created_event.response, param_name, None)}"
             )
             completed_event = chunks[-1]
             assert completed_event.type == "response.completed"
-            assert getattr(completed_event.response, param_name) == stored_expected_value, (
-                f"Expected completed {param_name}={stored_expected_value}, got {getattr(completed_event.response, param_name)}"
+            assert getattr(completed_event.response, param_name, None) == stored_expected_value, (
+                f"Expected completed {param_name}={stored_expected_value}, got {getattr(completed_event.response, param_name, None)}"
             )
 
         mock_chat_completions.assert_called_once()
@@ -2311,8 +2327,8 @@ async def test_params_passed_through_full_chain_to_backend_service(
         if store:
             mock_responses_store.upsert_response_object.assert_called()
             stored_response = mock_responses_store.upsert_response_object.call_args.kwargs["response_object"]
-            assert getattr(stored_response, param_name) == stored_expected_value, (
-                f"Expected stored {param_name}={stored_expected_value}, got {getattr(stored_response, param_name)}"
+            assert getattr(stored_response, param_name, None) == stored_expected_value, (
+                f"Expected stored {param_name}={stored_expected_value}, got {getattr(stored_response, param_name, None)}"
             )
         else:
             mock_responses_store.upsert_response_object.assert_not_called()
@@ -2327,6 +2343,12 @@ async def test_params_passed_through_full_chain_to_backend_service(
         ("prompt_cache_key", "geography-cache-001", "prompt_cache_key", "geography-cache-001"),
         ("service_tier", ServiceTier.flex, "service_tier", "flex"),
         ("top_p", 0.9, "top_p", 0.9),
+        (
+            "extra_body",
+            {"chat_template_kwargs": {"thinking": True}},
+            "extra_body",
+            {"chat_template_kwargs": {"thinking": True}},
+        ),
     ],
 )
 async def test_params_passed_through_full_chain_to_backend_service_litellm(


### PR DESCRIPTION
# What does this PR do?

Like the equivalent support for chat completions (#3777), allow provider-specific parameters to pass through the responses API. Without this, requests with extra fields fail with `Extra inputs are not permitted`.

Changes:
- `CreateResponseRequest`: `extra="forbid"` → `extra="allow"`
- Thread `extra_body` (from `request.model_extra`) through `agents.py` → `openai_responses.py` → `streaming.py` → `OpenAIChatCompletionRequestWithExtraBody`
- `LiteLLMOpenAIMixin`: forward `model_extra` as `extra_body` in both `atext_completion` and `acompletion` (matches `OpenAIMixin`)
- Update `guided_choice` tests → `structured_outputs` to match  vllm-project/vllm#22772

## Test Plan

Unit tests (136 passed):
```
uv run pytest tests/unit/providers/agents/meta_reference/ -v
```

Integration tests recorded against vLLM 0.15.1 (`Qwen/Qwen3-0.6B`):
```
uv run pytest -s -v \
  tests/integration/responses/test_basic_responses.py::test_response_extra_body_guided_choice \
  tests/integration/inference/test_openai_completion.py::test_openai_completion_guided_choice \
  --stack-config=server:starter --setup=vllm --inference-mode=record \
  --embedding-model="" --color=yes
```

Output:
```
tests/integration/responses/test_basic_responses.py::test_response_extra_body_guided_choice[txt=vllm/Qwen/Qwen3-0.6B] PASSED
tests/integration/inference/test_openai_completion.py::test_openai_completion_guided_choice[txt=vllm/Qwen/Qwen3-0.6B] PASSED
============================== 2 passed in 3.85s ==============================
```

Pre-commit (all passed):
```
PATH="/opt/homebrew/bin:$PATH" uv run pre-commit run --all-files
```