### PR TITLE
chore(ci): bump pinned action commit hashes in integration-tests.yml

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -146,7 +146,7 @@ jobs:
       # called from pull_request_target workflows.
       - name: Setup test environment
         if: ${{ matrix.config.allowed_clients == null || contains(matrix.config.allowed_clients, matrix.client) }}
-        uses: llamastack/llama-stack/.github/actions/setup-test-environment@c518b35a65f8bd1370c938c688dfb2e2a00cceab
+        uses: llamastack/llama-stack/.github/actions/setup-test-environment@c7cdb40d34d057166cd5d883a070a72ef4490f4b
         with:
           python-version: ${{ matrix.python-version }}
           client-version: ${{ matrix.client-version }}
@@ -167,13 +167,13 @@ jobs:
       - name: Setup TypeScript client
         if: ${{ matrix.client == 'server' }}
         id: setup-ts-client
-        uses: llamastack/llama-stack/.github/actions/setup-typescript-client@c518b35a65f8bd1370c938c688dfb2e2a00cceab
+        uses: llamastack/llama-stack/.github/actions/setup-typescript-client@c7cdb40d34d057166cd5d883a070a72ef4490f4b
         with:
           client-version: ${{ matrix.client-version }}
 
       - name: Run tests
         if: ${{ matrix.config.allowed_clients == null || contains(matrix.config.allowed_clients, matrix.client) }}
-        uses: llamastack/llama-stack/.github/actions/run-and-record-tests@c518b35a65f8bd1370c938c688dfb2e2a00cceab
+        uses: llamastack/llama-stack/.github/actions/run-and-record-tests@c7cdb40d34d057166cd5d883a070a72ef4490f4b
         env:
           OPENAI_API_KEY: dummy
           AWS_BEARER_TOKEN_BEDROCK: replay-mode-dummy-key


### PR DESCRIPTION
we just updated some of this logic, we need to bump the hash so it gets pulled in