### PR TITLE
fix: resolve StorageConfig default env vars at construction time

### DIFF
--- a/tests/unit/core/test_storage_references.py
+++ b/tests/unit/core/test_storage_references.py
@@ -6,6 +6,8 @@
 
 """Unit tests for storage backend/reference validation."""
 
+import os
+
 import pytest
 from pydantic import ValidationError
 
@@ -82,3 +84,44 @@ def test_valid_configuration_passes_validation():
     assert stores.metadata is not None and stores.metadata.backend == "kv_default"
     assert stores.inference is not None and stores.inference.backend == "sql_default"
     assert stores.conversations is not None and stores.conversations.backend == "sql_default"
+
+
+@pytest.mark.parametrize("backend_key", ["kv_default", "sql_default"])
+def test_default_backends_resolve_env_vars(backend_key, monkeypatch):
+    """Default StorageConfig backends must contain real paths, not literal
+    ``${env.SQLITE_STORE_DIR:=...}`` strings.  Pydantic defaults are set at
+    object-construction time — before ``replace_env_vars()`` processes the
+    YAML — so they must resolve environment variables eagerly.
+
+    See https://github.com/llamastack/llama-stack/issues/4896
+    """
+    monkeypatch.delenv("SQLITE_STORE_DIR", raising=False)
+    config = StorageConfig()
+    db_path = config.backends[backend_key].db_path
+    assert "${env." not in db_path, f"Unresolved env var syntax in default {backend_key}: {db_path}"
+
+
+def test_default_backends_respect_sqlite_store_dir(monkeypatch):
+    """When SQLITE_STORE_DIR is set, the default backends should use it."""
+    monkeypatch.setenv("SQLITE_STORE_DIR", "/tmp/custom-store")
+    config = StorageConfig()
+    assert config.backends["kv_default"].db_path == "/tmp/custom-store/kvstore.db"
+    assert config.backends["sql_default"].db_path == "/tmp/custom-store/sql_store.db"
+
+
+def test_default_backends_fallback_to_distribs_base_dir(monkeypatch):
+    """When SQLITE_STORE_DIR is unset, defaults should use DISTRIBS_BASE_DIR."""
+    from llama_stack.core.utils.config_dirs import DISTRIBS_BASE_DIR
+
+    monkeypatch.delenv("SQLITE_STORE_DIR", raising=False)
+    config = StorageConfig()
+    assert config.backends["kv_default"].db_path == os.path.join(str(DISTRIBS_BASE_DIR), "kvstore.db")
+    assert config.backends["sql_default"].db_path == os.path.join(str(DISTRIBS_BASE_DIR), "sql_store.db")
+
+
+def test_default_backends_expand_user_home(monkeypatch):
+    """Tilde in SQLITE_STORE_DIR should be expanded to the user home directory."""
+    monkeypatch.setenv("SQLITE_STORE_DIR", "~/custom-store")
+    config = StorageConfig()
+    for key in ("kv_default", "sql_default"):
+        assert "~" not in config.backends[key].db_path


### PR DESCRIPTION
## What does this PR do?

The `StorageConfig.backends` Pydantic field default embeds literal `${env.SQLITE_STORE_DIR:=...}` strings that are only understood by `replace_env_vars()`. When `StorageConfig` is instantiated via Pydantic defaults (i.e., no explicit `storage:` section in `run.yaml`), these strings are set during Python object construction — **before** `replace_env_vars()` processes the YAML config. The unresolved literal string then flows through to `SqliteKVStoreImpl.initialize()`, which calls `os.makedirs()` on it and crashes with `PermissionError` on any container with a read-only filesystem.

This affects deployments that:
1. Configure postgres via `metadata_store` in `run.yaml` (without an explicit `storage:` section)
2. Run in a container without `SQLITE_STORE_DIR` set in the environment
3. Have a non-writable home directory (standard for OpenShift/Kubernetes)

The fix replaces the inline default with a `default_factory` that resolves `SQLITE_STORE_DIR` via `os.environ.get()` at construction time, ensuring the default is always a real filesystem path.

Closes #4896

## Test Plan

Three new tests in `tests/unit/core/test_storage_references.py` verify default backends contain no unresolved `${env.` literals and that `SQLITE_STORE_DIR` overrides the default path.