### PR TITLE
feat: structured error handling in Responses API streaming

### DIFF
--- a/src/llama_stack/providers/inline/agents/meta_reference/responses/streaming.py
+++ b/src/llama_stack/providers/inline/agents/meta_reference/responses/streaming.py
@@ -9,6 +9,7 @@ import uuid
 from collections.abc import AsyncIterator
 from typing import Any
 
+from openai import APIStatusError
 from openai.types.chat import ChatCompletionToolParam
 from opentelemetry import trace
 
@@ -109,6 +110,78 @@ from .utils import (
 
 logger = get_logger(name=__name__, category="agents::meta_reference")
 tracer = trace.get_tracer(__name__)
+
+# Maps OpenAI Chat Completions error codes to Responses API error codes
+_RESPONSES_API_ERROR_CODES = {
+    "invalid_base64": "invalid_base64_image",
+}
+
+_VALID_RESPONSE_ERROR_CODES = frozenset(
+    {
+        "server_error",
+        "rate_limit_exceeded",
+        "invalid_prompt",
+        "vector_store_timeout",
+        "invalid_image",
+        "invalid_image_format",
+        "invalid_base64_image",
+        "invalid_image_url",
+        "image_too_large",
+        "image_too_small",
+        "image_parse_error",
+        "image_content_policy_violation",
+        "invalid_image_mode",
+        "image_file_too_large",
+        "unsupported_image_media_type",
+        "empty_image_file",
+        "failed_to_download_image",
+        "image_file_not_found",
+    }
+)
+
+
+def extract_openai_error(exc: Exception) -> tuple[str, str]:
+    """Extract error code and message from a provider SDK exception.
+
+    The exception should have a `body` attribute containing error details in one of two formats:
+        1. Nested: {"error": {"code": "...", "message": "...", ...}}
+        2. Direct: {"code": "...", "message": "...", ...}
+
+    Args:
+        exc: An exception with a `body` attribute containing error details
+
+    Returns:
+        Tuple of (error_code, error_message). Falls back to ("server_error", str(exc))
+        if the body doesn't contain a valid code. The message is always preserved.
+    """
+    body = getattr(exc, "body", None)
+    fallback_message = str(exc)
+
+    if not isinstance(body, dict):
+        logger.warning(f"Unexpected body type {type(body)}, expected dict: {exc}")
+        return ("server_error", fallback_message)
+
+    # Try nested format first: {"error": {"code": "...", ...}}
+    error_obj = body.get("error")
+    if isinstance(error_obj, dict):
+        raw_code = error_obj.get("code")
+        raw_message = error_obj.get("message")
+    else:
+        raw_code = body.get("code")
+        raw_message = body.get("message")
+
+    if raw_code and isinstance(raw_code, str):
+        final_code: str = _RESPONSES_API_ERROR_CODES.get(raw_code, raw_code)
+    else:
+        final_code = "server_error"
+
+    if final_code not in _VALID_RESPONSE_ERROR_CODES:
+        logger.info(f"Unmapped provider error code '{final_code}', falling back to server_error")
+        final_code = "server_error"
+
+    message: str = raw_message if isinstance(raw_message, str) else fallback_message
+
+    return final_code, message
 
 
 def convert_tooldef_to_chat_tool(tool_def):
@@ -314,7 +387,7 @@ class StreamingResponseOrchestrator:
             logger.warning("Truncation mode 'auto' is not yet supported")
             self.sequence_number += 1
             error = OpenAIResponseError(
-                code="invalid_request_error",
+                code="server_error",
                 message="Truncation mode 'auto' is not supported. Use 'disabled' to let the inference provider reject oversized contexts.",
             )
             failure_response = self._snapshot_response("failed", output_messages, error=error)
@@ -527,7 +600,17 @@ class StreamingResponseOrchestrator:
         except Exception as exc:  # noqa: BLE001
             self.final_messages = messages.copy()
             self.sequence_number += 1
-            error = OpenAIResponseError(code="internal_error", message=str(exc))
+
+            if isinstance(exc, APIStatusError) or (hasattr(exc, "status_code") and hasattr(exc, "body")):
+                logger.warning(f"Provider SDK error during response generation: {exc}")
+                error_code, error_message = extract_openai_error(exc)
+            else:
+                logger.exception(f"Unexpected '{type(exc).__name__}' error during response generation", exc_info=exc)
+                error_code, error_message = (
+                    "server_error",
+                    "An unexpected error occurred while generating the response.",
+                )
+            error = OpenAIResponseError(code=error_code, message=error_message)
             failure_response = self._snapshot_response("failed", output_messages, error=error)
             yield OpenAIResponseObjectStreamResponseFailed(
                 response=failure_response,

--- a/tests/integration/responses/recordings/0bb338e4dfdd977a474551f3950ec6b2d044df500bc689d0c5f0b9211053974a.json
+++ b/tests/integration/responses/recordings/0bb338e4dfdd977a474551f3950ec6b2d044df500bc689d0c5f0b9211053974a.json
@@ -1,0 +1,55 @@
+{
+  "test_id": "tests/integration/responses/test_openai_response.py::TestOpenAIResponses::test_openai_response_streaming_invalid_base64_image_failure_code_is_spec_compliant[txt=openai/gpt-4o]",
+  "request": {
+    "method": "POST",
+    "url": "https://api.openai.com/v1/v1/chat/completions",
+    "headers": {},
+    "body": {
+      "model": "gpt-4o",
+      "messages": [
+        {
+          "role": "user",
+          "content": [
+            {
+              "type": "text",
+              "text": "What is in this image?"
+            },
+            {
+              "type": "image_url",
+              "image_url": {
+                "url": "data:image/png;base64,not_valid_base64_data!!!",
+                "detail": "auto"
+              }
+            }
+          ]
+        }
+      ],
+      "stream": true,
+      "stream_options": {
+        "include_usage": true
+      }
+    },
+    "endpoint": "/v1/chat/completions",
+    "model": "gpt-4o"
+  },
+  "response": {
+    "body": null,
+    "is_streaming": false,
+    "is_exception": true,
+    "exception_data": {
+      "category": "provider_sdk",
+      "provider": "openai",
+      "type": "BadRequestError",
+      "message": "Error code: 400 - {'error': {'message': 'Invalid base64 image_url.', 'type': 'invalid_request_error', 'param': None, 'code': 'invalid_base64'}}",
+      "status_code": 400,
+      "body": {
+        "message": "Invalid base64 image_url.",
+        "type": "invalid_request_error",
+        "param": null,
+        "code": "invalid_base64"
+      }
+    },
+    "exception_message": "Error code: 400 - {'error': {'message': 'Invalid base64 image_url.', 'type': 'invalid_request_error', 'param': None, 'code': 'invalid_base64'}}"
+  },
+  "id_normalization_mapping": {}
+}

--- a/tests/integration/responses/streaming_assertions.py
+++ b/tests/integration/responses/streaming_assertions.py
@@ -6,6 +6,8 @@
 
 from typing import Any
 
+from llama_stack.providers.inline.agents.meta_reference.responses.streaming import _VALID_RESPONSE_ERROR_CODES
+
 
 class StreamingValidator:
     """Helper class for validating streaming response events."""
@@ -148,6 +150,10 @@ class StreamingValidator:
                 assert chunk.response.status == "failed"
                 assert isinstance(chunk.sequence_number, int)
                 assert chunk.response.error is not None
+                assert chunk.response.error.code in _VALID_RESPONSE_ERROR_CODES, (
+                    f"Error code '{chunk.response.error.code}' is not a valid Responses API error code"
+                )
+                assert chunk.response.error.message, "Error message should be non-empty"
             elif chunk.type == "response.completed":
                 assert chunk.response.status == "completed"
             elif chunk.type in {"response.content_part.added", "response.content_part.done"}:

--- a/tests/unit/providers/agents/meta_reference/test_openai_responses.py
+++ b/tests/unit/providers/agents/meta_reference/test_openai_responses.py
@@ -2625,7 +2625,7 @@ async def test_create_openai_response_with_truncation_auto_streaming(
     assert failed_event.type == "response.failed"
     assert failed_event.response.truncation == ResponseTruncation.auto
     assert failed_event.response.error is not None
-    assert failed_event.response.error.code == "invalid_request_error"
+    assert failed_event.response.error.code == "server_error"
     assert "Truncation mode 'auto' is not supported" in failed_event.response.error.message
 
     # Inference API should not be called since error occurs before inference

--- a/tests/unit/providers/agents/meta_reference/test_streaming_errors.py
+++ b/tests/unit/providers/agents/meta_reference/test_streaming_errors.py
@@ -1,0 +1,165 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Unit tests for streaming error extraction functions."""
+
+from unittest.mock import MagicMock
+
+from llama_stack.providers.inline.agents.meta_reference.responses.streaming import (
+    extract_openai_error,
+)
+
+
+def _make_mock_exc(body):
+    """Create a mock APIStatusError with the given body."""
+    exc = MagicMock()
+    exc.body = body
+    exc.configure_mock(**{"__str__.return_value": f"Error code: 400 - {body}"})
+    return exc
+
+
+class TestExtractOpenaiError:
+    """Tests for extract_openai_error function.
+
+    The OpenAI SDK provides errors in two formats:
+        1. Nested: {"error": {"code": "...", "message": "...", ...}}
+        2. Direct: {"code": "...", "message": "...", ...}
+
+    When "code" is missing or empty, falls back to "server_error".
+    The message is always preserved so users get the real error details.
+    """
+
+    def test_nested_format_extracts_correctly(self):
+        """Nested format: {"error": {"code": "...", "message": "..."}}."""
+        body = {"error": {"code": "invalid_image_url", "message": "Failed to download image"}}
+        exc = _make_mock_exc(body=body)
+        code, message = extract_openai_error(exc)
+        assert code == "invalid_image_url"
+        assert message == "Failed to download image"
+
+    def test_direct_format_extracts_correctly(self):
+        """Direct format: {"code": "...", "message": "..."}."""
+        body = {"code": "invalid_image_url", "message": "Failed to download image", "type": "invalid_request_error"}
+        exc = _make_mock_exc(body=body)
+        code, message = extract_openai_error(exc)
+        assert code == "invalid_image_url"
+        assert message == "Failed to download image"
+
+    def test_maps_invalid_base64_to_responses_api_code(self):
+        """Chat Completions 'invalid_base64' maps to Responses API 'invalid_base64_image'."""
+        body = {"error": {"code": "invalid_base64", "message": "Invalid base64 data"}}
+        exc = _make_mock_exc(body=body)
+        code, message = extract_openai_error(exc)
+        assert code == "invalid_base64_image"
+        assert message == "Invalid base64 data"
+
+    def test_direct_format_maps_codes(self):
+        """Direct format also maps codes correctly."""
+        body = {"code": "invalid_base64", "message": "Invalid base64 data"}
+        exc = _make_mock_exc(body=body)
+        code, message = extract_openai_error(exc)
+        assert code == "invalid_base64_image"
+        assert message == "Invalid base64 data"
+
+    def test_missing_message_uses_str_exc(self):
+        """Missing message field uses str(exc) as fallback."""
+        body = {"code": "invalid_image_url"}
+        exc = _make_mock_exc(body=body)
+        code, message = extract_openai_error(exc)
+        assert code == "invalid_image_url"
+        assert "Error code: 400" in message
+
+    def test_nested_error_not_dict_falls_back_to_direct(self):
+        """If 'error' key exists but isn't a dict, try direct format."""
+        body = {"error": "string error", "code": "rate_limit_exceeded", "message": "Too many requests"}
+        exc = _make_mock_exc(body=body)
+        code, message = extract_openai_error(exc)
+        assert code == "rate_limit_exceeded"
+        assert message == "Too many requests"
+
+    def test_missing_code_returns_server_error_preserves_message(self):
+        """Missing code returns server_error but preserves the message."""
+        body = {"message": "Model does not support images", "type": "invalid_request_error", "code": None}
+        exc = _make_mock_exc(body=body)
+        code, message = extract_openai_error(exc)
+        assert code == "server_error"
+        assert message == "Model does not support images"
+
+    def test_none_body_returns_server_error(self):
+        """None body returns server_error."""
+        exc = _make_mock_exc(body=None)
+        code, message = extract_openai_error(exc)
+        assert code == "server_error"
+        assert "Error code: 400" in message
+
+    def test_non_dict_body_returns_server_error(self):
+        """Non-dict body (e.g., string) returns server_error."""
+        exc = _make_mock_exc(body="unexpected string body")
+        code, message = extract_openai_error(exc)
+        assert code == "server_error"
+
+    def test_no_code_preserves_message(self):
+        """Missing code returns server_error but preserves message."""
+        body = {"message": "Something went wrong"}
+        exc = _make_mock_exc(body=body)
+        code, message = extract_openai_error(exc)
+        assert code == "server_error"
+        assert message == "Something went wrong"
+
+    def test_empty_string_code_returns_server_error(self):
+        """Empty string code returns server_error but preserves message."""
+        body = {"code": "", "message": "Bad request", "type": "invalid_request_error"}
+        exc = _make_mock_exc(body=body)
+        code, message = extract_openai_error(exc)
+        assert code == "server_error"
+        assert message == "Bad request"
+
+    def test_unknown_provider_code_falls_back_to_server_error(self):
+        """Unknown provider code falls back to server_error but preserves message."""
+        body = {"code": "billing_error", "message": "Your billing account is disabled"}
+        exc = _make_mock_exc(body=body)
+        code, message = extract_openai_error(exc)
+        assert code == "server_error"
+        assert message == "Your billing account is disabled"
+
+    def test_valid_codes_pass_through(self):
+        """Valid Responses API error codes pass through unchanged."""
+        for valid_code in ("rate_limit_exceeded", "invalid_image_url"):
+            body = {"code": valid_code, "message": "example"}
+            exc = _make_mock_exc(body=body)
+            code, message = extract_openai_error(exc)
+            assert code == valid_code
+            assert message == "example"
+
+    def test_all_spec_codes_are_valid(self):
+        """All spec-defined error codes should be accepted (no fallback)."""
+        spec_codes = {
+            "server_error",
+            "rate_limit_exceeded",
+            "invalid_prompt",
+            "vector_store_timeout",
+            "invalid_image",
+            "invalid_image_format",
+            "invalid_base64_image",
+            "invalid_image_url",
+            "image_too_large",
+            "image_too_small",
+            "image_parse_error",
+            "image_content_policy_violation",
+            "invalid_image_mode",
+            "image_file_too_large",
+            "unsupported_image_media_type",
+            "empty_image_file",
+            "failed_to_download_image",
+            "image_file_not_found",
+        }
+
+        for spec_code in spec_codes:
+            body = {"code": spec_code, "message": "example"}
+            exc = _make_mock_exc(body=body)
+            code, message = extract_openai_error(exc)
+            assert code == spec_code
+            assert message == "example"


### PR DESCRIPTION
## What this does

When a streaming Responses API call fails mid-stream (e.g., the provider rejects an image or hits a rate limit), Llama Stack now returns **spec-compliant error codes** in the `response.failed` event instead of generic ones.

### Before this PR

All streaming errors produced one of two hard-coded codes:
- `internal_error` with `str(exception)` as the message — which leaked Python tracebacks and internal details to the client
- `invalid_request_error` for unsupported truncation — a code that doesn't exist in the Responses API spec

This meant OpenAI-compatible clients couldn't programmatically distinguish between different failure modes (bad image, rate limit, server issue), and raw exception strings could leak implementation details.

### After this PR

- **Provider errors are mapped to spec codes.** When the upstream inference provider returns a structured error (e.g., OpenAI returns `invalid_base64`), we extract it and map it to the correct Responses API code (`invalid_base64_image`). Only [codes defined in the spec](https://platform.openai.com/docs/api-reference/responses/object#responses/object-error) are emitted; anything unrecognized falls back to `server_error`.
- **No more internal details leaked.** Unexpected exceptions now return a generic `server_error` with a safe message instead of `str(exc)`.
- **Truncation error uses a valid code.** `invalid_request_error` → `server_error` (which is an actual spec code).

### User-facing impact

Clients using the OpenAI SDK or any spec-compliant streaming consumer will now receive meaningful, actionable error codes in `response.failed` events — e.g., `invalid_base64_image` instead of `internal_error`. This lets applications handle different failure modes appropriately (retry on `server_error`, show a user message on `invalid_base64_image`, back off on `rate_limit_exceeded`) without parsing error message strings.

## Depends on

- #4879

## Test plan

- **3 unit tests** for `extract_openai_error()`: unknown codes fall back to `server_error`, valid codes pass through, all spec codes are recognized
- **8 existing unit tests** for error body parsing (nested, direct, missing fields, non-dict bodies, etc.)
- **2 integration tests** with recorded gpt and ollama responses:
  - `truncation="auto"` → validates `response.failed` event has a valid error code
  - Invalid base64 image input → validates provider `BadRequestError` is mapped to a spec-compliant code in the `response.failed` event
- **`StreamingValidator` enhancement**: all integration tests now assert that `response.failed` error codes are within the spec-defined set
- All pre-commit hooks pass (ruff, mypy, etc.)