### PR TITLE
chore: bump version to 0.4.5 for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "setuptools-scm>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-fallback_version = "0.4.4"
+fallback_version = "0.4.5"
 
 [tool.uv]
 required-version = ">=0.7.0"
@@ -60,7 +60,7 @@ dependencies = [
 
 [project.optional-dependencies]
 client = [
-    "llama-stack-client==0.4.4",
+    "llama-stack-client==0.4.5",
 ]
 
 [dependency-groups]
@@ -109,7 +109,7 @@ type_checking = [
     "lm-format-enforcer",
     "mcp",
     "ollama",
-    "llama-stack-client==0.4.4",
+    "llama-stack-client==0.4.5",
 ]
 # These are the dependencies required for running unit tests.
 unit = [

--- a/src/llama_stack_api/pyproject.toml
+++ b/src/llama_stack_api/pyproject.toml
@@ -89,7 +89,7 @@ llama_stack_api = ["py.typed", "**/*.json", "**/*.yaml"]
 
 [tool.setuptools_scm]
 root = "../.."
-fallback_version = "0.4.4"
+fallback_version = "0.4.5"
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
# What does this PR do?

- Update fallback_version to 0.4.5 in pyproject.toml and src/llama_stack_api/pyproject.toml
- Update llama-stack-client pin to 0.4.5 in [project.optional-dependencies] and [dependency-groups]