### PR TITLE
fix: pass request objects to Files API in Responses content conversion

### DIFF
--- a/src/llama_stack/providers/inline/agents/meta_reference/responses/utils.py
+++ b/src/llama_stack/providers/inline/agents/meta_reference/responses/utils.py
@@ -53,6 +53,8 @@ from llama_stack_api import (
     OpenAIToolMessageParam,
     OpenAIUserMessageParam,
     ResponseGuardrailSpec,
+    RetrieveFileContentRequest,
+    RetrieveFileRequest,
     RunModerationRequest,
     Safety,
 )
@@ -68,7 +70,7 @@ async def extract_bytes_from_file(file_id: str, files_api: Files) -> bytes:
     :raises: ValueError if file cannot be retrieved
     """
     try:
-        response = await files_api.openai_retrieve_file_content(file_id)
+        response = await files_api.openai_retrieve_file_content(RetrieveFileContentRequest(file_id=file_id))
         return bytes(response.body)
     except Exception as e:
         raise ValueError(f"Failed to retrieve file content for file_id '{file_id}': {str(e)}") from e
@@ -155,7 +157,9 @@ async def convert_response_content_to_chat_content(
             elif content_part.file_id:
                 if files_api is None:
                     raise ValueError("file_ids are not supported by this implementation of the Stack")
-                image_file_response = await files_api.openai_retrieve_file(content_part.file_id)
+                image_file_response = await files_api.openai_retrieve_file(
+                    RetrieveFileRequest(file_id=content_part.file_id)
+                )
                 if image_file_response.filename:
                     image_mime_type, _ = mimetypes.guess_type(image_file_response.filename)
                 raw_image_bytes = await extract_bytes_from_file(content_part.file_id, files_api)
@@ -184,7 +188,7 @@ async def convert_response_content_to_chat_content(
                 if files_api is None:
                     raise ValueError("file_ids are not supported by this implementation of the Stack")
 
-                file_response = await files_api.openai_retrieve_file(file_id)
+                file_response = await files_api.openai_retrieve_file(RetrieveFileRequest(file_id=file_id))
                 if not filename:
                     filename = file_response.filename
                 file_mime_type, _ = mimetypes.guess_type(file_response.filename)


### PR DESCRIPTION
`openai_retrieve_file` and `openai_retrieve_file_content` both expect a request object (`RetrieveFileRequest` / `RetrieveFileContentRequest`), but three call sites in `convert_response_content_to_chat_content` and `extract_bytes_from_file` were passing a bare `str`. Any request that included an `input_image` block referencing a `file_id`, or an `input_file` block, would fail at runtime with:

    AttributeError: 'str' object has no attribute 'file_id'

Changes -

`src/llama_stack/providers/inline/agents/meta_reference/responses/utils.py` -

- Added `RetrieveFileRequest` and `RetrieveFileContentRequest` to the `llama_stack_api` import block.
- Wrapped the `openai_retrieve_file` call in the `input_image`+`file_id` branch with `RetrieveFileRequest(file_id=...)`.
- Wrapped the `openai_retrieve_file` call in the `input_file`+`file_id` branch with `RetrieveFileRequest(file_id=...)`.
- Wrapped the `openai_retrieve_file_content` call in `extract_bytes_from_file` with `RetrieveFileContentRequest(file_id=...)`.

`tests/unit/providers/agents/meta_reference/test_response_conversion_utils.py` -

- Added `test_convert_image_content_with_file_id_calls_retrieve_with_request_objects`: verifies `openai_retrieve_file` and `openai_retrieve_file_content` are called with the correct request objects when an `input_image` block references a `file_id`.
- Added `test_convert_file_content_with_file_id_calls_retrieve_with_request_objects`: same verification for `input_file` blocks referencing a `file_id`.
