### PR TITLE
feat: auto-merge PRs on stable release branches via Mergify + CI gate

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -21,3 +21,16 @@ pull_request_rules:
     label:
       remove:
         - needs-rebase
+
+- name: auto-merge on stable release branches
+  conditions:
+      - base~=^release-[0-9]+\.[0-9]+\.x$
+      - check-success=ci-status
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+      - -conflict
+      - -draft
+      - -closed
+  actions:
+    merge:
+      method: merge

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,6 +6,7 @@ Llama Stack uses GitHub Actions for Continuous Integration (CI). Below is a tabl
 | ---- | ---- | ------- |
 | Backward Compatibility Check | [backward-compat.yml](backward-compat.yml) | Check backward compatibility for config.yaml files |
 | Build Distribution Images | [build-distributions.yml](build-distributions.yml) | Build Distribution Images |
+| CI Status | [ci-status.yml](ci-status.yml) | Aggregate CI check status |
 | CodeQL Workflow Security Scan | [codeql.yml](codeql.yml) | CodeQL Workflow Security Scan |
 | Documentation Build | [docs-build.yml](docs-build.yml) | Build and validate documentation |
 | Installer CI | [install-script-ci.yml](install-script-ci.yml) | Test the installation script |

--- a/.github/workflows/ci-status.yml
+++ b/.github/workflows/ci-status.yml
@@ -1,0 +1,96 @@
+name: CI Status
+
+run-name: Aggregate CI check status
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release-[0-9]+.[0-9]+.x'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  ci-status:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      checks: read
+    steps:
+      - name: Wait for CI checks to complete
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const sha = context.payload.pull_request.head.sha;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Wait for other workflows to get queued
+            core.info('Waiting 60s for CI workflows to get queued...');
+            await new Promise(r => setTimeout(r, 60000));
+
+            const excludedChecks = new Set(['ci-status']);
+            const excludedApps = new Set(['mergify']);
+
+            const terminalStatuses = new Set(['completed']);
+            const successConclusions = new Set(['success', 'skipped', 'neutral']);
+            const failureConclusions = new Set(['failure', 'cancelled', 'timed_out']);
+
+            while (true) {
+              const { data: checkRuns } = await github.rest.checks.listForRef({
+                owner,
+                repo,
+                ref: sha,
+                per_page: 100,
+              });
+
+              // Filter to only GitHub Actions checks, excluding ourselves and bots
+              const relevant = checkRuns.check_runs.filter(cr => {
+                if (excludedChecks.has(cr.name)) return false;
+                if (cr.app && excludedApps.has(cr.app.slug)) return false;
+                // Only include GitHub Actions checks
+                if (!cr.app || cr.app.slug !== 'github-actions') return false;
+                return true;
+              });
+
+              if (relevant.length === 0) {
+                core.info('No other CI checks found yet, waiting...');
+                await new Promise(r => setTimeout(r, 30000));
+                continue;
+              }
+
+              const pending = relevant.filter(cr => !terminalStatuses.has(cr.status));
+              const completed = relevant.filter(cr => terminalStatuses.has(cr.status));
+
+              core.info(`Checks: ${completed.length} completed, ${pending.length} pending out of ${relevant.length} total`);
+
+              for (const cr of completed) {
+                core.info(`  ✓ ${cr.name}: ${cr.conclusion}`);
+              }
+              for (const cr of pending) {
+                core.info(`  ⏳ ${cr.name}: ${cr.status}`);
+              }
+
+              if (pending.length > 0) {
+                core.info('Waiting 30s for pending checks...');
+                await new Promise(r => setTimeout(r, 30000));
+                continue;
+              }
+
+              // All checks completed — evaluate conclusions
+              const failed = completed.filter(cr => failureConclusions.has(cr.conclusion));
+
+              if (failed.length > 0) {
+                for (const cr of failed) {
+                  core.error(`${cr.name} concluded with: ${cr.conclusion}`);
+                }
+                core.setFailed(`${failed.length} CI check(s) failed.`);
+                return;
+              }
+
+              const succeeded = completed.filter(cr => successConclusions.has(cr.conclusion));
+              core.info(`All ${succeeded.length} CI checks passed.`);
+              return;
+            }


### PR DESCRIPTION
Add a ci-status workflow that aggregates all CI check results into a single status check, and a Mergify rule that auto-merges PRs targeting release-X.Y.x branches once ci-status passes, at least one human approval is present, and there are no conflicts.

The aggregation workflow polls the GitHub Checks API for all check runs on the PR's head SHA, filtering to GitHub Actions checks only (excluding itself and Mergify). It succeeds when all checks complete with success, skipped, or neutral, and fails if any check has failure, cancelled, or timed_out.

Why a polling workflow instead of simpler alternatives:

- Listing individual check names directly in Mergify conditions would break with path-filtered workflows (e.g. unit-tests only runs on changes to src/llama_stack/**). If a workflow doesn't trigger, its check never appears and check-success blocks forever.

- gh pr checks --watch has no way to exclude its own check, causing a deadlock.

- A single workflow with needs: can't span multiple workflow files.

The polling approach correctly handles path-filtered workflows by only evaluating checks that actually exist on the SHA.
