### PR TITLE
fix: strip inline:: prefix from model in vector io tests

### DIFF
--- a/src/llama_stack/core/stack.py
+++ b/src/llama_stack/core/stack.py
@@ -765,7 +765,7 @@ def run_config_from_adhoc_config_spec(
 
         provider_configs_by_api[api_str] = [
             Provider(
-                provider_id=provider,
+                provider_id=provider_spec.provider_type.split("::")[-1],
                 provider_type=provider_spec.provider_type,
                 config=provider_config,
             )

--- a/tests/integration/fixtures/common.py
+++ b/tests/integration/fixtures/common.py
@@ -325,10 +325,9 @@ def instantiate_llama_stack_client(session):
 
         # --stack-config bypasses template so need this to set default embedding model
         if "vector_io" in config and "inference" in config:
-            if "inline" in session.config.getoption("embedding_model"):
-                provider_id = "inline::sentence-transformers"
-            else:
-                provider_id = parse_vector_io_provider(config)
+            embedding_model_opt = session.config.getoption("embedding_model") or ""
+            # Model identifiers are in provider_id/model_id format; extract the provider.
+            provider_id = embedding_model_opt.split("/")[0] if "/" in embedding_model_opt else "sentence-transformers"
             passed_model = extract_model(session.config.getoption("embedding_model"), "nomic-ai/nomic-embed-text-v1.5")
             passed_emb = session.config.getoption("embedding_dimension")
 


### PR DESCRIPTION
Problem -

The vector IO integration tests were using a non-standard model name: `inline::sentence-transformers/nomic-ai/nomic-embed-text-v1.5`

The vector IO test setup in `conftest.py` and `fixtures/common.py` had hardcoded the same wrong value, masking the bug — lookups accidentally matched the incorrectly-prefixed key.

Fix -

**`stack.py`** — use the bare provider type without the `inline::`/`remote::` namespace as the routing-table key.

**`fixtures/common.py`** — `QualifiedModel.provider_id` is used for a routing-table lookup; derive it from the bare portion of the `embedding_model` option string (`"sentence-transformers/model"` → `"sentence-transformers"`) rather than hardcoding `"inline::sentence-transformers"`.

Cleanup -

As a side effect, `conftest.py`'s `parse_vector_io_providers_from_config` (which manually re-parsed the `--stack-config` string) and an analogous substring check in `pytest_configure` are replaced with calls to `run_config_from_adhoc_config_spec`, reading provider IDs directly from the resulting `StackConfig` instead of duplicating the parsing logic. to read provider IDs directly.
