### PR TITLE
fix: populate required OpenResponses fields with non-null defaults

### DIFF
--- a/src/llama_stack/providers/inline/agents/meta_reference/responses/streaming.py
+++ b/src/llama_stack/providers/inline/agents/meta_reference/responses/streaming.py
@@ -215,16 +215,21 @@ class StreamingResponseOrchestrator:
 
         # Create a completed refusal response
         refusal_response = OpenAIResponseObject(
+            background=False,
             id=self.response_id,
             created_at=self.created_at,
             model=self.ctx.model,
             status="completed",
             output=[OpenAIResponseMessage(role="assistant", content=[refusal_content], type="message")],
+            temperature=self.ctx.temperature if self.ctx.temperature is not None else 1.0,
+            top_p=self.ctx.top_p if self.ctx.top_p is not None else 1.0,
+            tools=self.ctx.available_tools(),
+            tool_choice=self.ctx.tool_choice or OpenAIResponseInputToolChoiceMode.auto,
+            truncation=self.truncation or "disabled",
             max_output_tokens=self.max_output_tokens,
             safety_identifier=self.safety_identifier,
-            service_tier=self.service_tier,
+            service_tier=self.service_tier or "default",
             metadata=self.metadata,
-            truncation=self.truncation,
             store=self.store,
             prompt_cache_key=self.prompt_cache_key,
         )
@@ -250,6 +255,7 @@ class StreamingResponseOrchestrator:
     ) -> OpenAIResponseObject:
         completed_at = int(time.time()) if status == "completed" else None
         return OpenAIResponseObject(
+            background=False,
             created_at=self.created_at,
             completed_at=completed_at,
             id=self.response_id,
@@ -258,9 +264,10 @@ class StreamingResponseOrchestrator:
             status=status,
             output=self._clone_outputs(outputs),
             text=self.text,
-            top_p=self.ctx.top_p,
+            temperature=self.ctx.temperature if self.ctx.temperature is not None else 1.0,
+            top_p=self.ctx.top_p if self.ctx.top_p is not None else 1.0,
             tools=self.ctx.available_tools(),
-            tool_choice=self.ctx.tool_choice,
+            tool_choice=self.ctx.tool_choice or OpenAIResponseInputToolChoiceMode.auto,
             error=error,
             incomplete_details=incomplete_details,
             usage=self.accumulated_usage,
@@ -271,9 +278,9 @@ class StreamingResponseOrchestrator:
             reasoning=self.reasoning,
             max_output_tokens=self.max_output_tokens,
             safety_identifier=self.safety_identifier,
-            service_tier=self.service_tier,
+            service_tier=self.service_tier or "default",
             metadata=self.metadata,
-            truncation=self.truncation,
+            truncation=self.truncation or "disabled",
             store=self.store,
             prompt_cache_key=self.prompt_cache_key,
         )
@@ -1050,7 +1057,7 @@ class StreamingResponseOrchestrator:
                     OpenAIResponseOutputMessageContentOutputText(
                         text=final_text,
                         annotations=[],
-                        logprobs=chat_response_logprobs if chat_response_logprobs else None,
+                        logprobs=chat_response_logprobs if chat_response_logprobs else [],
                     )
                 )
 

--- a/src/llama_stack/providers/inline/agents/meta_reference/responses/utils.py
+++ b/src/llama_stack/providers/inline/agents/meta_reference/responses/utils.py
@@ -110,7 +110,7 @@ async def convert_chat_choice_to_response_message(
     output_content = choice.message.content or ""
 
     annotations, clean_text = _extract_citations_from_text(output_content, citation_files or {})
-    logprobs = choice.logprobs.content if choice.logprobs and choice.logprobs.content else None
+    logprobs = choice.logprobs.content if choice.logprobs and choice.logprobs.content else []
 
     return OpenAIResponseMessage(
         id=message_id or f"msg_{uuid.uuid4()}",

--- a/src/llama_stack_api/openai_responses.py
+++ b/src/llama_stack_api/openai_responses.py
@@ -712,7 +712,7 @@ class OpenAIResponseIncompleteDetails(BaseModel):
 class OpenAIResponseObject(BaseModel):
     """Complete OpenAI response object containing generation results and metadata.
 
-    :param background: Whether this response was run in background mode
+    :param background: Whether this response was run in background mode (default: False)
     :param created_at: Unix timestamp when the response was created
     :param completed_at: (Optional) Unix timestamp when the response was completed
     :param error: (Optional) Error details if the response generation failed

--- a/tests/integration/responses/test_basic_responses.py
+++ b/tests/integration/responses/test_basic_responses.py
@@ -243,7 +243,7 @@ def test_include_logprobs_non_streaming(client_with_models, text_model_id):
     assert len(response_w_o_logprobs.output) == 1
     message_outputs = [output for output in response_w_o_logprobs.output if output.type == "message"]
     assert len(message_outputs) == 1, f"Expected one message output, got {len(message_outputs)}"
-    assert message_outputs[0].content[0].logprobs is None, "Expected no logprobs in the returned response"
+    assert message_outputs[0].content[0].logprobs == [], "Expected no logprobs in the returned response"
 
     # Create a response with include["message.output_text.logprobs"]
     response_with_logprobs = client_with_models.responses.create(


### PR DESCRIPTION
# What does this PR do?

The OpenResponses conformance suite validates responses using strict Zod schemas. Several fields that the OpenAI spec marks as **optional** (omittable) are treated by OpenResponses as **required and non-nullable**. llama-stack was returning \`null\` for these fields, failing Zod validation before any semantic checks could run.

## Why not just change the schema types?

The Python schema in `openai_responses.py` is the source of truth for our generated OpenAPI spec, which is diffed against `openai-spec-2.3.0.yml` via `oasdiff --check-regression` in pre-commit. Changing a field from `list | None` to `list` (non-nullable) would alter the generated spec and lower our OpenAI conformance score.

**Example  `logprobs` on `OutputTextContent`:**

The OpenAI spec at `docs/static/openai-spec-2.3.0.yml` defines:

```yaml
OutputTextContent:
  properties:
    logprobs:
      items:
        $ref: '#/components/schemas/LogProb'
      type: array          # non-nullable when present
  required:
    - type
    - text
    - annotations          # logprobs is NOT required — field may be omitted
```

The OpenAI spec says: *if logprobs is present it must be an array, never null* but the field itself is optional (can be absent). Our old code returned `null`, which violates even the OpenAI spec. OpenResponses goes further and requires the field to always be present.

The fix: **keep the schema as `list | None = None`** (preserving our oasdiff baseline) but **always emit `[]` in construction code** when logprobs aren't available. This satisfies both: it's a valid non-null array per OpenAI spec, and it's always present per OpenResponses. The same rationale applies to every other field fixed in this PR.

## Fields fixed

For each field the schema definition is unchanged; only the construction code is updated to emit a concrete non-null default:

- `background`: always `False` for non-background responses (was `None`)
- `tool_choice`: defaults to `"auto"` when not specified (was `None`)
- `truncation`: defaults to `"disabled"` when not specified (was `None`)
- `service_tier`: defaults to `"default"` when not specified (was `None`)
-  `tools`: always an array; `available_tools()` already returns `[]` not `None`
- `temperature`: defaults to `1.0` when not specified (was `None`)
- `top_p`: defaults to `1.0` when not specified (was `None`)
- `logprobs`: always `[]` when not requested (was `None`, which also violates the OpenAI spec)

Closes #4987
Closes #4988
Closes #4990

## Test Plan

- Integration tests for all three modes (docker, library, server) with GPT provider pass
- `conformance.mdx` score is unchanged (no regression in OpenAI spec conformance)
- OpenResponses conformance test (informational) passes