### PR TITLE
feat: auto-merge dependabot github-deps PRs via Mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -34,3 +34,15 @@ pull_request_rules:
   actions:
     merge:
       method: merge
+
+- name: auto-merge dependabot github-deps PRs
+  conditions:
+      - author=dependabot[bot]
+      - title~=^chore\(github-deps\)
+      - check-success=ci-status
+      - -conflict
+      - -draft
+      - -closed
+  actions:
+    merge:
+      method: merge


### PR DESCRIPTION
Add a Mergify rule to auto-merge Dependabot PRs with the chore(github-deps) title prefix once CI passes. No human approval required since these are automated dependency pin updates scoped to GitHub Actions dependencies.