### PR TITLE
fix: correct PYPDF adapter method signature to match FileProcessors protocol

### DIFF
--- a/src/llama_stack/providers/inline/file_processor/pypdf/adapter.py
+++ b/src/llama_stack/providers/inline/file_processor/pypdf/adapter.py
@@ -4,12 +4,10 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from typing import Any
 
 from fastapi import UploadFile
 
-from llama_stack_api.file_processors import ProcessFileResponse
-from llama_stack_api.vector_io import VectorStoreChunkingStrategy
+from llama_stack_api.file_processors import ProcessFileRequest, ProcessFileResponse
 
 from .config import PyPDFFileProcessorConfig
 from .pypdf import PyPDFFileProcessor
@@ -25,15 +23,13 @@ class PyPDFFileProcessorAdapter:
 
     async def process_file(
         self,
+        request: ProcessFileRequest,
         file: UploadFile | None = None,
-        file_id: str | None = None,
-        options: dict[str, Any] | None = None,
-        chunking_strategy: VectorStoreChunkingStrategy | None = None,
     ) -> ProcessFileResponse:
         """Process a file using PyPDF processor."""
         return await self.processor.process_file(
             file=file,
-            file_id=file_id,
-            options=options,
-            chunking_strategy=chunking_strategy,
+            file_id=request.file_id,
+            options=request.options,
+            chunking_strategy=request.chunking_strategy,
         )


### PR DESCRIPTION
# What does this PR do?
The adapter's process_file method signature was incompatible with the FileProcessors protocol, causing ValueError when processing files. Updated to use the correct signature: process_file(request: ProcessFileRequest, file: UploadFile | None = None)
<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->
1. Start server
OLLAMA_URL=http://localhost:11434/v1 uv run --with llama-stack llama stack run starter

2. Process PDF with direct upload to file processor api or via files api and generated file_id
_Process PDF with direct file upload_
  curl -sS -X POST http://localhost:8321/v1alpha/file-processors/process \
    -F "file=@**/path/to.pdf**" \
    | jq '{
      processor: .metadata.processor,
      page_count: .metadata.page_count,
      file_size: .metadata.file_size_bytes,
      processing_time_ms: .metadata.processing_time_ms,
      n_chunks: (.chunks | length),
      first_chunk_preview: .chunks[0].content[0:100] + "...",
      tokenizer: .chunks[0].chunk_metadata.chunk_tokenizer
    }'
_Upload file to Files API first_
  FILE_ID=$(curl -sS -X POST http://localhost:8321/v1/files \
    -F "file=@/home/alina/dev/llama/llama-stack/tests/integration/responses/fixtures/pdfs/llama_stack_and_models.pdf" \
    -F "purpose=assistants" \
    | jq -r '.id')

      echo "Uploaded file with ID: $FILE_ID"
    
    _Process using file_id reference_
      curl -sS -X POST http://localhost:8321/v1alpha/file-processors/process \
        -F "file_id=$FILE_ID" \
        | jq '{
          processor: .metadata.processor,
          page_count: .metadata.page_count,
          n_chunks: (.chunks | length),
          file_id_from_metadata: .chunks[0].metadata.file_id
        }'

3. Compare Default vs. Auto Chunking
echo "1. Default chunking (no chunking strat set):"
  curl -sS -X POST http://localhost:8321/v1alpha/file-processors/process \
    -F "file_id=$FILE_ID" \
    | jq '{chunks: (.chunks | length), tokens: .chunks[0].chunk_metadata.content_token_count}'

    echo "2. Auto chunking:"
      curl -sS -X POST http://localhost:8321/v1alpha/file-processors/process \
        -F "file_id=$FILE_ID" \
        -F 'chunking_strategy={"type": "auto"}' \
        | jq '{chunks: (.chunks | length), avg_tokens: ([.chunks[].chunk_metadata.content_token_count] | add / length)}'

