### PR TITLE
feat: allow stream usage from vllm when telemetry enabled

### DIFF
--- a/src/llama_stack/providers/remote/inference/vllm/vllm.py
+++ b/src/llama_stack/providers/remote/inference/vllm/vllm.py
@@ -38,9 +38,6 @@ class VLLMInferenceAdapter(OpenAIMixin):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    # vLLM does not support the stream_options parameter
-    supports_stream_options: bool = False
-
     provider_data_api_key_field: str = "vllm_api_token"
 
     def get_api_key(self) -> str | None:


### PR DESCRIPTION
vLLM has supported stream_options since v0.5.0 (june 2024, https://github.com/vllm-project/vllm/releases/tag/v0.5.0)
