### PR TITLE
feat: allow stream usage from ollama when telemetry enabled

### DIFF
--- a/src/llama_stack/providers/remote/inference/ollama/ollama.py
+++ b/src/llama_stack/providers/remote/inference/ollama/ollama.py
@@ -28,9 +28,6 @@ class OllamaInferenceAdapter(OpenAIMixin):
     # automatically set by the resolver when instantiating the provider
     __provider_id__: str
 
-    # Ollama does not support the stream_options parameter
-    supports_stream_options: bool = False
-
     embedding_model_metadata: dict[str, dict[str, int]] = {
         "all-minilm:l6-v2": {
             "embedding_dimension": 384,


### PR DESCRIPTION
Ollama has supported stream_options since v0.5.2 (dec 2024, https://github.com/ollama/ollama/releases/tag/v0.5.2)
