### PR TITLE
fix: guard against NoneType in content join for tool-call messages

### DIFF
--- a/src/llama_stack/providers/inline/agents/meta_reference/responses/types.py
+++ b/src/llama_stack/providers/inline/agents/meta_reference/responses/types.py
@@ -72,7 +72,7 @@ class ChatCompletionResult:
     @property
     def content_text(self) -> str:
         """Get joined content as string."""
-        return "".join(self.content)
+        return "".join(c for c in self.content if c is not None)
 
     @property
     def has_tool_calls(self) -> bool:

--- a/src/llama_stack/providers/utils/inference/prompt_adapter.py
+++ b/src/llama_stack/providers/utils/inference/prompt_adapter.py
@@ -33,7 +33,7 @@ def interleaved_content_as_str(
         if isinstance(c, str):
             return c
         elif isinstance(c, TextContentItem) or isinstance(c, OpenAIChatCompletionContentPartTextParam):
-            return c.text
+            return c.text or ""
         elif isinstance(c, ImageContentItem) or isinstance(c, OpenAIChatCompletionContentPartImageParam):
             return "<image>"
         elif isinstance(c, OpenAIFile):

--- a/tests/unit/providers/utils/inference/test_prompt_adapter_none_safety.py
+++ b/tests/unit/providers/utils/inference/test_prompt_adapter_none_safety.py
@@ -1,0 +1,50 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Tests for None-safety in interleaved_content_as_str.
+
+Regression tests for https://github.com/meta-llama/llama-stack/issues/4996
+Models like Qwen3 via vLLM may return tool-call messages with content: null,
+causing str.join() to crash with TypeError when None values flow through.
+"""
+
+from llama_stack.providers.utils.inference.prompt_adapter import interleaved_content_as_str
+
+
+class TestInterleavedContentAsStrNoneSafety:
+    """Ensure interleaved_content_as_str never passes None into join()."""
+
+    def test_none_content_returns_empty_string(self):
+        assert interleaved_content_as_str(None) == ""
+
+    def test_string_content(self):
+        assert interleaved_content_as_str("hello") == "hello"
+
+    def test_list_of_strings(self):
+        assert interleaved_content_as_str(["a", "b", "c"]) == "a b c"
+
+    def test_empty_list(self):
+        assert interleaved_content_as_str([]) == ""
+
+    def test_text_content_item_with_none_text(self):
+        """TextContentItem with text=None must not crash join().
+
+        When an upstream provider (e.g. vLLM) returns content: null,
+        the deserialized object may have text=None despite the Pydantic
+        schema requiring str.  model_construct() simulates this.
+        """
+        from llama_stack_api.common.content_types import TextContentItem
+
+        item = TextContentItem.model_construct(text=None)
+        result = interleaved_content_as_str([item])
+        assert result == ""
+
+    def test_text_content_item_with_valid_text(self):
+        from llama_stack_api.common.content_types import TextContentItem
+
+        item = TextContentItem(text="hello world")
+        result = interleaved_content_as_str([item])
+        assert result == "hello world"


### PR DESCRIPTION
## Summary

Fixes #4996

When models like **Qwen3 via vLLM** return tool-call messages with `content: null`, several code paths crash with:
```
TypeError: sequence item 0: expected str instance, NoneType found
```

## Reproducer

### 1. vLLM command (v0.8.x+, with tool parser enabled)

```bash
python -m vllm.entrypoints.openai.api_server \
  --model Qwen/Qwen3-8B \
  --enable-auto-tool-choice \
  --tool-call-parser hermes \
  --port 8000
```

### 2. Llama Stack config + run

```yaml
# stack_config.yaml
inference:
  - provider_id: vllm
    provider_type: remote::vllm
    config:
      url: http://localhost:8000/v1
```

```bash
llama stack run stack_config.yaml --port 8321
```

### 3. Client request (triggers the crash)

```bash
curl -s -X POST http://localhost:8321/v1/responses \
  -H "Content-Type: application/json" \
  -d '{"model": "Qwen/Qwen3-8B", "input": "What is the weather in Brno?", "tools": [{"type": "function", "name": "get_weather", "description": "Get the current weather for a location", "parameters": {"type": "object", "properties": {"location": {"type": "string", "description": "City name"}}, "required": ["location"]}}]}'
```

**Without fix:** `TypeError: sequence item 0: expected str instance, NoneType found`
**With fix:** Tool call processed normally.

The crash is deterministic: vLLM returns `content: null` on assistant tool-call messages (per OpenAI spec), and `str.join()` chokes on the `None`.

## Root Cause

The OpenAI Chat Completion API spec allows `content: null` on assistant messages that contain `tool_calls`. When this happens, `None` values propagate through code paths that call `str.join()` without filtering.

## Changes

### 1. `prompt_adapter.py` — `interleaved_content_as_str()`
```python
# Before
return c.text
# After
return c.text or ""
```
The `_process()` helper returns `c.text` for `TextContentItem`, which can be `None` when the upstream provider sets `content: null`. The `or ""` guard prevents `None` from entering the `sep.join()` call.

### 2. `types.py` — `ChatCompletionResult.content_text`
```python
# Before
return "".join(self.content)
# After
return "".join(c for c in self.content if c is not None)
```
Filters out any `None` entries in the content list before joining. This is the core fix for the crash scenario.

> **Note on streaming.py:** An earlier version of this PR also changed `_build_chat_completion()` to emit `content=None` when `tool_calls` are present (to match the OpenAI spec). This change was intentionally reverted after it caused integration test failures — the `content_text or None` expression evaluated to `None` for empty-string content, breaking tests that expected `content=""`. The two changes above fully address the crash; the streaming.py spec-alignment is a separate, non-blocking improvement.

## Tests

Added `tests/unit/providers/utils/inference/test_prompt_adapter_none_safety.py` with 6 regression tests covering the crash scenario and edge cases.

All CI checks passing ✅ (unit tests, integration tests, pre-commit).