### PR TITLE
fix(security): pin google-cloud-aiplatform to >=1.131.0

### DIFF
--- a/src/llama_stack/providers/registry/inference.py
+++ b/src/llama_stack/providers/registry/inference.py
@@ -201,7 +201,7 @@ def available_providers() -> list[ProviderSpec]:
             adapter_type="vertexai",
             provider_type="remote::vertexai",
             pip_packages=[
-                "google-cloud-aiplatform",
+                "google-cloud-aiplatform>=1.131.0",
             ],
             module="llama_stack.providers.remote.inference.vertexai",
             config_class="llama_stack.providers.remote.inference.vertexai.VertexAIConfig",


### PR DESCRIPTION
https://www.cve.org/CVERecord?id=CVE-2026-2472
