### PR TITLE
fix: add missing shutdown method to PyPDF file processor adapter

### DIFF
--- a/src/llama_stack/providers/inline/file_processor/pypdf/adapter.py
+++ b/src/llama_stack/providers/inline/file_processor/pypdf/adapter.py
@@ -33,3 +33,7 @@ class PyPDFFileProcessorAdapter:
             options=request.options,
             chunking_strategy=request.chunking_strategy,
         )
+
+    async def shutdown(self) -> None:
+        """Shutdown the PyPDF file processor."""
+        pass


### PR DESCRIPTION
# What does this PR do?
Adds async shutdown() method to PyPDFFileProcessorAdapter to comply with stack shutdown protocol and eliminate warnings during shutdown.

## Test Plan
pre-commit and existing integration tests pass