### PR TITLE
fix(conversations): add ExceptionTranslatingRoute to conversations router

### DIFF
--- a/src/llama_stack_api/agents/fastapi_routes.py
+++ b/src/llama_stack_api/agents/fastapi_routes.py
@@ -17,9 +17,8 @@ import logging  # allow-direct-logging
 from collections.abc import AsyncIterator
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request, Response
+from fastapi import APIRouter, Body, Depends, Path, Query
 from fastapi.responses import StreamingResponse
-from fastapi.routing import APIRoute
 from pydantic import BaseModel
 
 from llama_stack_api.common.errors import OpenAIErrorResponse
@@ -31,9 +30,11 @@ from llama_stack_api.openai_responses import (
     OpenAIResponseObject,
 )
 from llama_stack_api.router_utils import (
+    ExceptionTranslatingRoute,
     create_path_dependency,
     create_query_dependency,
     standard_responses,
+    try_translate_to_http_exception,
 )
 from llama_stack_api.version import LLAMA_STACK_API_V1
 
@@ -74,7 +75,7 @@ async def sse_generator(event_gen):
         raise  # Re-raise to maintain proper cancellation semantics
     except Exception as e:
         logger.exception("Error in SSE generator")
-        http_exc = _try_translate_to_http_exception(e)
+        http_exc = try_translate_to_http_exception(e)
         status_code = http_exc.status_code if http_exc else 500
         detail = http_exc.detail if http_exc else "Internal server error: An unexpected error occurred."
         yield create_sse_event(OpenAIErrorResponse.from_message(detail, code=str(status_code)).to_dict())
@@ -119,55 +120,6 @@ async def get_list_response_input_items_request(
     )
 
 
-def _try_translate_to_http_exception(exc: Exception) -> HTTPException | None:
-    """Try to translate an exception to an HTTPException.
-
-    Returns an HTTPException for known exception types (HTTPException,
-    ValueError, and exceptions with a ``status_code`` attribute such as
-    LlamaStackError subclasses).  Returns ``None`` for unknown types so
-    the caller can decide whether to re-raise the original exception.
-
-    The full ``translate_exception`` pipeline lives in ``llama_stack.core``
-    which ``llama_stack_api`` must not import, so we duplicate the minimal
-    logic required here.
-    """
-    if isinstance(exc, HTTPException):
-        return exc
-    # LlamaStackError subclasses carry their own status_code
-    status_code = getattr(exc, "status_code", None)
-    if isinstance(status_code, int):
-        return HTTPException(status_code=status_code, detail=str(exc))
-    if isinstance(exc, ValueError):
-        return HTTPException(status_code=400, detail=str(exc) or "Invalid value")
-    return None
-
-
-class _ExceptionTranslatingRoute(APIRoute):
-    """Route class that converts known exception types to HTTPException.
-
-    ValueError and LlamaStackError (which carry a ``status_code``) are
-    translated to the appropriate HTTPException so that FastAPI's built-in
-    handler returns a proper JSON error response.  All other exceptions
-    are left untouched so they can propagate to the server's global
-    ``Exception`` handler registered via ``app.exception_handler(Exception)``.
-    """
-
-    def get_route_handler(self):
-        original = super().get_route_handler()
-
-        async def handler(request: Request) -> Response:
-            try:
-                resp: Response = await original(request)
-            except Exception as exc:
-                http_exc = _try_translate_to_http_exception(exc)
-                if http_exc is not None:
-                    raise http_exc from exc
-                raise
-            return resp
-
-        return handler
-
-
 def _preserve_context_for_sse(event_gen):
     # StreamingResponse runs in a different task, losing request contextvars.
     # create_task inside context.run captures the context at task creation.
@@ -203,7 +155,7 @@ def create_router(impl: Agents) -> APIRouter:
         prefix=f"/{LLAMA_STACK_API_V1}",
         tags=["Agents"],
         responses=standard_responses,
-        route_class=_ExceptionTranslatingRoute,
+        route_class=ExceptionTranslatingRoute,
     )
 
     @router.get(

--- a/src/llama_stack_api/conversations/fastapi_routes.py
+++ b/src/llama_stack_api/conversations/fastapi_routes.py
@@ -15,7 +15,12 @@ from typing import Annotated, Literal
 from fastapi import APIRouter, Body, Depends, Path
 from pydantic import BaseModel
 
-from llama_stack_api.router_utils import create_path_dependency, create_query_dependency, standard_responses
+from llama_stack_api.router_utils import (
+    ExceptionTranslatingRoute,
+    create_path_dependency,
+    create_query_dependency,
+    standard_responses,
+)
 from llama_stack_api.version import LLAMA_STACK_API_V1
 
 from .api import Conversations
@@ -62,6 +67,7 @@ def create_router(impl: Conversations) -> APIRouter:
         prefix=f"/{LLAMA_STACK_API_V1}",
         tags=["Conversations"],
         responses=standard_responses,
+        route_class=ExceptionTranslatingRoute,
     )
 
     @router.post(

--- a/src/llama_stack_api/router_utils.py
+++ b/src/llama_stack_api/router_utils.py
@@ -9,13 +9,19 @@
 This module provides standard error response definitions for FastAPI routers.
 These responses use OpenAPI $ref references to component responses defined
 in the OpenAPI specification.
+
+It also provides :class:`ExceptionTranslatingRoute`, a reusable route class
+that catches known exception types (``ValueError``, ``LlamaStackError``)
+and translates them to ``HTTPException`` so that FastAPI returns proper
+JSON error responses instead of dropping the connection.
 """
 
 import inspect
 from collections.abc import Callable
 from typing import Annotated, Any, TypeVar
 
-from fastapi import Path, Query
+from fastapi import HTTPException, Path, Query, Request, Response
+from fastapi.routing import APIRoute
 from pydantic import BaseModel
 
 # OpenAPI extension key to mark routes that don't require authentication.
@@ -158,3 +164,51 @@ def create_path_dependency[T: BaseModel](model_class: type[T]) -> Callable[..., 
     dependency_func.__name__ = f"get_{model_class.__name__.lower()}_request"  # type: ignore[attr-defined]
 
     return dependency_func
+
+
+def try_translate_to_http_exception(exc: Exception) -> HTTPException | None:
+    """Try to translate an exception to an HTTPException.
+
+    Returns an HTTPException for known exception types (HTTPException,
+    ValueError, and exceptions with a ``status_code`` attribute such as
+    LlamaStackError subclasses).  Returns ``None`` for unknown types so
+    the caller can decide whether to re-raise the original exception.
+
+    The full ``translate_exception`` pipeline lives in ``llama_stack.core``
+    which ``llama_stack_api`` must not import, so we duplicate the minimal
+    logic required here.
+    """
+    if isinstance(exc, HTTPException):
+        return exc
+    status_code = getattr(exc, "status_code", None)
+    if isinstance(status_code, int):
+        return HTTPException(status_code=status_code, detail=str(exc))
+    if isinstance(exc, ValueError):
+        return HTTPException(status_code=400, detail=str(exc) or "Invalid value")
+    return None
+
+
+class ExceptionTranslatingRoute(APIRoute):
+    """Route class that converts known exception types to HTTPException.
+
+    ValueError and LlamaStackError (which carry a ``status_code``) are
+    translated to the appropriate HTTPException so that FastAPI's built-in
+    handler returns a proper JSON error response.  All other exceptions
+    are left untouched so they can propagate to the server's global
+    ``Exception`` handler registered via ``app.exception_handler(Exception)``.
+    """
+
+    def get_route_handler(self):
+        original = super().get_route_handler()
+
+        async def handler(request: Request) -> Response:
+            try:
+                resp: Response = await original(request)
+            except Exception as exc:
+                http_exc = try_translate_to_http_exception(exc)
+                if http_exc is not None:
+                    raise http_exc from exc
+                raise
+            return resp
+
+        return handler

--- a/tests/unit/core/routers/test_conversations_router.py
+++ b/tests/unit/core/routers/test_conversations_router.py
@@ -1,0 +1,88 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from unittest.mock import AsyncMock
+
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from llama_stack.core.server.fastapi_router_registry import build_fastapi_router
+from llama_stack.core.server.server import global_exception_handler
+from llama_stack_api import Api
+from llama_stack_api.common.errors import ConversationNotFoundError
+from llama_stack_api.conversations import Conversations
+
+
+def _build_app(impl):
+    app = FastAPI()
+    app.add_exception_handler(Exception, global_exception_handler)
+    router = build_fastapi_router(Api.conversations, impl)
+    assert router is not None
+    app.include_router(router)
+    return app
+
+
+def test_get_conversation_maps_value_error_to_400():
+    """ExceptionTranslatingRoute converts ValueError to HTTP 400."""
+    impl = AsyncMock(spec=Conversations)
+    impl.get_conversation.side_effect = ValueError("invalid value")
+
+    client = TestClient(_build_app(impl), raise_server_exceptions=False)
+    resp = client.get("/v1/conversations/conv_abc")
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "invalid value"
+
+
+def test_get_conversation_maps_not_found_error():
+    """ExceptionTranslatingRoute converts ConversationNotFoundError to HTTP 404."""
+    impl = AsyncMock(spec=Conversations)
+    impl.get_conversation.side_effect = ConversationNotFoundError("conv_missing")
+
+    client = TestClient(_build_app(impl), raise_server_exceptions=False)
+    resp = client.get("/v1/conversations/conv_missing")
+
+    assert resp.status_code == 404
+    assert "conv_missing" in resp.json()["detail"]
+
+
+def test_unknown_exception_propagates_to_global_handler():
+    """Unknown exceptions propagate past the route class to the global handler."""
+    impl = AsyncMock(spec=Conversations)
+    impl.get_conversation.side_effect = RuntimeError("something broke")
+
+    client = TestClient(_build_app(impl), raise_server_exceptions=False)
+    resp = client.get("/v1/conversations/conv_abc")
+
+    assert resp.status_code == 500
+    assert "error" in resp.json()
+
+
+def test_consecutive_errors_keep_connection_alive():
+    """Route-level translation prevents connection resets on repeated errors."""
+    impl = AsyncMock(spec=Conversations)
+    impl.get_conversation.side_effect = ValueError("bad request")
+
+    client = TestClient(_build_app(impl), raise_server_exceptions=False)
+
+    resp1 = client.get("/v1/conversations/conv_abc")
+    assert resp1.status_code == 400
+
+    resp2 = client.get("/v1/conversations/conv_abc")
+    assert resp2.status_code == 400
+    assert resp2.json()["detail"] == "bad request"
+
+
+def test_delete_conversation_maps_value_error_to_400():
+    """ExceptionTranslatingRoute converts ValueError on DELETE to HTTP 400."""
+    impl = AsyncMock(spec=Conversations)
+    impl.openai_delete_conversation.side_effect = ValueError("cannot delete")
+
+    client = TestClient(_build_app(impl), raise_server_exceptions=False)
+    resp = client.delete("/v1/conversations/conv_abc")
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "cannot delete"


### PR DESCRIPTION
## Summary
- Moves `ExceptionTranslatingRoute` and `try_translate_to_http_exception` from `agents/fastapi_routes.py` to the shared `router_utils` module
- Adds `route_class=ExceptionTranslatingRoute` to the conversations router so it gets the same route-level exception translation as the agents router
- Adds unit tests verifying ValueError -> 400, ConversationNotFoundError -> 404, and connection keep-alive behavior on the conversations router

## Test plan
- [x] All 66 existing router tests pass
- [x] 5 new conversations router tests pass
- [ ] Verify on Linux that repeated errors don't cause connection resets

Made with [Cursor](https://cursor.com)