### PR TITLE
fix(conversations): validate conv_ prefix consistently on all endpoints

### DIFF
--- a/src/llama_stack/core/conversations/conversations.py
+++ b/src/llama_stack/core/conversations/conversations.py
@@ -143,6 +143,7 @@ class ConversationServiceImpl(Conversations):
 
     async def get_conversation(self, request: GetConversationRequest) -> Conversation:
         """Get a conversation with the given ID."""
+        self._validate_conversation_id(request.conversation_id)
         record = await self.sql_store.fetch_one(table="openai_conversations", where={"id": request.conversation_id})
 
         if record is None:
@@ -154,6 +155,7 @@ class ConversationServiceImpl(Conversations):
 
     async def update_conversation(self, conversation_id: str, request: UpdateConversationRequest) -> Conversation:
         """Update a conversation's metadata with the given ID"""
+        self._validate_conversation_id(conversation_id)
 
         # verify conversation exists and trigger ABAC check before updating
         record = await self.sql_store.fetch_one(table="openai_conversations", where={"id": conversation_id})
@@ -168,6 +170,7 @@ class ConversationServiceImpl(Conversations):
 
     async def openai_delete_conversation(self, request: DeleteConversationRequest) -> ConversationDeletedResource:
         """Delete a conversation with the given ID."""
+        self._validate_conversation_id(request.conversation_id)
 
         record = await self.sql_store.fetch_one(table="openai_conversations", where={"id": request.conversation_id})
         if record is None:
@@ -196,8 +199,7 @@ class ConversationServiceImpl(Conversations):
         return item.id
 
     async def _get_validated_conversation(self, conversation_id: str) -> Conversation:
-        """Validate conversation ID and return the conversation if it exists."""
-        self._validate_conversation_id(conversation_id)
+        """Validate conversation ID format and return the conversation if it exists."""
         return await self.get_conversation(GetConversationRequest(conversation_id=conversation_id))
 
     async def add_items(self, conversation_id: str, request: AddItemsRequest) -> ConversationItemList:
@@ -244,8 +246,7 @@ class ConversationServiceImpl(Conversations):
 
     async def retrieve(self, request: RetrieveItemRequest) -> ConversationItem:
         """Retrieve a conversation item."""
-        if not request.conversation_id:
-            raise InvalidParameterError("conversation_id", request.conversation_id, "Must be a non-empty string.")
+        self._validate_conversation_id(request.conversation_id)
         if not request.item_id:
             raise InvalidParameterError("item_id", request.item_id, "Must be a non-empty string.")
 
@@ -262,10 +263,7 @@ class ConversationServiceImpl(Conversations):
 
     async def list_items(self, request: ListItemsRequest) -> ConversationItemList:
         """List items in the conversation."""
-        if not request.conversation_id:
-            raise InvalidParameterError("conversation_id", request.conversation_id, "Must be a non-empty string.")
-
-        # check if conversation exists
+        # get_conversation validates the ID format and checks existence
         await self.get_conversation(GetConversationRequest(conversation_id=request.conversation_id))
 
         result = await self.sql_store.fetch_all(
@@ -298,11 +296,10 @@ class ConversationServiceImpl(Conversations):
 
     async def openai_delete_conversation_item(self, request: DeleteItemRequest) -> ConversationItemDeletedResource:
         """Delete a conversation item."""
-        if not request.conversation_id:
-            raise InvalidParameterError("conversation_id", request.conversation_id, "Must be a non-empty string.")
         if not request.item_id:
             raise InvalidParameterError("item_id", request.item_id, "Must be a non-empty string.")
 
+        # _get_validated_conversation validates ID format and checks existence
         _ = await self._get_validated_conversation(request.conversation_id)
 
         record = await self.sql_store.fetch_one(

--- a/tests/unit/conversations/test_conversations.py
+++ b/tests/unit/conversations/test_conversations.py
@@ -109,12 +109,24 @@ async def test_conversation_items(service):
 
 async def test_invalid_conversation_id(service):
     with pytest.raises(InvalidParameterError, match="Conversation ID must begin with 'conv_'"):
-        await service._get_validated_conversation("invalid_id")
+        await service.get_conversation(GetConversationRequest(conversation_id="invalid_id"))
 
 
-async def test_empty_parameter_validation(service):
-    with pytest.raises(InvalidParameterError, match="Must be a non-empty string"):
-        await service.retrieve(RetrieveItemRequest(conversation_id="", item_id="item_123"))
+async def test_invalid_conversation_id_on_retrieve(service):
+    with pytest.raises(InvalidParameterError, match="Conversation ID must begin with 'conv_'"):
+        await service.retrieve(RetrieveItemRequest(conversation_id="bad_id", item_id="item_123"))
+
+
+async def test_invalid_conversation_id_on_update(service):
+    from llama_stack_api.conversations import UpdateConversationRequest
+
+    with pytest.raises(InvalidParameterError, match="Conversation ID must begin with 'conv_'"):
+        await service.update_conversation("bad_id", UpdateConversationRequest(metadata={}))
+
+
+async def test_invalid_conversation_id_on_delete(service):
+    with pytest.raises(InvalidParameterError, match="Conversation ID must begin with 'conv_'"):
+        await service.openai_delete_conversation(DeleteConversationRequest(conversation_id="bad_id"))
 
 
 async def test_nonexistent_conversation_raises_conversation_not_found(service):


### PR DESCRIPTION
## Summary

Previously only `add_items` and `openai_delete_conversation_item` validated the `conv_` prefix on conversation IDs (via `_get_validated_conversation`). The other endpoints -- `get_conversation`, `update_conversation`, `openai_delete_conversation`, `retrieve`, and `list_items` -- skipped this check, so a malformed ID like `"foo"` would hit the database and return a generic `ConversationNotFoundError` instead of the more helpful `InvalidParameterError` telling the user the ID must begin with `conv_`.

This PR adds `_validate_conversation_id()` to all endpoints that accept a conversation ID, so users get a clear 400 error with actionable guidance regardless of which endpoint they call.

## Test plan
- [x] All 13 conversations unit tests pass
- [x] Existing `test_invalid_conversation_id` updated to test through public API
- [x] New tests for `retrieve`, `update`, and `delete` with malformed IDs