### PR TITLE
fix: prevent conversation sync failures from breaking response delivery

### DIFF
--- a/src/llama_stack/providers/inline/agents/meta_reference/responses/openai_responses.py
+++ b/src/llama_stack/providers/inline/agents/meta_reference/responses/openai_responses.py
@@ -1094,11 +1094,17 @@ class OpenAIResponsesImpl:
                     and failed_response is None
                 ):
                     if conversation:
-                        messages_to_store = list(
-                            filter(lambda x: not isinstance(x, OpenAISystemMessageParam), orchestrator.final_messages)
-                        )
-                        await self._sync_response_to_conversation(conversation, input, output_items)
-                        await self.responses_store.store_conversation_messages(conversation, messages_to_store)
+                        try:
+                            messages_to_store = list(
+                                filter(
+                                    lambda x: not isinstance(x, OpenAISystemMessageParam),
+                                    orchestrator.final_messages,
+                                )
+                            )
+                            await self._sync_response_to_conversation(conversation, input, output_items)
+                            await self.responses_store.store_conversation_messages(conversation, messages_to_store)
+                        except Exception as e:
+                            logger.exception("Failed to sync response to conversation %s: %s", conversation, e)
 
                 yield stream_chunk
 

--- a/tests/unit/providers/agents/meta_reference/test_openai_responses_conversations.py
+++ b/tests/unit/providers/agents/meta_reference/test_openai_responses_conversations.py
@@ -5,6 +5,8 @@
 # the root directory of this source tree.
 
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 # Fixtures imported from test_openai_responses via root conftest.py for pytest 8.4+ compatibility
@@ -156,6 +158,57 @@ class TestMessageSyncing:
         items = request.items
         # Should have input message + output message
         assert len(items) == 2
+
+
+_RESPONSES_MODULE = "llama_stack.providers.inline.agents.meta_reference.responses.openai_responses"
+
+
+class TestConversationSyncErrorHandling:
+    """Verify that conversation sync failures don't break the response."""
+
+    async def test_sync_failure_still_yields_completed_response(
+        self, responses_impl_with_conversations, mock_conversations_api, mock_responses_store
+    ):
+        """Conversation sync failure must not prevent the client from receiving its response."""
+        mock_conversations_api.list_items.return_value = ConversationItemList(
+            data=[], first_id=None, has_more=False, last_id=None, object="list"
+        )
+        mock_conversations_api.add_items.side_effect = Exception("store unavailable")
+
+        completed_response = OpenAIResponseObject(
+            id="resp_1",
+            created_at=0,
+            model="test-model",
+            object="response",
+            output=[],
+            status="completed",
+            store=True,
+        )
+
+        async def fake_create_response():
+            yield OpenAIResponseObjectStreamResponseCompleted(
+                response=completed_response, sequence_number=1, type="response.completed"
+            )
+
+        mock_orch = AsyncMock()
+        mock_orch.create_response = fake_create_response
+        mock_orch.final_messages = []
+
+        with (
+            patch(f"{_RESPONSES_MODULE}.MCPSessionManager") as mock_mcp,
+            patch(f"{_RESPONSES_MODULE}.ToolExecutor"),
+            patch(f"{_RESPONSES_MODULE}.StreamingResponseOrchestrator", return_value=mock_orch),
+        ):
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            response = await responses_impl_with_conversations.create_openai_response(
+                input="Hello", model="test-model", conversation="conv_test123", stream=False, store=False
+            )
+
+        assert response.id == "resp_1"
+        assert response.status == "completed"
+        mock_conversations_api.add_items.assert_called_once()
 
 
 class TestIntegrationWorkflow:


### PR DESCRIPTION
## Summary

When a response is created with a `conversation` parameter, `_create_streaming_response` syncs the input and output items to the conversation after inference completes. Previously, if this sync failed (e.g. the conversation store was temporarily unavailable or `add_items` raised), the exception propagated through the streaming generator. For non-streaming callers this meant losing the completed response entirely; for streaming callers the `response.completed` event was never yielded. In both cases the client lost a successfully generated response because of a secondary side-effect failure.

This PR wraps the conversation sync block in a `try/except` so that sync failures are logged with the full traceback but don't prevent the client from receiving its response. The `_sync_response_to_conversation` method itself still raises, so callers that invoke it directly retain the original behavior.

## Test plan
- [x] New `test_sync_failure_still_yields_completed_response` passes with the fix and fails without it
- [x] Existing `test_sync_response_to_conversation_api_error` still passes (method itself still raises)
- [x] All 9 conversation tests pass