### PR TITLE
chore: bump fallback_version to 0.5.3.dev0 after 0.5.2 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "setuptools-scm>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-fallback_version = "0.5.2.dev0"
+fallback_version = "0.5.3.dev0"
 
 [tool.uv]
 required-version = ">=0.7.0"

--- a/src/llama_stack_api/pyproject.toml
+++ b/src/llama_stack_api/pyproject.toml
@@ -91,7 +91,7 @@ llama_stack_api = ["py.typed", "**/*.json", "**/*.yaml"]
 
 [tool.setuptools_scm]
 root = "../.."
-fallback_version = "0.5.2.dev0"
+fallback_version = "0.5.3.dev0"
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
this failed in the release actions so opening manually 