### PR TITLE
perf: lazy-load numpy, faiss, and sqlite_vec in vector_io providers

### DIFF
--- a/src/llama_stack/providers/inline/vector_io/faiss/faiss.py
+++ b/src/llama_stack/providers/inline/vector_io/faiss/faiss.py
@@ -8,11 +8,45 @@ import asyncio
 import base64
 import io
 import json
-from typing import Any
+import threading
+from typing import TYPE_CHECKING, Any
 
-import faiss  # type: ignore[import-untyped]
-import numpy as np
-from numpy.typing import NDArray
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+_faiss: Any = None
+_faiss_lock = threading.Lock()
+
+
+def _get_faiss() -> Any:
+    global _faiss
+    if _faiss is not None:
+        return _faiss
+    with _faiss_lock:
+        if _faiss is not None:
+            return _faiss
+        import faiss  # type: ignore[import-untyped]
+
+        _faiss = faiss
+        return _faiss
+
+
+_numpy: Any = None
+_numpy_lock = threading.Lock()
+
+
+def _get_numpy() -> Any:
+    global _numpy
+    if _numpy is not None:
+        return _numpy
+    with _numpy_lock:
+        if _numpy is not None:
+            return _numpy
+        import numpy
+
+        _numpy = numpy
+        return _numpy
+
 
 from llama_stack.core.storage.kvstore import kvstore_impl
 from llama_stack.log import get_logger
@@ -70,7 +104,7 @@ OPENAI_VECTOR_STORES_FILES_CONTENTS_PREFIX = f"openai_vector_stores_files_conten
 
 class FaissIndex(EmbeddingIndex):
     def __init__(self, dimension: int, kvstore: KVStore | None = None, bank_id: str | None = None):
-        self.index = faiss.IndexFlatL2(dimension)
+        self.index = _get_faiss().IndexFlatL2(dimension)
         self.chunk_by_index: dict[int, EmbeddedChunk] = {}
         self.kvstore = kvstore
         self.bank_id = bank_id
@@ -107,7 +141,7 @@ class FaissIndex(EmbeddingIndex):
 
             buffer = io.BytesIO(base64.b64decode(data["faiss_index"]))
             try:
-                self.index = faiss.deserialize_index(np.load(buffer, allow_pickle=False))
+                self.index = _get_faiss().deserialize_index(_get_numpy().load(buffer, allow_pickle=False))
                 self.chunk_ids = [embedded_chunk.chunk_id for embedded_chunk in self.chunk_by_index.values()]
                 # Rebuild inverted metadata index from loaded chunks
                 for pos, chunk in self.chunk_by_index.items():
@@ -125,9 +159,9 @@ class FaissIndex(EmbeddingIndex):
         if not self.kvstore or not self.bank_id:
             return
 
-        np_index = faiss.serialize_index(self.index)
+        np_index = _get_faiss().serialize_index(self.index)
         buffer = io.BytesIO()
-        np.save(buffer, np_index, allow_pickle=False)
+        _get_numpy().save(buffer, np_index, allow_pickle=False)
         data = {
             "chunk_by_index": {k: v.model_dump_json() for k, v in self.chunk_by_index.items()},
             "faiss_index": base64.b64encode(buffer.getvalue()).decode("utf-8"),
@@ -147,6 +181,7 @@ class FaissIndex(EmbeddingIndex):
             return
 
         # Extract embeddings and validate dimensions
+        np = _get_numpy()
         embeddings = np.array([ec.embedding for ec in embedded_chunks], dtype=np.float32)
         embedding_dim = embeddings.shape[1] if len(embeddings.shape) > 1 else embeddings.shape[0]
         if embedding_dim != self.index.d:
@@ -174,7 +209,7 @@ class FaissIndex(EmbeddingIndex):
 
         def remove_chunk(chunk_id: str):
             removed_pos = self.chunk_ids.index(chunk_id)
-            self.index.remove_ids(np.array([removed_pos]))
+            self.index.remove_ids(_get_numpy().array([removed_pos]))
 
             # Remove deleted position from _meta_index
             for val_map in self._meta_index.values():
@@ -246,7 +281,7 @@ class FaissIndex(EmbeddingIndex):
         }
 
     async def query_vector(
-        self, embedding: NDArray, k: int, score_threshold: float, filters: Filter | None = None
+        self, embedding: "NDArray", k: int, score_threshold: float, filters: Filter | None = None
     ) -> QueryChunksResponse:
         """
         Performs vector-based search using Faiss similarity search.
@@ -254,6 +289,8 @@ class FaissIndex(EmbeddingIndex):
         inverted _meta_index and passes them directly to Faiss via IDSelectorBatch,
         eliminating the need for post-hoc filtering or over-retrieval heuristics.
         """
+        np = _get_numpy()
+        faiss = _get_faiss()
         if filters is not None:
             candidate_positions = self._resolve_filter_positions(filters)
             if not candidate_positions:
@@ -290,7 +327,7 @@ class FaissIndex(EmbeddingIndex):
 
     async def query_hybrid(
         self,
-        embedding: NDArray,
+        embedding: "NDArray",
         query_string: str,
         k: int,
         score_threshold: float,
@@ -343,7 +380,7 @@ class FaissVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProtoco
         """
         try:
             vector_dimension = 128  # sample dimension
-            faiss.IndexFlatL2(vector_dimension)
+            _get_faiss().IndexFlatL2(vector_dimension)
             return HealthResponse(status=HealthStatus.OK)
         except Exception as e:
             return HealthResponse(status=HealthStatus.ERROR, message=f"Health check failed: {str(e)}")

--- a/src/llama_stack/providers/inline/vector_io/sqlite_vec/sqlite_vec.py
+++ b/src/llama_stack/providers/inline/vector_io/sqlite_vec/sqlite_vec.py
@@ -9,11 +9,45 @@ import json
 import re
 import sqlite3
 import struct
-from typing import Any
+import threading
+from typing import TYPE_CHECKING, Any
 
-import numpy as np
-import sqlite_vec  # type: ignore[import-untyped]
-from numpy.typing import NDArray
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+_numpy: Any = None
+_numpy_lock = threading.Lock()
+
+
+def _get_numpy() -> Any:
+    global _numpy
+    if _numpy is not None:
+        return _numpy
+    with _numpy_lock:
+        if _numpy is not None:
+            return _numpy
+        import numpy
+
+        _numpy = numpy
+        return _numpy
+
+
+_sqlite_vec: Any = None
+_sqlite_vec_lock = threading.Lock()
+
+
+def _get_sqlite_vec() -> Any:
+    global _sqlite_vec
+    if _sqlite_vec is not None:
+        return _sqlite_vec
+    with _sqlite_vec_lock:
+        if _sqlite_vec is not None:
+            return _sqlite_vec
+        import sqlite_vec  # type: ignore[import-untyped]
+
+        _sqlite_vec = sqlite_vec
+        return _sqlite_vec
+
 
 from llama_stack.core.storage.kvstore import kvstore_impl
 from llama_stack.log import get_logger
@@ -76,7 +110,7 @@ def _create_sqlite_connection(db_path: str):
     """Create a SQLite connection with sqlite_vec extension loaded."""
     connection = sqlite3.connect(db_path)
     connection.enable_load_extension(True)
-    sqlite_vec.load(connection)
+    _get_sqlite_vec().load(connection)
     connection.enable_load_extension(False)
     return connection
 
@@ -165,6 +199,7 @@ class SQLiteVecIndex(EmbeddingIndex):
         Also inserts chunk content into FTS table for keyword search support.
         """
         chunks = embedded_chunks  # EmbeddedChunk now inherits from Chunk
+        np = _get_numpy()
         embeddings = np.array([ec.embedding for ec in embedded_chunks], dtype=np.float32)
         assert all(isinstance(chunk.content, str) for chunk in chunks), "SQLiteVecIndex only supports text chunks"
 
@@ -284,7 +319,7 @@ class SQLiteVecIndex(EmbeddingIndex):
         return operator.join(clauses), params
 
     async def query_vector(
-        self, embedding: NDArray, k: int, score_threshold: float, filters: Filter | None = None
+        self, embedding: "NDArray", k: int, score_threshold: float, filters: Filter | None = None
     ) -> QueryChunksResponse:
         """
         Performs vector-based search using a virtual table for vector similarity.
@@ -297,7 +332,7 @@ class SQLiteVecIndex(EmbeddingIndex):
             connection = _create_sqlite_connection(self.db_path)
             cur = connection.cursor()
             try:
-                emb_list = embedding.tolist() if isinstance(embedding, np.ndarray) else list(embedding)
+                emb_list = embedding.tolist() if isinstance(embedding, _get_numpy().ndarray) else list(embedding)
                 emb_blob = serialize_vector(emb_list)
 
                 # Build query with optional filter clause
@@ -383,7 +418,7 @@ class SQLiteVecIndex(EmbeddingIndex):
 
     async def query_hybrid(
         self,
-        embedding: NDArray,
+        embedding: "NDArray",
         query_string: str,
         k: int,
         score_threshold: float,

--- a/src/llama_stack/providers/utils/memory/vector_store.py
+++ b/src/llama_stack/providers/utils/memory/vector_store.py
@@ -4,18 +4,38 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 import io
+import threading
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
 from functools import cache
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import chardet
-import numpy as np
 import tiktoken
-from numpy.typing import NDArray
 from pypdf import PdfReader
+
+if TYPE_CHECKING:
+    import numpy as np
+    from numpy.typing import NDArray
+
+_numpy: Any = None
+_numpy_lock = threading.Lock()
+
+
+def _get_numpy() -> Any:
+    global _numpy
+    if _numpy is not None:
+        return _numpy
+    with _numpy_lock:
+        if _numpy is not None:
+            return _numpy
+        import numpy
+
+        _numpy = numpy
+        return _numpy
+
 
 from llama_stack.core.datatypes import VectorStoresConfig
 from llama_stack.log import get_logger
@@ -163,6 +183,7 @@ type EmbeddingSequence = Sequence[float | int | np.number] | NDArray[Any]
 
 def _validate_embedding(embedding: EmbeddingSequence, index: int, expected_dimension: int):
     """Helper method to validate embedding format and dimensions"""
+    np = _get_numpy()
     if not isinstance(embedding, (list | np.ndarray)):
         raise ValueError(f"Embedding at index {index} must be a list or numpy array, got {type(embedding)}")
 
@@ -188,7 +209,7 @@ class EmbeddingIndex(ABC):
 
     @abstractmethod
     async def query_vector(
-        self, embedding: NDArray, k: int, score_threshold: float, filters: Filter | None = None
+        self, embedding: "NDArray", k: int, score_threshold: float, filters: Filter | None = None
     ) -> QueryChunksResponse:
         raise NotImplementedError()
 
@@ -201,7 +222,7 @@ class EmbeddingIndex(ABC):
     @abstractmethod
     async def query_hybrid(
         self,
-        embedding: NDArray,
+        embedding: "NDArray",
         query_string: str,
         k: int,
         score_threshold: float,
@@ -313,6 +334,7 @@ class VectorStoreWithIndex:
                     model=self.vector_store.embedding_model, input=[query_string]
                 )
             embeddings_response = await self.inference_api.openai_embeddings(embeddings_request)
+            np = _get_numpy()
             query_vector = np.array(embeddings_response.data[0].embedding, dtype=np.float32)
             if mode == "hybrid":
                 response = await self.index.query_hybrid(

--- a/tests/unit/providers/test_lazy_imports.py
+++ b/tests/unit/providers/test_lazy_imports.py
@@ -122,3 +122,36 @@ class TestEmbeddingMixinLazyImports:
             ["torch"],
         )
         assert ok, f"embedding_mixin.py eagerly loaded: {loaded}"
+
+
+class TestFaissLazyImports:
+    """Verify faiss.py does not eagerly import faiss or numpy."""
+
+    def test_no_faiss_numpy_on_import(self):
+        ok, loaded = _check_no_forbidden_imports(
+            "llama_stack.providers.inline.vector_io.faiss.faiss",
+            ["faiss", "numpy"],
+        )
+        assert ok, f"faiss.py eagerly loaded: {loaded}"
+
+
+class TestSqliteVecLazyImports:
+    """Verify sqlite_vec.py does not eagerly import numpy or sqlite_vec."""
+
+    def test_no_numpy_sqlite_vec_on_import(self):
+        ok, loaded = _check_no_forbidden_imports(
+            "llama_stack.providers.inline.vector_io.sqlite_vec.sqlite_vec",
+            ["numpy", "sqlite_vec"],
+        )
+        assert ok, f"sqlite_vec.py eagerly loaded: {loaded}"
+
+
+class TestVectorStoreLazyImports:
+    """Verify vector_store.py does not eagerly import numpy."""
+
+    def test_no_numpy_on_import(self):
+        ok, loaded = _check_no_forbidden_imports(
+            "llama_stack.providers.utils.memory.vector_store",
+            ["numpy"],
+        )
+        assert ok, f"vector_store.py eagerly loaded: {loaded}"

--- a/tests/unit/providers/vector_io/test_faiss.py
+++ b/tests/unit/providers/vector_io/test_faiss.py
@@ -347,8 +347,10 @@ async def test_health_success():
     inference_api = MagicMock()
     files_api = MagicMock()
 
-    with patch("llama_stack.providers.inline.vector_io.faiss.faiss.faiss.IndexFlatL2") as mock_index_flat:
-        mock_index_flat.return_value = MagicMock()
+    mock_faiss = MagicMock()
+    mock_faiss.IndexFlatL2.return_value = MagicMock()
+
+    with patch("llama_stack.providers.inline.vector_io.faiss.faiss._get_faiss", return_value=mock_faiss):
         adapter = FaissVectorIOAdapter(config=config, inference_api=inference_api, files_api=files_api)
 
         # Calling the health method directly
@@ -360,7 +362,7 @@ async def test_health_success():
         assert "message" not in response
 
         # Verifying that IndexFlatL2 was called with the correct dimension
-        mock_index_flat.assert_called_once_with(128)  # VECTOR_DIMENSION is 128
+        mock_faiss.IndexFlatL2.assert_called_once_with(128)  # VECTOR_DIMENSION is 128
 
 
 async def test_health_failure():
@@ -370,9 +372,10 @@ async def test_health_failure():
     inference_api = MagicMock()
     files_api = MagicMock()
 
-    with patch("llama_stack.providers.inline.vector_io.faiss.faiss.faiss.IndexFlatL2") as mock_index_flat:
-        mock_index_flat.side_effect = Exception("Test error")
+    mock_faiss = MagicMock()
+    mock_faiss.IndexFlatL2.side_effect = Exception("Test error")
 
+    with patch("llama_stack.providers.inline.vector_io.faiss.faiss._get_faiss", return_value=mock_faiss):
         adapter = FaissVectorIOAdapter(config=config, inference_api=inference_api, files_api=files_api)
 
         # Calling the health method directly


### PR DESCRIPTION
## Summary

Defer importing heavy dependencies (`numpy` ~30MB, `faiss` ~50MB, `sqlite_vec`) at module load time by replacing top-level imports with thread-safe lazy loaders using a double-check locking pattern. This reduces startup memory for distributions that register these providers but do not immediately use them.

- **`vector_store.py`**: lazy-load `numpy` via `_get_numpy()`
- **`faiss.py`**: lazy-load `faiss` via `_get_faiss()` and `numpy` via `_get_numpy()`
- **`sqlite_vec.py`**: lazy-load `sqlite_vec` via `_get_sqlite_vec()` and `numpy` via `_get_numpy()`
- **`test_faiss.py`**: update health check test patches for lazy loaders
- **`test_lazy_imports.py`**: add subprocess-based tests verifying no eager loading of heavy dependencies

Inspired by the approach in #4826 by @rhuss.

## Test plan

- [x] `pytest tests/unit/providers/test_lazy_imports.py` — 3 new tests verify no eager imports of numpy/faiss/sqlite_vec
- [x] `pytest tests/unit/providers/vector_io/test_faiss.py` — all 12 existing tests pass
- [x] `pre-commit run --all-files` — all hooks pass (ruff, mypy, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)