### PR TITLE
ci(mergify): skip conflict comments on stale PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -3,6 +3,7 @@ pull_request_rules:
   conditions:
       - conflict
       - -closed
+      - -label~=stale
   actions:
     label:
       add:


### PR DESCRIPTION
## Summary

- Skip conflict comment notifications on PRs that have the `stale` label, avoiding unnecessary noise on abandoned PRs.
- This actually removes the stale label on PRs, highjacking the bot, we don't want that

## Test plan

- Verify Mergify config is valid via Mergify dashboard
- Confirm stale PRs with conflicts no longer receive rebase comments

Generated with [Claude Code](https://claude.com/claude-code)