### PR TITLE
fix: optimize connector listing

### DIFF
--- a/src/llama_stack/core/connectors/connectors.py
+++ b/src/llama_stack/core/connectors/connectors.py
@@ -128,13 +128,8 @@ class ConnectorServiceImpl(Connectors):
 
     async def list_connectors(self) -> ListConnectorsResponse:
         """List all connectors."""
-        connectors = []
-        for key in await self.kvstore.keys_in_range(start_key=KEY_PREFIX, end_key=KEY_PREFIX + "\uffff"):
-            connector_json = await self.kvstore.get(key)
-            if not connector_json:
-                continue
-            connector = Connector.model_validate_json(connector_json)
-            connectors.append(connector)
+        values = await self.kvstore.values_in_range(start_key=KEY_PREFIX, end_key=KEY_PREFIX + "\uffff")
+        connectors = [Connector.model_validate_json(v) for v in values]
         return ListConnectorsResponse(data=connectors)
 
     async def get_connector_tool(self, request: GetConnectorToolRequest, authorization: str | None = None) -> ToolDef:

--- a/tests/unit/core/connectors/test_connectors.py
+++ b/tests/unit/core/connectors/test_connectors.py
@@ -44,6 +44,9 @@ def mock_kvstore():
         async def keys_in_range(self, start_key, end_key):
             return [k for k in storage.keys() if start_key <= k < end_key]
 
+        async def values_in_range(self, start_key, end_key):
+            return [v for k, v in storage.items() if start_key <= k < end_key]
+
         async def close(self):
             pass
 


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->

**connectors.py**: `list_connectors()` was calling `keys_in_range()` followed by individual `get()` for each key. Replaced with a single `values_in_range()` call, eliminating the N+1 query pattern.

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->

<!-- For API changes, include:
1. A testing script (Python, curl, etc.) that exercises the new/modified endpoints
2. The output from running your script

Example:
```python
...
...
```

Output:
```
<paste actual output here>
```
-->
