### PR TITLE
fix(vertexai): extract model ID from Vertex AI resource paths

### DIFF
--- a/src/llama_stack/providers/remote/inference/vertexai/converters.py
+++ b/src/llama_stack/providers/remote/inference/vertexai/converters.py
@@ -142,11 +142,14 @@ def convert_finish_reason(
 def convert_model_name(model: str) -> str:
     """Ensure model ID is in the bare form expected by the Gemini API.
 
-    Strips ``google/`` or ``models/`` prefixes if present so callers can
-    pass either ``"gemini-2.5-flash"`` or ``"google/gemini-2.5-flash"``.
+    Strips vendor and resource prefixes so callers can pass any of:
+    ``"gemini-2.5-flash"``, ``"google/gemini-2.5-flash"``,
+    ``"models/gemini-2.5-flash"``, or the full Vertex AI resource path
+    ``"publishers/google/models/gemini-2.5-flash"``.
     """
     model = model.removeprefix("google/")
-    model = model.removeprefix("models/")
+    # Handle both "models/..." and "publishers/.../models/..." formats.
+    model = model.rsplit("models/", 1)[-1] if "models/" in model else model
     return model
 
 

--- a/src/llama_stack/providers/remote/inference/vertexai/vertexai.py
+++ b/src/llama_stack/providers/remote/inference/vertexai/vertexai.py
@@ -314,7 +314,9 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
                 continue
 
             name = getattr(model, "name", "") or ""
-            model_id = name.removeprefix("models/")
+            # Handle both Gemini API ("models/...") and Vertex AI
+            # ("publishers/google/models/...") name formats.
+            model_id = name.rsplit("models/", 1)[-1] if "models/" in name else name
             if not model_id:
                 continue
             result.append(model_id)

--- a/tests/unit/providers/inference/vertexai/test_adapter.py
+++ b/tests/unit/providers/inference/vertexai/test_adapter.py
@@ -272,6 +272,11 @@ class TestVertexAIModelListing:
             SimpleNamespace(name="models/gemini-2.5-pro", supported_actions=[]),
             SimpleNamespace(name="models/text-embedding-004", supported_actions=["embedContent"]),
             SimpleNamespace(name="", supported_actions=["generateContent"]),
+            # Vertex AI resource path format (publishers/google/models/...)
+            SimpleNamespace(
+                name="publishers/google/models/gemini-2.0-flash",
+                supported_actions=["generateContent"],
+            ),
         ]
 
         async def fake_list(**kwargs):
@@ -286,7 +291,10 @@ class TestVertexAIModelListing:
         assert "gemini-2.5-flash" in result
         assert "gemini-2.5-pro" in result
         assert "text-embedding-004" in result
+        assert "gemini-2.0-flash" in result
         assert "" not in result
+        # Full Vertex AI resource paths must not leak through
+        assert "publishers/google/models/gemini-2.0-flash" not in result
 
     @pytest.mark.parametrize(
         "index,expected_id,expected_type,expected_metadata",

--- a/tests/unit/providers/inference/vertexai/test_converters.py
+++ b/tests/unit/providers/inference/vertexai/test_converters.py
@@ -187,6 +187,9 @@ class TestConvertModelName:
         [
             ("google/gemini-2.5-flash", "gemini-2.5-flash"),
             ("gemini-2.5-flash", "gemini-2.5-flash"),
+            ("models/gemini-2.5-flash", "gemini-2.5-flash"),
+            ("publishers/google/models/gemini-2.5-flash", "gemini-2.5-flash"),
+            ("publishers/meta/models/llama-3", "llama-3"),
             ("meta/llama-3", "meta/llama-3"),
             ("", ""),
             ("google/", ""),


### PR DESCRIPTION
# What does this PR do?

`list_provider_model_ids()` and `convert_model_name()` used `removeprefix("models/")` to extract model IDs from API responses. This only works for the Gemini API name format (`models/gemini-2.5-flash`) but silently passes through the Vertex AI format (`publishers/google/models/gemini-2.5-flash`) unchanged, causing downstream model lookup failures.

Switched to `rsplit("models/", 1)[-1]` which correctly extracts the model ID from both formats.

Closes #5161

## Test Plan

Existing unit tests updated with Vertex AI format test cases. Full vertexai test suite passes (265/265):

```
$ uv run --group unit pytest -x tests/unit/providers/inference/vertexai/
============================= 265 passed in 0.22s ==============================
```

Key new test cases:
- `publishers/google/models/gemini-2.5-flash` → `gemini-2.5-flash`
- `publishers/meta/models/llama-3` → `llama-3`
- `models/gemini-2.5-flash` → `gemini-2.5-flash` (existing format, was untested in converters)
- Negative assertion that full resource paths don't leak through `list_provider_model_ids()`