### PR TITLE
fix: update recording workflow action SHAs to include skip-commit support

### DIFF
--- a/.github/workflows/record-integration-tests.yml
+++ b/.github/workflows/record-integration-tests.yml
@@ -190,7 +190,7 @@ jobs:
       # a trusted commit, not from PR checkout. This is critical for security.
       - name: Setup test environment
         if: steps.should_run.outputs.run == 'true'
-        uses: llamastack/llama-stack/.github/actions/setup-test-environment@ce063acfe127393537cb0a5deb29cd20063c76af
+        uses: llamastack/llama-stack/.github/actions/setup-test-environment@4a4f48ffda71163aba27360a8cb172d4fddb398c
         with:
           python-version: "3.12"
           client-version: "latest"
@@ -200,7 +200,7 @@ jobs:
 
       - name: Run and record tests
         if: steps.should_run.outputs.run == 'true'
-        uses: llamastack/llama-stack/.github/actions/run-and-record-tests@ce063acfe127393537cb0a5deb29cd20063c76af
+        uses: llamastack/llama-stack/.github/actions/run-and-record-tests@4a4f48ffda71163aba27360a8cb172d4fddb398c
         env:
           OPENAI_API_KEY: ${{ matrix.provider.setup == 'gpt' && secrets.OPENAI_API_KEY || '' }}
           AZURE_API_KEY: ${{ matrix.provider.setup == 'azure' && secrets.AZURE_API_KEY || '' }}


### PR DESCRIPTION
## Summary
Updates the pinned action SHAs in the recording workflow to point to the current main branch that includes the merged changes from #5123.

## Problem
The workflow was failing with:
```
remote: Permission to llamastack/llama-stack.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/llamastack/llama-stack/': The requested URL returned error: 403
```

This happened because the pinned SHAs (`ce063acf`) were from before #5123 merged, so they didn't support the `skip-commit: true` parameter. The old action tried to push recordings directly (which fails with read-only permissions).

## Solution
Updated both action SHAs to `4a4f48ff` (current main) which:
- Respects `skip-commit: true` parameter
- Uploads recordings as artifacts
- Allows the companion workflow to handle commits with proper write permissions

## Test plan
- [x] Verified the workflow now uses the correct action version that supports skip-commit
- [ ] Manual workflow_dispatch trigger should now work without 403 errors

Fixes the workflow failures seen in https://github.com/llamastack/llama-stack/actions/runs/23263329503