### PR TITLE
fix: clean up artifacts before cloning fork PR branch

### DIFF
--- a/.github/workflows/commit-recordings.yml
+++ b/.github/workflows/commit-recordings.yml
@@ -182,6 +182,8 @@ jobs:
         run: |
           # Move artifacts out of the way before cloning, then restore after.
           mv recordings-temp /tmp/recordings-temp 2>/dev/null || true
+          # Clean up workspace files (artifacts, metadata) to ensure empty directory for clone
+          rm -f recordings-*.zip pr-metadata.zip pr-info.json
           git clone --depth 1 --branch "${HEAD_REF}" "https://x-access-token:${GH_TOKEN}@github.com/${HEAD_REPO}.git" .
           mv /tmp/recordings-temp recordings-temp 2>/dev/null || true
 


### PR DESCRIPTION
Fixes the commit-recordings workflow failure when handling fork PRs.

The workflow was failing with `fatal: destination path '.' already exists and is not an empty directory` because artifact files remained in the workspace before the `git clone` step.

This cleans up `recordings-*.zip`, `pr-metadata.zip`, and `pr-info.json` before cloning to ensure an empty directory.

Resolves: https://github.com/llamastack/llama-stack/actions/runs/23300028696