### PR TITLE
feat: enable cancel responses

### DIFF
--- a/client-sdks/stainless/openapi.yml
+++ b/client-sdks/stainless/openapi.yml
@@ -3963,6 +3963,41 @@ paths:
       summary: Get service version
       description: Get the version of the service.
       operationId: version_v1alpha_admin_version_get
+  /v1/responses/{response_id}/cancel:
+    post:
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OpenAIResponseObject'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+          description: Bad Request
+        '429':
+          $ref: '#/components/responses/TooManyRequests429'
+          description: Too Many Requests
+        '500':
+          $ref: '#/components/responses/InternalServerError500'
+          description: Internal Server Error
+        default:
+          $ref: '#/components/responses/DefaultError'
+          description: Default Response
+      tags:
+      - Agents
+      summary: Cancel an in-progress response.
+      description: Cancel an in-progress response. The response status will be set to 'cancelled'.
+      operationId: cancel_openai_response_v1_responses__response_id__cancel_post
+      parameters:
+      - name: response_id
+        in: path
+        required: true
+        schema:
+          type: string
+          description: The ID of the response to cancel.
+          title: Response Id
+        description: The ID of the response to cancel.
   /v1alpha/file-processors/process:
     post:
       responses:

--- a/docs/docs/api-openai/conformance.mdx
+++ b/docs/docs/api-openai/conformance.mdx
@@ -27,11 +27,11 @@ This documentation is auto-generated from the OpenAI API specification compariso
 
 ## Integration Test Coverage
 
-**Overall Test Coverage Score: 45.3%**
+**Overall Test Coverage Score: 45.8%**
 
 | Category | Covered | Total | Score |
 |----------|---------|-------|-------|
-| CRUD Operations | 4 | 5 | 80.0% |
+| CRUD Operations | 5 | 6 | 83.3% |
 | Conversations | 5 | 9 | 55.6% |
 | Request Parameters | 21 | 24 | 87.5% |
 | Streaming Events | 16 | 53 | 30.2% |

--- a/docs/docs/api-openai/provider_matrix.md
+++ b/docs/docs/api-openai/provider_matrix.md
@@ -21,10 +21,10 @@ inference provider, based on integration test results.
 
 | Provider | Tested | Passing | Failing | Coverage |
 |----------|--------|---------|---------|----------|
-| azure | 101 | 101 | 0 | 86% |
-| openai | 118 | 118 | 0 | 100% |
+| azure | 102 | 102 | 0 | 85% |
+| openai | 120 | 120 | 0 | 100% |
 | vllm | 1 | 1 | 0 | 1% |
-| watsonx | 56 | 56 | 0 | 48% |
+| watsonx | 56 | 56 | 0 | 47% |
 
 ## Provider Details
 
@@ -88,6 +88,8 @@ Models, endpoints, and versions used during test recordings.
 | --- | --- | --- | --- | --- |
 | background false is synchronous | ✅ | ✅ | — | ✅ |
 | background returns queued | ✅ | ✅ | — | ✅ |
+| cancel already cancelled is idempotent | ⏭️ | ✅ | — | ⏭️ |
+| cancel completed response raises bad request | ✅ | ✅ | — | ⏭️ |
 | incomplete details length | ✅ | ✅ | — | ✅ |
 | incomplete details length streaming | ✅ | ✅ | — | ✅ |
 | incomplete details max iterations exceeded | ✅ | ✅ | — | ✅ |

--- a/docs/static/llama-stack-spec.yaml
+++ b/docs/static/llama-stack-spec.yaml
@@ -2775,6 +2775,41 @@ paths:
       description: Get the version of the service.
       operationId: version_v1_version_get
       x-public: true
+  /v1/responses/{response_id}/cancel:
+    post:
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OpenAIResponseObject'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+          description: Bad Request
+        '429':
+          $ref: '#/components/responses/TooManyRequests429'
+          description: Too Many Requests
+        '500':
+          $ref: '#/components/responses/InternalServerError500'
+          description: Internal Server Error
+        default:
+          $ref: '#/components/responses/DefaultError'
+          description: Default Response
+      tags:
+      - Agents
+      summary: Cancel an in-progress response.
+      description: Cancel an in-progress response. The response status will be set to 'cancelled'.
+      operationId: cancel_openai_response_v1_responses__response_id__cancel_post
+      parameters:
+      - name: response_id
+        in: path
+        required: true
+        schema:
+          type: string
+          description: The ID of the response to cancel.
+          title: Response Id
+        description: The ID of the response to cancel.
 components:
   schemas:
     Error:

--- a/docs/static/stainless-llama-stack-spec.yaml
+++ b/docs/static/stainless-llama-stack-spec.yaml
@@ -3963,6 +3963,41 @@ paths:
       summary: Get service version
       description: Get the version of the service.
       operationId: version_v1alpha_admin_version_get
+  /v1/responses/{response_id}/cancel:
+    post:
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OpenAIResponseObject'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+          description: Bad Request
+        '429':
+          $ref: '#/components/responses/TooManyRequests429'
+          description: Too Many Requests
+        '500':
+          $ref: '#/components/responses/InternalServerError500'
+          description: Internal Server Error
+        default:
+          $ref: '#/components/responses/DefaultError'
+          description: Default Response
+      tags:
+      - Agents
+      summary: Cancel an in-progress response.
+      description: Cancel an in-progress response. The response status will be set to 'cancelled'.
+      operationId: cancel_openai_response_v1_responses__response_id__cancel_post
+      parameters:
+      - name: response_id
+        in: path
+        required: true
+        schema:
+          type: string
+          description: The ID of the response to cancel.
+          title: Response Id
+        description: The ID of the response to cancel.
   /v1alpha/file-processors/process:
     post:
       responses:

--- a/src/llama_stack/providers/inline/agents/builtin/agents.py
+++ b/src/llama_stack/providers/inline/agents/builtin/agents.py
@@ -12,6 +12,7 @@ from llama_stack.log import get_logger
 from llama_stack.providers.utils.responses.responses_store import ResponsesStore
 from llama_stack_api import (
     Agents,
+    CancelResponseRequest,
     Connectors,
     Conversations,
     CreateResponseRequest,
@@ -168,6 +169,13 @@ class BuiltinAgentsImpl(Agents):
             request.limit,
             request.order,
         )
+
+    async def cancel_openai_response(
+        self,
+        request: CancelResponseRequest,
+    ) -> OpenAIResponseObject:
+        assert self.openai_responses_impl is not None, "OpenAI responses not initialized"
+        return await self.openai_responses_impl.cancel_openai_response(request.response_id)
 
     async def delete_openai_response(
         self,

--- a/src/llama_stack/providers/inline/agents/builtin/responses/openai_responses.py
+++ b/src/llama_stack/providers/inline/agents/builtin/responses/openai_responses.py
@@ -1112,6 +1112,20 @@ class OpenAIResponsesImpl:
 
                 yield stream_chunk
 
+    async def cancel_openai_response(self, response_id: str) -> OpenAIResponseObject:
+        existing = await self.responses_store.get_response_object(response_id)
+
+        # Idempotent: already cancelled, just return
+        if existing.status == "cancelled":
+            return existing.to_response_object()
+
+        if existing.status not in ("queued", "in_progress"):
+            raise ValueError(f"Response {response_id} cannot be cancelled: current status is '{existing.status}'")
+
+        existing.status = "cancelled"
+        await self.responses_store.update_response_object(existing)
+        return existing.to_response_object()
+
     async def delete_openai_response(self, response_id: str) -> OpenAIDeleteResponseObject:
         return await self.responses_store.delete_response_object(response_id)
 

--- a/src/llama_stack_api/__init__.py
+++ b/src/llama_stack_api/__init__.py
@@ -53,6 +53,7 @@ from .admin import (
 # Import all public API symbols
 from .agents import (
     Agents,
+    CancelResponseRequest,
     CreateResponseRequest,
     DeleteResponseRequest,
     ListResponseInputItemsRequest,
@@ -587,6 +588,7 @@ __all__ = [
     "Agents",
     "AggregationFunctionType",
     # Agents Request Models
+    "CancelResponseRequest",
     "CreateResponseRequest",
     "DeleteResponseRequest",
     "ListResponseInputItemsRequest",

--- a/src/llama_stack_api/agents/__init__.py
+++ b/src/llama_stack_api/agents/__init__.py
@@ -14,6 +14,7 @@ The FastAPI router is defined in llama_stack_api.agents.fastapi_routes.
 from . import fastapi_routes
 from .api import Agents
 from .models import (
+    CancelResponseRequest,
     CreateResponseRequest,
     DeleteResponseRequest,
     ListResponseInputItemsRequest,
@@ -28,6 +29,7 @@ from .models import (
 
 __all__ = [
     "Agents",
+    "CancelResponseRequest",
     "CreateResponseRequest",
     "DeleteResponseRequest",
     "ListResponseInputItemsRequest",

--- a/src/llama_stack_api/agents/api.py
+++ b/src/llama_stack_api/agents/api.py
@@ -16,6 +16,7 @@ from llama_stack_api.openai_responses import (
 )
 
 from .models import (
+    CancelResponseRequest,
     CreateResponseRequest,
     DeleteResponseRequest,
     ListResponseInputItemsRequest,
@@ -45,6 +46,11 @@ class Agents(Protocol):
         self,
         request: ListResponseInputItemsRequest,
     ) -> ListOpenAIResponseInputItem: ...
+
+    async def cancel_openai_response(
+        self,
+        request: CancelResponseRequest,
+    ) -> OpenAIResponseObject: ...
 
     async def delete_openai_response(
         self,

--- a/src/llama_stack_api/agents/fastapi_routes.py
+++ b/src/llama_stack_api/agents/fastapi_routes.py
@@ -40,6 +40,7 @@ from llama_stack_api.version import LLAMA_STACK_API_V1
 
 from .api import Agents
 from .models import (
+    CancelResponseRequest,
     CreateResponseRequest,
     DeleteResponseRequest,
     ListResponseInputItemsRequest,
@@ -83,6 +84,7 @@ async def sse_generator(event_gen):
 
 # Automatically generate dependency functions from Pydantic models
 get_retrieve_response_request = create_path_dependency(RetrieveResponseRequest)
+get_cancel_response_request = create_path_dependency(CancelResponseRequest)
 get_delete_response_request = create_path_dependency(DeleteResponseRequest)
 get_list_responses_request = create_query_dependency(ListResponsesRequest)
 
@@ -199,6 +201,17 @@ def create_router(impl: Agents) -> APIRouter:
             )
 
         return result
+
+    @router.post(
+        "/responses/{response_id}/cancel",
+        response_model=OpenAIResponseObject,
+        summary="Cancel an in-progress response.",
+        description="Cancel an in-progress response. The response status will be set to 'cancelled'.",
+    )
+    async def cancel_openai_response(
+        request: Annotated[CancelResponseRequest, Depends(get_cancel_response_request)],
+    ) -> OpenAIResponseObject:
+        return await impl.cancel_openai_response(request)
 
     @router.get(
         "/responses",

--- a/src/llama_stack_api/agents/models.py
+++ b/src/llama_stack_api/agents/models.py
@@ -245,6 +245,14 @@ class ListResponseInputItemsRequest(BaseModel):
     order: Order | None = Field(default=Order.desc, description="The order to return the input items in.")
 
 
+class CancelResponseRequest(BaseModel):
+    """Request model for canceling a response that is in progress."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    response_id: str = Field(..., min_length=1, description="The ID of the response to cancel.")
+
+
 class DeleteResponseRequest(BaseModel):
     """Request model for deleting a response."""
 

--- a/tests/integration/responses/recordings/24276de974b4a4a1c371d096f2d4eb87ad54f79b044a63197f4acf158545187f.json
+++ b/tests/integration/responses/recordings/24276de974b4a4a1c371d096f2d4eb87ad54f79b044a63197f4acf158545187f.json
@@ -1,0 +1,384 @@
+{
+  "test_id": "tests/integration/responses/test_openai_responses.py::TestOpenAIResponses::test_cancel_completed_response_raises_bad_request[txt=azure/gpt-4o]",
+  "request": {
+    "method": "POST",
+    "url": "https://llama-stack-test.openai.azure.com/openai/v1/v1/chat/completions",
+    "headers": {},
+    "body": {
+      "model": "gpt-4o",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Say hello"
+        }
+      ],
+      "stream": true,
+      "stream_options": {
+        "include_usage": true
+      }
+    },
+    "endpoint": "/v1/chat/completions",
+    "model": "gpt-4o",
+    "provider_metadata": {
+      "openai_sdk_version": "2.5.0"
+    }
+  },
+  "response": {
+    "body": [
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-24276de974b4",
+          "choices": [
+            {
+              "delta": {
+                "content": "",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_af7f7349a4",
+          "usage": null,
+          "obfuscation": "goSsj4DFCUCue2"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-24276de974b4",
+          "choices": [
+            {
+              "delta": {
+                "content": "Hello",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_af7f7349a4",
+          "usage": null,
+          "obfuscation": "Yk0zA95runz"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-24276de974b4",
+          "choices": [
+            {
+              "delta": {
+                "content": "!",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_af7f7349a4",
+          "usage": null,
+          "obfuscation": "Nok2qI22S6CAm89"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-24276de974b4",
+          "choices": [
+            {
+              "delta": {
+                "content": " \ud83d\ude0a",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_af7f7349a4",
+          "usage": null,
+          "obfuscation": "Q68Us9Fe1wPrPM"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-24276de974b4",
+          "choices": [
+            {
+              "delta": {
+                "content": " How",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_af7f7349a4",
+          "usage": null,
+          "obfuscation": "cBc1asPd81ws"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-24276de974b4",
+          "choices": [
+            {
+              "delta": {
+                "content": " can",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_af7f7349a4",
+          "usage": null,
+          "obfuscation": "srwrjVrDPC7I"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-24276de974b4",
+          "choices": [
+            {
+              "delta": {
+                "content": " I",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_af7f7349a4",
+          "usage": null,
+          "obfuscation": "BFmaKuye568Qr1"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-24276de974b4",
+          "choices": [
+            {
+              "delta": {
+                "content": " assist",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_af7f7349a4",
+          "usage": null,
+          "obfuscation": "UBJLpGHoM"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-24276de974b4",
+          "choices": [
+            {
+              "delta": {
+                "content": " you",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_af7f7349a4",
+          "usage": null,
+          "obfuscation": "NlLYgFh3fGQB"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-24276de974b4",
+          "choices": [
+            {
+              "delta": {
+                "content": " today",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_af7f7349a4",
+          "usage": null,
+          "obfuscation": "Tl2E7YAol9"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-24276de974b4",
+          "choices": [
+            {
+              "delta": {
+                "content": "?",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_af7f7349a4",
+          "usage": null,
+          "obfuscation": "xzlrvJOxAdQJLIu"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-24276de974b4",
+          "choices": [
+            {
+              "delta": {
+                "content": null,
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": "stop",
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_af7f7349a4",
+          "usage": null,
+          "obfuscation": "hoUNaDJMYd"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-24276de974b4",
+          "choices": [],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_af7f7349a4",
+          "usage": {
+            "completion_tokens": 11,
+            "prompt_tokens": 9,
+            "total_tokens": 20,
+            "completion_tokens_details": {
+              "accepted_prediction_tokens": 0,
+              "audio_tokens": 0,
+              "reasoning_tokens": 0,
+              "rejected_prediction_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "audio_tokens": 0,
+              "cached_tokens": 0
+            }
+          },
+          "obfuscation": ""
+        }
+      }
+    ],
+    "is_streaming": true
+  },
+  "id_normalization_mapping": {}
+}

--- a/tests/integration/responses/recordings/2d74863b46554dee175b4ea2bc8f4bf11448d60a6dc4c86366b0657c91e61a94.json
+++ b/tests/integration/responses/recordings/2d74863b46554dee175b4ea2bc8f4bf11448d60a6dc4c86366b0657c91e61a94.json
@@ -1,0 +1,357 @@
+{
+  "test_id": "tests/integration/responses/test_openai_responses.py::TestOpenAIResponses::test_cancel_completed_response_raises_bad_request[txt=openai/gpt-4o]",
+  "request": {
+    "method": "POST",
+    "url": "https://api.openai.com/v1/v1/chat/completions",
+    "headers": {},
+    "body": {
+      "model": "gpt-4o",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Say hello"
+        }
+      ],
+      "stream": true,
+      "stream_options": {
+        "include_usage": true
+      }
+    },
+    "endpoint": "/v1/chat/completions",
+    "model": "gpt-4o",
+    "provider_metadata": {
+      "openai_sdk_version": "2.5.0"
+    }
+  },
+  "response": {
+    "body": [
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-2d74863b4655",
+          "choices": [
+            {
+              "delta": {
+                "content": "",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_08dbb3f46a",
+          "usage": null,
+          "obfuscation": "s0tOKKHnWJZTkC"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-2d74863b4655",
+          "choices": [
+            {
+              "delta": {
+                "content": "Hello",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_08dbb3f46a",
+          "usage": null,
+          "obfuscation": "8HDsizFGYup"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-2d74863b4655",
+          "choices": [
+            {
+              "delta": {
+                "content": "!",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_08dbb3f46a",
+          "usage": null,
+          "obfuscation": "vFLnLCsqHHuuet6"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-2d74863b4655",
+          "choices": [
+            {
+              "delta": {
+                "content": " How",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_08dbb3f46a",
+          "usage": null,
+          "obfuscation": "cgqbEpxomS95"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-2d74863b4655",
+          "choices": [
+            {
+              "delta": {
+                "content": " can",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_08dbb3f46a",
+          "usage": null,
+          "obfuscation": "NCl0v0eqoten"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-2d74863b4655",
+          "choices": [
+            {
+              "delta": {
+                "content": " I",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_08dbb3f46a",
+          "usage": null,
+          "obfuscation": "Rn7UuTyfoiGXVa"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-2d74863b4655",
+          "choices": [
+            {
+              "delta": {
+                "content": " assist",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_08dbb3f46a",
+          "usage": null,
+          "obfuscation": "mc41nOj5p"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-2d74863b4655",
+          "choices": [
+            {
+              "delta": {
+                "content": " you",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_08dbb3f46a",
+          "usage": null,
+          "obfuscation": "4wjExWkUeRx0"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-2d74863b4655",
+          "choices": [
+            {
+              "delta": {
+                "content": " today",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_08dbb3f46a",
+          "usage": null,
+          "obfuscation": "8mMx5RF5Ax"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-2d74863b4655",
+          "choices": [
+            {
+              "delta": {
+                "content": "?",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_08dbb3f46a",
+          "usage": null,
+          "obfuscation": "z3SuKCinsiQk3wC"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-2d74863b4655",
+          "choices": [
+            {
+              "delta": {
+                "content": null,
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": "stop",
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_08dbb3f46a",
+          "usage": null,
+          "obfuscation": "31L05SNqah"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-2d74863b4655",
+          "choices": [],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_08dbb3f46a",
+          "usage": {
+            "completion_tokens": 9,
+            "prompt_tokens": 9,
+            "total_tokens": 18,
+            "completion_tokens_details": {
+              "accepted_prediction_tokens": 0,
+              "audio_tokens": 0,
+              "reasoning_tokens": 0,
+              "rejected_prediction_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "audio_tokens": 0,
+              "cached_tokens": 0
+            }
+          },
+          "obfuscation": "E"
+        }
+      }
+    ],
+    "is_streaming": true
+  },
+  "id_normalization_mapping": {}
+}

--- a/tests/integration/responses/recordings/48ce449d6488dffd735341fba2e0d6828fa8703b1bbc0861a0df0055b31cb975.json
+++ b/tests/integration/responses/recordings/48ce449d6488dffd735341fba2e0d6828fa8703b1bbc0861a0df0055b31cb975.json
@@ -1,0 +1,357 @@
+{
+  "test_id": "tests/integration/responses/test_openai_responses.py::TestOpenAIResponses::test_cancel_already_cancelled_is_idempotent[txt=openai/gpt-4o]",
+  "request": {
+    "method": "POST",
+    "url": "https://api.openai.com/v1/v1/chat/completions",
+    "headers": {},
+    "body": {
+      "model": "gpt-4o",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Say hello"
+        }
+      ],
+      "stream": true,
+      "stream_options": {
+        "include_usage": true
+      }
+    },
+    "endpoint": "/v1/chat/completions",
+    "model": "gpt-4o",
+    "provider_metadata": {
+      "openai_sdk_version": "2.5.0"
+    }
+  },
+  "response": {
+    "body": [
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-48ce449d6488",
+          "choices": [
+            {
+              "delta": {
+                "content": "",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_6dc3064ee0",
+          "usage": null,
+          "obfuscation": "xc1BVerA7WCfRe"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-48ce449d6488",
+          "choices": [
+            {
+              "delta": {
+                "content": "Hello",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_6dc3064ee0",
+          "usage": null,
+          "obfuscation": "nQcbdPFSawF"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-48ce449d6488",
+          "choices": [
+            {
+              "delta": {
+                "content": "!",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_6dc3064ee0",
+          "usage": null,
+          "obfuscation": "uqY2HvOGmXSxlWs"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-48ce449d6488",
+          "choices": [
+            {
+              "delta": {
+                "content": " How",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_6dc3064ee0",
+          "usage": null,
+          "obfuscation": "offmi5UrIhWx"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-48ce449d6488",
+          "choices": [
+            {
+              "delta": {
+                "content": " can",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_6dc3064ee0",
+          "usage": null,
+          "obfuscation": "uIEXizYhKsTG"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-48ce449d6488",
+          "choices": [
+            {
+              "delta": {
+                "content": " I",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_6dc3064ee0",
+          "usage": null,
+          "obfuscation": "C1GXYtRHwFRc2Q"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-48ce449d6488",
+          "choices": [
+            {
+              "delta": {
+                "content": " assist",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_6dc3064ee0",
+          "usage": null,
+          "obfuscation": "6JF1hySc3"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-48ce449d6488",
+          "choices": [
+            {
+              "delta": {
+                "content": " you",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_6dc3064ee0",
+          "usage": null,
+          "obfuscation": "s55KxwDTwHAZ"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-48ce449d6488",
+          "choices": [
+            {
+              "delta": {
+                "content": " today",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_6dc3064ee0",
+          "usage": null,
+          "obfuscation": "Z59WSoicU0"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-48ce449d6488",
+          "choices": [
+            {
+              "delta": {
+                "content": "?",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_6dc3064ee0",
+          "usage": null,
+          "obfuscation": "2vvGagOlUNr4g7g"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-48ce449d6488",
+          "choices": [
+            {
+              "delta": {
+                "content": null,
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": "stop",
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_6dc3064ee0",
+          "usage": null,
+          "obfuscation": "uEGpEN6cKf"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-48ce449d6488",
+          "choices": [],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_6dc3064ee0",
+          "usage": {
+            "completion_tokens": 9,
+            "prompt_tokens": 9,
+            "total_tokens": 18,
+            "completion_tokens_details": {
+              "accepted_prediction_tokens": 0,
+              "audio_tokens": 0,
+              "reasoning_tokens": 0,
+              "rejected_prediction_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "audio_tokens": 0,
+              "cached_tokens": 0
+            }
+          },
+          "obfuscation": "G"
+        }
+      }
+    ],
+    "is_streaming": true
+  },
+  "id_normalization_mapping": {}
+}

--- a/tests/integration/responses/recordings/d31ea3ef91ecbda5d7f14a351b57386b7fb730654a30a689088193d2f9781aa0.json
+++ b/tests/integration/responses/recordings/d31ea3ef91ecbda5d7f14a351b57386b7fb730654a30a689088193d2f9781aa0.json
@@ -1,0 +1,330 @@
+{
+  "test_id": "tests/integration/responses/test_openai_responses.py::TestOpenAIResponses::test_cancel_already_cancelled_is_idempotent[txt=openai/gpt-4o]",
+  "request": {
+    "method": "POST",
+    "url": "https://api.openai.com/v1/v1/chat/completions",
+    "headers": {},
+    "body": {
+      "model": "gpt-4o",
+      "messages": [
+        {
+          "role": "user",
+          "content": "What is 2+2?"
+        }
+      ],
+      "stream": true,
+      "stream_options": {
+        "include_usage": true
+      }
+    },
+    "endpoint": "/v1/chat/completions",
+    "model": "gpt-4o",
+    "provider_metadata": {
+      "openai_sdk_version": "2.5.0"
+    }
+  },
+  "response": {
+    "body": [
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-d31ea3ef91ec",
+          "choices": [
+            {
+              "delta": {
+                "content": "",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_6dc3064ee0",
+          "usage": null,
+          "obfuscation": "muiuiGGVOdjL5H"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-d31ea3ef91ec",
+          "choices": [
+            {
+              "delta": {
+                "content": "2",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_6dc3064ee0",
+          "usage": null,
+          "obfuscation": "MLhTWf0avpvq18J"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-d31ea3ef91ec",
+          "choices": [
+            {
+              "delta": {
+                "content": " +",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_6dc3064ee0",
+          "usage": null,
+          "obfuscation": "FCE2IjtLTW68g6"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-d31ea3ef91ec",
+          "choices": [
+            {
+              "delta": {
+                "content": " ",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_6dc3064ee0",
+          "usage": null,
+          "obfuscation": "urugv2gErYO9Biu"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-d31ea3ef91ec",
+          "choices": [
+            {
+              "delta": {
+                "content": "2",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_6dc3064ee0",
+          "usage": null,
+          "obfuscation": "trDCEFprK2kanLN"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-d31ea3ef91ec",
+          "choices": [
+            {
+              "delta": {
+                "content": " equals",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_6dc3064ee0",
+          "usage": null,
+          "obfuscation": "5G59YsKvq"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-d31ea3ef91ec",
+          "choices": [
+            {
+              "delta": {
+                "content": " ",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_6dc3064ee0",
+          "usage": null,
+          "obfuscation": "UKDW0stJIjj1BEf"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-d31ea3ef91ec",
+          "choices": [
+            {
+              "delta": {
+                "content": "4",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_6dc3064ee0",
+          "usage": null,
+          "obfuscation": "iCrcKu49yzwlhOO"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-d31ea3ef91ec",
+          "choices": [
+            {
+              "delta": {
+                "content": ".",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_6dc3064ee0",
+          "usage": null,
+          "obfuscation": "Q193KZC7HDyx4MM"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-d31ea3ef91ec",
+          "choices": [
+            {
+              "delta": {
+                "content": null,
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": "stop",
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_6dc3064ee0",
+          "usage": null,
+          "obfuscation": "cVhyQm4ZL0"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-d31ea3ef91ec",
+          "choices": [],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": "fp_6dc3064ee0",
+          "usage": {
+            "completion_tokens": 8,
+            "prompt_tokens": 14,
+            "total_tokens": 22,
+            "completion_tokens_details": {
+              "accepted_prediction_tokens": 0,
+              "audio_tokens": 0,
+              "reasoning_tokens": 0,
+              "rejected_prediction_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "audio_tokens": 0,
+              "cached_tokens": 0
+            }
+          },
+          "obfuscation": ""
+        }
+      }
+    ],
+    "is_streaming": true
+  },
+  "id_normalization_mapping": {}
+}

--- a/tests/integration/responses/test_openai_responses.py
+++ b/tests/integration/responses/test_openai_responses.py
@@ -7,6 +7,7 @@
 import time
 
 import pytest
+from openai import BadRequestError, NotFoundError
 
 from .streaming_assertions import StreamingValidator
 
@@ -579,6 +580,66 @@ class TestOpenAIResponses:
 
         assert response2.id.startswith("resp_")
         assert response2.parallel_tool_calls is False
+
+    def test_cancel_completed_response_raises_bad_request(self, openai_client, text_model_id):
+        """Test that cancelling a completed response returns 400 BadRequestError."""
+        response = openai_client.responses.create(
+            model=text_model_id,
+            input="Say hello",
+            stream=False,
+        )
+        assert response.status == "completed"
+
+        with pytest.raises(BadRequestError) as exc_info:
+            openai_client.responses.cancel(response.id)
+
+        assert exc_info.value.status_code == 400
+        assert "cannot be cancelled" in str(exc_info.value).lower()
+
+    def test_cancel_nonexistent_response_raises_not_found(self, openai_client):
+        """Test that cancelling a nonexistent response returns 404 NotFoundError."""
+        with pytest.raises(NotFoundError):
+            openai_client.responses.cancel("resp_nonexistent_cancel_test")
+
+    def test_cancel_already_cancelled_is_idempotent(self, openai_client, text_model_id):
+        """Test that cancelling an already-cancelled background response is idempotent."""
+        # Create a background response (starts as queued)
+        response = openai_client.responses.create(
+            model=text_model_id,
+            input="Say hello",
+            background=True,
+        )
+        assert response.status == "queued"
+
+        # Cancel it
+        cancelled = openai_client.responses.cancel(response.id)
+        assert cancelled.status == "cancelled"
+
+        # Cancel again — should succeed without error (idempotent)
+        cancelled_again = openai_client.responses.cancel(response.id)
+        assert cancelled_again.status == "cancelled"
+        assert cancelled_again.id == response.id
+
+    def test_cancel_background_response(self, openai_client, text_model_id):
+        """Test cancelling a background response.
+
+        Note: There is a race between the cancel request and the background
+        worker picking up the response. The cancel API itself should succeed,
+        but the worker may have already moved the response to in_progress or
+        completed before the cancel takes effect. We verify the cancel call
+        succeeds and returns cancelled status.
+        """
+        response = openai_client.responses.create(
+            model=text_model_id,
+            input="Write a very long essay about the history of computing.",
+            background=True,
+        )
+        assert response.status == "queued"
+
+        # Cancel it — the cancel call itself should return cancelled status
+        cancelled = openai_client.responses.cancel(response.id)
+        assert cancelled.status == "cancelled"
+        assert cancelled.id == response.id
 
     def test_openai_response_background_returns_queued(self, openai_client, text_model_id):
         """Test that background=True returns immediately with queued status."""

--- a/tests/unit/core/routers/test_agents_router.py
+++ b/tests/unit/core/routers/test_agents_router.py
@@ -13,6 +13,7 @@ from llama_stack.core.server.fastapi_router_registry import build_fastapi_router
 from llama_stack.core.server.server import global_exception_handler
 from llama_stack_api import Agents, Api
 from llama_stack_api.agents.models import (
+    CancelResponseRequest,
     CreateResponseRequest,
     DeleteResponseRequest,
     ListResponseInputItemsRequest,
@@ -397,6 +398,55 @@ def test_delete_response_maps_value_error_to_400():
 
     assert resp.status_code == 400
     assert "not found" in resp.json()["detail"].lower()
+
+
+async def test_cancel_response_returns_cancelled_object():
+    """Test POST /v1/responses/{response_id}/cancel returns cancelled response."""
+    app = FastAPI()
+    impl = AsyncMock(spec=Agents)
+
+    expected_response = OpenAIResponseObject(
+        id="resp_123",
+        created_at=1234567890,
+        model="test-model",
+        status="cancelled",
+        output=[],
+        store=True,
+    )
+    impl.cancel_openai_response.return_value = expected_response
+
+    router = build_fastapi_router(Api.agents, impl)
+    assert router is not None
+    app.include_router(router)
+
+    cancel_endpoint = next(
+        r.endpoint for r in router.routes if getattr(r, "path", None) == "/v1/responses/{response_id}/cancel"
+    )
+
+    request = CancelResponseRequest(response_id="resp_123")
+    response = await cancel_endpoint(request)
+
+    assert response.id == "resp_123"
+    assert response.status == "cancelled"
+    impl.cancel_openai_response.assert_awaited_once()
+
+
+def test_cancel_response_maps_invalid_parameter_error_to_400():
+    """Cancel on a completed response returns HTTP 400."""
+    app = FastAPI()
+    app.add_exception_handler(Exception, global_exception_handler)
+    impl = AsyncMock(spec=Agents)
+    impl.cancel_openai_response.side_effect = ValueError("cannot be cancelled")
+
+    router = build_fastapi_router(Api.agents, impl)
+    assert router is not None
+    app.include_router(router)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.post("/v1/responses/resp_completed/cancel")
+
+    assert resp.status_code == 400
+    assert "cannot be cancelled" in resp.json()["detail"].lower()
 
 
 def test_request_validation_error_passes_through_route_class():

--- a/tests/unit/providers/agents/builtin/test_cancel_response.py
+++ b/tests/unit/providers/agents/builtin/test_cancel_response.py
@@ -1,0 +1,131 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Unit tests for cancel_openai_response in Responses API."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from llama_stack.providers.inline.agents.builtin.responses.openai_responses import (
+    OpenAIResponsesImpl,
+)
+from llama_stack.providers.utils.responses.responses_store import (
+    ResponsesStore,
+    _OpenAIResponseObjectWithInputAndMessages,
+)
+from llama_stack_api import InvalidParameterError  # noqa: F401
+from llama_stack_api.openai_responses import OpenAIResponseObject
+
+
+@pytest.fixture
+def mock_responses_store():
+    return AsyncMock(spec=ResponsesStore)
+
+
+@pytest.fixture
+def openai_responses_impl(mock_responses_store):
+    return OpenAIResponsesImpl(
+        inference_api=AsyncMock(),
+        tool_groups_api=AsyncMock(),
+        tool_runtime_api=AsyncMock(),
+        responses_store=mock_responses_store,
+        vector_io_api=AsyncMock(),
+        safety_api=AsyncMock(),
+        conversations_api=AsyncMock(),
+        prompts_api=AsyncMock(),
+        files_api=AsyncMock(),
+        connectors_api=AsyncMock(),
+    )
+
+
+def _make_stored_response(response_id: str, status: str, **kwargs) -> _OpenAIResponseObjectWithInputAndMessages:
+    return _OpenAIResponseObjectWithInputAndMessages(
+        id=response_id,
+        created_at=1234567890,
+        model="test-model",
+        status=status,
+        output=[],
+        input=[],
+        store=True,
+        **kwargs,
+    )
+
+
+class TestCancelOpenAIResponse:
+    """Tests for OpenAIResponsesImpl.cancel_openai_response."""
+
+    async def test_cancel_queued_response(self, openai_responses_impl, mock_responses_store):
+        """Cancelling a queued response sets status to cancelled."""
+        stored = _make_stored_response("resp_1", "queued", background=True)
+        mock_responses_store.get_response_object.return_value = stored
+
+        result = await openai_responses_impl.cancel_openai_response("resp_1")
+
+        assert isinstance(result, OpenAIResponseObject)
+        assert result.status == "cancelled"
+        assert result.id == "resp_1"
+        mock_responses_store.update_response_object.assert_awaited_once()
+
+    async def test_cancel_in_progress_response(self, openai_responses_impl, mock_responses_store):
+        """Cancelling an in_progress response sets status to cancelled."""
+        stored = _make_stored_response("resp_2", "in_progress")
+        mock_responses_store.get_response_object.return_value = stored
+
+        result = await openai_responses_impl.cancel_openai_response("resp_2")
+
+        assert result.status == "cancelled"
+        assert result.id == "resp_2"
+        mock_responses_store.update_response_object.assert_awaited_once()
+
+    async def test_cancel_already_cancelled_is_idempotent(self, openai_responses_impl, mock_responses_store):
+        """Cancelling an already-cancelled response returns it without error."""
+        stored = _make_stored_response("resp_3", "cancelled")
+        mock_responses_store.get_response_object.return_value = stored
+
+        result = await openai_responses_impl.cancel_openai_response("resp_3")
+
+        assert result.status == "cancelled"
+        assert result.id == "resp_3"
+        # Should NOT call update since status is already cancelled
+        mock_responses_store.update_response_object.assert_not_awaited()
+
+    async def test_cancel_completed_response_raises(self, openai_responses_impl, mock_responses_store):
+        """Cancelling a completed response raises InvalidParameterError."""
+        stored = _make_stored_response("resp_4", "completed")
+        mock_responses_store.get_response_object.return_value = stored
+
+        with pytest.raises(ValueError, match="cannot be cancelled"):
+            await openai_responses_impl.cancel_openai_response("resp_4")
+
+        mock_responses_store.update_response_object.assert_not_awaited()
+
+    async def test_cancel_failed_response_raises(self, openai_responses_impl, mock_responses_store):
+        """Cancelling a failed response raises InvalidParameterError."""
+        stored = _make_stored_response("resp_5", "failed")
+        mock_responses_store.get_response_object.return_value = stored
+
+        with pytest.raises(ValueError, match="cannot be cancelled"):
+            await openai_responses_impl.cancel_openai_response("resp_5")
+
+    async def test_cancel_incomplete_response_raises(self, openai_responses_impl, mock_responses_store):
+        """Cancelling an incomplete response raises InvalidParameterError."""
+        stored = _make_stored_response("resp_6", "incomplete")
+        mock_responses_store.get_response_object.return_value = stored
+
+        with pytest.raises(ValueError, match="cannot be cancelled"):
+            await openai_responses_impl.cancel_openai_response("resp_6")
+
+    @pytest.mark.parametrize("terminal_status", ["completed", "failed", "incomplete"])
+    async def test_cancel_terminal_status_includes_current_status_in_error(
+        self, openai_responses_impl, mock_responses_store, terminal_status
+    ):
+        """Error message includes the current status for clarity."""
+        stored = _make_stored_response("resp_7", terminal_status)
+        mock_responses_store.get_response_object.return_value = stored
+
+        with pytest.raises(ValueError, match=terminal_status):
+            await openai_responses_impl.cancel_openai_response("resp_7")


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->

Add `POST /v1/responses/{response_id}/cancel` endpoint to allow clients to cancel background responses that are in `queued` or `in_progress` status. The internal cancellation mechanism already existed (background workers poll response status and exit early on `cancelled`), but there was no HTTP endpoint to trigger it, this PR closes that gap.

@leseb @cdoern 

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->

<!-- For API changes, include:
1. A testing script (Python, curl, etc.) that exercises the new/modified endpoints
2. The output from running your script

Example:
```python
...
...
```

Output:
```
<paste actual output here>
```
-->
