### PR TITLE
chore: remove duplicate WatsonX inference provider in ci-tests config

### DIFF
--- a/src/llama_stack/distributions/ci-tests/ci_tests.py
+++ b/src/llama_stack/distributions/ci-tests/ci_tests.py
@@ -10,7 +10,6 @@ from llama_stack.distributions.template import DistributionTemplate
 from llama_stack.providers.inline.inference.sentence_transformers.config import (
     SentenceTransformersInferenceConfig,
 )
-from llama_stack.providers.remote.inference.watsonx.config import WatsonXConfig
 from llama_stack_api import ConnectorInput, ModelInput, ModelType
 
 from ..starter.starter import get_distribution_template as get_starter_distribution_template
@@ -64,12 +63,6 @@ def get_distribution_template() -> DistributionTemplate:
         }
     }
 
-    watsonx_provider = Provider(
-        provider_id="${env.WATSONX_API_KEY:+watsonx}",
-        provider_type="remote::watsonx",
-        config=WatsonXConfig.sample_run_config(),
-    )
-
     # Override sentence-transformers to use trust_remote_code=True for CI tests
     sentence_transformers_provider = Provider(
         provider_id="sentence-transformers",
@@ -86,9 +79,6 @@ def get_distribution_template() -> DistributionTemplate:
             run_config.default_models = []
         run_config.default_models.append(azure_model)
         run_config.default_models.append(watsonx_model)
-
-        # Add WatsonX inference provider
-        run_config.provider_overrides["inference"].append(watsonx_provider)
 
         # Replace sentence-transformers provider with one that has trust_remote_code=True
         inference_providers = run_config.provider_overrides["inference"]

--- a/src/llama_stack/distributions/ci-tests/config.yaml
+++ b/src/llama_stack/distributions/ci-tests/config.yaml
@@ -97,12 +97,6 @@ providers:
       trust_remote_code: true
   - provider_id: transformers
     provider_type: inline::transformers
-  - provider_id: ${env.WATSONX_API_KEY:+watsonx}
-    provider_type: remote::watsonx
-    config:
-      base_url: ${env.WATSONX_BASE_URL:=https://us-south.ml.cloud.ibm.com}
-      api_key: ${env.WATSONX_API_KEY:=}
-      project_id: ${env.WATSONX_PROJECT_ID:=}
   vector_io:
   - provider_id: faiss
     provider_type: inline::faiss

--- a/src/llama_stack/distributions/ci-tests/run-with-postgres-store.yaml
+++ b/src/llama_stack/distributions/ci-tests/run-with-postgres-store.yaml
@@ -97,12 +97,6 @@ providers:
       trust_remote_code: true
   - provider_id: transformers
     provider_type: inline::transformers
-  - provider_id: ${env.WATSONX_API_KEY:+watsonx}
-    provider_type: remote::watsonx
-    config:
-      base_url: ${env.WATSONX_BASE_URL:=https://us-south.ml.cloud.ibm.com}
-      api_key: ${env.WATSONX_API_KEY:=}
-      project_id: ${env.WATSONX_PROJECT_ID:=}
   vector_io:
   - provider_id: faiss
     provider_type: inline::faiss


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->

@cdoern ^^

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->

<!-- For API changes, include:
1. A testing script (Python, curl, etc.) that exercises the new/modified endpoints
2. The output from running your script

Example:
```python
...
...
```

Output:
```
<paste actual output here>
```
-->
