### PR TITLE
fix: tolerate null response content joins

### DIFF
--- a/src/llama_stack/providers/inline/agents/builtin/responses/types.py
+++ b/src/llama_stack/providers/inline/agents/builtin/responses/types.py
@@ -58,7 +58,7 @@ class ChatCompletionResult:
     """Result of processing streaming chat completion chunks."""
 
     response_id: str
-    content: list[str]
+    content: list[str | None]
     tool_calls: dict[int, OpenAIChatCompletionToolCall]
     created: int
     model: str
@@ -72,7 +72,7 @@ class ChatCompletionResult:
     @property
     def content_text(self) -> str:
         """Get joined content as string."""
-        return "".join(self.content)
+        return "".join(content for content in self.content if content is not None)
 
     @property
     def has_tool_calls(self) -> bool:

--- a/src/llama_stack/providers/utils/inference/prompt_adapter.py
+++ b/src/llama_stack/providers/utils/inference/prompt_adapter.py
@@ -33,7 +33,7 @@ def interleaved_content_as_str(
         if isinstance(c, str):
             return c
         elif isinstance(c, TextContentItem) or isinstance(c, OpenAIChatCompletionContentPartTextParam):
-            return c.text
+            return c.text or ""
         elif isinstance(c, ImageContentItem) or isinstance(c, OpenAIChatCompletionContentPartImageParam):
             return "<image>"
         elif isinstance(c, OpenAIFile):

--- a/tests/unit/providers/inline/agents/builtin/responses/test_types.py
+++ b/tests/unit/providers/inline/agents/builtin/responses/test_types.py
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Regression tests for None-safe response content joins."""
+
+from llama_stack.providers.inline.agents.builtin.responses.types import ChatCompletionResult
+
+
+def _build_result(content: list[str | None]) -> ChatCompletionResult:
+    return ChatCompletionResult(
+        response_id="resp_123",
+        content=content,
+        tool_calls={},
+        created=0,
+        model="test-model",
+        finish_reason="stop",
+        message_item_id="msg_123",
+        tool_call_item_ids={},
+        content_part_emitted=False,
+    )
+
+
+def test_content_text_skips_none_entries():
+    assert _build_result([None, "tool result"]).content_text == "tool result"
+
+
+def test_content_text_returns_empty_string_for_none_only_content():
+    assert _build_result([None]).content_text == ""

--- a/tests/unit/providers/utils/inference/test_prompt_adapter_none_safety.py
+++ b/tests/unit/providers/utils/inference/test_prompt_adapter_none_safety.py
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Regression tests for None-safe prompt content joins."""
+
+from llama_stack.providers.utils.inference.prompt_adapter import interleaved_content_as_str
+from llama_stack_api.common.content_types import TextContentItem
+
+
+class TestInterleavedContentAsStrNoneSafety:
+    def test_none_content_returns_empty_string(self):
+        assert interleaved_content_as_str(None) == ""
+
+    def test_text_content_item_with_none_text_returns_empty_string(self):
+        item = TextContentItem.model_construct(text=None)
+
+        assert interleaved_content_as_str([item]) == ""
+
+    def test_text_content_item_with_valid_text_is_preserved(self):
+        item = TextContentItem(text="hello world")
+
+        assert interleaved_content_as_str([item]) == "hello world"


### PR DESCRIPTION
## Summary
- tolerate `TextContentItem(text=None)` when flattening interleaved content
- tolerate `None` entries when joining `ChatCompletionResult.content_text`
- add focused regressions for both null-content join paths

## Why
Current `main` still reproduces the null-content crash from #4996:

1. `interleaved_content_as_str([TextContentItem.model_construct(text=None)])`
2. `ChatCompletionResult(..., content=[None, "tool result"], ...).content_text`

Both currently raise:

```py
TypeError: sequence item 0: expected str instance, NoneType found
```

The earlier closed attempt in #5029 fixed the same underlying issue, but it targeted the older `meta_reference` responses layout. After the current `builtin/responses` refactor, the same bug is still present on `main` under the new path.

## Validation
- `.venv/bin/ruff check src/llama_stack/providers/utils/inference/prompt_adapter.py src/llama_stack/providers/inline/agents/builtin/responses/types.py tests/unit/providers/utils/inference/test_prompt_adapter_none_safety.py tests/unit/providers/inline/agents/builtin/responses/test_types.py`
- `.venv/bin/python -m pytest tests/unit/providers/utils/inference/test_prompt_adapter_none_safety.py tests/unit/providers/inline/agents/builtin/responses/test_types.py tests/unit/providers/inline/agents/builtin/responses/test_streaming.py -q`
- exact source-tree proof on clean `origin/main` vs this branch showing `main` still raises `TypeError` in both paths while this branch returns `""` / `"tool result"`

Closes #4996
Supersedes #5029
