### PR TITLE
fix: bump nltk to 3.9.4 (CVE-2026-33236)

### DIFF
--- a/src/llama_stack/providers/registry/eval.py
+++ b/src/llama_stack/providers/registry/eval.py
@@ -13,7 +13,7 @@ def available_providers() -> list[ProviderSpec]:
         InlineProviderSpec(
             api=Api.eval,
             provider_type="inline::builtin",
-            pip_packages=["tree_sitter", "pythainlp", "langdetect", "emoji", "nltk>=3.9.3"],
+            pip_packages=["tree_sitter", "pythainlp", "langdetect", "emoji", "nltk>=3.9.4"],
             module="llama_stack.providers.inline.eval.builtin",
             config_class="llama_stack.providers.inline.eval.builtin.BuiltinEvalConfig",
             api_dependencies=[

--- a/src/llama_stack/providers/registry/tool_runtime.py
+++ b/src/llama_stack/providers/registry/tool_runtime.py
@@ -25,7 +25,7 @@ def available_providers() -> list[ProviderSpec]:
                 "numpy",
                 "scikit-learn",
                 "scipy",
-                "nltk>=3.9.3",
+                "nltk>=3.9.4",
                 "sentencepiece",
                 "transformers",
             ],


### PR DESCRIPTION
Addresses https://github.com/advisories/GHSA-469j-vmhf-r6v7