### PR TITLE
chore: add type hints to FastAPI SSE generator functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -331,7 +331,6 @@ exclude = [
     "^src/llama_stack_api/inference/fastapi_routes\\.py$",
     "^src/llama_stack_api/models/models\\.py$",
     "^src/llama_stack_api/prompts/models\\.py$",
-    "^src/llama_stack_api/responses/fastapi_routes\\.py$",
     "^src/llama_stack_api/router_utils\\.py$",
     # Core files (28 files)
     "^src/llama_stack/core/access_control/conditions\\.py$",

--- a/src/llama_stack_api/responses/fastapi_routes.py
+++ b/src/llama_stack_api/responses/fastapi_routes.py
@@ -118,7 +118,7 @@ def create_sse_event(data: Any) -> str:
     return f"data: {data}\n\n"
 
 
-async def sse_generator(event_gen):
+async def sse_generator(event_gen: AsyncIterator[Any]) -> AsyncIterator[str]:
     """Convert an async generator to SSE format.
 
     This function iterates over an async generator and formats each yielded
@@ -179,16 +179,16 @@ async def get_list_response_input_items_request(
     )
 
 
-def _preserve_context_for_sse(event_gen):
+def _preserve_context_for_sse(event_gen: AsyncIterator[str]) -> AsyncIterator[str]:
     # StreamingResponse runs in a different task, losing request contextvars.
     # create_task inside context.run captures the context at task creation.
     context = contextvars.copy_context()
 
-    async def wrapper():
+    async def wrapper() -> AsyncIterator[str]:
         try:
             while True:
                 try:
-                    task = context.run(asyncio.create_task, event_gen.__anext__())
+                    task: asyncio.Task[str] = context.run(asyncio.create_task, event_gen.__anext__())  # type: ignore[arg-type]
                     item = await task
                 except StopAsyncIteration:
                     break
@@ -284,7 +284,10 @@ def create_router(impl: Responses) -> APIRouter:
         description="List input items.",
     )
     async def list_openai_response_input_items(
-        request: Annotated[ListResponseInputItemsRequest, Depends(get_list_response_input_items_request)],
+        request: Annotated[
+            ListResponseInputItemsRequest,
+            Depends(get_list_response_input_items_request),
+        ],
     ) -> ListOpenAIResponseInputItem:
         return await impl.list_openai_response_input_items(request)
 


### PR DESCRIPTION
# What does this PR do?

  This change adds complete type annotations to sse_generator and
  _preserve_context_for_sse functions in agents/fastapi_routes.py to satisfy
  mypy's --disallow-untyped-defs requirement. These functions handle
  Server-Sent Events streaming for the Agents API responses.

  The sse_generator function converts async iterators to SSE format, while
  _preserve_context_for_sse preserves request context across async tasks for
  streaming responses. Type hints use AsyncIterator to properly type the
  async generator functions.

  A type ignore comment is used for the contextvars.Context.run pattern where
  the type system has limitations in expressing the dynamic task creation. All
  changes pass mypy strict checking and maintain full backward compatibility.

## Test Plan

```bash
# 1. Run standard mypy check
  ./scripts/uv-run-with-index.sh run --group dev --group type_checking mypy \
    src/llama_stack_api/agents/fastapi_routes.py

  # 2. Run strict type checking (the key test)
  ./scripts/uv-run-with-index.sh run --group dev --group type_checking mypy --disallow-untyped-defs \
    src/llama_stack_api/agents/fastapi_routes.py

  # 3. Run all checks in one command
  ./scripts/uv-run-with-index.sh run --group dev --group type_checking mypy --disallow-untyped-defs \
    src/llama_stack_api/agents/fastapi_routes.py && \
  uv run ruff check \
    src/llama_stack_api/agents/fastapi_routes.py && \
  uv run black --check \
    src/llama_stack_api/agents/fastapi_routes.py && \
  ./scripts/uv-run-with-index.sh run --group dev --group type_checking mypy
