### PR TITLE
fix(inference): normalize streaming usage to final chunk only

### DIFF
--- a/src/llama_stack/providers/remote/inference/vertexai/converters.py
+++ b/src/llama_stack/providers/remote/inference/vertexai/converters.py
@@ -692,7 +692,7 @@ def convert_gemini_stream_chunk_to_openai(
         choices=choices,
         created=created,
         model=model,
-        usage=extract_usage(chunk),
+        usage=None,  # Usage is emitted in a separate final chunk (see _stream_chat_completion)
     )
 
 

--- a/src/llama_stack/providers/utils/inference/openai_mixin.py
+++ b/src/llama_stack/providers/utils/inference/openai_mixin.py
@@ -305,10 +305,26 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
             new_id = f"cltsd-{uuid.uuid4()}" if self.overwrite_completion_id else None
 
             async def _gen():
+                # Buffer usage and only attach it to the final chunk.
+                # Some providers (e.g. Gemini) return usage in every streaming chunk,
+                # violating the OpenAI spec which expects usage only in the last chunk.
+                # We strip usage from intermediate chunks and re-attach the latest
+                # usage to the final chunk before yielding it. Fix for #5122
+                last_usage = None
+                prev_chunk = None
                 async for chunk in resp:
                     if new_id:
                         chunk.id = new_id
-                    yield chunk
+                    if getattr(chunk, "usage", None) is not None:
+                        last_usage = chunk.usage
+                        chunk.usage = None
+                    if prev_chunk is not None:
+                        yield prev_chunk
+                    prev_chunk = chunk
+                # Yield the final chunk with the buffered usage attached
+                if prev_chunk is not None:
+                    prev_chunk.usage = last_usage
+                    yield prev_chunk
 
             return _gen()
         else:

--- a/tests/unit/providers/inference/vertexai/test_converters.py
+++ b/tests/unit/providers/inference/vertexai/test_converters.py
@@ -982,8 +982,12 @@ class TestConvertGeminiStreamChunkToOpenAI:
         assert result.choices[0].delta.content is None
         assert result.choices[0].finish_reason is None
 
-    def test_stream_usage(self):
-        """Test that stream usage."""
+    def test_stream_usage_not_on_content_chunks(self):
+        """Usage should not be on content chunks; it is emitted in a separate final chunk.
+
+        See _stream_chat_completion() which emits a final usage-only chunk.
+        Fix for #5122: Gemini overcounts tokens when usage is on every chunk.
+        """
         chunk = _make_response(
             candidates=[_make_candidate(parts=[_make_text_part("done")], finish_reason="STOP")],
             prompt_token_count=10,
@@ -991,9 +995,7 @@ class TestConvertGeminiStreamChunkToOpenAI:
             total_token_count=15,
         )
         result = convert_gemini_stream_chunk_to_openai(chunk, "model", "chatcmpl-u", is_first_chunk=False)
-        assert result.usage is not None
-        assert result.usage.prompt_tokens == 10
-        assert result.usage.completion_tokens == 5
+        assert result.usage is None
 
     def test_safety_filtered_chunk(self):
         """Test that safety filtered chunk."""

--- a/tests/unit/providers/utils/test_openai_mixin_streaming.py
+++ b/tests/unit/providers/utils/test_openai_mixin_streaming.py
@@ -5,11 +5,10 @@
 # the root directory of this source tree.
 
 """
-Regression tests for issue #3185: AsyncStream passed where AsyncIterator expected.
+Regression tests for streaming behavior in OpenAIMixin._maybe_overwrite_id().
 
-The bug: OpenAI SDK's AsyncStream has close(), not aclose(), but Python's
-AsyncIterator protocol requires aclose(). The fix ensures _maybe_overwrite_id()
-always wraps streaming responses in an async generator.
+- Issue #3185: AsyncStream passed where AsyncIterator expected.
+- Issue #5122: Gemini overcounts tokens when usage is returned in every chunk.
 """
 
 import inspect
@@ -42,10 +41,18 @@ class MockAsyncStream:
         pass
 
 
+class MockUsage:
+    def __init__(self, prompt_tokens: int, completion_tokens: int, total_tokens: int):
+        self.prompt_tokens = prompt_tokens
+        self.completion_tokens = completion_tokens
+        self.total_tokens = total_tokens
+
+
 class MockChunk:
-    def __init__(self, chunk_id: str, content: str = "test"):
+    def __init__(self, chunk_id: str, content: str = "test", usage: MockUsage | None = None):
         self.id = chunk_id
         self.content = content
+        self.usage = usage
 
 
 class OpenAIMixinTestImpl(OpenAIMixin):
@@ -123,3 +130,89 @@ class TestIdOverwriting:
         received = [c async for c in result]
         assert received[0].id == "orig-1"
         assert received[1].id == "orig-2"
+
+
+class TestIssue5122UsageNormalization:
+    """Regression tests for #5122: Gemini overcounts tokens in streaming mode.
+
+    Gemini's OpenAI-compatible endpoint returns usage in every streaming chunk.
+    The fix normalizes this so usage only appears on the final chunk.
+    """
+
+    async def test_usage_only_on_final_chunk_when_every_chunk_has_usage(self, mixin):
+        """When a provider (e.g. Gemini) sends usage on every chunk, only the last chunk should have it."""
+        chunks = [
+            MockChunk("1", "Hello", usage=MockUsage(10, 1, 11)),
+            MockChunk("1", " world", usage=MockUsage(10, 2, 12)),
+            MockChunk("1", "!", usage=MockUsage(10, 3, 13)),
+        ]
+        result = await mixin._maybe_overwrite_id(MockAsyncStream(chunks), stream=True)
+
+        received = [c async for c in result]
+        assert len(received) == 3
+        # Intermediate chunks should have no usage
+        assert received[0].usage is None
+        assert received[1].usage is None
+        # Final chunk should have the last reported usage
+        assert received[2].usage is not None
+        assert received[2].usage.prompt_tokens == 10
+        assert received[2].usage.completion_tokens == 3
+        assert received[2].usage.total_tokens == 13
+
+    async def test_usage_preserved_when_only_on_final_chunk(self, mixin):
+        """When a compliant provider sends usage only on the final chunk, behavior is unchanged."""
+        chunks = [
+            MockChunk("1", "Hello"),
+            MockChunk("1", " world"),
+            MockChunk("1", "", usage=MockUsage(10, 5, 15)),
+        ]
+        result = await mixin._maybe_overwrite_id(MockAsyncStream(chunks), stream=True)
+
+        received = [c async for c in result]
+        assert len(received) == 3
+        assert received[0].usage is None
+        assert received[1].usage is None
+        assert received[2].usage is not None
+        assert received[2].usage.completion_tokens == 5
+
+    async def test_no_usage_when_provider_sends_none(self, mixin):
+        """When no chunks have usage, the final chunk should have None usage."""
+        chunks = [
+            MockChunk("1", "Hello"),
+            MockChunk("1", " world"),
+        ]
+        result = await mixin._maybe_overwrite_id(MockAsyncStream(chunks), stream=True)
+
+        received = [c async for c in result]
+        assert len(received) == 2
+        assert received[0].usage is None
+        assert received[1].usage is None
+
+    async def test_single_chunk_with_usage(self, mixin):
+        """Single chunk with usage should preserve it."""
+        chunks = [MockChunk("1", "Hi", usage=MockUsage(5, 1, 6))]
+        result = await mixin._maybe_overwrite_id(MockAsyncStream(chunks), stream=True)
+
+        received = [c async for c in result]
+        assert len(received) == 1
+        assert received[0].usage is not None
+        assert received[0].usage.total_tokens == 6
+
+    async def test_content_preserved_with_usage_normalization(self, mixin):
+        """Content should be unaffected by usage normalization."""
+        chunks = [
+            MockChunk("1", "a", usage=MockUsage(10, 1, 11)),
+            MockChunk("1", "b", usage=MockUsage(10, 2, 12)),
+            MockChunk("1", "c", usage=MockUsage(10, 3, 13)),
+        ]
+        result = await mixin._maybe_overwrite_id(MockAsyncStream(chunks), stream=True)
+
+        received = [c async for c in result]
+        assert [c.content for c in received] == ["a", "b", "c"]
+
+    async def test_empty_stream(self, mixin):
+        """Empty stream should produce no chunks."""
+        result = await mixin._maybe_overwrite_id(MockAsyncStream([]), stream=True)
+
+        received = [c async for c in result]
+        assert len(received) == 0


### PR DESCRIPTION
## Summary

- Fix token overcounting in streaming mode for Gemini and VertexAI providers
- Normalize streaming chunks so usage only appears on the final chunk (per OpenAI spec)
- Add 6 regression tests for usage normalization behavior

Fixes #5122

## Root Cause

Gemini's OpenAI-compatible streaming endpoint returns `usage` data in **every** streaming chunk, violating the OpenAI spec which expects usage only in the final chunk (when `stream_options={"include_usage": true}`). This caused:

1. **Direct API clients** to see usage on every chunk, leading to potential overcounting
2. **Agent orchestration** (`_accumulate_chunk_usage()`) to sum usage from all chunks, massively overcounting tokens

The VertexAI provider had a similar issue: `convert_gemini_stream_chunk_to_openai()` included usage on every content chunk, even though a separate final usage-only chunk was already emitted.

## Changes

### `src/llama_stack/providers/utils/inference/openai_mixin.py`
- Modified `_maybe_overwrite_id()` to buffer usage from all streaming chunks and only attach it to the final chunk
- Uses a one-chunk-ahead buffer pattern — no extra chunks emitted, no behavior change for compliant providers

### `src/llama_stack/providers/remote/inference/vertexai/converters.py`
- Set `usage=None` in `convert_gemini_stream_chunk_to_openai()` since `_stream_chat_completion()` already emits a proper final usage-only chunk

### Tests
- Added `TestIssue5122UsageNormalization` class with 6 tests covering: Gemini-style every-chunk usage, compliant final-only usage, no usage, single chunk, content preservation, empty stream
- Updated existing VertexAI test to match corrected behavior

## Test plan

- [x] 6 new regression tests pass
- [x] 5 existing streaming mixin tests pass
- [x] 257 VertexAI tests pass (including updated test)
- [x] 333 total relevant tests pass with zero failures
- [ ] Manual verification with Gemini streaming endpoint (requires API key)
