### PR TITLE
refactor: decouple server startup from sku_list.py model registry

### DIFF
--- a/src/llama_stack/providers/inline/inference/meta_reference/__init__.py
+++ b/src/llama_stack/providers/inline/inference/meta_reference/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.

--- a/src/llama_stack/providers/inline/inference/meta_reference/config.py
+++ b/src/llama_stack/providers/inline/inference/meta_reference/config.py
@@ -1,0 +1,95 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from typing import Any
+
+from pydantic import BaseModel, field_validator
+
+from llama_stack.models.llama.sku_list import all_registered_models
+from llama_stack.models.llama.sku_types import (
+    CheckpointQuantizationFormat,
+    CoreModelId,
+    Model,
+    ModelFamily,
+)
+from llama_stack_api import QuantizationConfig
+
+
+def _is_supported_safety_model(model: Model) -> bool:
+    if model.quantization_format != CheckpointQuantizationFormat.bf16:
+        return False
+    return model.core_model_id in [
+        CoreModelId.llama_guard_3_8b,
+        CoreModelId.llama_guard_3_1b,
+        CoreModelId.llama_guard_3_11b_vision,
+    ]
+
+
+def supported_inference_models() -> list[Model]:
+    return [
+        m
+        for m in all_registered_models()
+        if (
+            m.model_family in {ModelFamily.llama3_1, ModelFamily.llama3_2, ModelFamily.llama3_3, ModelFamily.llama4}
+            or _is_supported_safety_model(m)
+        )
+    ]
+
+
+class MetaReferenceInferenceConfig(BaseModel):
+    # this is a placeholder to indicate inference model id
+    # the actual inference model id is dtermined by the moddel id in the request
+    # Note: you need to register the model before using it for inference
+    # models in the resouce list in the config.yaml config will be registered automatically
+    model: str | None = None
+    torch_seed: int | None = None
+    max_seq_len: int = 4096
+    max_batch_size: int = 1
+    model_parallel_size: int | None = None
+
+    # when this is False, we assume that the distributed process group is setup by someone
+    # outside of this code (e.g., when run inside `torchrun`). that is useful for clients
+    # (including our testing code) who might be using llama-stack as a library.
+    create_distributed_process_group: bool = True
+
+    # By default, the implementation will look at ~/.llama/checkpoints/<model> but you
+    # can override by specifying the directory explicitly
+    checkpoint_dir: str | None = None
+
+    quantization: QuantizationConfig | None = None
+
+    @field_validator("model")
+    @classmethod
+    def validate_model(cls, model: str) -> str:
+        permitted_models = supported_inference_models()
+        descriptors = [m.descriptor() for m in permitted_models]
+        repos = [m.huggingface_repo for m in permitted_models if m.huggingface_repo is not None]
+        if model not in (descriptors + repos):
+            model_list = "\n\t".join(repos)
+            raise ValueError(f"Unknown model: `{model}`. Choose from [\n\t{model_list}\n]")
+        return model
+
+    @classmethod
+    def sample_run_config(
+        cls,
+        model: str = "Llama3.2-3B-Instruct",
+        checkpoint_dir: str = "${env.CHECKPOINT_DIR:=null}",
+        quantization_type: str = "${env.QUANTIZATION_TYPE:=bf16}",
+        model_parallel_size: str = "${env.MODEL_PARALLEL_SIZE:=0}",
+        max_batch_size: str = "${env.MAX_BATCH_SIZE:=1}",
+        max_seq_len: str = "${env.MAX_SEQ_LEN:=4096}",
+        **kwargs,
+    ) -> dict[str, Any]:
+        return {
+            "model": model,
+            "checkpoint_dir": checkpoint_dir,
+            "quantization": {
+                "type": quantization_type,
+            },
+            "model_parallel_size": model_parallel_size,
+            "max_batch_size": max_batch_size,
+            "max_seq_len": max_seq_len,
+        }

--- a/src/llama_stack/providers/utils/inference/__init__.py
+++ b/src/llama_stack/providers/utils/inference/__init__.py
@@ -4,6 +4,58 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from llama_stack.models.llama.sku_list import all_registered_models
-
-ALL_HUGGINGFACE_REPOS_TO_MODEL_DESCRIPTOR = {m.huggingface_repo: m.descriptor() for m in all_registered_models()}
+# Static mapping from HuggingFace repo names to Llama model descriptors.
+# This is the only data the server needs at runtime from the model registry.
+#
+# To regenerate after adding new models to sku_list.py, run:
+#   uv run python3 -c "
+#   from llama_stack.models.llama.sku_list import all_registered_models
+#   d = {m.huggingface_repo: m.descriptor() for m in all_registered_models()}
+#   for k, v in d.items():
+#       print(f'    \"{k}\": \"{v}\",')
+#   "
+ALL_HUGGINGFACE_REPOS_TO_MODEL_DESCRIPTOR: dict[str, str] = {
+    "meta-llama/Llama-2-7b": "Llama-2-7b",
+    "meta-llama/Llama-2-13b": "Llama-2-13b",
+    "meta-llama/Llama-2-70b": "Llama-2-70b",
+    "meta-llama/Llama-2-7b-chat": "Llama-2-7b-chat",
+    "meta-llama/Llama-2-13b-chat": "Llama-2-13b-chat",
+    "meta-llama/Llama-2-70b-chat": "Llama-2-70b-chat",
+    "meta-llama/Llama-3-8B": "Llama-3-8B",
+    "meta-llama/Llama-3-70B": "Llama-3-70B",
+    "meta-llama/Llama-3-8B-Instruct": "Llama-3-8B-Instruct",
+    "meta-llama/Llama-3-70B-Instruct": "Llama-3-70B-Instruct",
+    "meta-llama/Llama-3.1-8B": "Llama3.1-8B",
+    "meta-llama/Llama-3.1-70B": "Llama3.1-70B",
+    "meta-llama/Llama-3.1-405B": "Llama3.1-405B:bf16-mp16",
+    "meta-llama/Llama-3.1-405B-FP8": "Llama3.1-405B",
+    "meta-llama/Llama-3.1-8B-Instruct": "Llama3.1-8B-Instruct",
+    "meta-llama/Llama-3.1-70B-Instruct": "Llama3.1-70B-Instruct",
+    "meta-llama/Llama-3.1-405B-Instruct": "Llama3.1-405B-Instruct:bf16-mp16",
+    "meta-llama/Llama-3.1-405B-Instruct-FP8": "Llama3.1-405B-Instruct",
+    "meta-llama/Llama-3.2-1B": "Llama3.2-1B",
+    "meta-llama/Llama-3.2-3B": "Llama3.2-3B",
+    "meta-llama/Llama-3.2-11B-Vision": "Llama3.2-11B-Vision",
+    "meta-llama/Llama-3.2-90B-Vision": "Llama3.2-90B-Vision",
+    "meta-llama/Llama-3.2-1B-Instruct": "Llama3.2-1B-Instruct",
+    "meta-llama/Llama-3.2-3B-Instruct": "Llama3.2-3B-Instruct",
+    "meta-llama/Llama-3.2-1B-Instruct-QLORA_INT4_EO8": "Llama3.2-1B-Instruct:int4-qlora-eo8",
+    "meta-llama/Llama-3.2-1B-Instruct-SpinQuant_INT4_EO8": "Llama3.2-1B-Instruct:int4-spinquant-eo8",
+    "meta-llama/Llama-3.2-3B-Instruct-QLORA_INT4_EO8": "Llama3.2-3B-Instruct:int4-qlora-eo8",
+    "meta-llama/Llama-3.2-3B-Instruct-SpinQuant_INT4_EO8": "Llama3.2-3B-Instruct:int4-spinquant-eo8",
+    "meta-llama/Llama-3.2-11B-Vision-Instruct": "Llama3.2-11B-Vision-Instruct",
+    "meta-llama/Llama-3.2-90B-Vision-Instruct": "Llama3.2-90B-Vision-Instruct",
+    "meta-llama/Llama-3.3-70B-Instruct": "Llama3.3-70B-Instruct",
+    "meta-llama/Llama-4-Scout-17B-16E": "Llama-4-Scout-17B-16E",
+    "meta-llama/Llama-4-Maverick-17B-128E": "Llama-4-Maverick-17B-128E",
+    "meta-llama/Llama-4-Scout-17B-16E-Instruct": "Llama-4-Scout-17B-16E-Instruct",
+    "meta-llama/Llama-4-Maverick-17B-128E-Instruct": "Llama-4-Maverick-17B-128E-Instruct",
+    "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": "Llama-4-Maverick-17B-128E-Instruct:fp8",
+    "meta-llama/Llama-Guard-4-12B": "Llama-Guard-4-12B",
+    "meta-llama/Llama-Guard-3-11B-Vision": "Llama-Guard-3-11B-Vision",
+    "meta-llama/Llama-Guard-3-1B-INT4": "Llama-Guard-3-1B:int4",
+    "meta-llama/Llama-Guard-3-1B": "Llama-Guard-3-1B",
+    "meta-llama/Llama-Guard-3-8B": "Llama-Guard-3-8B",
+    "meta-llama/Llama-Guard-3-8B-INT8": "Llama-Guard-3-8B:int8",
+    "meta-llama/Llama-Guard-2-8B": "Llama-Guard-2-8B",
+}


### PR DESCRIPTION
## Summary

Replace the dynamic import of `all_registered_models()` from `sku_list.py` (1029 lines) with a static dict mapping HuggingFace repo names to model descriptors. This is the only data the server needs at runtime for model registration validation.

**Before:** Every remote inference provider imported `sku_list.py` → `sku_types.py` at startup just to build a `{hf_repo: descriptor}` dict.

**After:** `providers/utils/inference/__init__.py` contains a static 43-entry dict. No import of `sku_list.py` or `sku_types.py` on the server hot path.

`sku_list.py` and `sku_types.py` remain untouched — they're still used by:
- `meta_reference` inline provider (runs Llama models locally)
- `torchtune` provider
- `prompt_adapter.py`
- `scripts/generate_prompt_format.py`

A regeneration command is documented in a comment above the dict for when new models are added.

## Test plan

- [x] Unit tests pass
- [x] Pre-commit hooks pass (including mypy)
- [x] Static dict verified to exactly match the dynamic computation output

🤖 Generated with [Claude Code](https://claude.com/claude-code)