### PR TITLE
fix(vllm): make embedding URL optional for inference-only deployments

### DIFF
--- a/docs/docs/providers/inference/remote_vllm.mdx
+++ b/docs/docs/providers/inference/remote_vllm.mdx
@@ -36,12 +36,14 @@ Remote vLLM inference provider for connecting to vLLM servers.
 | `network.headers` | `dict[str, str] \| None` | No |  | Additional HTTP headers to include in all requests. |
 | `base_url` | `HttpUrl \| None` | No |  | The URL for the vLLM model serving endpoint |
 | `max_tokens` | `int` | No | 4096 | Maximum number of tokens to generate. |
+| `embedding_url` | `HttpUrl \| None` | No |  | The URL for a separate vLLM embedding endpoint, if different from base_url. When set, embedding requests are routed here instead of base_url. If not set, embedding requests will fail with a clear error, enabling inference-only deployments. |
 | `tls_verify` | `bool \| str \| None` | No |  | DEPRECATED: Use 'network.tls.verify' instead. Whether to verify TLS certificates. Can be a boolean or a path to a CA certificate file. |
 
 ## Sample Configuration
 
 ```yaml
 base_url: ${env.VLLM_URL:=}
+embedding_url: ${env.VLLM_EMBEDDING_URL:=}
 max_tokens: ${env.VLLM_MAX_TOKENS:=4096}
 api_token: ${env.VLLM_API_TOKEN:=fake}
 network:

--- a/src/llama_stack/providers/remote/inference/vllm/config.py
+++ b/src/llama_stack/providers/remote/inference/vllm/config.py
@@ -32,6 +32,12 @@ class VLLMInferenceAdapterConfig(RemoteInferenceProviderConfig):
         alias="api_token",
         description="The API token",
     )
+    embedding_url: HttpUrl | None = Field(
+        default=None,
+        description="The URL for a separate vLLM embedding endpoint, if different from base_url. "
+        "When set, embedding requests are routed here instead of base_url. "
+        "If not set, embedding requests will fail with a clear error, enabling inference-only deployments.",
+    )
     tls_verify: bool | str | None = Field(
         default=None,
         deprecated=True,
@@ -68,6 +74,7 @@ class VLLMInferenceAdapterConfig(RemoteInferenceProviderConfig):
     ):
         return {
             "base_url": base_url,
+            "embedding_url": "${env.VLLM_EMBEDDING_URL:=}",
             "max_tokens": "${env.VLLM_MAX_TOKENS:=4096}",
             "api_token": "${env.VLLM_API_TOKEN:=fake}",
             "network": {

--- a/src/llama_stack/providers/remote/inference/vllm/vllm.py
+++ b/src/llama_stack/providers/remote/inference/vllm/vllm.py
@@ -6,10 +6,12 @@
 import os
 import ssl
 from collections.abc import AsyncIterator
+from typing import Any
 from urllib.parse import urljoin
 
 import aiohttp
 import httpx
+from openai import AsyncOpenAI, DefaultAsyncHttpxClient
 from pydantic import ConfigDict
 
 from llama_stack.log import get_logger
@@ -24,8 +26,13 @@ from llama_stack_api import (
     OpenAIChatCompletionContentPartImageParam,
     OpenAIChatCompletionContentPartTextParam,
     OpenAIChatCompletionRequestWithExtraBody,
+    OpenAIEmbeddingData,
+    OpenAIEmbeddingsRequestWithExtraBody,
+    OpenAIEmbeddingsResponse,
+    OpenAIEmbeddingUsage,
     RerankData,
     RerankResponse,
+    validate_embeddings_input_is_text,
 )
 from llama_stack_api.inference import RerankRequest
 
@@ -132,6 +139,50 @@ class VLLMInferenceAdapter(OpenAIMixin):
                 model_type=ModelType.rerank,
             )
         return super().construct_model_from_identifier(identifier)
+
+    async def openai_embeddings(
+        self,
+        params: OpenAIEmbeddingsRequestWithExtraBody,
+    ) -> OpenAIEmbeddingsResponse:
+        if not self.config.embedding_url:
+            raise ValueError(
+                "Failed to process embedding request: no embedding_url configured. "
+                "Set embedding_url in the vLLM provider config (or via VLLM_EMBEDDING_URL) "
+                "to enable embedding support."
+            )
+        validate_embeddings_input_is_text(params)
+
+        provider_model_id = await self._get_provider_model_id(params.model)
+        self._validate_model_allowed(provider_model_id)
+
+        api_key = self._get_api_key_from_config_or_provider_data() or "NO KEY REQUIRED"
+        embedding_client = AsyncOpenAI(
+            api_key=api_key,
+            base_url=str(self.config.embedding_url),
+            http_client=DefaultAsyncHttpxClient(verify=self.shared_ssl_context),
+        )
+
+        request_params: dict[str, Any] = {
+            "model": provider_model_id,
+            "input": params.input,
+        }
+        if params.encoding_format is not None:
+            request_params["encoding_format"] = params.encoding_format
+        if params.dimensions is not None:
+            request_params["dimensions"] = params.dimensions
+        if params.user is not None:
+            request_params["user"] = params.user
+        if params.model_extra:
+            request_params["extra_body"] = params.model_extra
+
+        response = await embedding_client.embeddings.create(**request_params)
+
+        data = [OpenAIEmbeddingData(embedding=d.embedding, index=i) for i, d in enumerate(response.data)]
+        usage = OpenAIEmbeddingUsage(
+            prompt_tokens=response.usage.prompt_tokens,
+            total_tokens=response.usage.total_tokens,
+        )
+        return OpenAIEmbeddingsResponse(data=data, model=params.model, usage=usage)
 
     async def rerank(
         self,

--- a/tests/unit/providers/inference/test_remote_vllm.py
+++ b/tests/unit/providers/inference/test_remote_vllm.py
@@ -24,6 +24,7 @@ from llama_stack_api import (
     OpenAICompletion,
     OpenAICompletionChoice,
     OpenAICompletionRequestWithExtraBody,
+    OpenAIEmbeddingsRequestWithExtraBody,
 )
 
 # These are unit test for the remote vllm provider
@@ -311,3 +312,62 @@ async def test_vllm_chat_completion_extra_body():
         assert "extra_body" in call_kwargs
         assert "chat_template_kwargs" in call_kwargs["extra_body"]
         assert call_kwargs["extra_body"]["chat_template_kwargs"] == {"thinking": True}
+
+
+async def test_embeddings_without_embedding_url_raises_clear_error():
+    """
+    Verify that calling openai_embeddings without embedding_url set raises a clear error.
+
+    This covers the inference-only deployment case where no embedding endpoint exists.
+    """
+    config = VLLMInferenceAdapterConfig(base_url="http://mocked.localhost:12345")
+    adapter = VLLMInferenceAdapter(config=config)
+    adapter.model_store = AsyncMock()  # type: ignore[attr-defined]
+    await adapter.initialize()
+
+    params = OpenAIEmbeddingsRequestWithExtraBody(
+        model="some-embed-model",
+        input=["hello world"],
+    )
+
+    with pytest.raises(ValueError, match="no embedding_url configured"):
+        await adapter.openai_embeddings(params)
+
+
+async def test_embeddings_with_embedding_url_uses_separate_client():
+    """
+    Verify that when embedding_url is configured, openai_embeddings routes to that URL.
+    """
+    config = VLLMInferenceAdapterConfig(
+        base_url="http://mocked.localhost:12345",
+        embedding_url="http://mocked-embeddings.localhost:12346",  # type: ignore[arg-type]
+    )
+    adapter = VLLMInferenceAdapter(config=config)
+    adapter.model_store = AsyncMock()  # type: ignore[attr-defined]
+    adapter.model_store.has_model = AsyncMock(return_value=False)
+    await adapter.initialize()
+
+    params = OpenAIEmbeddingsRequestWithExtraBody(
+        model="some-embed-model",
+        input=["hello world"],
+    )
+
+    mock_response = MagicMock()
+    mock_response.data = [MagicMock(embedding=[0.1, 0.2, 0.3])]
+    mock_response.usage = MagicMock(prompt_tokens=2, total_tokens=2)
+    mock_response.model = "some-embed-model"
+
+    with (
+        patch("llama_stack.providers.remote.inference.vllm.vllm.AsyncOpenAI") as mock_openai_cls,
+        patch.object(adapter, "get_request_provider_data", return_value=None),
+    ):
+        mock_client = MagicMock()
+        mock_client.embeddings.create = AsyncMock(return_value=mock_response)
+        mock_openai_cls.return_value = mock_client
+
+        result = await adapter.openai_embeddings(params)
+
+    # the AsyncOpenAI client was constructed with the embedding URL
+    call_kwargs = mock_openai_cls.call_args.kwargs
+    assert "12346" in call_kwargs["base_url"]
+    assert result.data[0].embedding == [0.1, 0.2, 0.3]


### PR DESCRIPTION
  What does this PR do?

  vLLM inference providers that serve only an LLM (no embedding model) would fail at runtime on any embedding request
  because the single base_url was always used for everything. This adds an optional embedding_url config field (readable
  from VLLM_EMBEDDING_URL) so embedding requests can be routed to a separate endpoint when one is available. When
  embedding_url is not set, embedding calls fail immediately with a clear error message instead of silently sending a
  request to the wrong endpoint, unblocking inference-only deployments.

  Test Plan

  Unit tests cover both cases:

  uv run pytest tests/unit/providers/inference/test_remote_vllm.py -v

  Output:
  PASSED test_embeddings_without_embedding_url_raises_clear_error
  PASSED test_embeddings_with_embedding_url_uses_separate_client
