### PR TITLE
fix: improve MCP server readiness check in tests

### DIFF
--- a/tests/common/mcp.py
+++ b/tests/common/mcp.py
@@ -244,10 +244,8 @@ def make_mcp_server(
     logger.debug(f"Starting MCP server thread on port {port}")
     server_thread.start()
 
-    # Wait for the server thread to be running
-    # Note: We can't use a simple HTTP GET health check on /sse because it's an SSE endpoint
-    # that expects a long-lived connection, not a simple request/response
-    timeout = 2
+    # Wait for the server to be actually listening on the port
+    timeout = 5
     start_time = time.time()
 
     # Determine the appropriate host for the server URL based on test environment
@@ -257,18 +255,32 @@ def make_mcp_server(
 
     mcp_host = os.environ.get("LLAMA_STACK_TEST_MCP_HOST", "localhost")
     server_url = f"http://{mcp_host}:{port}/sse"
-    logger.debug(f"Waiting for MCP server thread to start on port {port} (accessible via {mcp_host})")
+    logger.debug(f"Waiting for MCP server to listen on port {port} (accessible via {mcp_host})")
 
+    import socket
+
+    server_ready = False
     while time.time() - start_time < timeout:
-        if server_thread.is_alive():
-            # Give the server a moment to bind to the port
-            time.sleep(0.1)
-            logger.debug(f"MCP server is ready on port {port}")
+        if not server_thread.is_alive():
+            logger.error(f"MCP server thread died unexpectedly on port {port}")
             break
-        time.sleep(0.05)
-    else:
-        # If we exit the loop due to timeout
-        logger.error(f"MCP server thread failed to start within {timeout} seconds on port {port}")
+
+        # Check if port is actually listening
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.settimeout(0.1)
+                result = sock.connect_ex(("127.0.0.1", port))
+                if result == 0:
+                    logger.debug(f"MCP server is ready on port {port}")
+                    server_ready = True
+                    break
+        except Exception as e:
+            logger.debug(f"Port check failed: {e}")
+
+        time.sleep(0.1)
+
+    if not server_ready:
+        logger.error(f"MCP server failed to become ready within {timeout} seconds on port {port}")
 
     try:
         yield {"server_url": server_url}


### PR DESCRIPTION
Replace weak thread-alive check with actual port connectivity test to prevent connection refused errors in docker mode integration tests.

--
Testing is this is the cause of flakes