### PR TITLE
fix: make Mergify queue compatible with branch protection

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -2,7 +2,11 @@ queue_rules:
 - name: default
   merge_method: squash
   update_method: merge
-  batch_size: 5
+  batch_size: 1
+  merge_conditions:
+      - check-success=ci-status
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
 
 pull_request_rules:
 - name: ping author on conflicts and add 'needs-rebase' label


### PR DESCRIPTION
## Summary

Follow-up to #5310. The merge queue config is incompatible with the branch protection setting "Require branches to be up to date before merging".

Fix by setting `batch_size: 1` and adding `merge_conditions` that match the queue entry conditions, which enables in-place checks instead of draft PR checks.

## Test plan

- [x] Mergify config syntax valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)