### PR TITLE
fix: make Mergify merge_conditions identical to queue_conditions

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -4,9 +4,14 @@ queue_rules:
   update_method: merge
   batch_size: 1
   merge_conditions:
+      - base=main
       - check-success=ci-status
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
+      - -conflict
+      - -draft
+      - -closed
+      - -label~=stale
 
 pull_request_rules:
 - name: ping author on conflicts and add 'needs-rebase' label


### PR DESCRIPTION
## Summary

Follow-up to #5310 and #5315. The `merge_conditions` must be **identical** to the queue entry `conditions` for in-place checks to work with the branch protection setting "Require branches to be up to date before merging".

Previously `merge_conditions` only had 3 conditions while the queue entry had 8. Now they match exactly.

## Test plan

- [x] Mergify config syntax valid
- [x] `merge_conditions` matches `conditions` in "queue approved PRs for merge" rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)