### PR TITLE
fix(docs): use inline author definition in responses-api blog post

### DIFF
--- a/docs/blog/2026-03-18-responses-api.md
+++ b/docs/blog/2026-03-18-responses-api.md
@@ -1,7 +1,10 @@
 ---
 slug: responses-api
 title: "Your Agent, Your Rules: Building Powerful Agents with the Responses API in Llama Stack"
-authors: [jwm4]
+authors:
+  - name: Bill Murdock
+    url: https://github.com/jwm4
+    image_url: https://github.com/jwm4.png
 tags: [responses-api, agents, rag, mcp, open-responses]
 date: 2026-03-18
 ---


### PR DESCRIPTION
The blog post referenced author `jwm4` as a key, but no authors map file (`authors.yml`) exists in `docs/blog/`. This broke the Docusaurus docs build on llamastack.github.io with:

```
Can't reference blog post authors by a key (such as 'jwm4') because no authors map file could be loaded.
```

This PR switches to an inline author definition with `name`, `url`, and `image_url` — consistent with all the other blog posts.