### PR TITLE
chore: add type hints to inference FastAPI SSE generator function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -321,16 +321,14 @@ exclude = [
     "^src/llama_stack/telemetry/__init__\\.py$",
     #
     # ============================================================================
-    # Section 2: Files that need strict typing issues fixed (137 files)
+    # Section 2: Files that need strict typing issues fixed (135 files)
     # ============================================================================
     # These files have some type hints but fail strict type checking due to
     # incomplete annotations, Any usage, or other strict mode violations.
     #
-    # llama_stack_api files (7 files)
+    # llama_stack_api files (5 files)
     "^src/llama_stack_api/common/content_types\\.py$",
-    "^src/llama_stack_api/inference/fastapi_routes\\.py$",
     "^src/llama_stack_api/models/models\\.py$",
-    "^src/llama_stack_api/prompts/models\\.py$",
     "^src/llama_stack_api/responses/fastapi_routes\\.py$",
     "^src/llama_stack_api/router_utils\\.py$",
     # Core files (28 files)

--- a/src/llama_stack_api/inference/fastapi_routes.py
+++ b/src/llama_stack_api/inference/fastapi_routes.py
@@ -87,7 +87,7 @@ def _http_exception_from_sse_error(exc: Exception) -> HTTPException:
     return HTTPException(status_code=500, detail="Internal server error: An unexpected error occurred.")
 
 
-def _preserve_context_for_sse(event_gen):
+def _preserve_context_for_sse(event_gen: AsyncIterator[str]) -> AsyncIterator[str]:
     """Preserve request context for SSE streaming.
 
     StreamingResponse runs in a different task, losing request contextvars.
@@ -95,11 +95,11 @@ def _preserve_context_for_sse(event_gen):
     """
     context = contextvars.copy_context()
 
-    async def wrapper():
+    async def wrapper() -> AsyncIterator[str]:
         try:
             while True:
                 try:
-                    task = context.run(asyncio.create_task, event_gen.__anext__())
+                    task: asyncio.Task[str] = context.run(asyncio.create_task, event_gen.__anext__())  # type: ignore[arg-type]
                     item = await task
                 except StopAsyncIteration:
                     break

--- a/src/llama_stack_api/prompts/models.py
+++ b/src/llama_stack_api/prompts/models.py
@@ -12,6 +12,7 @@ using Pydantic with Field descriptions for OpenAPI schema generation.
 
 import re
 import secrets
+from typing import Self
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -59,7 +60,7 @@ class Prompt(BaseModel):
         return prompt_version
 
     @model_validator(mode="after")
-    def validate_prompt_variables(self):
+    def validate_prompt_variables(self) -> Self:
         """Validate that all variables used in the prompt are declared in the variables list."""
         if not self.prompt:
             return self


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
   
 
  This change adds complete type annotations to the _preserve_context_for_sse
   function in inference/fastapi_routes.py to satisfy mypy's
   --disallow-untyped-defs requirement. This function handles Server-Sent Events
   streaming for the Inference API responses (chat completions, completions, and
   embeddings).

   The _preserve_context_for_sse function preserves request context across async
   tasks for streaming responses. Type hints use AsyncIterator[str] to properly
   type the async generator function and its wrapper.
