### PR TITLE
chore: add type hints to telemetry module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,13 +310,9 @@ follow_imports = "silent"
 # to exclude the entire directory.
 exclude = [
     # ============================================================================
-    # Section 1: Files that need type hints added (1 file)
+    # Section 1: Files that need type hints added (0 files)
     # ============================================================================
-    # These files are missing type annotations on functions/methods. Functions
-    # lack parameter and/or return type hints.
-    #
-    # Other (1 file)
-    "^src/llama_stack/telemetry/__init__\\.py$",
+    # All files now have type annotations! 🎉
     #
     # ============================================================================
     # Section 2: Files that need strict typing issues fixed (131 files)

--- a/src/llama_stack/telemetry/__init__.py
+++ b/src/llama_stack/telemetry/__init__.py
@@ -17,7 +17,7 @@ from llama_stack.log import get_logger
 logger = get_logger(__name__, category="telemetry")
 
 
-def setup_telemetry():
+def setup_telemetry() -> None:
     """Initialize OpenTelemetry metrics exporter if configured via environment.
 
     This function checks for OTEL_EXPORTER_OTLP_ENDPOINT and configures the


### PR DESCRIPTION
# What does this PR do?

This change adds a return type annotation to the setup_telemetry function in src/llama_stack/telemetry/__init__.py to satisfy mypy's --disallow-untyped-defs requirement. This function initializes OpenTelemetry metrics exporter if configured via environment variables.

The function returns None and is called automatically when the module is imported to set up telemetry configuration based on OTEL environment variables.

