### PR TITLE
chore: add type hints to core configuration and build modules

### DIFF
--- a/src/llama_stack/core/build.py
+++ b/src/llama_stack/core/build.py
@@ -86,7 +86,7 @@ def get_provider_dependencies(
     return list(set(normal_deps)), list(set(special_deps)), list(set(external_provider_deps))
 
 
-def print_pip_install_help(config: StackConfig):
+def print_pip_install_help(config: StackConfig) -> None:
     """Print pip install commands needed for the given stack configuration's provider dependencies.
 
     Args:

--- a/src/llama_stack/core/configure.py
+++ b/src/llama_stack/core/configure.py
@@ -148,7 +148,7 @@ def upgrade_from_routing_table(
         The upgraded configuration dictionary using the providers schema.
     """
 
-    def get_providers(entries):
+    def get_providers(entries: Any) -> list[Provider]:
         return [
             Provider(
                 provider_id=(f"{entry['provider_type']}-{i:02d}" if len(entries) > 1 else entry["provider_type"]),

--- a/src/llama_stack/core/connectors/connectors.py
+++ b/src/llama_stack/core/connectors/connectors.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+from __future__ import annotations
+
 import json
 
 from pydantic import BaseModel, Field
@@ -35,7 +37,7 @@ class ConnectorServiceConfig(BaseModel):
     config: StackConfig = Field(..., description="Stack run configuration for resolving persistence")
 
 
-async def get_provider_impl(config: ConnectorServiceConfig):
+async def get_provider_impl(config: ConnectorServiceConfig) -> ConnectorServiceImpl:
     """Get the connector service implementation."""
     impl = ConnectorServiceImpl(config)
     return impl
@@ -55,7 +57,7 @@ class ConnectorServiceImpl(Connectors):
         """Get the KVStore key for a connector."""
         return f"{KEY_PREFIX}{connector_id}"
 
-    async def initialize(self):
+    async def initialize(self) -> None:
         """Initialize the connector service."""
 
         # Use connectors store reference from run config
@@ -101,7 +103,7 @@ class ConnectorServiceImpl(Connectors):
 
         return connector
 
-    async def unregister_connector(self, connector_id: str):
+    async def unregister_connector(self, connector_id: str) -> None:
         """Unregister a connector."""
         key = self._get_key(connector_id)
         if not await self.kvstore.get(key):
@@ -152,6 +154,6 @@ class ConnectorServiceImpl(Connectors):
         tools = await list_mcp_tools(endpoint=connector.url, authorization=authorization)
         return ListToolsResponse(data=tools.data)
 
-    async def shutdown(self):
+    async def shutdown(self) -> None:
         """Shutdown the connector service."""
         await self.kvstore.shutdown()

--- a/src/llama_stack/core/utils/dynamic.py
+++ b/src/llama_stack/core/utils/dynamic.py
@@ -5,9 +5,10 @@
 # the root directory of this source tree.
 
 import importlib
+from typing import Any
 
 
-def instantiate_class_type(fully_qualified_name):
+def instantiate_class_type(fully_qualified_name: str) -> type[Any]:
     """Import and return a class from its fully qualified module path.
 
     Args:
@@ -18,4 +19,4 @@ def instantiate_class_type(fully_qualified_name):
     """
     module_name, class_name = fully_qualified_name.rsplit(".", 1)
     module = importlib.import_module(module_name)
-    return getattr(module, class_name)
+    return getattr(module, class_name)  # type: ignore[no-any-return]


### PR DESCRIPTION
# What does this PR do?

Add return type annotations to configuration, build, and connector service modules to satisfy mypy strict mode. Also add type hints to dynamic utility module used by configuration.

