### PR TITLE
chore: add type hints to core storage modules

### DIFF
--- a/src/llama_stack/core/storage/datatypes.py
+++ b/src/llama_stack/core/storage/datatypes.py
@@ -52,7 +52,7 @@ class RedisKVStoreConfig(CommonConfig):
         return ["redis"]
 
     @classmethod
-    def sample_run_config(cls):
+    def sample_run_config(cls) -> dict[str, str]:
         return {
             "type": StorageBackendType.KV_REDIS.value,
             "host": "${env.REDIS_HOST:=localhost}",
@@ -73,7 +73,7 @@ class SqliteKVStoreConfig(CommonConfig):
         return ["aiosqlite"]
 
     @classmethod
-    def sample_run_config(cls, __distro_dir__: str, db_name: str = "kvstore.db"):
+    def sample_run_config(cls, __distro_dir__: str, db_name: str = "kvstore.db") -> dict[str, str]:
         return {
             "type": StorageBackendType.KV_SQLITE.value,
             "db_path": "${env.SQLITE_STORE_DIR:=" + __distro_dir__ + "}/" + db_name,
@@ -94,7 +94,7 @@ class PostgresKVStoreConfig(CommonConfig):
     table_name: str = "llamastack_kvstore"
 
     @classmethod
-    def sample_run_config(cls, table_name: str = "llamastack_kvstore", **kwargs):
+    def sample_run_config(cls, table_name: str = "llamastack_kvstore", **kwargs: object) -> dict[str, str]:
         return {
             "type": StorageBackendType.KV_POSTGRES.value,
             "host": "${env.POSTGRES_HOST:=localhost}",
@@ -142,7 +142,7 @@ class MongoDBKVStoreConfig(CommonConfig):
         return ["pymongo"]
 
     @classmethod
-    def sample_run_config(cls, collection_name: str = "llamastack_kvstore"):
+    def sample_run_config(cls, collection_name: str = "llamastack_kvstore") -> dict[str, str]:
         return {
             "type": StorageBackendType.KV_MONGODB.value,
             "host": "${env.MONGODB_HOST:=localhost}",
@@ -182,7 +182,7 @@ class SqliteSqlStoreConfig(SqlAlchemySqlStoreConfig):
         return "sqlite+aiosqlite:///" + Path(self.db_path).expanduser().as_posix()
 
     @classmethod
-    def sample_run_config(cls, __distro_dir__: str, db_name: str = "sqlstore.db"):
+    def sample_run_config(cls, __distro_dir__: str, db_name: str = "sqlstore.db") -> dict[str, str]:
         return {
             "type": StorageBackendType.SQL_SQLITE.value,
             "db_path": "${env.SQLITE_STORE_DIR:=" + __distro_dir__ + "}/" + db_name,
@@ -215,7 +215,7 @@ class PostgresSqlStoreConfig(SqlAlchemySqlStoreConfig):
         return super().pip_packages() + ["asyncpg"]
 
     @classmethod
-    def sample_run_config(cls, **kwargs):
+    def sample_run_config(cls, **kwargs: object) -> dict[str, str]:
         return {
             "type": StorageBackendType.SQL_POSTGRES.value,
             "host": "${env.POSTGRES_HOST:=localhost}",

--- a/src/llama_stack/core/storage/kvstore/kvstore.py
+++ b/src/llama_stack/core/storage/kvstore/kvstore.py
@@ -16,19 +16,20 @@ from collections import defaultdict
 from datetime import datetime
 from typing import cast
 
-from llama_stack.core.storage.datatypes import KVStoreReference, StorageBackendConfig
-from llama_stack_api.internal.kvstore import KVStore
-
-from .config import (
-    KVStoreConfig,
+from llama_stack.core.storage.datatypes import (
+    KVStoreReference,
     MongoDBKVStoreConfig,
     PostgresKVStoreConfig,
     RedisKVStoreConfig,
     SqliteKVStoreConfig,
+    StorageBackendConfig,
 )
+from llama_stack_api.internal.kvstore import KVStore
+
+from .config import KVStoreConfig
 
 
-def kvstore_dependencies():
+def kvstore_dependencies() -> list[str]:
     """
     Returns all possible kvstore dependencies for registry/provider specifications.
 
@@ -42,7 +43,7 @@ def kvstore_dependencies():
 class InmemoryKVStoreImpl(KVStore):
     """In-memory key-value store implementation for testing and ephemeral usage."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._store: dict[str, str] = {}
 
     async def initialize(self) -> None:
@@ -121,15 +122,15 @@ async def kvstore_impl(reference: KVStoreReference) -> KVStore:
 
         impl: KVStore
         if isinstance(config, RedisKVStoreConfig):
-            from .redis import RedisKVStoreImpl
+            from .redis import RedisKVStoreImpl  # type: ignore[attr-defined]
 
             impl = RedisKVStoreImpl(config)
         elif isinstance(config, SqliteKVStoreConfig):
-            from .sqlite import SqliteKVStoreImpl
+            from .sqlite import SqliteKVStoreImpl  # type: ignore[attr-defined]
 
             impl = SqliteKVStoreImpl(config)
         elif isinstance(config, PostgresKVStoreConfig):
-            from .postgres import PostgresKVStoreImpl
+            from .postgres import PostgresKVStoreImpl  # type: ignore[attr-defined]
 
             impl = PostgresKVStoreImpl(config)
         elif isinstance(config, MongoDBKVStoreConfig):

--- a/src/llama_stack/core/storage/kvstore/sqlite/sqlite.py
+++ b/src/llama_stack/core/storage/kvstore/sqlite/sqlite.py
@@ -12,7 +12,7 @@ import aiosqlite
 from llama_stack.log import get_logger
 from llama_stack_api.internal.kvstore import KVStore
 
-from ..config import SqliteKVStoreConfig
+from ..config import SqliteKVStoreConfig  # type: ignore[attr-defined]
 
 logger = get_logger(name=__name__, category="providers::utils")
 
@@ -20,19 +20,19 @@ logger = get_logger(name=__name__, category="providers::utils")
 class SqliteKVStoreImpl(KVStore):
     """SQLite-backed key-value store implementation."""
 
-    def __init__(self, config: SqliteKVStoreConfig):
+    def __init__(self, config: SqliteKVStoreConfig) -> None:
         self.db_path = config.db_path
         self.table_name = "kvstore"
         self._conn: aiosqlite.Connection | None = None
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"SqliteKVStoreImpl(db_path={self.db_path}, table_name={self.table_name})"
 
     def _is_memory_db(self) -> bool:
         """Check if this is an in-memory database."""
         return self.db_path == ":memory:" or "mode=memory" in self.db_path
 
-    async def initialize(self):
+    async def initialize(self) -> None:
         # Skip directory creation for in-memory databases and file: URIs
         if not self._is_memory_db() and not self.db_path.startswith("file:"):
             db_dir = os.path.dirname(self.db_path)
@@ -67,7 +67,7 @@ class SqliteKVStoreImpl(KVStore):
                 )
                 await db.commit()
 
-    async def shutdown(self):
+    async def shutdown(self) -> None:
         """Close the persistent connection (only for in-memory databases)."""
         if self._conn:
             await self._conn.close()

--- a/src/llama_stack/core/storage/sqlstore/sqlalchemy_sqlstore.py
+++ b/src/llama_stack/core/storage/sqlstore/sqlalchemy_sqlstore.py
@@ -22,8 +22,11 @@ from sqlalchemy import (
     select,
     text,
 )
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.ext.asyncio.engine import AsyncEngine
+from sqlalchemy.ext.asyncio.session import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
 
 from llama_stack.core.storage.datatypes import PostgresSqlStoreConfig, SqlAlchemySqlStoreConfig
@@ -44,7 +47,7 @@ TYPE_MAPPING: dict[ColumnType, Any] = {
 }
 
 
-def _build_where_expr(column: ColumnElement, value: Any) -> ColumnElement:
+def _build_where_expr(column: ColumnElement[Any], value: Any) -> ColumnElement[Any]:
     """Return a SQLAlchemy expression for a where condition.
 
     `value` may be a simple scalar (equality) or a mapping like {">": 123}.
@@ -71,17 +74,17 @@ def _build_where_expr(column: ColumnElement, value: Any) -> ColumnElement:
 class SqlAlchemySqlStoreImpl(SqlStore):
     """SQLAlchemy-based SQL store implementation supporting SQLite and PostgreSQL backends."""
 
-    def __init__(self, config: SqlAlchemySqlStoreConfig):
+    def __init__(self, config: SqlAlchemySqlStoreConfig) -> None:
         self.config = config
         self._is_sqlite_backend = "sqlite" in self.config.engine_str
         self._engine: AsyncEngine | None = None  # Lazy initialization
-        self.async_session = None
+        self.async_session: async_sessionmaker[AsyncSession] | None = None
         self.metadata = MetaData()
         self._pending_columns: dict[
             str, list[tuple[str, ColumnType, bool]]
         ] = {}  # table -> [(col_name, col_type, nullable)]
 
-    async def _ensure_engine(self):
+    async def _ensure_engine(self) -> None:
         """Lazy initialization: create engine on first use in the current event loop.
 
         This fixes event loop mismatch issues when Stack is initialized in a different
@@ -103,7 +106,7 @@ class SqlAlchemySqlStoreImpl(SqlStore):
                     await self._add_column_now(table_name, col_name, col_type, nullable)
             self._pending_columns.clear()
 
-    async def shutdown(self):
+    async def shutdown(self) -> None:
         """Dispose of the async engine and close all connections."""
         if self._engine:
             await self._engine.dispose()
@@ -134,7 +137,7 @@ class SqlAlchemySqlStoreImpl(SqlStore):
         if self._is_sqlite_backend:
 
             @event.listens_for(engine.sync_engine, "connect")
-            def set_sqlite_pragma(dbapi_conn, connection_record):
+            def set_sqlite_pragma(dbapi_conn: Any, connection_record: Any) -> None:
                 cursor = dbapi_conn.cursor()
                 # Enable Write-Ahead Logging for better concurrency
                 cursor.execute("PRAGMA journal_mode=WAL")
@@ -157,7 +160,7 @@ class SqlAlchemySqlStoreImpl(SqlStore):
         if not schema:
             raise ValueError(f"No columns defined for table '{table}'.")
 
-        sqlalchemy_columns: list[Column] = []
+        sqlalchemy_columns: list[Column[Any]] = []
 
         for col_name, col_props in schema.items():
             col_type = None
@@ -395,7 +398,7 @@ class SqlAlchemySqlStoreImpl(SqlStore):
         try:
             async with self._engine.begin() as conn:
 
-                def check_column_exists(sync_conn):
+                def check_column_exists(sync_conn: Any) -> tuple[bool, bool]:
                     inspector = inspect(sync_conn)
 
                     table_names = inspector.get_table_names()
@@ -431,12 +434,8 @@ class SqlAlchemySqlStoreImpl(SqlStore):
             logger.error("Error adding column to table", column_name=column_name, table=table, error=str(e))
             pass
 
-    def _get_dialect_insert(self, table: Table):
+    def _get_dialect_insert(self, table: Table) -> Any:
         if self._is_sqlite_backend:
-            from sqlalchemy.dialects.sqlite import insert as sqlite_insert
-
             return sqlite_insert(table)
         else:
-            from sqlalchemy.dialects.postgresql import insert as pg_insert
-
             return pg_insert(table)


### PR DESCRIPTION
# What does this PR do?

Add comprehensive type annotations to storage layer including datatypes, KV store implementations, and SQL store. Add type parameters to SQLAlchemy generic types and fix async session manager typing.

