### PR TITLE
fix: convert Path to str in _build_ssl_context() for httpx compatibility

### DIFF
--- a/src/llama_stack/providers/utils/inference/http_client.py
+++ b/src/llama_stack/providers/utils/inference/http_client.py
@@ -22,13 +22,13 @@ from llama_stack.providers.utils.inference.model_registry import (
 logger = get_logger(name=__name__, category="providers::utils")
 
 
-def _build_ssl_context(tls_config: TLSConfig) -> ssl.SSLContext | bool | Path:
+def _build_ssl_context(tls_config: TLSConfig) -> ssl.SSLContext | bool | str:
     """
     Build an SSL context from TLS configuration.
 
     Returns:
         - ssl.SSLContext if advanced options (min_version, ciphers, or mTLS) are configured
-        - Path if only a CA bundle path is specified
+        - str if only a CA bundle path is specified (httpx requires str, not Path)
         - bool if only verify is specified as boolean
     """
     has_advanced_options = (
@@ -36,6 +36,8 @@ def _build_ssl_context(tls_config: TLSConfig) -> ssl.SSLContext | bool | Path:
     )
 
     if not has_advanced_options:
+        if isinstance(tls_config.verify, Path):
+            return str(tls_config.verify)
         return tls_config.verify
 
     ctx = ssl.create_default_context()

--- a/tests/unit/providers/utils/inference/test_network_config.py
+++ b/tests/unit/providers/utils/inference/test_network_config.py
@@ -273,7 +273,7 @@ class TestBuildSSLContext:
         assert result is False
 
     def test_verify_with_path(self):
-        """Test SSL context with CA path returns the path."""
+        """Test SSL context with CA path returns a string (httpx requires str, not Path)."""
         with tempfile.NamedTemporaryFile(suffix=".crt", delete=False) as f:
             f.write(b"fake cert")
             cert_path = f.name
@@ -281,7 +281,8 @@ class TestBuildSSLContext:
         try:
             tls_config = TLSConfig(verify=cert_path)
             result = _build_ssl_context(tls_config)
-            assert result.resolve() == Path(cert_path).resolve()
+            assert isinstance(result, str)
+            assert Path(result).resolve() == Path(cert_path).resolve()
         finally:
             Path(cert_path).unlink()
 


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->

<!-- If resolving an issue, uncomment and update the line below -->

Fixed #5379 

Fix `_build_ssl_context()` in `http_client.py` to convert `Path` to `str` before returning, since httpx's `verify` parameter only accepts `str | bool | ssl.SSLContext`, not `Path`

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->

<!-- For API changes, include:
1. A testing script (Python, curl, etc.) that exercises the new/modified endpoints
2. The output from running your script

Example:
```python
...
...
```

Output:
```
<paste actual output here>
```
-->
