### PR TITLE
ci: remove Mergify queue config in favor of GitHub merge queue

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,18 +1,3 @@
-queue_rules:
-- name: default
-  merge_method: squash
-  update_method: merge
-  batch_size: 1
-  merge_conditions:
-      - base=main
-      - check-success=ci-status
-      - "#approved-reviews-by>=1"
-      - "#changes-requested-reviews-by=0"
-      - -conflict
-      - -draft
-      - -closed
-      - -label~=stale
-
 pull_request_rules:
 - name: ping author on conflicts and add 'needs-rebase' label
   conditions:
@@ -37,33 +22,6 @@ pull_request_rules:
     label:
       remove:
         - needs-rebase
-
-- name: queue approved PRs for merge
-  conditions:
-      - base=main
-      - check-success=ci-status
-      - "#approved-reviews-by>=1"
-      - "#changes-requested-reviews-by=0"
-      - -conflict
-      - -draft
-      - -closed
-      - -label~=stale
-  actions:
-    queue:
-      name: default
-
-- name: queue approved PRs on stable release branches
-  conditions:
-      - base~=^release-[0-9]+\.[0-9]+\.x$
-      - check-success=ci-status
-      - "#approved-reviews-by>=1"
-      - "#changes-requested-reviews-by=0"
-      - -conflict
-      - -draft
-      - -closed
-  actions:
-    queue:
-      name: default
 
 - name: auto-approve dependabot github-deps PRs
   conditions:


### PR DESCRIPTION
## Summary

GitHub's native merge queue has been re-enabled, so the Mergify queue rules are no longer needed. Remove `queue_rules` and the queue actions from pull_request_rules.

What remains:
- Conflict detection + `needs-rebase` label
- Dependabot github-deps auto-approve

## Test plan

- [x] YAML syntax valid
- [x] Pre-commit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)