### PR TITLE
fix: surface tiktoken encoding check at provider startup

### DIFF
--- a/src/llama_stack/providers/utils/memory/openai_vector_store_mixin.py
+++ b/src/llama_stack/providers/utils/memory/openai_vector_store_mixin.py
@@ -26,6 +26,7 @@ from llama_stack.providers.utils.inference.prompt_adapter import (
 from llama_stack.providers.utils.memory.vector_store import (
     content_from_data_and_mime_type,
     make_overlapped_chunks,
+    validate_tiktoken_encoding,
 )
 from llama_stack.providers.utils.vector_io.filters import parse_filter
 from llama_stack_api import (
@@ -400,6 +401,7 @@ class OpenAIVectorStoreMixin(ABC):
 
     async def initialize_openai_vector_stores(self) -> None:
         """Load existing OpenAI vector stores and file batches into the in-memory cache."""
+        validate_tiktoken_encoding()
         if not self.files_api:
             logger.warning(
                 "Files API is not available. File attachment operations on vector stores will fail. "

--- a/src/llama_stack/providers/utils/memory/vector_store.py
+++ b/src/llama_stack/providers/utils/memory/vector_store.py
@@ -77,6 +77,19 @@ def _get_encoding(name: str) -> tiktoken.Encoding:
         ) from e
 
 
+def validate_tiktoken_encoding(name: str = "cl100k_base") -> None:
+    """Validate that the tiktoken encoding is available.
+
+    Call this during provider initialization so a misconfigured environment
+    fails fast with a clear operator-facing message to end users on their first vector store file operation.
+
+    Raises:
+        RuntimeError: if the encoding cannot be loaded (e.g. air-gapped env
+            without a pre-cached encoding file).
+    """
+    _get_encoding(name)
+
+
 # Constants for reranker types
 RERANKER_TYPE_RRF = "rrf"
 RERANKER_TYPE_WEIGHTED = "weighted"

--- a/tests/unit/providers/utils/memory/test_vector_store.py
+++ b/tests/unit/providers/utils/memory/test_vector_store.py
@@ -8,8 +8,25 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from llama_stack.providers.utils.memory.vector_store import content_from_data_and_mime_type
+from llama_stack.providers.utils.memory.vector_store import (
+    content_from_data_and_mime_type,
+    validate_tiktoken_encoding,
+)
 from llama_stack_api import URL, RAGDocument
+
+
+def test_validate_tiktoken_encoding_succeeds():
+    """validate_tiktoken_encoding does not raise when tiktoken is available."""
+    validate_tiktoken_encoding("cl100k_base")
+
+
+def test_validate_tiktoken_encoding_raises_on_failure():
+    """validate_tiktoken_encoding raises RuntimeError with operator context on failure."""
+    import llama_stack.providers.utils.memory.vector_store as vs_module
+
+    with patch.object(vs_module, "_get_encoding", side_effect=RuntimeError("encoding unavailable")):
+        with pytest.raises(RuntimeError, match="encoding unavailable"):
+            validate_tiktoken_encoding("cl100k_base")
 
 
 def test_content_from_data_and_mime_type_success_utf8():


### PR DESCRIPTION
# What does this PR do

Addresses the review feedback from @mattf and @leseb on #5391: the `RuntimeError` raised by `_get_encoding()` was only triggered at request time during `vector_stores.files.create()`. This gave end users an opaque 500 error containing operator-level deployment details (`TIKTOKEN_CACHE_DIR`, container build instructions) they had no way to act on.

Closes #5391 (follow-up)

## Changes

- **`vector_store.py`**: adds `validate_tiktoken_encoding(name="cl100k_base")` — a thin wrapper around `_get_encoding()` intended to be called at provider init time
- **`openai_vector_store_mixin.py`**: calls `validate_tiktoken_encoding()` as the first step in `initialize_openai_vector_stores()`, which all vector IO providers (faiss, sqlite-vec, chroma, pgvector, qdrant, milvus, weaviate, etc.) invoke during their `initialize()` lifecycle
- **`test_vector_store.py`**: two new unit tests — one confirming the validation succeeds when tiktoken is available, one confirming it propagates `RuntimeError` on failure

## Behaviour before / after

**Before:** server starts fine; first `vector_stores.files.create()` call in an air-gapped environment returns a 500 with internal infrastructure details.

**After:** server fails to start immediately with a clear operator-facing message in the logs; no request ever reaches a user in a broken state.

## Test Plan

```bash
uv run pytest tests/unit/providers/utils/memory/test_vector_store.py -v -k "tiktoken"
```

Output:
```
tests/unit/providers/utils/memory/test_vector_store.py::test_validate_tiktoken_encoding_succeeds PASSED
tests/unit/providers/utils/memory/test_vector_store.py::test_validate_tiktoken_encoding_raises_on_failure PASSED
```

Made with [Cursor](https://cursor.com)