### PR TITLE
ci: remove starter-gpu and dell from Docker image build matrix

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -763,11 +763,6 @@ jobs:
             platforms: linux/amd64,linux/arm64
           - distro: postgres-demo
             platforms: linux/amd64,linux/arm64
-          - distro: dell
-            platforms: linux/amd64,linux/arm64
-          # GPU distributions — amd64 only
-          - distro: starter-gpu
-            platforms: linux/amd64
 
     steps:
       - name: Free disk space


### PR DESCRIPTION
## Summary
- Remove `starter-gpu` and `dell` distributions from the Docker image publishing matrix in the release workflow
- These distributions are no longer produced

## Test plan
- [x] Verify the release workflow still builds `starter` and `postgres-demo` images

Generated with [Claude Code](https://claude.com/claude-code)