### PR TITLE
ci: disable version check in file processors test

### DIFF
--- a/.github/workflows/file-processors-tests.yml
+++ b/.github/workflows/file-processors-tests.yml
@@ -51,6 +51,8 @@ jobs:
         run: uv pip install docling
 
       - name: Start Llama Stack server with docling
+        env:
+          LLAMA_STACK_DISABLE_VERSION_CHECK: "1"
         run: |
           uv run --no-sync llama stack run \
             --providers "file_processors=inline::docling,files=inline::localfs" \


### PR DESCRIPTION
## Summary

The file processors (Docling) integration test fails on every PR in the merge queue because the `ClientVersionMiddleware` rejects requests when the PyPI client version (`0.7.0-alpha.2`) doesn't match the dev server version (`0.6.2.dev`).

Fix: set `LLAMA_STACK_DISABLE_VERSION_CHECK=1` when starting the server in the test workflow. This env var is already supported by the middleware.

## Test plan

- [x] Pre-commit passes
- [x] Only CI workflow file changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)