### PR TITLE
chore(mypy): add protocol stores and type hints to 7 inline providers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -515,6 +515,8 @@ module = [
     "google.genai.*",
     "docling.*",
     "docling_core.*",
+    "codeshield.*",
+    "autoevals.*",
 ]
 ignore_missing_imports = true
 

--- a/src/llama_stack/providers/inline/datasetio/localfs/datasetio.py
+++ b/src/llama_stack/providers/inline/datasetio/localfs/datasetio.py
@@ -3,16 +3,30 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
-from llama_stack.core.storage.kvstore import kvstore_impl
+from llama_stack.core.storage.kvstore import KVStore, kvstore_impl
 from llama_stack.providers.utils.datasetio.url_utils import get_dataframe_from_uri
 from llama_stack.providers.utils.pagination import paginate_records
 from llama_stack_api import Dataset, DatasetIO, DatasetsProtocolPrivate, PaginatedResponse
+from llama_stack_api.datasetio import AppendRowsParams, IterRowsRequest
+
+if TYPE_CHECKING:
+    import pandas
 
 from .config import LocalFSDatasetIOConfig
 
 DATASETS_PREFIX = "localfs_datasets:"
+
+
+class SimpleDatasetStore:
+    """Simple dataset store implementation."""
+
+    def __init__(self, dataset_infos: dict[str, Dataset]) -> None:
+        self.dataset_infos = dataset_infos
+
+    def get_dataset(self, dataset_id: str) -> Dataset:
+        return self.dataset_infos[dataset_id]
 
 
 class PandasDataframeDataset:
@@ -21,7 +35,7 @@ class PandasDataframeDataset:
     def __init__(self, dataset_def: Dataset, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.dataset_def = dataset_def
-        self.df = None
+        self.df: pandas.DataFrame | None = None
 
     def __len__(self) -> int:
         assert self.df is not None, "Dataset not loaded. Please call .load() first"
@@ -48,7 +62,8 @@ class PandasDataframeDataset:
             raise ValueError(f"Unsupported dataset source type: {self.dataset_def.source.type}")
 
         if self.df is None:
-            raise ValueError(f"Failed to load dataset from {self.dataset_def.url}")
+            source_type = self.dataset_def.source.type
+            raise ValueError(f"Failed to load dataset from source type: {source_type}")
 
 
 class LocalFSDatasetIOImpl(DatasetIO, DatasetsProtocolPrivate):
@@ -57,8 +72,9 @@ class LocalFSDatasetIOImpl(DatasetIO, DatasetsProtocolPrivate):
     def __init__(self, config: LocalFSDatasetIOConfig) -> None:
         self.config = config
         # local registry for keeping track of datasets within the provider
-        self.dataset_infos = {}
-        self.kvstore = None
+        self.dataset_infos: dict[str, Dataset] = {}
+        self.dataset_store = SimpleDatasetStore(self.dataset_infos)
+        self.kvstore: KVStore | None = None
 
     async def initialize(self) -> None:
         self.kvstore = await kvstore_impl(self.config.kvstore)
@@ -67,8 +83,8 @@ class LocalFSDatasetIOImpl(DatasetIO, DatasetsProtocolPrivate):
         end_key = f"{DATASETS_PREFIX}\xff"
         stored_datasets = await self.kvstore.values_in_range(start_key, end_key)
 
-        for dataset in stored_datasets:
-            dataset = Dataset.model_validate_json(dataset)
+        for dataset_json in stored_datasets:
+            dataset = Dataset.model_validate_json(dataset_json)
             self.dataset_infos[dataset.identifier] = dataset
 
     async def shutdown(self) -> None: ...
@@ -77,6 +93,7 @@ class LocalFSDatasetIOImpl(DatasetIO, DatasetsProtocolPrivate):
         self,
         dataset_def: Dataset,
     ) -> None:
+        assert self.kvstore is not None, "KVStore must be initialized"
         # Store in kvstore
         key = f"{DATASETS_PREFIX}{dataset_def.identifier}"
         await self.kvstore.set(
@@ -86,29 +103,30 @@ class LocalFSDatasetIOImpl(DatasetIO, DatasetsProtocolPrivate):
         self.dataset_infos[dataset_def.identifier] = dataset_def
 
     async def unregister_dataset(self, dataset_id: str) -> None:
+        assert self.kvstore is not None, "KVStore must be initialized"
         key = f"{DATASETS_PREFIX}{dataset_id}"
         await self.kvstore.delete(key=key)
         del self.dataset_infos[dataset_id]
 
     async def iterrows(
         self,
-        dataset_id: str,
-        start_index: int | None = None,
-        limit: int | None = None,
+        request: IterRowsRequest,
     ) -> PaginatedResponse:
-        dataset_def = self.dataset_infos[dataset_id]
+        dataset_def = self.dataset_infos[request.dataset_id]
         dataset_impl = PandasDataframeDataset(dataset_def)
         await dataset_impl.load()
 
-        records = dataset_impl.df.to_dict("records")
-        return paginate_records(records, start_index, limit)
+        assert dataset_impl.df is not None, "Dataset DataFrame should be loaded"
+        records = cast(list[dict[str, Any]], dataset_impl.df.to_dict("records"))
+        return paginate_records(records, request.start_index, request.limit)
 
-    async def append_rows(self, dataset_id: str, rows: list[dict[str, Any]]) -> None:
+    async def append_rows(self, params: AppendRowsParams) -> None:
         import pandas
 
-        dataset_def = self.dataset_infos[dataset_id]
+        dataset_def = self.dataset_infos[params.dataset_id]
         dataset_impl = PandasDataframeDataset(dataset_def)
         await dataset_impl.load()
 
-        new_rows_df = pandas.DataFrame(rows)
+        new_rows_df = pandas.DataFrame(params.rows)
+        assert dataset_impl.df is not None, "Dataset DataFrame should be loaded"
         dataset_impl.df = pandas.concat([dataset_impl.df, new_rows_df], ignore_index=True)

--- a/src/llama_stack/providers/inline/safety/code_scanner/code_scanner.py
+++ b/src/llama_stack/providers/inline/safety/code_scanner/code_scanner.py
@@ -5,10 +5,10 @@
 # the root directory of this source tree.
 
 import uuid
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from codeshield.cs import CodeShieldScanResult
+    from codeshield.cs import CodeShieldScanResult  # type: ignore[import-not-found]
 
 from llama_stack.log import get_logger
 from llama_stack.providers.utils.inference.prompt_adapter import (
@@ -37,11 +37,28 @@ ALLOWED_CODE_SCANNER_MODEL_IDS = [
 ]
 
 
+class SimpleShieldStore:
+    """Simple shield store implementation."""
+
+    def __init__(self, deps: Any) -> None:
+        self.deps = deps
+        self.shields: dict[str, Shield] = {}
+
+    async def get_shield(self, request: GetShieldRequest) -> Shield:
+        if request.identifier in self.shields:
+            return self.shields[request.identifier]
+        raise ValueError(f"Shield {request.identifier} not found")
+
+    def register_shield(self, shield: Shield) -> None:
+        self.shields[shield.identifier] = shield
+
+
 class BuiltinCodeScannerSafetyImpl(Safety):
     """Safety provider that scans generated code for security vulnerabilities using CodeShield."""
 
-    def __init__(self, config: CodeScannerConfig, deps) -> None:
+    def __init__(self, config: CodeScannerConfig, deps: Any) -> None:
         self.config = config
+        self.shield_store = SimpleShieldStore(deps)
 
     async def initialize(self) -> None:
         pass
@@ -54,6 +71,7 @@ class BuiltinCodeScannerSafetyImpl(Safety):
             raise ValueError(
                 f"Unsupported Code Scanner ID: {shield.provider_resource_id}. Allowed IDs: {ALLOWED_CODE_SCANNER_MODEL_IDS}"
             )
+        self.shield_store.register_shield(shield)
 
     async def run_shield(self, request: RunShieldRequest) -> RunShieldResponse:
         shield = await self.shield_store.get_shield(GetShieldRequest(identifier=request.shield_id))

--- a/src/llama_stack/providers/inline/safety/llama_guard/llama_guard.py
+++ b/src/llama_stack/providers/inline/safety/llama_guard/llama_guard.py
@@ -7,6 +7,7 @@
 import re
 import uuid
 from string import Template
+from typing import Any
 
 from llama_stack.core.datatypes import Api
 from llama_stack.log import get_logger
@@ -19,6 +20,9 @@ from llama_stack_api import (
     Inference,
     ModerationObject,
     ModerationObjectResults,
+    OpenAIChatCompletion,
+    OpenAIChatCompletionContentPartImageParam,
+    OpenAIChatCompletionContentPartTextParam,
     OpenAIChatCompletionRequestWithExtraBody,
     OpenAIMessageParam,
     OpenAIUserMessageParam,
@@ -140,12 +144,32 @@ PROMPT_TEMPLATE = Template(f"{PROMPT_TASK}{SAFETY_CATEGORIES}{PROMPT_CONVERSATIO
 logger = get_logger(name=__name__, category="safety")
 
 
+class SimpleShieldStore:
+    """Simple shield store implementation."""
+
+    def __init__(self) -> None:
+        self.shields: dict[str, Shield] = {}
+
+    async def get_shield(self, request: GetShieldRequest) -> Shield:
+        if request.identifier in self.shields:
+            return self.shields[request.identifier]
+        raise ValueError(f"Shield {request.identifier} not found")
+
+    def register_shield(self, shield: Shield) -> None:
+        self.shields[shield.identifier] = shield
+
+    def unregister_shield(self, identifier: str) -> None:
+        if identifier in self.shields:
+            del self.shields[identifier]
+
+
 class LlamaGuardSafetyImpl(Safety, ShieldsProtocolPrivate):
     """Safety provider implementation using Llama Guard models for content moderation."""
 
-    def __init__(self, config: LlamaGuardConfig, deps) -> None:
+    def __init__(self, config: LlamaGuardConfig, deps: Any) -> None:
         self.config = config
         self.inference_api = deps[Api.inference]
+        self.shield_store = SimpleShieldStore()
 
     async def initialize(self) -> None:
         pass
@@ -157,11 +181,10 @@ class LlamaGuardSafetyImpl(Safety, ShieldsProtocolPrivate):
         model_id = shield.provider_resource_id
         if not model_id:
             raise ValueError("Llama Guard shield must have a model id")
+        self.shield_store.register_shield(shield)
 
     async def unregister_shield(self, identifier: str) -> None:
-        # LlamaGuard doesn't need to do anything special for unregistration
-        # The routing table handles the removal from the registry
-        pass
+        self.shield_store.unregister_shield(identifier)
 
     async def run_shield(self, request: RunShieldRequest) -> RunShieldResponse:
         shield = await self.shield_store.get_shield(GetShieldRequest(identifier=request.shield_id))
@@ -172,11 +195,17 @@ class LlamaGuardSafetyImpl(Safety, ShieldsProtocolPrivate):
         # some shields like llama-guard require the first message to be a user message
         # since this might be a tool call, first role might not be user
         if len(messages) > 0 and messages[0].role != "user":
-            messages[0] = OpenAIUserMessageParam(content=messages[0].content)
+            content = messages[0].content
+            # Convert content to the expected type
+            if content is None:
+                content = ""
+            messages[0] = OpenAIUserMessageParam(content=content)  # type: ignore[arg-type]
 
         # Use the inference API's model resolution instead of hardcoded mappings
         # This allows the shield to work with any registered model
         model_id = shield.provider_resource_id
+        if not model_id:
+            raise ValueError("Shield must have a provider_resource_id")
 
         # Determine safety categories based on the model type
         # For known Llama Guard models, use specific categories
@@ -202,12 +231,12 @@ class LlamaGuardSafetyImpl(Safety, ShieldsProtocolPrivate):
             raise ValueError("Llama Guard moderation requires a model identifier.")
 
         if isinstance(request.input, list):
-            messages = request.input.copy()
+            input_list = request.input.copy()
         else:
-            messages = [request.input]
+            input_list = [request.input]
 
         # convert to user messages format with role
-        messages = [OpenAIUserMessageParam(content=m) for m in messages]
+        messages: list[OpenAIMessageParam] = [OpenAIUserMessageParam(content=m) for m in input_list]
 
         # Determine safety categories based on the model type
         # For known Llama Guard models, use specific categories
@@ -307,7 +336,9 @@ class LlamaGuardShield:
             temperature=0.0,  # default is 1, which is too high for safety
         )
         response = await self.inference_api.openai_chat_completion(params)
+        assert isinstance(response, OpenAIChatCompletion), "Streaming not supported for shield"
         content = response.choices[0].message.content
+        assert content is not None, "Expected content in shield response"
         content = content.strip()
         return self.get_shield_response(content)
 
@@ -326,7 +357,9 @@ class LlamaGuardShield:
                     most_recent_img = m.content
                     conversation.append(m)
             elif isinstance(m.content, list):
-                content = []
+                content: list[
+                    str | OpenAIChatCompletionContentPartTextParam | OpenAIChatCompletionContentPartImageParam
+                ] = []
                 for c in m.content:
                     if isinstance(c, str) or isinstance(c, TextContentItem):
                         content.append(c)
@@ -337,16 +370,21 @@ class LlamaGuardShield:
                     else:
                         raise ValueError(f"Unknown content type: {c}")
 
-                conversation.append(OpenAIUserMessageParam(content=content))
+                conversation.append(OpenAIUserMessageParam(content=content))  # type: ignore[arg-type]
             else:
                 raise ValueError(f"Unknown content type: {m.content}")
 
-        prompt = []
+        prompt: list[
+            str
+            | OpenAIChatCompletionContentPartTextParam
+            | OpenAIChatCompletionContentPartImageParam
+            | ImageContentItem
+        ] = []
         if most_recent_img is not None:
             prompt.append(most_recent_img)
         prompt.append(self.build_prompt(conversation[::-1]))
 
-        return OpenAIUserMessageParam(content=prompt)
+        return OpenAIUserMessageParam(content=prompt)  # type: ignore[arg-type]
 
     def build_prompt(self, messages: list[OpenAIMessageParam]) -> str:
         categories = self.get_safety_categories()
@@ -395,7 +433,9 @@ class LlamaGuardShield:
             temperature=0.0,  # default is 1, which is too high for safety
         )
         response = await self.inference_api.openai_chat_completion(params)
+        assert isinstance(response, OpenAIChatCompletion), "Streaming not supported for moderation"
         content = response.choices[0].message.content
+        assert content is not None, "Expected content in moderation response"
         content = content.strip()
         return self.get_moderation_object(content)
 
@@ -412,10 +452,10 @@ class LlamaGuardShield:
         # Set default values for safe case
         categories = dict.fromkeys(SAFETY_CATEGORIES_TO_CODE_MAP.keys(), False)
         category_scores = dict.fromkeys(SAFETY_CATEGORIES_TO_CODE_MAP.keys(), 1.0)
-        category_applied_input_types = {key: [] for key in SAFETY_CATEGORIES_TO_CODE_MAP.keys()}
+        category_applied_input_types: dict[str, list[str]] = {key: [] for key in SAFETY_CATEGORIES_TO_CODE_MAP.keys()}
         flagged = False
         user_message = None
-        metadata = {}
+        metadata: dict[str, Any] = {}
 
         # Handle unsafe case
         if unsafe_code:

--- a/src/llama_stack/providers/inline/scoring/basic/scoring.py
+++ b/src/llama_stack/providers/inline/scoring/basic/scoring.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+
+from llama_stack.providers.utils.scoring.base_scoring_fn import RegisteredBaseScoringFn
 from llama_stack_api import (
     DatasetIO,
     Datasets,
@@ -38,6 +40,22 @@ FIXED_FNS = [
 ]
 
 
+class SimpleScoringFunctionStore:
+    """Simple scoring function store implementation."""
+
+    def __init__(self, scoring_fn_id_impls: dict[str, RegisteredBaseScoringFn]) -> None:
+        self.scoring_fn_id_impls = scoring_fn_id_impls
+
+    def get_scoring_function(self, scoring_fn_id: str) -> ScoringFn:
+        if scoring_fn_id not in self.scoring_fn_id_impls:
+            raise KeyError(f"Scoring function {scoring_fn_id} not found")
+        impl = self.scoring_fn_id_impls[scoring_fn_id]
+        for fn in impl.get_supported_scoring_fn_defs():
+            if fn.identifier == scoring_fn_id:
+                return fn
+        raise KeyError(f"Scoring function {scoring_fn_id} not found")
+
+
 class BasicScoringImpl(
     Scoring,
     ScoringFunctionsProtocolPrivate,
@@ -53,13 +71,14 @@ class BasicScoringImpl(
         self.config = config
         self.datasetio_api = datasetio_api
         self.datasets_api = datasets_api
-        self.scoring_fn_id_impls = {}
+        self.scoring_fn_id_impls: dict[str, RegisteredBaseScoringFn] = {}
 
     async def initialize(self) -> None:
         for fn in FIXED_FNS:
-            impl = fn()
+            impl = fn()  # type: ignore[abstract]
             for fn_defs in impl.get_supported_scoring_fn_defs():
                 self.scoring_fn_id_impls[fn_defs.identifier] = impl
+        self.scoring_function_store = SimpleScoringFunctionStore(self.scoring_fn_id_impls)
 
     async def shutdown(self) -> None: ...
 

--- a/src/llama_stack/providers/inline/scoring/braintrust/braintrust.py
+++ b/src/llama_stack/providers/inline/scoring/braintrust/braintrust.py
@@ -98,6 +98,18 @@ def _get_braintrust_evaluators() -> dict[str, Any]:
         return _braintrust_evaluators
 
 
+class SimpleScoringFunctionStore:
+    """Simple scoring function store implementation."""
+
+    def __init__(self, supported_fn_defs_registry: dict[str, ScoringFn]) -> None:
+        self.supported_fn_defs_registry = supported_fn_defs_registry
+
+    def get_scoring_function(self, scoring_fn_id: str) -> ScoringFn:
+        if scoring_fn_id not in self.supported_fn_defs_registry:
+            raise KeyError(f"Scoring function {scoring_fn_id} not found")
+        return self.supported_fn_defs_registry[scoring_fn_id]
+
+
 class BraintrustScoringImpl(
     Scoring,
     ScoringFunctionsProtocolPrivate,
@@ -115,6 +127,7 @@ class BraintrustScoringImpl(
         self.datasetio_api = datasetio_api
         self.datasets_api = datasets_api
         self.supported_fn_defs_registry = SUPPORTED_BRAINTRUST_SCORING_FN_DEFS
+        self.scoring_function_store = SimpleScoringFunctionStore(self.supported_fn_defs_registry)
 
     async def initialize(self) -> None: ...
 
@@ -195,15 +208,16 @@ class BraintrustScoringImpl(
                 raise ValueError(f"Scoring function {scoring_fn_id} is not supported.")
 
             score_results = [await self.score_row(input_row, scoring_fn_id) for input_row in request.input_rows]
-            aggregation_functions = self.supported_fn_defs_registry[scoring_fn_id].params.aggregation_functions
+            fn_def = self.supported_fn_defs_registry[scoring_fn_id]
+            aggregation_functions = fn_def.params.aggregation_functions if fn_def.params else None
 
             # override scoring_fn params if provided
-            if request.scoring_functions[scoring_fn_id] is not None:
-                override_params = request.scoring_functions[scoring_fn_id]
+            override_params = request.scoring_functions[scoring_fn_id]
+            if override_params is not None and hasattr(override_params, "aggregation_functions"):
                 if override_params.aggregation_functions:
                     aggregation_functions = override_params.aggregation_functions
 
-            agg_results = aggregate_metrics(score_results, aggregation_functions)
+            agg_results = aggregate_metrics(score_results, aggregation_functions or [])
             res[scoring_fn_id] = ScoringResult(
                 score_rows=score_results,
                 aggregated_results=agg_results,

--- a/src/llama_stack/providers/inline/scoring/llm_as_judge/scoring.py
+++ b/src/llama_stack/providers/inline/scoring/llm_as_judge/scoring.py
@@ -25,6 +25,19 @@ from .scoring_fn.llm_as_judge_scoring_fn import LlmAsJudgeScoringFn
 LLM_JUDGE_FN = LlmAsJudgeScoringFn
 
 
+class SimpleScoringFunctionStore:
+    """Simple scoring function store implementation."""
+
+    def __init__(self, scoring_fn: LlmAsJudgeScoringFn) -> None:
+        self.scoring_fn = scoring_fn
+
+    def get_scoring_function(self, scoring_fn_id: str) -> ScoringFn:
+        for fn in self.scoring_fn.get_supported_scoring_fn_defs():
+            if fn.identifier == scoring_fn_id:
+                return fn
+        raise KeyError(f"Scoring function {scoring_fn_id} not found")
+
+
 class LlmAsJudgeScoringImpl(
     Scoring,
     ScoringFunctionsProtocolPrivate,
@@ -46,6 +59,7 @@ class LlmAsJudgeScoringImpl(
     async def initialize(self) -> None:
         impl = LLM_JUDGE_FN(inference_api=self.inference_api)
         self.llm_as_judge_fn = impl
+        self.scoring_function_store = SimpleScoringFunctionStore(self.llm_as_judge_fn)
 
     async def shutdown(self) -> None: ...
 


### PR DESCRIPTION
# What does this PR do?

Resolve 36 mypy strict type checking errors by implementing required protocol store attributes and adding type annotations.

Protocol stores added:
- SimpleScoringFunctionStore for Scoring protocol (llm_as_judge, basic, braintrust)
- SimpleShieldStore for Safety protocol (code_scanner, llama_guard)
- SimpleDatasetStore for DatasetIO protocol (localfs)

Type annotations added:
- Variable type hints: scoring_fn_id_impls, df, dataset_infos, kvstore
- Parameter type hints: deps, messages, content lists
- Return type assertions for AsyncIterator and None checks

Method signature fixes:
- datasetio/localfs: Use IterRowsRequest and AppendRowsParams to match protocol

Additional fixes:
- Add codeshield.* and autoevals.* to mypy ignore list (no type stubs)
- Fix union-attr errors with None checks before attribute access
- Add type: ignore comments for complex OpenAI content type unions
- Fix variable shadowing (dataset → dataset_json)
