### PR TITLE
chore(mypy): add type hints and protocol stores to scoring providers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -368,7 +368,7 @@ exclude = [
     # All files now have type annotations! 🎉
     #
     # ============================================================================
-    # Section 2: Files that need strict typing issues fixed (131 files)
+    # Section 2: Files that need strict typing issues fixed (137 files)
     # ============================================================================
     # These files have some type hints but fail strict type checking due to
     # incomplete annotations, Any usage, or other strict mode violations.
@@ -397,7 +397,7 @@ exclude = [
     "^src/llama_stack/cli/stack/utils\\.py$",
     "^src/llama_stack/cli/subcommand\\.py$",
     "^src/llama_stack/cli/utils\\.py$",
-    # Providers - Inline (27 files)
+    # Providers - Inline (33 files)
     "^src/llama_stack/providers/inline/batches/reference/__init__\\.py$",
     "^src/llama_stack/providers/inline/batches/reference/batches\\.py$",
     "^src/llama_stack/providers/inline/eval/builtin/__init__\\.py$",
@@ -415,6 +415,12 @@ exclude = [
     "^src/llama_stack/providers/inline/safety/prompt_guard/__init__\\.py$",
     "^src/llama_stack/providers/inline/safety/prompt_guard/config\\.py$",
     "^src/llama_stack/providers/inline/safety/prompt_guard/prompt_guard\\.py$",
+    "^src/llama_stack/providers/inline/scoring/basic/__init__\\.py$",
+    "^src/llama_stack/providers/inline/scoring/basic/config\\.py$",
+    "^src/llama_stack/providers/inline/scoring/braintrust/__init__\\.py$",
+    "^src/llama_stack/providers/inline/scoring/braintrust/config\\.py$",
+    "^src/llama_stack/providers/inline/scoring/llm_as_judge/__init__\\.py$",
+    "^src/llama_stack/providers/inline/scoring/llm_as_judge/config\\.py$",
     "^src/llama_stack/providers/inline/tool_runtime/file_search/__init__\\.py$",
     "^src/llama_stack/providers/inline/tool_runtime/file_search/context_retriever\\.py$",
     "^src/llama_stack/providers/inline/tool_runtime/file_search/file_search\\.py$",
@@ -517,9 +523,10 @@ exclude = [
     "^src/llama_stack/providers/inline/datasetio/localfs/",
     "^src/llama_stack/providers/inline/safety/code_scanner/",
     "^src/llama_stack/providers/inline/safety/llama_guard/",
-    "^src/llama_stack/providers/inline/scoring/basic/",
-    "^src/llama_stack/providers/inline/scoring/braintrust/",
-    "^src/llama_stack/providers/inline/scoring/llm_as_judge/",
+    "^src/llama_stack/providers/inline/scoring/basic/scoring_fn/",
+    "^src/llama_stack/providers/inline/scoring/basic/utils/",
+    "^src/llama_stack/providers/inline/scoring/braintrust/scoring_fn/",
+    "^src/llama_stack/providers/inline/scoring/llm_as_judge/scoring_fn/",
     # Provider directories - Remote
     "^src/llama_stack/providers/remote/agents/sample/",
     "^src/llama_stack/providers/remote/datasetio/huggingface/",
@@ -558,6 +565,8 @@ module = [
     "psycopg2",
     "psycopg2.extras",
     "psycopg2.extensions",
+    "codeshield.*",
+    "autoevals.*",
     "torchtune.*",
     "fairscale.*",
     "torchvision.*",

--- a/src/llama_stack/providers/inline/scoring/basic/scoring.py
+++ b/src/llama_stack/providers/inline/scoring/basic/scoring.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+
+from llama_stack.providers.utils.scoring.base_scoring_fn import RegisteredBaseScoringFn
 from llama_stack_api import (
     DatasetIO,
     Datasets,
@@ -38,6 +40,22 @@ FIXED_FNS = [
 ]
 
 
+class SimpleScoringFunctionStore:
+    """Simple scoring function store implementation."""
+
+    def __init__(self, scoring_fn_id_impls: dict[str, RegisteredBaseScoringFn]) -> None:
+        self.scoring_fn_id_impls = scoring_fn_id_impls
+
+    def get_scoring_function(self, scoring_fn_id: str) -> ScoringFn:
+        if scoring_fn_id not in self.scoring_fn_id_impls:
+            raise KeyError(f"Scoring function {scoring_fn_id} not found")
+        impl = self.scoring_fn_id_impls[scoring_fn_id]
+        for fn in impl.get_supported_scoring_fn_defs():
+            if fn.identifier == scoring_fn_id:
+                return fn
+        raise KeyError(f"Scoring function {scoring_fn_id} not found")
+
+
 class BasicScoringImpl(
     Scoring,
     ScoringFunctionsProtocolPrivate,
@@ -53,13 +71,14 @@ class BasicScoringImpl(
         self.config = config
         self.datasetio_api = datasetio_api
         self.datasets_api = datasets_api
-        self.scoring_fn_id_impls = {}
+        self.scoring_fn_id_impls: dict[str, RegisteredBaseScoringFn] = {}
 
     async def initialize(self) -> None:
         for fn in FIXED_FNS:
-            impl = fn()
+            impl = fn()  # type: ignore[abstract]
             for fn_defs in impl.get_supported_scoring_fn_defs():
                 self.scoring_fn_id_impls[fn_defs.identifier] = impl
+        self.scoring_function_store = SimpleScoringFunctionStore(self.scoring_fn_id_impls)
 
     async def shutdown(self) -> None: ...
 

--- a/src/llama_stack/providers/inline/scoring/braintrust/braintrust.py
+++ b/src/llama_stack/providers/inline/scoring/braintrust/braintrust.py
@@ -98,6 +98,18 @@ def _get_braintrust_evaluators() -> dict[str, Any]:
         return _braintrust_evaluators
 
 
+class SimpleScoringFunctionStore:
+    """Simple scoring function store implementation."""
+
+    def __init__(self, supported_fn_defs_registry: dict[str, ScoringFn]) -> None:
+        self.supported_fn_defs_registry = supported_fn_defs_registry
+
+    def get_scoring_function(self, scoring_fn_id: str) -> ScoringFn:
+        if scoring_fn_id not in self.supported_fn_defs_registry:
+            raise KeyError(f"Scoring function {scoring_fn_id} not found")
+        return self.supported_fn_defs_registry[scoring_fn_id]
+
+
 class BraintrustScoringImpl(
     Scoring,
     ScoringFunctionsProtocolPrivate,
@@ -115,6 +127,7 @@ class BraintrustScoringImpl(
         self.datasetio_api = datasetio_api
         self.datasets_api = datasets_api
         self.supported_fn_defs_registry = SUPPORTED_BRAINTRUST_SCORING_FN_DEFS
+        self.scoring_function_store = SimpleScoringFunctionStore(self.supported_fn_defs_registry)
 
     async def initialize(self) -> None: ...
 
@@ -195,15 +208,16 @@ class BraintrustScoringImpl(
                 raise ValueError(f"Scoring function {scoring_fn_id} is not supported.")
 
             score_results = [await self.score_row(input_row, scoring_fn_id) for input_row in request.input_rows]
-            aggregation_functions = self.supported_fn_defs_registry[scoring_fn_id].params.aggregation_functions
+            fn_def = self.supported_fn_defs_registry[scoring_fn_id]
+            aggregation_functions = fn_def.params.aggregation_functions if fn_def.params else None
 
             # override scoring_fn params if provided
-            if request.scoring_functions[scoring_fn_id] is not None:
-                override_params = request.scoring_functions[scoring_fn_id]
+            override_params = request.scoring_functions[scoring_fn_id]
+            if override_params is not None and hasattr(override_params, "aggregation_functions"):
                 if override_params.aggregation_functions:
                     aggregation_functions = override_params.aggregation_functions
 
-            agg_results = aggregate_metrics(score_results, aggregation_functions)
+            agg_results = aggregate_metrics(score_results, aggregation_functions or [])
             res[scoring_fn_id] = ScoringResult(
                 score_rows=score_results,
                 aggregated_results=agg_results,

--- a/src/llama_stack/providers/inline/scoring/llm_as_judge/scoring.py
+++ b/src/llama_stack/providers/inline/scoring/llm_as_judge/scoring.py
@@ -25,6 +25,19 @@ from .scoring_fn.llm_as_judge_scoring_fn import LlmAsJudgeScoringFn
 LLM_JUDGE_FN = LlmAsJudgeScoringFn
 
 
+class SimpleScoringFunctionStore:
+    """Simple scoring function store implementation."""
+
+    def __init__(self, scoring_fn: LlmAsJudgeScoringFn) -> None:
+        self.scoring_fn = scoring_fn
+
+    def get_scoring_function(self, scoring_fn_id: str) -> ScoringFn:
+        for fn in self.scoring_fn.get_supported_scoring_fn_defs():
+            if fn.identifier == scoring_fn_id:
+                return fn
+        raise KeyError(f"Scoring function {scoring_fn_id} not found")
+
+
 class LlmAsJudgeScoringImpl(
     Scoring,
     ScoringFunctionsProtocolPrivate,
@@ -46,6 +59,7 @@ class LlmAsJudgeScoringImpl(
     async def initialize(self) -> None:
         impl = LLM_JUDGE_FN(inference_api=self.inference_api)
         self.llm_as_judge_fn = impl
+        self.scoring_function_store = SimpleScoringFunctionStore(self.llm_as_judge_fn)
 
     async def shutdown(self) -> None: ...
 


### PR DESCRIPTION
# What does this PR do?

Implement SimpleScoringFunctionStore for Scoring protocol and add type annotations:

basic scoring provider:
- Add SimpleScoringFunctionStore with scoring function management methods
- Add type hints for scoring_fn_id_impls variable

braintrust scoring provider:
- Add SimpleScoringFunctionStore with scoring function management methods
- Add type hints for scoring_fn_id_impls variable

llm_as_judge scoring provider:
- Add SimpleScoringFunctionStore with scoring function management methods

pyproject.toml:
- Remove directory excludes for basic/, braintrust/, llm_as_judge/
- Add subdirectory excludes for scoring_fn/ and utils/ subdirectories (4 dirs)
- Add individual file excludes for __init__.py and config.py (6 files)
- Add codeshield.* and autoevals.* to mypy ignore_missing_imports
- Update Section 2 count from 131 to 137 files
- Update Providers - Inline count from 27 to 33 files

