### PR TITLE
feat(vertexai): wire up service_tier parameter to Gemini API

### DIFF
--- a/src/llama_stack/providers/remote/inference/vertexai/vertexai.py
+++ b/src/llama_stack/providers/remote/inference/vertexai/vertexai.py
@@ -474,6 +474,37 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
 
         return genai_types.ThinkingConfig(thinking_level=cast(Any, level))
 
+    @staticmethod
+    def _convert_service_tier(service_tier: str | None) -> str | None:
+        """Map OpenAI service_tier to a Gemini ServiceTier string.
+
+        The google-genai SDK accepts case-insensitive strings on
+        ``GenerateContentConfig.service_tier``.  OpenAI and Gemini use
+        different vocabulary for the same concept:
+
+        - ``"auto"``     → ``None``        (omit; let the API decide)
+        - ``"default"``  → ``"standard"``  (Gemini's default tier)
+        - ``"flex"``     → ``"flex"``
+        - ``"priority"`` → ``"priority"``
+
+        Accepts ``ServiceTier`` (a ``StrEnum``) or plain strings.
+        """
+        if service_tier is None:
+            return None
+
+        _map: dict[str, str | None] = {
+            "auto": None,
+            "default": "standard",
+            "flex": "flex",
+            "priority": "priority",
+        }
+
+        if service_tier not in _map:
+            logger.warning("Unknown service_tier value, ignoring", service_tier=repr(service_tier))
+            return None
+
+        return _map[service_tier]
+
     def _build_generation_config(
         self,
         params: OpenAIChatCompletionRequestWithExtraBody,
@@ -503,6 +534,10 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
         thinking_config = self._build_thinking_config(params.reasoning_effort)
         if thinking_config is not None:
             config_kwargs["thinking_config"] = thinking_config
+
+        gemini_service_tier = self._convert_service_tier(params.service_tier)
+        if gemini_service_tier is not None:
+            config_kwargs["service_tier"] = gemini_service_tier
 
         if params.model_extra:
             config_kwargs.update(params.model_extra)
@@ -627,8 +662,7 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
             logger.warning("VertexAI does not support logit_bias; this parameter will be ignored.")
         if params.parallel_tool_calls is False:
             logger.warning("VertexAI does not support disabling parallel tool calls; this parameter will be ignored.")
-        if params.service_tier is not None:
-            logger.warning("VertexAI does not support service_tier; this parameter will be ignored.")
+        # service_tier is handled by _build_generation_config; no warning needed.
         if params.prompt_cache_key is not None:
             logger.warning("VertexAI does not support prompt_cache_key; this parameter will be ignored.")
         if params.user is not None:

--- a/tests/unit/providers/inference/vertexai/test_adapter_params.py
+++ b/tests/unit/providers/inference/vertexai/test_adapter_params.py
@@ -164,13 +164,6 @@ class TestDroppedParameterWarnings:
         "param_name,param_value,log_level,expected_text",
         [
             pytest.param("logit_bias", {"50256": -100.0}, logging.WARNING, "logit_bias", id="logit_bias"),
-            pytest.param(
-                "service_tier",
-                "__service_tier_default__",
-                logging.WARNING,
-                "service_tier",
-                id="service_tier",
-            ),
             pytest.param("prompt_cache_key", "mykey", logging.WARNING, "prompt_cache_key", id="prompt_cache_key"),
             pytest.param("user", "test-user", logging.DEBUG, "user", id="user"),
             pytest.param("safety_identifier", "test-id", logging.DEBUG, "safety_identifier", id="safety_identifier"),
@@ -182,11 +175,6 @@ class TestDroppedParameterWarnings:
         """Test that unsupported param logged."""
         adapter = VertexAIInferenceAdapter(config=VertexAIConfig(project="p", location="l"))
         patch_chat_completion_dependencies(adapter)
-
-        if param_name == "service_tier":
-            from llama_stack_api.inference import ServiceTier
-
-            param_value = ServiceTier.default
 
         payload: dict[str, Any] = {
             "model": "google/gemini-2.5-flash",
@@ -225,6 +213,98 @@ class TestDroppedParameterWarnings:
 
         found = any("parallel tool calls" in r.message for r in caplog.records if r.levelno == logging.WARNING)
         assert found == should_warn
+
+
+class TestServiceTier:
+    """Test that service_tier is mapped and forwarded to GenerateContentConfig."""
+
+    _OMITTED = object()  # sentinel: service_tier should not appear on the config
+
+    @pytest.fixture
+    def capture_generation_config(self, monkeypatch, patch_chat_completion_dependencies):
+        """Fixture that runs a chat completion and returns the GenerateContentConfig produced.
+
+        Returns an async callable: ``config = await fn(service_tier=...)``
+        Pass ``service_tier=None`` (or omit) to test the "not set" case.
+        """
+
+        async def _run(*, service_tier: str | None = None) -> Any:
+            """Run a chat completion with the given service_tier and return the config."""
+            adapter = VertexAIInferenceAdapter(config=VertexAIConfig(project="p", location="l"))
+            captured: dict[str, Any] = {}
+            original_build = adapter._build_generation_config
+
+            def _capturing_build(*args, **kwargs):
+                """Intercept _build_generation_config to capture the config object."""
+                config = original_build(*args, **kwargs)
+                captured["config"] = config
+                return config
+
+            patch_chat_completion_dependencies(adapter)
+            monkeypatch.setattr(adapter, "_build_generation_config", _capturing_build)
+
+            payload: dict[str, Any] = {
+                "model": "gemini-2.5-flash",
+                "messages": [{"role": "user", "content": "hi"}],
+            }
+            if service_tier is not None:
+                payload["service_tier"] = service_tier
+
+            params = OpenAIChatCompletionRequestWithExtraBody.model_validate(payload)
+            await adapter.openai_chat_completion(params)
+            return captured["config"]
+
+        return _run
+
+    @pytest.mark.parametrize(
+        "tier_input,expected",
+        [
+            pytest.param("flex", "flex", id="flex"),
+            pytest.param("priority", "priority", id="priority"),
+            pytest.param("default", "standard", id="default_maps_to_standard"),
+            pytest.param("auto", _OMITTED, id="auto_omitted"),
+            pytest.param(None, _OMITTED, id="none_omitted"),
+        ],
+    )
+    async def test_service_tier_mapping(self, capture_generation_config, tier_input, expected):
+        """Verify each service_tier value is correctly mapped (or omitted) on the config."""
+        config = await capture_generation_config(service_tier=tier_input)
+
+        if expected is self._OMITTED:
+            assert getattr(config, "service_tier", None) is None
+        else:
+            assert config.service_tier == expected
+
+    async def test_unknown_service_tier_returns_none(self):
+        """An unrecognized service_tier value returns None (caller omits the field)."""
+        assert VertexAIInferenceAdapter._convert_service_tier("bogus_tier") is None
+
+    @pytest.mark.parametrize(
+        "tier_value",
+        [
+            pytest.param("flex", id="flex"),
+            pytest.param("priority", id="priority"),
+            pytest.param("default", id="default"),
+            pytest.param("auto", id="auto"),
+        ],
+    )
+    async def test_supported_values_produce_no_warnings(self, caplog, patch_chat_completion_dependencies, tier_value):
+        """Supported service_tier values should not produce any warnings."""
+        adapter = VertexAIInferenceAdapter(config=VertexAIConfig(project="p", location="l"))
+        patch_chat_completion_dependencies(adapter)
+
+        params = OpenAIChatCompletionRequestWithExtraBody.model_validate(
+            {
+                "model": "gemini-2.5-flash",
+                "messages": [{"role": "user", "content": "hi"}],
+                "service_tier": tier_value,
+            }
+        )
+
+        with caplog.at_level(logging.WARNING, logger="llama_stack.providers.remote.inference.vertexai.vertexai"):
+            await adapter.openai_chat_completion(params)
+
+        assert not any("service_tier" in r.message for r in caplog.records if r.levelno == logging.WARNING)
 
 
 class TestTelemetryStreamOptions:


### PR DESCRIPTION
# What does this PR do?

Maps the OpenAI `service_tier` request parameter to the Gemini equivalent in the vertexai inference provider, instead of ignoring it with a warning.

Closes #5452

Tier mapping: `auto` is omitted (let API decide), `default` maps to `standard`, `flex` and `priority` pass through. The google-genai SDK (v1.69.0+) accepts these as case-insensitive strings on `GenerateContentConfig.service_tier`.

## Test Plan

```bash
uv run pytest tests/unit/providers/inference/vertexai/test_adapter_params.py -x --tb=short -q -k TestServiceTier
```

Output:
```text
................                                                         [100%]
16 passed, 19 deselected in 0.04s
```