### PR TITLE
feat: enable native messages for vllm

### DIFF
--- a/src/llama_stack/providers/inline/messages/impl.py
+++ b/src/llama_stack/providers/inline/messages/impl.py
@@ -119,7 +119,10 @@ class BuiltinMessagesImpl(Messages):
     # -- Native passthrough for providers with /v1/messages support --
 
     # Module paths of provider impls known to support /v1/messages natively
-    _NATIVE_MESSAGES_MODULES = {"llama_stack.providers.remote.inference.ollama"}
+    _NATIVE_MESSAGES_MODULES = {
+        "llama_stack.providers.remote.inference.ollama",
+        "llama_stack.providers.remote.inference.vllm",
+    }
 
     async def _get_passthrough_url(self, model: str) -> str | None:
         """Check if the model's provider supports /v1/messages natively.


### PR DESCRIPTION
# What does this PR do?

vllm has a messages API impl, enable it similarly to ollama:

```
(APIServer pid=1) INFO 04-09 20:10:27 [launcher.py:46] Route: /v1/messages, Methods: POST
(APIServer pid=1) INFO 04-09 20:10:27 [launcher.py:46] Route: /v1/messages/count_tokens, Methods: POST
```
