### PR TITLE
feat(messages): add native count_tokens support for passthrough providers

### DIFF
--- a/src/llama_stack/providers/inline/messages/impl.py
+++ b/src/llama_stack/providers/inline/messages/impl.py
@@ -119,7 +119,10 @@ class BuiltinMessagesImpl(Messages):
     # -- Native passthrough for providers with /v1/messages support --
 
     # Module paths of provider impls known to support /v1/messages natively
-    _NATIVE_MESSAGES_MODULES = {"llama_stack.providers.remote.inference.ollama"}
+    _NATIVE_MESSAGES_MODULES = {
+        "llama_stack.providers.remote.inference.ollama",
+        "llama_stack.providers.remote.inference.vllm",
+    }
 
     async def _get_passthrough_url(self, model: str) -> str | None:
         """Check if the model's provider supports /v1/messages natively.

--- a/src/llama_stack/providers/inline/messages/impl.py
+++ b/src/llama_stack/providers/inline/messages/impl.py
@@ -32,6 +32,7 @@ from llama_stack_api.messages import (
     Messages,
 )
 from llama_stack_api.messages.models import (
+    ANTHROPIC_VERSION,
     AnthropicContentBlock,
     AnthropicCountTokensRequest,
     AnthropicCountTokensResponse,
@@ -181,7 +182,7 @@ class BuiltinMessagesImpl(Messages):
         body["model"] = provider_model
         headers = {
             "content-type": "application/json",
-            "anthropic-version": "2023-06-01",
+            "anthropic-version": ANTHROPIC_VERSION,
             "x-api-key": "no-key-required",
         }
 
@@ -274,7 +275,7 @@ class BuiltinMessagesImpl(Messages):
         body["model"] = provider_model
         headers = {
             "content-type": "application/json",
-            "anthropic-version": "2023-06-01",
+            "anthropic-version": ANTHROPIC_VERSION,
             "x-api-key": "no-key-required",
         }
 

--- a/src/llama_stack/providers/inline/messages/impl.py
+++ b/src/llama_stack/providers/inline/messages/impl.py
@@ -114,7 +114,12 @@ class BuiltinMessagesImpl(Messages):
         self,
         request: AnthropicCountTokensRequest,
     ) -> AnthropicCountTokensResponse:
-        raise NotImplementedError("Token counting is not yet implemented")
+        passthrough_url = await self._get_passthrough_url(request.model)
+        if passthrough_url:
+            return await self._passthrough_count_tokens(passthrough_url, request)
+
+        # Translation mode: use Inference API's count_tokens if available
+        raise NotImplementedError("Token counting via translation mode is not yet implemented")
 
     # -- Native passthrough for providers with /v1/messages support --
 
@@ -246,6 +251,36 @@ class BuiltinMessagesImpl(Messages):
         if event_type == "message_stop":
             return MessageStopEvent()
         return None
+
+    async def _passthrough_count_tokens(
+        self,
+        base_url: str,
+        request: AnthropicCountTokensRequest,
+    ) -> AnthropicCountTokensResponse:
+        """Forward the count_tokens request to the provider's /v1/messages/count_tokens endpoint."""
+        url = f"{base_url}/v1/messages/count_tokens"
+        # Use the provider_resource_id (model name without provider prefix)
+        provider_model = request.model
+        router = self.inference_api
+        if hasattr(router, "routing_table"):
+            try:
+                obj = await router.routing_table.get_object_by_identifier("model", request.model)
+                if obj:
+                    provider_model = obj.provider_resource_id
+            except Exception:
+                pass
+
+        body = request.model_dump(exclude_none=True)
+        body["model"] = provider_model
+        headers = {
+            "content-type": "application/json",
+            "anthropic-version": "2023-06-01",
+            "x-api-key": "no-key-required",
+        }
+
+        resp = await self._client.post(url, json=body, headers=headers, timeout=30)
+        resp.raise_for_status()
+        return AnthropicCountTokensResponse(**resp.json())
 
     # -- Request translation --
 

--- a/src/llama_stack_api/messages/fastapi_routes.py
+++ b/src/llama_stack_api/messages/fastapi_routes.py
@@ -27,6 +27,7 @@ from llama_stack_api.version import LLAMA_STACK_API_V1
 
 from .api import Messages
 from .models import (
+    ANTHROPIC_VERSION,
     AnthropicCountTokensRequest,
     AnthropicCountTokensResponse,
     AnthropicCreateMessageRequest,
@@ -36,9 +37,6 @@ from .models import (
 )
 
 logger = logging.LoggerAdapter(logging.getLogger(__name__), {"category": "messages"})
-
-# Anthropic API version we are compatible with
-_ANTHROPIC_VERSION = "2023-06-01"
 
 
 def _create_anthropic_sse_event(event_type: str, data: Any) -> str:
@@ -160,7 +158,7 @@ def create_router(impl: Messages) -> APIRouter:
             logger.exception("Failed to create message")
             return _anthropic_error_response(500, "Internal server error")
 
-        response_headers = {"anthropic-version": _ANTHROPIC_VERSION}
+        response_headers = {"anthropic-version": ANTHROPIC_VERSION}
 
         if isinstance(result, AsyncIterator):
             return StreamingResponse(
@@ -196,7 +194,7 @@ def create_router(impl: Messages) -> APIRouter:
 
         return JSONResponse(
             content=result.model_dump(),
-            headers={"anthropic-version": _ANTHROPIC_VERSION},
+            headers={"anthropic-version": ANTHROPIC_VERSION},
         )
 
     return router

--- a/src/llama_stack_api/messages/models.py
+++ b/src/llama_stack_api/messages/models.py
@@ -16,6 +16,9 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+# Anthropic API version we are compatible with
+ANTHROPIC_VERSION = "2023-06-01"
+
 # -- Content blocks --
 
 


### PR DESCRIPTION
## Summary

Implements `count_message_tokens()` to forward requests to providers that natively support `/v1/messages/count_tokens` (vLLM).

**Note:** This PR depends on the vLLM Messages API PR and should be merged after that PR is merged.

## Changes

- Implement `count_message_tokens()` with passthrough logic
- Add `_passthrough_count_tokens()` helper that forwards requests to `/v1/messages/count_tokens`
- Return `NotImplementedError` for translation mode (OpenAI providers have no direct equivalent)

## How it works

When a provider supports the Messages API natively (vLLM, Ollama), token counting requests are forwarded directly to the provider's endpoint at `/v1/messages/count_tokens`. This enables accurate token counting using the provider's actual tokenizer.

## Server Logs

**vLLM:**
```
(APIServer pid=1) INFO:     10.195.155.194:44004 - "GET /v1/models HTTP/1.1" 200 OK
(APIServer pid=1) INFO:     10.195.155.194:60092 - "POST /v1/messages/count_tokens HTTP/1.1" 200 OK
(APIServer pid=1) INFO:     10.195.155.194:46482 - "POST /v1/messages/count_tokens HTTP/1.1" 200 OK
```

**Llama Stack:**
```
INFO     2026-04-09T20:21:18.746331Z  ::1:57948 - "POST /v1/messages/count_tokens HTTP/1.1" 200  category=server
```

## Test Plan

```bash
# Test basic count_tokens request
curl -s http://localhost:8321/v1/messages/count_tokens -X POST \
  -H "Content-Type: application/json" \
  -H "anthropic-version: 2023-06-01" \
  -d '{
    "model": "vllm/my-model",
    "messages": [
      {"role": "user", "content": "Hello, how are you today?"}
    ]
  }' | jq .

# Expected output:
# {
#   "input_tokens": 15
# }

# Test with system message
curl -s http://localhost:8321/v1/messages/count_tokens -X POST \
  -H "Content-Type: application/json" \
  -H "anthropic-version: 2023-06-01" \
  -d '{
    "model": "vllm/my-model",
    "system": "You are a helpful assistant.",
    "messages": [
      {"role": "user", "content": "What is 2+2?"}
    ]
  }' | jq .

# Expected output:
# {
#   "input_tokens": 26
# }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)