### PR TITLE
docs: remove leftover TODO comments from getting started notebooks

### DIFF
--- a/docs/getting_started.ipynb
+++ b/docs/getting_started.ipynb
@@ -779,8 +779,6 @@
    ],
    "source": [
     "model_id = \"together/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8\"\n",
-    "# TODO remove\n",
-    "# model_id = \"openai/gpt-4o\"\n",
     "\n",
     "response = client.chat.completions.create(\n",
     "    model=model_id,\n",

--- a/docs/getting_started_llama_api.ipynb
+++ b/docs/getting_started_llama_api.ipynb
@@ -606,7 +606,6 @@
     }
    ],
    "source": [
-    "# TODO: update this with a vision model\n",
     "model_id = \"meta-llama/Llama-4-Maverick-17B-128E-Instruct\"\n",
     "\n",
     "response = client.chat.completions.create(\n",


### PR DESCRIPTION
## Summary

- Remove dead `# TODO remove` comment and commented-out `openai/gpt-4o` model_id from `docs/getting_started.ipynb` (leftover from development)
- Remove stale `# TODO: update this with a vision model` comment from `docs/getting_started_llama_api.ipynb` (already using current Llama 4 model)

Small cleanup to keep the notebooks clean for new users.