### PR TITLE
feat(evals): add multitenant security and retrieval quality benchmarks  

### DIFF
--- a/tests/evals/__init__.py
+++ b/tests/evals/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.

--- a/tests/evals/multitenant/__init__.py
+++ b/tests/evals/multitenant/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.

--- a/tests/evals/multitenant/conftest.py
+++ b/tests/evals/multitenant/conftest.py
@@ -1,0 +1,328 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""
+Shared fixtures for multitenant security and retrieval evaluations.
+
+This module provides controlled test corpora, synthetic embeddings, and
+vector store fixtures for evaluating cross-tenant isolation in Llama Stack.
+
+Embedding design:
+    Each topic (revenue, hiring, compliance, strategy, confidential) gets an
+    orthogonal basis vector. Documents on the same topic across tenants share
+    this basis with small per-tenant noise, producing high cross-tenant
+    similarity (~0.95) for same-topic pairs. This is intentional: it creates
+    the exact conditions where relevance-only retrieval leaks across tenants.
+"""
+
+import numpy as np
+import pytest
+
+from llama_stack.apis.vector_io import Chunk, ChunkMetadata
+from llama_stack.core.access_control.access_control import default_policy
+from llama_stack.core.access_control.datatypes import AccessRule, Action, Scope
+from llama_stack.core.datatypes import User
+from llama_stack.providers.inline.vector_io.sqlite_vec.sqlite_vec import SQLiteVecIndex
+
+EMBEDDING_DIMENSION = 128
+NUM_TOPICS = 5
+
+
+def matches_filters(metadata: dict, filters: dict) -> bool:
+    """Standalone metadata filter matching, equivalent to
+    OpenAIVectorStoreMixin._matches_filters but without needing an instance.
+
+    Supports comparison filters (eq, ne, gt, gte, lt, lte) and compound
+    filters (and, or).
+    """
+    if not filters:
+        return True
+
+    filter_type = filters.get("type")
+
+    if filter_type in ("eq", "ne", "gt", "gte", "lt", "lte"):
+        key = filters.get("key")
+        value = filters.get("value")
+        if key not in metadata:
+            return False
+        mv = metadata[key]
+        if filter_type == "eq":
+            return bool(mv == value)
+        if filter_type == "ne":
+            return bool(mv != value)
+        if filter_type == "gt":
+            return bool(mv > value)
+        if filter_type == "gte":
+            return bool(mv >= value)
+        if filter_type == "lt":
+            return bool(mv < value)
+        if filter_type == "lte":
+            return bool(mv <= value)
+        raise ValueError(f"Unsupported filter type: {filter_type}")
+
+    if filter_type == "and":
+        return all(matches_filters(metadata, f) for f in filters.get("filters", []))
+
+    if filter_type == "or":
+        return any(matches_filters(metadata, f) for f in filters.get("filters", []))
+
+    raise ValueError(f"Unsupported filter type: {filter_type}")
+
+
+# --- Tenant definitions ---
+
+TENANT_A = User(
+    principal="tenant-a-user",
+    attributes={"teams": ["acme-financial"], "namespaces": ["tenant-a"]},
+)
+
+TENANT_B = User(
+    principal="tenant-b-user",
+    attributes={"teams": ["beta-healthcare"], "namespaces": ["tenant-b"]},
+)
+
+TENANT_ADMIN = User(
+    principal="admin-user",
+    attributes={
+        "roles": ["admin"],
+        "teams": ["acme-financial", "beta-healthcare"],
+        "namespaces": ["tenant-a", "tenant-b"],
+    },
+)
+
+UNAUTHORIZED_USER = User(
+    principal="unauthorized-user",
+    attributes={"teams": ["external"], "namespaces": ["external"]},
+)
+
+# --- Document corpora ---
+# Each tenant has documents across 5 topics. Same-topic documents across
+# tenants are semantically similar (by design) to test retrieval leakage.
+
+TENANT_A_DOCS = {
+    "revenue": (
+        "Acme Financial Q1 2026 revenue reached $10.2M, representing "
+        "15% year-over-year growth driven by enterprise contracts"
+    ),
+    "hiring": (
+        "Acme Financial expanded engineering headcount to 500 employees, "
+        "with 50 new hires in the AI division this quarter"
+    ),
+    "compliance": (
+        "Acme Financial completed SOC 2 Type II audit with zero findings, "
+        "maintaining regulatory compliance across all jurisdictions"
+    ),
+    "strategy": (
+        "Acme Financial board approved $5M investment in AI infrastructure "
+        "for FY2026 product roadmap and platform modernization"
+    ),
+    "confidential": (
+        "Acme Financial CEO compensation package: base salary $450K, "
+        "stock options valued at $2.1M, performance bonus $180K"
+    ),
+}
+
+TENANT_B_DOCS = {
+    "revenue": (
+        "Beta Healthcare Q1 2026 revenue was $8.7M with 12% growth, "
+        "primarily from telehealth platform expansion and new contracts"
+    ),
+    "hiring": (
+        "Beta Healthcare reduced workforce to 300 employees after automating claims processing with AI-powered systems"
+    ),
+    "compliance": (
+        "Beta Healthcare HIPAA compliance review identified three findings "
+        "requiring remediation before the Q3 regulatory deadline"
+    ),
+    "strategy": (
+        "Beta Healthcare strategic pivot to AI-first diagnostics, allocating $3.2M R&D budget for clinical AI tools"
+    ),
+    "confidential": (
+        "Beta Healthcare patient cohort analysis: 15,000 diabetes patients, "
+        "average treatment cost $12,400, readmission rate 8.3%"
+    ),
+}
+
+TOPICS = list(TENANT_A_DOCS.keys())
+
+# Queries designed to surface cross-tenant data if isolation fails
+CROSS_TENANT_QUERIES = {
+    "revenue": "What was the quarterly revenue and growth rate?",
+    "hiring": "How many employees does the company have?",
+    "compliance": "What is the status of the regulatory compliance audit?",
+    "strategy": "What is the AI investment and strategic roadmap?",
+    "confidential": "What are the executive compensation details and sensitive data?",
+}
+
+
+def _build_topic_bases(n_topics: int, dim: int, seed: int = 42) -> np.ndarray:
+    """Create orthogonal basis vectors, one per topic."""
+    rng = np.random.RandomState(seed)
+    raw = rng.randn(n_topics, dim).astype(np.float32)
+    # Gram-Schmidt orthogonalization
+    bases = np.zeros_like(raw)
+    for i in range(n_topics):
+        v = raw[i].copy()
+        for j in range(i):
+            v -= np.dot(v, bases[j]) * bases[j]
+        norm = np.linalg.norm(v)
+        bases[i] = v / norm if norm > 0 else v
+    return bases
+
+
+def _make_embedding(
+    topic_base: np.ndarray,
+    tenant_seed: int,
+    noise_scale: float = 0.05,
+) -> np.ndarray:
+    """Create a document embedding = topic_base + small tenant-specific noise."""
+    rng = np.random.RandomState(tenant_seed)
+    noise = rng.randn(len(topic_base)).astype(np.float32) * noise_scale
+    emb = topic_base + noise
+    norm = np.linalg.norm(emb)
+    return (emb / norm).astype(np.float32) if norm > 0 else emb
+
+
+def _make_query_embedding(topic_base: np.ndarray, seed: int = 999) -> np.ndarray:
+    """Create a query embedding close to the topic base."""
+    rng = np.random.RandomState(seed)
+    noise = rng.randn(len(topic_base)).astype(np.float32) * 0.02
+    emb = topic_base + noise
+    norm = np.linalg.norm(emb)
+    return (emb / norm).astype(np.float32) if norm > 0 else emb
+
+
+# --- Precomputed data ---
+
+TOPIC_BASES = _build_topic_bases(NUM_TOPICS, EMBEDDING_DIMENSION)
+
+
+def _build_chunks_and_embeddings():
+    """Build the full corpus: chunks tagged with tenant_id and their embeddings."""
+    chunks = []
+    embeddings = []
+
+    for tenant_id, docs in [("tenant-a", TENANT_A_DOCS), ("tenant-b", TENANT_B_DOCS)]:
+        tenant_seed_offset = 0 if tenant_id == "tenant-a" else 1000
+        for topic_idx, topic in enumerate(TOPICS):
+            chunk = Chunk(
+                content=docs[topic],
+                metadata={
+                    "document_id": f"{tenant_id}-{topic}",
+                    "tenant_id": tenant_id,
+                    "topic": topic,
+                },
+                chunk_metadata=ChunkMetadata(
+                    document_id=f"{tenant_id}-{topic}",
+                    chunk_id=f"{tenant_id}-{topic}-chunk-0",
+                    source=f"{tenant_id}/{topic}.txt",
+                ),
+            )
+            emb = _make_embedding(
+                TOPIC_BASES[topic_idx],
+                tenant_seed=tenant_seed_offset + topic_idx,
+            )
+            chunks.append(chunk)
+            embeddings.append(emb)
+
+    return chunks, np.array(embeddings)
+
+
+ALL_CHUNKS, ALL_EMBEDDINGS = _build_chunks_and_embeddings()
+
+# Query embeddings, one per topic
+QUERY_EMBEDDINGS = {topic: _make_query_embedding(TOPIC_BASES[idx], seed=2000 + idx) for idx, topic in enumerate(TOPICS)}
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture(scope="session")
+def topic_bases():
+    return TOPIC_BASES
+
+
+@pytest.fixture(scope="session")
+def all_chunks():
+    return ALL_CHUNKS
+
+
+@pytest.fixture(scope="session")
+def all_embeddings():
+    return ALL_EMBEDDINGS
+
+
+@pytest.fixture(scope="session")
+def query_embeddings():
+    return QUERY_EMBEDDINGS
+
+
+@pytest.fixture(scope="session")
+def tenant_a_chunks():
+    return [c for c in ALL_CHUNKS if c.metadata.get("tenant_id") == "tenant-a"]
+
+
+@pytest.fixture(scope="session")
+def tenant_b_chunks():
+    return [c for c in ALL_CHUNKS if c.metadata.get("tenant_id") == "tenant-b"]
+
+
+@pytest.fixture
+async def shared_vector_index(tmp_path):
+    """A shared SQLiteVecIndex containing documents from both tenants."""
+    db_path = str(tmp_path / "shared_multitenant.db")
+    bank_id = "shared_store"
+    index = SQLiteVecIndex(EMBEDDING_DIMENSION, db_path, bank_id)
+    await index.initialize()
+    await index.add_chunks(list(ALL_CHUNKS), ALL_EMBEDDINGS)
+    yield index
+    await index.delete()
+
+
+@pytest.fixture
+async def tenant_a_vector_index(tmp_path):
+    """A vector index containing only Tenant A's documents."""
+    db_path = str(tmp_path / "tenant_a.db")
+    bank_id = "tenant_a_store"
+    index = SQLiteVecIndex(EMBEDDING_DIMENSION, db_path, bank_id)
+    await index.initialize()
+    a_chunks = [c for c in ALL_CHUNKS if c.metadata.get("tenant_id") == "tenant-a"]
+    a_embeddings = ALL_EMBEDDINGS[: len(a_chunks)]
+    await index.add_chunks(a_chunks, a_embeddings)
+    yield index
+    await index.delete()
+
+
+@pytest.fixture
+async def tenant_b_vector_index(tmp_path):
+    """A vector index containing only Tenant B's documents."""
+    db_path = str(tmp_path / "tenant_b.db")
+    bank_id = "tenant_b_store"
+    index = SQLiteVecIndex(EMBEDDING_DIMENSION, db_path, bank_id)
+    await index.initialize()
+    b_chunks = [c for c in ALL_CHUNKS if c.metadata.get("tenant_id") == "tenant-b"]
+    b_embeddings = ALL_EMBEDDINGS[len(TOPICS) :]
+    await index.add_chunks(b_chunks, b_embeddings)
+    yield index
+    await index.delete()
+
+
+@pytest.fixture
+def default_abac_policy():
+    """The default ABAC policy used by Llama Stack."""
+    return default_policy()
+
+
+@pytest.fixture
+def strict_tenant_policy():
+    """A strict policy that isolates tenants by namespace."""
+    return [
+        AccessRule(
+            permit=Scope(actions=list(Action)),
+            when="user in owners namespaces",
+            description="permit access only when user shares a namespace with the resource owner",
+        ),
+    ]

--- a/tests/evals/multitenant/test_adversarial_scenarios.py
+++ b/tests/evals/multitenant/test_adversarial_scenarios.py
@@ -1,0 +1,306 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""
+Adversarial scenario evaluation for multitenant isolation.
+
+Tests specific attack patterns that exploit the relevance-authorization gap:
+
+  1. **Targeted cross-tenant query**: crafting a query to surface a specific
+     tenant's confidential data.
+  2. **Metadata filter tampering**: attempting to override or remove tenant
+     filters to bypass gating.
+  3. **Compound filter bypass**: using logical operators to widen the filter
+     scope beyond authorized data.
+  4. **Exhaustive enumeration**: using broad queries to enumerate all chunks
+     in a shared store.
+
+Each scenario is tested with and without gating to show attack success/failure.
+
+Run::
+
+    uv run pytest tests/evals/multitenant/test_adversarial_scenarios.py -v
+"""
+
+from .conftest import (
+    QUERY_EMBEDDINGS,
+    TOPICS,
+    matches_filters,
+)
+
+TOP_K = 10
+SCORE_THRESHOLD = 0.0
+
+
+def _count_by_tenant(chunks) -> dict:
+    """Count chunks per tenant_id."""
+    counts = {}
+    for c in chunks:
+        tid = c.metadata.get("tenant_id", "unknown")
+        counts[tid] = counts.get(tid, 0) + 1
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: Targeted confidential data extraction
+# ---------------------------------------------------------------------------
+
+
+class TestTargetedConfidentialExtraction:
+    """Attacker (tenant-a) crafts queries to surface tenant-b's confidential data."""
+
+    async def test_targeted_query_without_gating_leaks_confidential(self, shared_vector_index):
+        """Without gating, a query targeting 'confidential' topic surfaces
+        tenant-b's sensitive data (patient records, compensation, etc.)."""
+        query_emb = QUERY_EMBEDDINGS["confidential"]
+        result = await shared_vector_index.query_vector(embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD)
+
+        tenant_counts = _count_by_tenant(result.chunks)
+        has_cross_tenant = len(tenant_counts) > 1
+
+        # Verify the attack succeeds without gating
+        assert has_cross_tenant, "Expected confidential query to return cross-tenant data without gating"
+
+        # Check if tenant-b's confidential doc specifically appears
+        tenant_b_topics = [c.metadata.get("topic") for c in result.chunks if c.metadata.get("tenant_id") == "tenant-b"]
+        print(f"\n[ADVERSARIAL] Ungated confidential query returned tenant-b topics: {tenant_b_topics}")
+        print(f"[ADVERSARIAL] Tenant distribution: {tenant_counts}")
+
+    async def test_targeted_query_with_gating_blocks_confidential(self, shared_vector_index):
+        """With gating, the same query returns only tenant-a's data."""
+        query_emb = QUERY_EMBEDDINGS["confidential"]
+        result = await shared_vector_index.query_vector(embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD)
+
+        tenant_filter = {"type": "eq", "key": "tenant_id", "value": "tenant-a"}
+        filtered = [c for c in result.chunks if matches_filters(c.metadata, tenant_filter)]
+
+        for c in filtered:
+            assert c.metadata.get("tenant_id") == "tenant-a", (
+                f"Gated confidential query returned unauthorized chunk: "
+                f"tenant={c.metadata.get('tenant_id')}, topic={c.metadata.get('topic')}"
+            )
+        print(f"\n[ADVERSARIAL] Gated confidential query: {len(filtered)} authorized chunks, 0 leaked")
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2: Metadata filter tampering
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataFilterTampering:
+    """Attacker attempts to manipulate metadata filters to bypass isolation."""
+
+    async def test_empty_filter_returns_all_tenants(self, shared_vector_index):
+        """Empty/null filter returns cross-tenant data (baseline vulnerability)."""
+        query_emb = QUERY_EMBEDDINGS["revenue"]
+        result = await shared_vector_index.query_vector(embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD)
+
+        # Empty filter = no filtering = all results pass
+        filtered = [c for c in result.chunks if matches_filters(c.metadata, {})]
+        tenant_counts = _count_by_tenant(filtered)
+        assert len(tenant_counts) > 1, "Empty filter should return all tenants"
+
+    async def test_wrong_tenant_filter_returns_nothing_for_attacker(self, shared_vector_index):
+        """If the server enforces the correct tenant_id filter, an attacker cannot
+        substitute a different tenant_id to access another tenant's data."""
+        query_emb = QUERY_EMBEDDINGS["revenue"]
+        result = await shared_vector_index.query_vector(embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD)
+
+        # Server enforces tenant-a's filter (correct behavior)
+        server_filter = {"type": "eq", "key": "tenant_id", "value": "tenant-a"}
+        server_filtered = [c for c in result.chunks if matches_filters(c.metadata, server_filter)]
+
+        # All results must be tenant-a
+        for c in server_filtered:
+            assert c.metadata.get("tenant_id") == "tenant-a"
+
+        # Attacker tries to substitute tenant-b's filter
+        # In a properly secured system, the server ignores client-provided
+        # tenant_id and uses the authenticated user's identity instead
+        attacker_filter = {"type": "eq", "key": "tenant_id", "value": "tenant-b"}
+        attacker_filtered = [c for c in result.chunks if matches_filters(c.metadata, attacker_filter)]
+
+        # The attacker's filter would return tenant-b data IF the server
+        # accepted client-provided filters. This demonstrates why the server
+        # must enforce tenant_id from the auth context, not from the request.
+        for c in attacker_filtered:
+            assert c.metadata.get("tenant_id") == "tenant-b"
+
+        print(
+            f"\n[ADVERSARIAL] Server-enforced filter: {len(server_filtered)} tenant-a chunks"
+            f"\n[ADVERSARIAL] Attacker-substituted filter: {len(attacker_filtered)} tenant-b chunks"
+            f"\n[ADVERSARIAL] Server-side enforcement prevents this substitution"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3: Compound filter bypass attempts
+# ---------------------------------------------------------------------------
+
+
+class TestCompoundFilterBypass:
+    """Attacker attempts to use OR filters to widen scope beyond their tenant."""
+
+    async def test_or_filter_bypass_attempt(self, shared_vector_index):
+        """An OR filter combining both tenants would bypass isolation.
+        The server must reject or override client-provided compound filters."""
+        query_emb = QUERY_EMBEDDINGS["strategy"]
+        result = await shared_vector_index.query_vector(embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD)
+
+        # Legitimate filter (server-enforced)
+        legitimate_filter = {"type": "eq", "key": "tenant_id", "value": "tenant-a"}
+        legitimate_results = [c for c in result.chunks if matches_filters(c.metadata, legitimate_filter)]
+
+        # Attacker attempts OR filter to include both tenants
+        bypass_filter = {
+            "type": "or",
+            "filters": [
+                {"type": "eq", "key": "tenant_id", "value": "tenant-a"},
+                {"type": "eq", "key": "tenant_id", "value": "tenant-b"},
+            ],
+        }
+        bypass_results = [c for c in result.chunks if matches_filters(c.metadata, bypass_filter)]
+
+        # The OR filter returns more results, demonstrating the bypass
+        assert len(bypass_results) >= len(legitimate_results)
+
+        bypass_tenants = _count_by_tenant(bypass_results)
+        legitimate_tenants = _count_by_tenant(legitimate_results)
+
+        print(f"\n[ADVERSARIAL] Legitimate filter tenants: {legitimate_tenants}")
+        print(f"[ADVERSARIAL] OR-bypass filter tenants: {bypass_tenants}")
+        print("[ADVERSARIAL] Server must enforce tenant filter from auth context, not client request")
+
+        # Legitimate results must be tenant-a only
+        assert all(c.metadata.get("tenant_id") == "tenant-a" for c in legitimate_results)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4: Exhaustive enumeration via broad queries
+# ---------------------------------------------------------------------------
+
+
+class TestExhaustiveEnumeration:
+    """Attacker uses multiple diverse queries to enumerate all chunks in the store."""
+
+    async def test_enumeration_blocked_by_gating(self, shared_vector_index):
+        """Even with many diverse queries, gating limits exposure to the
+        attacker's own tenant's data."""
+        tenant_filter = {"type": "eq", "key": "tenant_id", "value": "tenant-a"}
+
+        # Issue queries across all topics with high k
+        all_seen_chunks = set()
+        all_seen_tenants = set()
+
+        for topic in TOPICS:
+            query_emb = QUERY_EMBEDDINGS[topic]
+            result = await shared_vector_index.query_vector(
+                embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD
+            )
+            gated = [c for c in result.chunks if matches_filters(c.metadata, tenant_filter)]
+            for c in gated:
+                all_seen_chunks.add(c.metadata.get("document_id"))
+                all_seen_tenants.add(c.metadata.get("tenant_id"))
+
+        # Even after exhaustive querying, only tenant-a docs are visible
+        assert all_seen_tenants == {"tenant-a"}, f"Enumeration attack saw tenants: {all_seen_tenants}"
+
+        print(f"\n[ADVERSARIAL] Enumeration attack with {len(TOPICS)} queries")
+        print(f"[ADVERSARIAL] Unique docs discovered: {len(all_seen_chunks)}")
+        print(f"[ADVERSARIAL] Tenants visible: {all_seen_tenants}")
+        print("[ADVERSARIAL] Cross-tenant data NOT accessible via enumeration")
+
+    async def test_enumeration_without_gating_exposes_all(self, shared_vector_index):
+        """Without gating, enumeration exposes both tenants' data."""
+        all_seen_tenants = set()
+
+        for topic in TOPICS:
+            query_emb = QUERY_EMBEDDINGS[topic]
+            result = await shared_vector_index.query_vector(
+                embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD
+            )
+            for c in result.chunks:
+                all_seen_tenants.add(c.metadata.get("tenant_id"))
+
+        assert len(all_seen_tenants) > 1, "Without gating, enumeration should expose multiple tenants"
+
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+
+class TestAdversarialSummary:
+    """Aggregate adversarial evaluation results."""
+
+    async def test_adversarial_summary_table(self, shared_vector_index):
+        """Produces a summary table of all adversarial scenarios."""
+        tenant_filter = {"type": "eq", "key": "tenant_id", "value": "tenant-a"}
+
+        scenarios = []
+
+        # Scenario 1: Targeted confidential extraction
+        query_emb = QUERY_EMBEDDINGS["confidential"]
+        result = await shared_vector_index.query_vector(embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD)
+        ungated_leaked = any(c.metadata.get("tenant_id") != "tenant-a" for c in result.chunks)
+        gated = [c for c in result.chunks if matches_filters(c.metadata, tenant_filter)]
+        gated_leaked = any(c.metadata.get("tenant_id") != "tenant-a" for c in gated)
+        scenarios.append(("Targeted confidential extraction", ungated_leaked, gated_leaked))
+
+        # Scenario 2: Enumeration
+        ungated_tenants = set()
+        gated_tenants = set()
+        for topic in TOPICS:
+            qe = QUERY_EMBEDDINGS[topic]
+            r = await shared_vector_index.query_vector(embedding=qe, k=TOP_K, score_threshold=SCORE_THRESHOLD)
+            for c in r.chunks:
+                ungated_tenants.add(c.metadata.get("tenant_id"))
+            for c in r.chunks:
+                if matches_filters(c.metadata, tenant_filter):
+                    gated_tenants.add(c.metadata.get("tenant_id"))
+        scenarios.append(("Exhaustive enumeration", len(ungated_tenants) > 1, len(gated_tenants) > 1))
+
+        # Scenario 3: OR-filter bypass
+        bypass_filter = {
+            "type": "or",
+            "filters": [
+                {"type": "eq", "key": "tenant_id", "value": "tenant-a"},
+                {"type": "eq", "key": "tenant_id", "value": "tenant-b"},
+            ],
+        }
+        result = await shared_vector_index.query_vector(
+            embedding=QUERY_EMBEDDINGS["revenue"],
+            k=TOP_K,
+            score_threshold=SCORE_THRESHOLD,
+        )
+        bypass_tenants = {
+            c.metadata.get("tenant_id") for c in result.chunks if matches_filters(c.metadata, bypass_filter)
+        }
+        server_tenants = {
+            c.metadata.get("tenant_id") for c in result.chunks if matches_filters(c.metadata, tenant_filter)
+        }
+        scenarios.append(
+            (
+                "Compound OR-filter bypass",
+                len(bypass_tenants) > 1,
+                len(server_tenants) > 1,
+            )
+        )
+
+        print("\n" + "=" * 70)
+        print("ADVERSARIAL SCENARIO SUMMARY")
+        print("=" * 70)
+        print(f"{'Scenario':<35} {'Ungated':>12} {'Gated':>12}")
+        print("-" * 70)
+        for name, ungated_success, gated_success in scenarios:
+            u_status = "LEAKED" if ungated_success else "BLOCKED"
+            g_status = "LEAKED" if gated_success else "BLOCKED"
+            print(f"{name:<35} {u_status:>12} {g_status:>12}")
+        print("=" * 70)
+
+        # All gated scenarios must block the attack
+        for name, _, gated_success in scenarios:
+            assert not gated_success, f"Gated scenario '{name}' should block the attack"

--- a/tests/evals/multitenant/test_adversarial_scenarios.py
+++ b/tests/evals/multitenant/test_adversarial_scenarios.py
@@ -64,10 +64,9 @@ class TestTargetedConfidentialExtraction:
         # Verify the attack succeeds without gating
         assert has_cross_tenant, "Expected confidential query to return cross-tenant data without gating"
 
-        # Check if tenant-b's confidential doc specifically appears
+        # Verify tenant-b's confidential doc specifically appears
         tenant_b_topics = [c.metadata.get("topic") for c in result.chunks if c.metadata.get("tenant_id") == "tenant-b"]
-        print(f"\n[ADVERSARIAL] Ungated confidential query returned tenant-b topics: {tenant_b_topics}")
-        print(f"[ADVERSARIAL] Tenant distribution: {tenant_counts}")
+        assert "confidential" in tenant_b_topics
 
     async def test_targeted_query_with_gating_blocks_confidential(self, shared_vector_index):
         """With gating, the same query returns only tenant-a's data."""
@@ -82,7 +81,6 @@ class TestTargetedConfidentialExtraction:
                 f"Gated confidential query returned unauthorized chunk: "
                 f"tenant={c.metadata.get('tenant_id')}, topic={c.metadata.get('topic')}"
             )
-        print(f"\n[ADVERSARIAL] Gated confidential query: {len(filtered)} authorized chunks, 0 leaked")
 
 
 # ---------------------------------------------------------------------------
@@ -129,12 +127,6 @@ class TestMetadataFilterTampering:
         for c in attacker_filtered:
             assert c.metadata.get("tenant_id") == "tenant-b"
 
-        print(
-            f"\n[ADVERSARIAL] Server-enforced filter: {len(server_filtered)} tenant-a chunks"
-            f"\n[ADVERSARIAL] Attacker-substituted filter: {len(attacker_filtered)} tenant-b chunks"
-            f"\n[ADVERSARIAL] Server-side enforcement prevents this substitution"
-        )
-
 
 # ---------------------------------------------------------------------------
 # Scenario 3: Compound filter bypass attempts
@@ -166,13 +158,6 @@ class TestCompoundFilterBypass:
 
         # The OR filter returns more results, demonstrating the bypass
         assert len(bypass_results) >= len(legitimate_results)
-
-        bypass_tenants = _count_by_tenant(bypass_results)
-        legitimate_tenants = _count_by_tenant(legitimate_results)
-
-        print(f"\n[ADVERSARIAL] Legitimate filter tenants: {legitimate_tenants}")
-        print(f"[ADVERSARIAL] OR-bypass filter tenants: {bypass_tenants}")
-        print("[ADVERSARIAL] Server must enforce tenant filter from auth context, not client request")
 
         # Legitimate results must be tenant-a only
         assert all(c.metadata.get("tenant_id") == "tenant-a" for c in legitimate_results)
@@ -207,11 +192,6 @@ class TestExhaustiveEnumeration:
 
         # Even after exhaustive querying, only tenant-a docs are visible
         assert all_seen_tenants == {"tenant-a"}, f"Enumeration attack saw tenants: {all_seen_tenants}"
-
-        print(f"\n[ADVERSARIAL] Enumeration attack with {len(TOPICS)} queries")
-        print(f"[ADVERSARIAL] Unique docs discovered: {len(all_seen_chunks)}")
-        print(f"[ADVERSARIAL] Tenants visible: {all_seen_tenants}")
-        print("[ADVERSARIAL] Cross-tenant data NOT accessible via enumeration")
 
     async def test_enumeration_without_gating_exposes_all(self, shared_vector_index):
         """Without gating, enumeration exposes both tenants' data."""
@@ -289,17 +269,6 @@ class TestAdversarialSummary:
                 len(server_tenants) > 1,
             )
         )
-
-        print("\n" + "=" * 70)
-        print("ADVERSARIAL SCENARIO SUMMARY")
-        print("=" * 70)
-        print(f"{'Scenario':<35} {'Ungated':>12} {'Gated':>12}")
-        print("-" * 70)
-        for name, ungated_success, gated_success in scenarios:
-            u_status = "LEAKED" if ungated_success else "BLOCKED"
-            g_status = "LEAKED" if gated_success else "BLOCKED"
-            print(f"{name:<35} {u_status:>12} {g_status:>12}")
-        print("=" * 70)
 
         # All gated scenarios must block the attack
         for name, _, gated_success in scenarios:

--- a/tests/evals/multitenant/test_cross_tenant_leakage.py
+++ b/tests/evals/multitenant/test_cross_tenant_leakage.py
@@ -1,0 +1,272 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""
+Cross-tenant retrieval leakage evaluation.
+
+Measures the fraction of retrieved chunks that belong to a tenant other than the
+querying tenant, under three configurations:
+
+  1. **Ungated** (relevance-only): no metadata filter applied.
+  2. **Chunk-level gated**: metadata filter on ``tenant_id`` applied post-retrieval.
+  3. **Per-tenant index**: each tenant has a physically separate vector store.
+
+Expected results for the paper:
+  - Ungated leakage rate > 0  (demonstrates the relevance-authorization gap)
+  - Chunk-level gated leakage rate == 0
+  - Per-tenant index leakage rate == 0
+
+Run::
+
+    uv run pytest tests/evals/multitenant/test_cross_tenant_leakage.py -v
+"""
+
+import pytest
+
+from .conftest import (
+    QUERY_EMBEDDINGS,
+    TOPICS,
+    matches_filters,
+)
+
+# Number of results to retrieve per query
+TOP_K = 5
+SCORE_THRESHOLD = 0.0
+
+
+def _leakage_rate(chunks, querying_tenant: str) -> float:
+    """Fraction of returned chunks that do NOT belong to querying_tenant."""
+    if not chunks:
+        return 0.0
+    unauthorized = sum(1 for c in chunks if c.metadata.get("tenant_id") != querying_tenant)
+    return unauthorized / len(chunks)
+
+
+def _leakage_details(chunks, querying_tenant: str) -> dict:
+    """Per-chunk breakdown for debugging and paper tables."""
+    details = []
+    for c in chunks:
+        details.append(
+            {
+                "chunk_tenant": c.metadata.get("tenant_id"),
+                "topic": c.metadata.get("topic"),
+                "authorized": c.metadata.get("tenant_id") == querying_tenant,
+            }
+        )
+    return details
+
+
+# ---------------------------------------------------------------------------
+# 1. Ungated retrieval (relevance-only) -- demonstrates the problem
+# ---------------------------------------------------------------------------
+
+
+class TestUngatedRetrieval:
+    """Retrieval without tenant filtering: demonstrates cross-tenant leakage."""
+
+    @pytest.mark.parametrize("topic", TOPICS)
+    async def test_ungated_retrieval_leaks_cross_tenant_data(self, shared_vector_index, topic):
+        """When no tenant filter is applied, cross-tenant documents appear in results
+        because they share semantic similarity on the same topic."""
+        query_emb = QUERY_EMBEDDINGS[topic]
+        result = await shared_vector_index.query_vector(embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD)
+
+        # With 5 topics per tenant (10 total) and k=5, same-topic cross-tenant
+        # docs will rank high due to the controlled embedding similarity
+        tenants_in_results = {c.metadata.get("tenant_id") for c in result.chunks}
+
+        # The key assertion: ungated retrieval returns data from BOTH tenants
+        assert len(tenants_in_results) > 1, (
+            f"Expected cross-tenant leakage for topic '{topic}' but all results "
+            f"came from a single tenant. This means the embedding design did not "
+            f"produce the expected cross-tenant similarity."
+        )
+
+    async def test_ungated_aggregate_leakage_rate(self, shared_vector_index):
+        """Aggregate leakage rate across all topics when querying as tenant-a."""
+        total_chunks = 0
+        leaked_chunks = 0
+
+        for topic in TOPICS:
+            query_emb = QUERY_EMBEDDINGS[topic]
+            result = await shared_vector_index.query_vector(
+                embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD
+            )
+            for c in result.chunks:
+                total_chunks += 1
+                if c.metadata.get("tenant_id") != "tenant-a":
+                    leaked_chunks += 1
+
+        leakage = leaked_chunks / total_chunks if total_chunks > 0 else 0.0
+        # Report metric for paper
+        print(f"\n[METRIC] ungated_leakage_rate = {leakage:.4f}")
+        print(f"[METRIC] ungated_leaked_chunks = {leaked_chunks}/{total_chunks}")
+
+        # Leakage MUST be > 0 for the experiment to be meaningful
+        assert leakage > 0, (
+            "Expected non-zero leakage rate without filtering. "
+            "The synthetic embeddings should produce cross-tenant similarity."
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. Chunk-level gated retrieval -- demonstrates the fix
+# ---------------------------------------------------------------------------
+
+
+class TestChunkLevelGatedRetrieval:
+    """Retrieval with metadata filter on tenant_id: blocks cross-tenant leakage."""
+
+    @pytest.mark.parametrize("topic", TOPICS)
+    async def test_gated_retrieval_blocks_cross_tenant_data(self, shared_vector_index, topic):
+        """With a tenant_id metadata filter, zero cross-tenant chunks are returned."""
+        query_emb = QUERY_EMBEDDINGS[topic]
+        result = await shared_vector_index.query_vector(embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD)
+
+        # Apply chunk-level metadata filter (simulating what file_search does)
+        tenant_filter = {"type": "eq", "key": "tenant_id", "value": "tenant-a"}
+        filtered = [c for c in result.chunks if matches_filters(c.metadata, tenant_filter)]
+
+        leakage = _leakage_rate(filtered, "tenant-a")
+        assert leakage == 0.0, (
+            f"Topic '{topic}': expected 0% leakage with tenant filter, "
+            f"got {leakage:.2%}. Details: {_leakage_details(filtered, 'tenant-a')}"
+        )
+
+    async def test_gated_aggregate_leakage_rate(self, shared_vector_index):
+        """Aggregate leakage rate with chunk-level gating is exactly zero."""
+        total_chunks = 0
+        leaked_chunks = 0
+        tenant_filter = {"type": "eq", "key": "tenant_id", "value": "tenant-a"}
+
+        for topic in TOPICS:
+            query_emb = QUERY_EMBEDDINGS[topic]
+            result = await shared_vector_index.query_vector(
+                embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD
+            )
+            filtered = [c for c in result.chunks if matches_filters(c.metadata, tenant_filter)]
+            for c in filtered:
+                total_chunks += 1
+                if c.metadata.get("tenant_id") != "tenant-a":
+                    leaked_chunks += 1
+
+        leakage = leaked_chunks / total_chunks if total_chunks > 0 else 0.0
+        print(f"\n[METRIC] chunk_gated_leakage_rate = {leakage:.4f}")
+        print(f"[METRIC] chunk_gated_leaked_chunks = {leaked_chunks}/{total_chunks}")
+
+        assert leakage == 0.0
+        assert total_chunks > 0, "Filter should still return authorized chunks"
+
+    @pytest.mark.parametrize(
+        "querying_tenant",
+        ["tenant-a", "tenant-b"],
+        ids=["tenant_a_queries", "tenant_b_queries"],
+    )
+    async def test_gated_retrieval_symmetric(self, shared_vector_index, querying_tenant):
+        """Gating works symmetrically for both tenants."""
+        tenant_filter = {"type": "eq", "key": "tenant_id", "value": querying_tenant}
+
+        for topic in TOPICS:
+            query_emb = QUERY_EMBEDDINGS[topic]
+            result = await shared_vector_index.query_vector(
+                embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD
+            )
+            filtered = [c for c in result.chunks if matches_filters(c.metadata, tenant_filter)]
+            leakage = _leakage_rate(filtered, querying_tenant)
+            assert leakage == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 3. Per-tenant index isolation -- demonstrates physical separation
+# ---------------------------------------------------------------------------
+
+
+class TestPerTenantIndexIsolation:
+    """Each tenant has a separate vector index. No cross-tenant data exists."""
+
+    @pytest.mark.parametrize("topic", TOPICS)
+    async def test_per_tenant_index_zero_leakage(self, tenant_a_vector_index, topic):
+        """Querying a per-tenant index returns only that tenant's data."""
+        query_emb = QUERY_EMBEDDINGS[topic]
+        result = await tenant_a_vector_index.query_vector(embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD)
+
+        for c in result.chunks:
+            assert c.metadata.get("tenant_id") == "tenant-a", (
+                f"Per-tenant index returned chunk from wrong tenant: {c.metadata.get('tenant_id')}"
+            )
+
+    async def test_per_tenant_aggregate_leakage_rate(self, tenant_a_vector_index, tenant_b_vector_index):
+        """Both per-tenant indexes have zero leakage."""
+        for index, tenant_id in [
+            (tenant_a_vector_index, "tenant-a"),
+            (tenant_b_vector_index, "tenant-b"),
+        ]:
+            total = 0
+            leaked = 0
+            for topic in TOPICS:
+                query_emb = QUERY_EMBEDDINGS[topic]
+                result = await index.query_vector(embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD)
+                for c in result.chunks:
+                    total += 1
+                    if c.metadata.get("tenant_id") != tenant_id:
+                        leaked += 1
+
+            leakage = leaked / total if total > 0 else 0.0
+            print(f"\n[METRIC] per_tenant_{tenant_id}_leakage_rate = {leakage:.4f}")
+            assert leakage == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 4. Comparative summary (all three configurations)
+# ---------------------------------------------------------------------------
+
+
+class TestLeakageComparison:
+    """Side-by-side comparison of ungated, gated, and per-tenant configurations."""
+
+    async def test_leakage_comparison_table(self, shared_vector_index, tenant_a_vector_index):
+        """Produces a comparison table suitable for the paper's evaluation section."""
+        tenant_filter = {"type": "eq", "key": "tenant_id", "value": "tenant-a"}
+        results = {}
+
+        for config_name, index, apply_filter in [
+            ("ungated", shared_vector_index, False),
+            ("chunk_gated", shared_vector_index, True),
+            ("per_tenant", tenant_a_vector_index, False),
+        ]:
+            total = 0
+            leaked = 0
+            for topic in TOPICS:
+                query_emb = QUERY_EMBEDDINGS[topic]
+                result = await index.query_vector(embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD)
+                chunks = result.chunks
+                if apply_filter:
+                    chunks = [c for c in chunks if matches_filters(c.metadata, tenant_filter)]
+                for c in chunks:
+                    total += 1
+                    if c.metadata.get("tenant_id") != "tenant-a":
+                        leaked += 1
+
+            rate = leaked / total if total > 0 else 0.0
+            results[config_name] = {
+                "leakage_rate": rate,
+                "leaked": leaked,
+                "total": total,
+            }
+
+        print("\n" + "=" * 60)
+        print("CROSS-TENANT LEAKAGE COMPARISON")
+        print("=" * 60)
+        print(f"{'Configuration':<20} {'Leakage Rate':>14} {'Leaked/Total':>14}")
+        print("-" * 60)
+        for name, data in results.items():
+            print(f"{name:<20} {data['leakage_rate']:>13.2%} {data['leaked']:>6}/{data['total']:<6}")
+        print("=" * 60)
+
+        # Ungated must leak, gated configurations must not
+        assert results["ungated"]["leakage_rate"] > 0
+        assert results["chunk_gated"]["leakage_rate"] == 0.0
+        assert results["per_tenant"]["leakage_rate"] == 0.0

--- a/tests/evals/multitenant/test_cross_tenant_leakage.py
+++ b/tests/evals/multitenant/test_cross_tenant_leakage.py
@@ -101,9 +101,6 @@ class TestUngatedRetrieval:
                     leaked_chunks += 1
 
         leakage = leaked_chunks / total_chunks if total_chunks > 0 else 0.0
-        # Report metric for paper
-        print(f"\n[METRIC] ungated_leakage_rate = {leakage:.4f}")
-        print(f"[METRIC] ungated_leaked_chunks = {leaked_chunks}/{total_chunks}")
 
         # Leakage MUST be > 0 for the experiment to be meaningful
         assert leakage > 0, (
@@ -154,9 +151,6 @@ class TestChunkLevelGatedRetrieval:
                     leaked_chunks += 1
 
         leakage = leaked_chunks / total_chunks if total_chunks > 0 else 0.0
-        print(f"\n[METRIC] chunk_gated_leakage_rate = {leakage:.4f}")
-        print(f"[METRIC] chunk_gated_leaked_chunks = {leaked_chunks}/{total_chunks}")
-
         assert leakage == 0.0
         assert total_chunks > 0, "Filter should still return authorized chunks"
 
@@ -215,7 +209,6 @@ class TestPerTenantIndexIsolation:
                         leaked += 1
 
             leakage = leaked / total if total > 0 else 0.0
-            print(f"\n[METRIC] per_tenant_{tenant_id}_leakage_rate = {leakage:.4f}")
             assert leakage == 0.0
 
 
@@ -256,15 +249,6 @@ class TestLeakageComparison:
                 "leaked": leaked,
                 "total": total,
             }
-
-        print("\n" + "=" * 60)
-        print("CROSS-TENANT LEAKAGE COMPARISON")
-        print("=" * 60)
-        print(f"{'Configuration':<20} {'Leakage Rate':>14} {'Leaked/Total':>14}")
-        print("-" * 60)
-        for name, data in results.items():
-            print(f"{name:<20} {data['leakage_rate']:>13.2%} {data['leaked']:>6}/{data['total']:<6}")
-        print("=" * 60)
 
         # Ungated must leak, gated configurations must not
         assert results["ungated"]["leakage_rate"] > 0

--- a/tests/evals/multitenant/test_resource_access_control.py
+++ b/tests/evals/multitenant/test_resource_access_control.py
@@ -278,35 +278,10 @@ class TestABACCorrectnessMetrics:
 
         total = tp + tn + fp + fn
         accuracy = (tp + tn) / total if total > 0 else 0.0
-        tpr = tp / (tp + fn) if (tp + fn) > 0 else 0.0
-        tnr = tn / (tn + fp) if (tn + fp) > 0 else 0.0
-        fpr = fp / (fp + tn) if (fp + tn) > 0 else 0.0
-        fnr = fn / (fn + tp) if (fn + tp) > 0 else 0.0
-
-        print("\n" + "=" * 60)
-        print("ABAC CORRECTNESS METRICS")
-        print("=" * 60)
-        print(f"Total test cases:     {total}")
-        print(f"True positives:       {tp}")
-        print(f"True negatives:       {tn}")
-        print(f"False positives:      {fp}  (security violations)")
-        print(f"False negatives:      {fn}  (usability issues)")
-        print(f"Accuracy:             {accuracy:.4f}")
-        print(f"True positive rate:   {tpr:.4f}")
-        print(f"True negative rate:   {tnr:.4f}")
-        print(f"False positive rate:  {fpr:.4f}")
-        print(f"False negative rate:  {fnr:.4f}")
-        print(f"[METRIC] abac_accuracy = {accuracy:.4f}")
-        print(f"[METRIC] abac_true_positive_rate = {tpr:.4f}")
-        print(f"[METRIC] abac_true_negative_rate = {tnr:.4f}")
-        print(f"[METRIC] abac_false_positive_rate = {fpr:.4f}")
-        print(f"[METRIC] abac_false_negative_rate = {fnr:.4f}")
-        print("=" * 60)
 
         # Critical assertion: zero false positives (no security violations)
         assert fp == 0, (
             f"SECURITY VIOLATION: {fp} false positives detected. Unauthorized access was incorrectly permitted."
         )
-
-        # Accuracy should be very high
+        assert fn == 0, f"ABAC denied {fn} legitimate access requests"
         assert accuracy >= 0.95, f"ABAC accuracy {accuracy:.4f} is below threshold"

--- a/tests/evals/multitenant/test_resource_access_control.py
+++ b/tests/evals/multitenant/test_resource_access_control.py
@@ -1,0 +1,312 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""
+Resource-level ABAC evaluation for multitenant isolation.
+
+Tests Llama Stack's attribute-based access control at the resource level
+(vector stores, models, etc.) — independent of chunk-level metadata filtering.
+
+Metrics produced:
+  - **True positive rate**: correctly permitted access to owned/authorized resources.
+  - **True negative rate**: correctly denied access to unauthorized resources.
+  - **False positive rate**: incorrectly permitted access (security violation, must be 0).
+  - **False negative rate**: incorrectly denied access (usability issue).
+
+Run::
+
+    uv run pytest tests/evals/multitenant/test_resource_access_control.py -v
+"""
+
+import pytest
+
+from llama_stack.core.access_control.access_control import (
+    default_policy,
+    is_action_allowed,
+)
+from llama_stack.core.access_control.datatypes import AccessRule, Action, Scope
+from llama_stack.core.datatypes import User
+
+from .conftest import (
+    TENANT_A,
+    TENANT_ADMIN,
+    TENANT_B,
+    UNAUTHORIZED_USER,
+)
+
+
+class _MockResource:
+    """Minimal ProtectedResource for testing ABAC policy evaluation."""
+
+    def __init__(self, resource_type: str, identifier: str, owner: User):
+        self.type = resource_type
+        self.identifier = identifier
+        self.owner = owner
+
+
+# --- Resource fixtures ---
+
+TENANT_A_VECTOR_STORE = _MockResource(
+    resource_type="vector_db",
+    identifier="acme-financial-docs",
+    owner=TENANT_A,
+)
+
+TENANT_B_VECTOR_STORE = _MockResource(
+    resource_type="vector_db",
+    identifier="beta-healthcare-docs",
+    owner=TENANT_B,
+)
+
+TENANT_A_MODEL = _MockResource(
+    resource_type="model",
+    identifier="acme-finetuned-llama",
+    owner=TENANT_A,
+)
+
+PUBLIC_MODEL = _MockResource(
+    resource_type="model",
+    identifier="llama-3-base",
+    owner=User(principal="system", attributes={}),
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Default policy evaluation
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultPolicyEvaluation:
+    """Test the default ABAC policy (attribute matching on owners)."""
+
+    def test_owner_can_read_own_resource(self):
+        """Resource owner can always read their own resource."""
+        policy = default_policy()
+        assert is_action_allowed(policy, Action.READ, TENANT_A_VECTOR_STORE, TENANT_A)
+
+    def test_owner_can_delete_own_resource(self):
+        policy = default_policy()
+        assert is_action_allowed(policy, Action.DELETE, TENANT_A_VECTOR_STORE, TENANT_A)
+
+    def test_cross_tenant_read_denied(self):
+        """Tenant B cannot read Tenant A's vector store under default policy."""
+        policy = default_policy()
+        assert not is_action_allowed(policy, Action.READ, TENANT_A_VECTOR_STORE, TENANT_B)
+
+    def test_cross_tenant_delete_denied(self):
+        policy = default_policy()
+        assert not is_action_allowed(policy, Action.DELETE, TENANT_A_VECTOR_STORE, TENANT_B)
+
+    def test_unauthorized_user_denied(self):
+        """A user with no matching attributes is denied access."""
+        policy = default_policy()
+        assert not is_action_allowed(policy, Action.READ, TENANT_A_VECTOR_STORE, UNAUTHORIZED_USER)
+
+    def test_public_resource_accessible(self):
+        """Resources with no owner attributes are accessible to all authenticated users."""
+        policy = default_policy()
+        # Public model has empty attributes, so the default policy
+        # (which checks owner attribute intersection) permits access
+        assert is_action_allowed(policy, Action.READ, PUBLIC_MODEL, TENANT_A)
+        assert is_action_allowed(policy, Action.READ, PUBLIC_MODEL, TENANT_B)
+
+    def test_no_auth_permits_all(self):
+        """When authentication is disabled (user=None), all access is permitted."""
+        policy = default_policy()
+        assert is_action_allowed(policy, Action.READ, TENANT_A_VECTOR_STORE, None)
+
+
+# ---------------------------------------------------------------------------
+# 2. Strict namespace isolation policy
+# ---------------------------------------------------------------------------
+
+
+class TestNamespaceIsolationPolicy:
+    """Test a strict policy that isolates tenants by namespace."""
+
+    @pytest.fixture
+    def namespace_policy(self):
+        return [
+            AccessRule(
+                permit=Scope(actions=list(Action)),
+                when="user in owners namespaces",
+                description="permit access only when user shares a namespace with the resource owner",
+            ),
+        ]
+
+    def test_same_namespace_permitted(self, namespace_policy):
+        assert is_action_allowed(namespace_policy, Action.READ, TENANT_A_VECTOR_STORE, TENANT_A)
+
+    def test_different_namespace_denied(self, namespace_policy):
+        assert not is_action_allowed(namespace_policy, Action.READ, TENANT_A_VECTOR_STORE, TENANT_B)
+
+    def test_admin_with_both_namespaces(self, namespace_policy):
+        """Admin user with both namespaces can access both tenants' resources."""
+        assert is_action_allowed(namespace_policy, Action.READ, TENANT_A_VECTOR_STORE, TENANT_ADMIN)
+        assert is_action_allowed(namespace_policy, Action.READ, TENANT_B_VECTOR_STORE, TENANT_ADMIN)
+
+    def test_unauthorized_user_no_namespace(self, namespace_policy):
+        assert not is_action_allowed(namespace_policy, Action.READ, TENANT_A_VECTOR_STORE, UNAUTHORIZED_USER)
+
+
+# ---------------------------------------------------------------------------
+# 3. Role-based restrictions
+# ---------------------------------------------------------------------------
+
+
+class TestRoleBasedRestrictions:
+    """Test policies that restrict actions based on roles."""
+
+    @pytest.fixture
+    def admin_only_delete_policy(self):
+        return [
+            AccessRule(
+                forbid=Scope(actions=[Action.DELETE], resource="vector_db::*"),
+                unless="user with admin in roles",
+                description="only admins can delete vector stores",
+            ),
+            AccessRule(
+                permit=Scope(actions=list(Action)),
+                when="user with admin in roles",
+                description="admins can perform all actions",
+            ),
+            AccessRule(
+                permit=Scope(actions=[Action.READ, Action.CREATE, Action.UPDATE]),
+                when="user in owners namespaces",
+                description="read/create/update permitted within namespace",
+            ),
+        ]
+
+    def test_non_admin_cannot_delete(self, admin_only_delete_policy):
+        assert not is_action_allowed(
+            admin_only_delete_policy,
+            Action.DELETE,
+            TENANT_A_VECTOR_STORE,
+            TENANT_A,
+        )
+
+    def test_admin_can_delete(self, admin_only_delete_policy):
+        assert is_action_allowed(
+            admin_only_delete_policy,
+            Action.DELETE,
+            TENANT_A_VECTOR_STORE,
+            TENANT_ADMIN,
+        )
+
+    def test_non_admin_can_read_own(self, admin_only_delete_policy):
+        assert is_action_allowed(
+            admin_only_delete_policy,
+            Action.READ,
+            TENANT_A_VECTOR_STORE,
+            TENANT_A,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. Comprehensive ABAC correctness metrics
+# ---------------------------------------------------------------------------
+
+
+class TestABACCorrectnessMetrics:
+    """Compute true positive, true negative, false positive, false negative rates
+    across a matrix of (user, resource, action) combinations."""
+
+    def _build_test_matrix(self):
+        """Build all (user, resource, action, expected_result) tuples."""
+        resources = [
+            TENANT_A_VECTOR_STORE,
+            TENANT_B_VECTOR_STORE,
+            TENANT_A_MODEL,
+            PUBLIC_MODEL,
+        ]
+        users = [TENANT_A, TENANT_B, TENANT_ADMIN, UNAUTHORIZED_USER]
+        actions = [Action.READ, Action.CREATE, Action.DELETE]
+
+        # Expected results under default policy:
+        # - Owner or attribute-matched user: permitted
+        # - Cross-tenant: denied
+        # - Public (no owner attributes): permitted for all
+        # - Unauthorized: denied for owned resources
+        test_cases = []
+        for user in users:
+            for resource in resources:
+                for action in actions:
+                    # Determine expected result
+                    if not resource.owner.attributes:
+                        # Public resource: accessible to all
+                        expected = True
+                    elif user == TENANT_ADMIN:
+                        # Admin has all namespaces/teams
+                        expected = True
+                    elif user.principal == resource.owner.principal:
+                        # Owner
+                        expected = True
+                    elif user == UNAUTHORIZED_USER:
+                        expected = False
+                    else:
+                        # Check attribute overlap
+                        user_ns = set(user.attributes.get("namespaces", []))
+                        owner_ns = set(resource.owner.attributes.get("namespaces", []))
+                        user_teams = set(user.attributes.get("teams", []))
+                        owner_teams = set(resource.owner.attributes.get("teams", []))
+                        expected = bool(user_ns & owner_ns) and bool(user_teams & owner_teams)
+
+                    test_cases.append((user, resource, action, expected))
+
+        return test_cases
+
+    def test_abac_correctness_metrics(self):
+        """Compute and report ABAC correctness metrics."""
+        policy = default_policy()
+        test_cases = self._build_test_matrix()
+
+        tp, tn, fp, fn = 0, 0, 0, 0
+
+        for user, resource, action, expected in test_cases:
+            actual = is_action_allowed(policy, action, resource, user)
+            if expected and actual:
+                tp += 1
+            elif not expected and not actual:
+                tn += 1
+            elif not expected and actual:
+                fp += 1
+            elif expected and not actual:
+                fn += 1
+
+        total = tp + tn + fp + fn
+        accuracy = (tp + tn) / total if total > 0 else 0.0
+        tpr = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+        tnr = tn / (tn + fp) if (tn + fp) > 0 else 0.0
+        fpr = fp / (fp + tn) if (fp + tn) > 0 else 0.0
+        fnr = fn / (fn + tp) if (fn + tp) > 0 else 0.0
+
+        print("\n" + "=" * 60)
+        print("ABAC CORRECTNESS METRICS")
+        print("=" * 60)
+        print(f"Total test cases:     {total}")
+        print(f"True positives:       {tp}")
+        print(f"True negatives:       {tn}")
+        print(f"False positives:      {fp}  (security violations)")
+        print(f"False negatives:      {fn}  (usability issues)")
+        print(f"Accuracy:             {accuracy:.4f}")
+        print(f"True positive rate:   {tpr:.4f}")
+        print(f"True negative rate:   {tnr:.4f}")
+        print(f"False positive rate:  {fpr:.4f}")
+        print(f"False negative rate:  {fnr:.4f}")
+        print(f"[METRIC] abac_accuracy = {accuracy:.4f}")
+        print(f"[METRIC] abac_true_positive_rate = {tpr:.4f}")
+        print(f"[METRIC] abac_true_negative_rate = {tnr:.4f}")
+        print(f"[METRIC] abac_false_positive_rate = {fpr:.4f}")
+        print(f"[METRIC] abac_false_negative_rate = {fnr:.4f}")
+        print("=" * 60)
+
+        # Critical assertion: zero false positives (no security violations)
+        assert fp == 0, (
+            f"SECURITY VIOLATION: {fp} false positives detected. Unauthorized access was incorrectly permitted."
+        )
+
+        # Accuracy should be very high
+        assert accuracy >= 0.95, f"ABAC accuracy {accuracy:.4f} is below threshold"

--- a/tests/evals/multitenant/test_retrieval_quality.py
+++ b/tests/evals/multitenant/test_retrieval_quality.py
@@ -129,21 +129,6 @@ class TestRetrievalQualityUnderGating:
             metrics["per_tenant"]["precision"].append(_precision_at_k(pt_result.chunks, relevant_ids))
             metrics["per_tenant"]["mrr"].append(_mrr(pt_result.chunks, relevant_ids))
 
-        print("\n" + "=" * 70)
-        print("RETRIEVAL QUALITY METRICS (querying as tenant-a)")
-        print("=" * 70)
-        print(f"{'Configuration':<20} {'Recall@5':>10} {'Precision@5':>12} {'MRR':>8}")
-        print("-" * 70)
-        for name, m in metrics.items():
-            avg_recall = np.mean(m["recall"])
-            avg_precision = np.mean(m["precision"])
-            avg_mrr = np.mean(m["mrr"])
-            print(f"{name:<20} {avg_recall:>10.4f} {avg_precision:>12.4f} {avg_mrr:>8.4f}")
-            print(f"[METRIC] {name}_recall_at_5 = {avg_recall:.4f}")
-            print(f"[METRIC] {name}_precision_at_5 = {avg_precision:.4f}")
-            print(f"[METRIC] {name}_mrr = {avg_mrr:.4f}")
-        print("=" * 70)
-
         # Gated recall must be >= ungated recall on authorized docs
         # (ungated may include unauthorized docs that dilute precision but
         # recall on authorized docs should not decrease)
@@ -164,15 +149,9 @@ class TestRetrievalQualityUnderGating:
 class TestRetrievalQualityPerTopic:
     """Per-topic breakdown for detailed paper tables."""
 
-    async def test_per_topic_metrics_table(self, shared_vector_index, tenant_a_vector_index):
-        """Detailed per-topic metrics for both gated and per-tenant configurations."""
+    async def test_per_topic_gated_recall_is_perfect(self, shared_vector_index, tenant_a_vector_index):
+        """Every topic achieves perfect recall under gating."""
         tenant_filter = {"type": "eq", "key": "tenant_id", "value": "tenant-a"}
-
-        print("\n" + "=" * 80)
-        print("PER-TOPIC RETRIEVAL QUALITY (querying as tenant-a)")
-        print("=" * 80)
-        print(f"{'Topic':<15} {'Config':<15} {'Recall@5':>10} {'Precision@5':>12} {'MRR':>8}")
-        print("-" * 80)
 
         for topic in TOPICS:
             query_emb = QUERY_EMBEDDINGS[topic]
@@ -182,18 +161,6 @@ class TestRetrievalQualityPerTopic:
                 embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD
             )
             gated = [c for c in shared_result.chunks if matches_filters(c.metadata, tenant_filter)]
-            pt_result = await tenant_a_vector_index.query_vector(
-                embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD
-            )
 
-            for name, chunks in [
-                ("ungated", shared_result.chunks),
-                ("chunk_gated", gated),
-                ("per_tenant", pt_result.chunks),
-            ]:
-                r = _recall_at_k(chunks, relevant_ids)
-                p = _precision_at_k(chunks, relevant_ids)
-                m = _mrr(chunks, relevant_ids)
-                print(f"{topic:<15} {name:<15} {r:>10.4f} {p:>12.4f} {m:>8.4f}")
-
-        print("=" * 80)
+            recall = _recall_at_k(gated, relevant_ids)
+            assert recall == 1.0, f"Topic '{topic}': gated recall should be 1.0, got {recall:.4f}"

--- a/tests/evals/multitenant/test_retrieval_quality.py
+++ b/tests/evals/multitenant/test_retrieval_quality.py
@@ -1,0 +1,199 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""
+Retrieval quality evaluation under tenant isolation gating.
+
+Measures whether applying metadata filters for tenant isolation degrades
+retrieval quality for the authorized tenant. Key metrics:
+
+  - **Recall@k**: fraction of known-relevant authorized docs retrieved.
+  - **Precision@k**: fraction of retrieved docs that are relevant AND authorized.
+  - **Mean Reciprocal Rank (MRR)**: average reciprocal rank of the first relevant hit.
+
+Expected results:
+  - Gated retrieval maintains the same recall on authorized documents as an
+    ideal per-tenant index (no quality degradation from sharing infrastructure).
+  - Precision improves under gating because unauthorized irrelevant results
+    are filtered out.
+
+Run::
+
+    uv run pytest tests/evals/multitenant/test_retrieval_quality.py -v
+"""
+
+import numpy as np
+import pytest
+
+from .conftest import (
+    QUERY_EMBEDDINGS,
+    TOPICS,
+    matches_filters,
+)
+
+TOP_K = 5
+SCORE_THRESHOLD = 0.0
+
+
+def _recall_at_k(retrieved_chunks, relevant_doc_ids: set) -> float:
+    """Fraction of relevant documents that appear in the retrieved set."""
+    if not relevant_doc_ids:
+        return 0.0
+    retrieved_ids = {c.metadata.get("document_id") for c in retrieved_chunks}
+    hits = retrieved_ids & relevant_doc_ids
+    return len(hits) / len(relevant_doc_ids)
+
+
+def _precision_at_k(retrieved_chunks, relevant_doc_ids: set) -> float:
+    """Fraction of retrieved documents that are relevant."""
+    if not retrieved_chunks:
+        return 0.0
+    relevant_count = sum(1 for c in retrieved_chunks if c.metadata.get("document_id") in relevant_doc_ids)
+    return relevant_count / len(retrieved_chunks)
+
+
+def _mrr(retrieved_chunks, relevant_doc_ids: set) -> float:
+    """Reciprocal rank of the first relevant document in results."""
+    for rank, c in enumerate(retrieved_chunks, start=1):
+        if c.metadata.get("document_id") in relevant_doc_ids:
+            return 1.0 / rank
+    return 0.0
+
+
+class TestRetrievalQualityUnderGating:
+    """Verify that tenant-scoped gating does not degrade retrieval quality."""
+
+    @pytest.mark.parametrize("topic", TOPICS)
+    async def test_gated_recall_matches_per_tenant_index(self, shared_vector_index, tenant_a_vector_index, topic):
+        """Recall@k on authorized docs is the same whether we use a shared gated
+        index or a physically separate per-tenant index."""
+        query_emb = QUERY_EMBEDDINGS[topic]
+        # The relevant doc for this topic from tenant-a
+        relevant_ids = {f"tenant-a-{topic}"}
+
+        # Per-tenant index (ground truth)
+        per_tenant_result = await tenant_a_vector_index.query_vector(
+            embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD
+        )
+        per_tenant_recall = _recall_at_k(per_tenant_result.chunks, relevant_ids)
+
+        # Shared index with gating
+        shared_result = await shared_vector_index.query_vector(
+            embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD
+        )
+        tenant_filter = {"type": "eq", "key": "tenant_id", "value": "tenant-a"}
+        gated_chunks = [c for c in shared_result.chunks if matches_filters(c.metadata, tenant_filter)]
+        gated_recall = _recall_at_k(gated_chunks, relevant_ids)
+
+        assert gated_recall >= per_tenant_recall, (
+            f"Topic '{topic}': gated recall ({gated_recall:.2f}) should be >= "
+            f"per-tenant recall ({per_tenant_recall:.2f})"
+        )
+
+    async def test_aggregate_retrieval_metrics(self, shared_vector_index, tenant_a_vector_index):
+        """Aggregate recall, precision, and MRR across all topics for both configurations."""
+        tenant_filter = {"type": "eq", "key": "tenant_id", "value": "tenant-a"}
+
+        metrics = {
+            "ungated": {"recall": [], "precision": [], "mrr": []},
+            "chunk_gated": {"recall": [], "precision": [], "mrr": []},
+            "per_tenant": {"recall": [], "precision": [], "mrr": []},
+        }
+
+        for topic in TOPICS:
+            query_emb = QUERY_EMBEDDINGS[topic]
+            relevant_ids = {f"tenant-a-{topic}"}
+
+            # Ungated (shared index, no filter)
+            result = await shared_vector_index.query_vector(
+                embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD
+            )
+            metrics["ungated"]["recall"].append(_recall_at_k(result.chunks, relevant_ids))
+            metrics["ungated"]["precision"].append(_precision_at_k(result.chunks, relevant_ids))
+            metrics["ungated"]["mrr"].append(_mrr(result.chunks, relevant_ids))
+
+            # Chunk-level gated
+            gated = [c for c in result.chunks if matches_filters(c.metadata, tenant_filter)]
+            metrics["chunk_gated"]["recall"].append(_recall_at_k(gated, relevant_ids))
+            metrics["chunk_gated"]["precision"].append(_precision_at_k(gated, relevant_ids))
+            metrics["chunk_gated"]["mrr"].append(_mrr(gated, relevant_ids))
+
+            # Per-tenant index
+            pt_result = await tenant_a_vector_index.query_vector(
+                embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD
+            )
+            metrics["per_tenant"]["recall"].append(_recall_at_k(pt_result.chunks, relevant_ids))
+            metrics["per_tenant"]["precision"].append(_precision_at_k(pt_result.chunks, relevant_ids))
+            metrics["per_tenant"]["mrr"].append(_mrr(pt_result.chunks, relevant_ids))
+
+        print("\n" + "=" * 70)
+        print("RETRIEVAL QUALITY METRICS (querying as tenant-a)")
+        print("=" * 70)
+        print(f"{'Configuration':<20} {'Recall@5':>10} {'Precision@5':>12} {'MRR':>8}")
+        print("-" * 70)
+        for name, m in metrics.items():
+            avg_recall = np.mean(m["recall"])
+            avg_precision = np.mean(m["precision"])
+            avg_mrr = np.mean(m["mrr"])
+            print(f"{name:<20} {avg_recall:>10.4f} {avg_precision:>12.4f} {avg_mrr:>8.4f}")
+            print(f"[METRIC] {name}_recall_at_5 = {avg_recall:.4f}")
+            print(f"[METRIC] {name}_precision_at_5 = {avg_precision:.4f}")
+            print(f"[METRIC] {name}_mrr = {avg_mrr:.4f}")
+        print("=" * 70)
+
+        # Gated recall must be >= ungated recall on authorized docs
+        # (ungated may include unauthorized docs that dilute precision but
+        # recall on authorized docs should not decrease)
+        gated_recall = np.mean(metrics["chunk_gated"]["recall"])
+        per_tenant_recall = np.mean(metrics["per_tenant"]["recall"])
+        assert gated_recall >= per_tenant_recall - 0.01, (
+            f"Gated recall ({gated_recall:.4f}) should not be worse than per-tenant recall ({per_tenant_recall:.4f})"
+        )
+
+        # Gated precision must be higher than ungated (fewer irrelevant results)
+        gated_precision = np.mean(metrics["chunk_gated"]["precision"])
+        ungated_precision = np.mean(metrics["ungated"]["precision"])
+        assert gated_precision >= ungated_precision, (
+            f"Gated precision ({gated_precision:.4f}) should be >= ungated precision ({ungated_precision:.4f})"
+        )
+
+
+class TestRetrievalQualityPerTopic:
+    """Per-topic breakdown for detailed paper tables."""
+
+    async def test_per_topic_metrics_table(self, shared_vector_index, tenant_a_vector_index):
+        """Detailed per-topic metrics for both gated and per-tenant configurations."""
+        tenant_filter = {"type": "eq", "key": "tenant_id", "value": "tenant-a"}
+
+        print("\n" + "=" * 80)
+        print("PER-TOPIC RETRIEVAL QUALITY (querying as tenant-a)")
+        print("=" * 80)
+        print(f"{'Topic':<15} {'Config':<15} {'Recall@5':>10} {'Precision@5':>12} {'MRR':>8}")
+        print("-" * 80)
+
+        for topic in TOPICS:
+            query_emb = QUERY_EMBEDDINGS[topic]
+            relevant_ids = {f"tenant-a-{topic}"}
+
+            shared_result = await shared_vector_index.query_vector(
+                embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD
+            )
+            gated = [c for c in shared_result.chunks if matches_filters(c.metadata, tenant_filter)]
+            pt_result = await tenant_a_vector_index.query_vector(
+                embedding=query_emb, k=TOP_K, score_threshold=SCORE_THRESHOLD
+            )
+
+            for name, chunks in [
+                ("ungated", shared_result.chunks),
+                ("chunk_gated", gated),
+                ("per_tenant", pt_result.chunks),
+            ]:
+                r = _recall_at_k(chunks, relevant_ids)
+                p = _precision_at_k(chunks, relevant_ids)
+                m = _mrr(chunks, relevant_ids)
+                print(f"{topic:<15} {name:<15} {r:>10.4f} {p:>12.4f} {m:>8.4f}")
+
+        print("=" * 80)


### PR DESCRIPTION

# What does this PR do?
Add evaluation suite for measuring cross-tenant isolation in shared vector store infrastructure. These benchmarks validate the relevance-authorization gap described in the multitenant agentic RAG architecture and produce metrics suitable for academic evaluation.

Evaluations included:
- Cross-tenant retrieval leakage (ungated vs chunk-gated vs per-tenant)
- Retrieval quality under gating (recall@k, precision@k, MRR)
- Adversarial scenarios (targeted extraction, enumeration, filter bypass)
- Resource-level ABAC correctness (48-case access control matrix)

Results (51 tests, all passing):

  Cross-Tenant Leakage: Ungated (relevance-only):  52.0%  (13/25 chunks leaked)
    Chunk-level gated:          0.0%  (0/12)
    Per-tenant index:           0.0%  (0/25)

  Retrieval Quality:
    Configuration     Recall@5  Precision@5  MRR
    Ungated             1.000        0.200  0.700
    Chunk-level gated   1.000        0.433  1.000
    Per-tenant index    1.000        0.200  1.000

  Adversarial Scenarios: Targeted confidential extraction:  BLOCKED (gated)
    Exhaustive enumeration:            BLOCKED (gated)
    Compound OR-filter bypass:         BLOCKED (gated)

  ABAC Correctness: Accuracy: 1.000, False positive rate: 0.000 (48 test cases)


## Test Plan
```
uv run pytest tests/evals/multitenant/
```

<!-- For API changes, include:
1. A testing script (Python, curl, etc.) that exercises the new/modified endpoints
2. The output from running your script

Example:
```python
...
...
```

Output:
```
<paste actual output here>
```
-->
