### PR TITLE
docs(messages): clarify provider description with passthrough and translation modes

### DIFF
--- a/docs/docs/providers/messages/inline_builtin.mdx
+++ b/docs/docs/providers/messages/inline_builtin.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Anthropic Messages API adapter that translates to the inference API."
+description: "Implements the Anthropic Messages API with two modes: native passthrough for providers that support /v1/messages natively (e.g. Ollama, vLLM), and automatic translation for all other providers by converting between Anthropic and OpenAI Chat Completions formats."
 sidebar_label: Builtin
 title: inline::builtin
 ---
@@ -8,7 +8,7 @@ title: inline::builtin
 
 ## Description
 
-Anthropic Messages API adapter that translates to the inference API.
+Implements the Anthropic Messages API with two modes: native passthrough for providers that support /v1/messages natively (e.g. Ollama, vLLM), and automatic translation for all other providers by converting between Anthropic and OpenAI Chat Completions formats.
 
 ## Sample Configuration
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -106,11 +106,63 @@ const sidebars: SidebarsConfig = {
         'providers/openai',
         {
           type: 'category',
+          label: 'Batches',
+          collapsed: false,
+          link: { type: 'doc', id: 'providers/batches/index' },
+          items: [
+            'providers/batches/inline_reference'
+          ],
+        },
+        {
+          type: 'category',
+          label: 'DatasetIO',
+          collapsed: false,
+          link: { type: 'doc', id: 'providers/datasetio/index' },
+          items: [
+            'providers/datasetio/inline_localfs',
+            'providers/datasetio/remote_huggingface',
+            'providers/datasetio/remote_nvidia'
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Eval',
+          collapsed: false,
+          link: { type: 'doc', id: 'providers/eval/index' },
+          items: [
+            'providers/eval/inline_builtin',
+            'providers/eval/remote_nvidia'
+          ],
+        },
+        {
+          type: 'category',
+          label: 'File Processors',
+          collapsed: false,
+          link: { type: 'doc', id: 'providers/file_processors/index' },
+          items: [
+            'providers/file_processors/inline_docling',
+            'providers/file_processors/inline_pypdf'
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Files',
+          collapsed: false,
+          link: { type: 'doc', id: 'providers/files/index' },
+          items: [
+            'providers/files/inline_localfs',
+            'providers/files/remote_s3',
+            'providers/files/remote_openai'
+          ],
+        },
+        {
+          type: 'category',
           label: 'Inference',
           collapsed: false,
+          link: { type: 'doc', id: 'providers/inference/index' },
           items: [
-            'providers/inference/index',
             'providers/inference/inline_sentence-transformers',
+            'providers/inference/inline_transformers',
             'providers/inference/remote_anthropic',
             'providers/inference/remote_azure',
             'providers/inference/remote_bedrock',
@@ -119,8 +171,10 @@ const sidebars: SidebarsConfig = {
             'providers/inference/remote_fireworks',
             'providers/inference/remote_gemini',
             'providers/inference/remote_groq',
+            'providers/inference/remote_llama-cpp-server',
             'providers/inference/remote_llama-openai-compat',
             'providers/inference/remote_nvidia',
+            'providers/inference/remote_oci',
             'providers/inference/remote_ollama',
             'providers/inference/remote_openai',
             'providers/inference/remote_passthrough',
@@ -130,54 +184,56 @@ const sidebars: SidebarsConfig = {
             'providers/inference/remote_vertexai',
             'providers/inference/remote_vllm',
             'providers/inference/remote_watsonx',
-            'providers/inference/inline_transformers',
-            'providers/inference/remote_oci',
-            'providers/inference/remote_llama-cpp-server'
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Interactions',
+          collapsed: false,
+          link: { type: 'doc', id: 'providers/interactions/index' },
+          items: [
+            'providers/interactions/inline_builtin'
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Messages',
+          collapsed: false,
+          link: { type: 'doc', id: 'providers/messages/index' },
+          items: [
+            'providers/messages/inline_builtin'
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Responses',
+          collapsed: false,
+          link: { type: 'doc', id: 'providers/responses/index' },
+          items: [
+            'providers/responses/inline_builtin'
           ],
         },
         {
           type: 'category',
           label: 'Safety',
           collapsed: false,
+          link: { type: 'doc', id: 'providers/safety/index' },
           items: [
-            'providers/safety/index',
             'providers/safety/inline_code-scanner',
             'providers/safety/inline_llama-guard',
             'providers/safety/inline_prompt-guard',
             'providers/safety/remote_bedrock',
             'providers/safety/remote_nvidia',
+            'providers/safety/remote_passthrough',
             'providers/safety/remote_sambanova',
-            'providers/safety/remote_passthrough'
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Vector IO',
-          collapsed: false,
-          items: [
-            'providers/vector_io/index',
-            'providers/vector_io/inline_chromadb',
-            'providers/vector_io/inline_faiss',
-            'providers/vector_io/inline_builtin',
-            'providers/vector_io/inline_milvus',
-            'providers/vector_io/inline_qdrant',
-            'providers/vector_io/inline_sqlite-vec',
-            'providers/vector_io/remote_chromadb',
-            'providers/vector_io/remote_milvus',
-            'providers/vector_io/remote_pgvector',
-            'providers/vector_io/remote_qdrant',
-            'providers/vector_io/remote_weaviate',
-            'providers/vector_io/remote_elasticsearch',
-            'providers/vector_io/remote_oci',
-            'providers/vector_io/remote_infinispan'
           ],
         },
         {
           type: 'category',
           label: 'Tool Runtime',
           collapsed: false,
+          link: { type: 'doc', id: 'providers/tool_runtime/index' },
           items: [
-            'providers/tool_runtime/index',
             'providers/tool_runtime/inline_file-search',
             'providers/tool_runtime/remote_bing-search',
             'providers/tool_runtime/remote_brave-search',
@@ -186,83 +242,26 @@ const sidebars: SidebarsConfig = {
             'providers/tool_runtime/remote_wolfram-alpha'
           ],
         },
-
         {
           type: 'category',
-          label: 'DatasetIO',
+          label: 'Vector IO',
           collapsed: false,
+          link: { type: 'doc', id: 'providers/vector_io/index' },
           items: [
-            'providers/datasetio/index',
-            'providers/datasetio/inline_localfs',
-            'providers/datasetio/remote_huggingface',
-            'providers/datasetio/remote_nvidia'
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Files',
-          collapsed: false,
-          items: [
-            'providers/files/index',
-            'providers/files/inline_localfs',
-            'providers/files/remote_s3',
-            'providers/files/remote_openai'
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Responses',
-          collapsed: false,
-          items: [
-            'providers/responses/index',
-            'providers/responses/inline_builtin'
-          ],
-        },
-        {
-          type: 'category',
-          label: 'File Processors',
-          collapsed: false,
-          items: [
-            'providers/file_processors/index',
-            'providers/file_processors/inline_docling',
-            'providers/file_processors/inline_pypdf'
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Eval',
-          collapsed: false,
-          items: [
-            'providers/eval/index',
-            'providers/eval/inline_builtin',
-            'providers/eval/remote_nvidia'
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Messages',
-          collapsed: false,
-          items: [
-            'providers/messages/index',
-            'providers/messages/inline_builtin'
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Interactions',
-          collapsed: false,
-          items: [
-            'providers/interactions/index',
-            'providers/interactions/inline_builtin'
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Batches',
-          collapsed: false,
-          items: [
-            'providers/batches/index',
-            'providers/batches/inline_reference'
+            'providers/vector_io/inline_builtin',
+            'providers/vector_io/inline_chromadb',
+            'providers/vector_io/inline_faiss',
+            'providers/vector_io/inline_milvus',
+            'providers/vector_io/inline_qdrant',
+            'providers/vector_io/inline_sqlite-vec',
+            'providers/vector_io/remote_chromadb',
+            'providers/vector_io/remote_elasticsearch',
+            'providers/vector_io/remote_infinispan',
+            'providers/vector_io/remote_milvus',
+            'providers/vector_io/remote_oci',
+            'providers/vector_io/remote_pgvector',
+            'providers/vector_io/remote_qdrant',
+            'providers/vector_io/remote_weaviate',
           ],
         },
       ],

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -43,6 +43,11 @@ const sidebars: SidebarsConfig = {
             'concepts/apis/google_interactions',
             'concepts/apis/external',
             'concepts/apis/api_leveling',
+            {
+              type: 'link',
+              label: 'Anthropic Messages',
+              href: '/docs/api-openai/anthropic_messages',
+            },
           ],
         },
         {

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -240,6 +240,24 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'category',
+          label: 'Messages',
+          collapsed: false,
+          items: [
+            'providers/messages/index',
+            'providers/messages/inline_builtin'
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Interactions',
+          collapsed: false,
+          items: [
+            'providers/interactions/index',
+            'providers/interactions/inline_builtin'
+          ],
+        },
+        {
+          type: 'category',
           label: 'Batches',
           collapsed: false,
           items: [

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -381,64 +381,64 @@ h3 {
   background-position: center;
 }
 
-/* Cpu - Inference */
+/* Layers - Batches */
 .theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(6) > .menu__list-item-collapsible > .menu__link::before {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='4' y='4' width='16' height='16' rx='2'/%3E%3Crect x='9' y='9' width='6' height='6'/%3E%3Cpath d='M15 2v2'/%3E%3Cpath d='M15 20v2'/%3E%3Cpath d='M2 15h2'/%3E%3Cpath d='M2 9h2'/%3E%3Cpath d='M20 15h2'/%3E%3Cpath d='M20 9h2'/%3E%3Cpath d='M9 2v2'/%3E%3Cpath d='M9 20v2'/%3E%3C/svg%3E");
-}
-
-/* Shield - Safety */
-.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(7) > .menu__list-item-collapsible > .menu__link::before {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z'/%3E%3C/svg%3E");
-}
-
-/* Database - Vector IO */
-.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(8) > .menu__list-item-collapsible > .menu__link::before {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cellipse cx='12' cy='5' rx='9' ry='3'/%3E%3Cpath d='M3 5v14c0 1.66 4.03 3 9 3s9-1.34 9-3V5'/%3E%3Cpath d='M3 12c0 1.66 4.03 3 9 3s9-1.34 9-3'/%3E%3C/svg%3E");
-}
-
-/* Wrench - Tool Runtime */
-.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(9) > .menu__list-item-collapsible > .menu__link::before {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 2L2 7l10 5 10-5-10-5z'/%3E%3Cpath d='M2 17l10 5 10-5'/%3E%3Cpath d='M2 12l10 5 10-5'/%3E%3C/svg%3E");
 }
 
 /* Table - DatasetIO */
-.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(10) > .menu__list-item-collapsible > .menu__link::before {
+.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(7) > .menu__list-item-collapsible > .menu__link::before {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 3v18'/%3E%3Crect x='3' y='3' width='18' height='18' rx='2'/%3E%3Cpath d='M3 9h18'/%3E%3Cpath d='M3 15h18'/%3E%3C/svg%3E");
 }
 
-/* FileText - Files */
-.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(11) > .menu__list-item-collapsible > .menu__link::before {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V7z'/%3E%3Cpath d='M14 2v4a2 2 0 002 2h4'/%3E%3Cpath d='M10 13H8'/%3E%3Cpath d='M16 17H8'/%3E%3Cpath d='M16 13h-2'/%3E%3C/svg%3E");
-}
-
-/* ArrowLeftRight - Responses */
-.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(12) > .menu__list-item-collapsible > .menu__link::before {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 7H3'/%3E%3Cpath d='M18 4l3 3-3 3'/%3E%3Cpath d='M3 17h18'/%3E%3Cpath d='M6 14l-3 3 3 3'/%3E%3C/svg%3E");
-}
-
-/* FileSearch - File Processors */
-.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(13) > .menu__list-item-collapsible > .menu__link::before {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V7z'/%3E%3Cpath d='M14 2v4a2 2 0 002 2h4'/%3E%3Ccircle cx='11.5' cy='14.5' r='2.5'/%3E%3Cpath d='M13.3 16.3L15 18'/%3E%3C/svg%3E");
-}
-
 /* ClipboardCheck - Eval */
-.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(14) > .menu__list-item-collapsible > .menu__link::before {
+.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(8) > .menu__list-item-collapsible > .menu__link::before {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='8' y='2' width='8' height='4' rx='1' ry='1'/%3E%3Cpath d='M16 4h2a2 2 0 012 2v14a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2h2'/%3E%3Cpath d='M9 14l2 2 4-4'/%3E%3C/svg%3E");
 }
 
-/* MessageSquare - Messages */
-.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(15) > .menu__list-item-collapsible > .menu__link::before {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z'/%3E%3C/svg%3E");
+/* FileSearch - File Processors */
+.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(9) > .menu__list-item-collapsible > .menu__link::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V7z'/%3E%3Cpath d='M14 2v4a2 2 0 002 2h4'/%3E%3Ccircle cx='11.5' cy='14.5' r='2.5'/%3E%3Cpath d='M13.3 16.3L15 18'/%3E%3C/svg%3E");
+}
+
+/* FileText - Files */
+.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(10) > .menu__list-item-collapsible > .menu__link::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V7z'/%3E%3Cpath d='M14 2v4a2 2 0 002 2h4'/%3E%3Cpath d='M10 13H8'/%3E%3Cpath d='M16 17H8'/%3E%3Cpath d='M16 13h-2'/%3E%3C/svg%3E");
+}
+
+/* Cpu - Inference */
+.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(11) > .menu__list-item-collapsible > .menu__link::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='4' y='4' width='16' height='16' rx='2'/%3E%3Crect x='9' y='9' width='6' height='6'/%3E%3Cpath d='M15 2v2'/%3E%3Cpath d='M15 20v2'/%3E%3Cpath d='M2 15h2'/%3E%3Cpath d='M2 9h2'/%3E%3Cpath d='M20 15h2'/%3E%3Cpath d='M20 9h2'/%3E%3Cpath d='M9 2v2'/%3E%3Cpath d='M9 20v2'/%3E%3C/svg%3E");
 }
 
 /* MessagesSquare - Interactions */
-.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(16) > .menu__list-item-collapsible > .menu__link::before {
+.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(12) > .menu__list-item-collapsible > .menu__link::before {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14 9a2 2 0 01-2 2H6l-4 4V3a2 2 0 012-2h8a2 2 0 012 2z'/%3E%3Cpath d='M18 9h2a2 2 0 012 2v11l-4-4h-6a2 2 0 01-2-2v-1'/%3E%3C/svg%3E");
 }
 
-/* Layers - Batches */
+/* MessageSquare - Messages */
+.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(13) > .menu__list-item-collapsible > .menu__link::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z'/%3E%3C/svg%3E");
+}
+
+/* ArrowLeftRight - Responses */
+.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(14) > .menu__list-item-collapsible > .menu__link::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 7H3'/%3E%3Cpath d='M18 4l3 3-3 3'/%3E%3Cpath d='M3 17h18'/%3E%3Cpath d='M6 14l-3 3 3 3'/%3E%3C/svg%3E");
+}
+
+/* Shield - Safety */
+.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(15) > .menu__list-item-collapsible > .menu__link::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z'/%3E%3C/svg%3E");
+}
+
+/* Wrench - Tool Runtime */
+.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(16) > .menu__list-item-collapsible > .menu__link::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z'/%3E%3C/svg%3E");
+}
+
+/* Database - Vector IO */
 .theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(17) > .menu__list-item-collapsible > .menu__link::before {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 2L2 7l10 5 10-5-10-5z'/%3E%3Cpath d='M2 17l10 5 10-5'/%3E%3Cpath d='M2 12l10 5 10-5'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cellipse cx='12' cy='5' rx='9' ry='3'/%3E%3Cpath d='M3 5v14c0 1.66 4.03 3 9 3s9-1.34 9-3V5'/%3E%3Cpath d='M3 12c0 1.66 4.03 3 9 3s9-1.34 9-3'/%3E%3C/svg%3E");
 }
 
 /* Dark mode: lighter icon stroke */

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -406,23 +406,38 @@ h3 {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 3v18'/%3E%3Crect x='3' y='3' width='18' height='18' rx='2'/%3E%3Cpath d='M3 9h18'/%3E%3Cpath d='M3 15h18'/%3E%3C/svg%3E");
 }
 
-/* Target - Scoring */
-.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(11) > .menu__list-item-collapsible > .menu__link::before {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Ccircle cx='12' cy='12' r='6'/%3E%3Ccircle cx='12' cy='12' r='2'/%3E%3C/svg%3E");
-}
-
 /* FileText - Files */
-.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(12) > .menu__list-item-collapsible > .menu__link::before {
+.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(11) > .menu__list-item-collapsible > .menu__link::before {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V7z'/%3E%3Cpath d='M14 2v4a2 2 0 002 2h4'/%3E%3Cpath d='M10 13H8'/%3E%3Cpath d='M16 17H8'/%3E%3Cpath d='M16 13h-2'/%3E%3C/svg%3E");
 }
 
-/* ClipboardCheck - Eval */
+/* ArrowLeftRight - Responses */
+.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(12) > .menu__list-item-collapsible > .menu__link::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 7H3'/%3E%3Cpath d='M18 4l3 3-3 3'/%3E%3Cpath d='M3 17h18'/%3E%3Cpath d='M6 14l-3 3 3 3'/%3E%3C/svg%3E");
+}
+
+/* FileSearch - File Processors */
 .theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(13) > .menu__list-item-collapsible > .menu__link::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V7z'/%3E%3Cpath d='M14 2v4a2 2 0 002 2h4'/%3E%3Ccircle cx='11.5' cy='14.5' r='2.5'/%3E%3Cpath d='M13.3 16.3L15 18'/%3E%3C/svg%3E");
+}
+
+/* ClipboardCheck - Eval */
+.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(14) > .menu__list-item-collapsible > .menu__link::before {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='8' y='2' width='8' height='4' rx='1' ry='1'/%3E%3Cpath d='M16 4h2a2 2 0 012 2v14a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2h2'/%3E%3Cpath d='M9 14l2 2 4-4'/%3E%3C/svg%3E");
 }
 
+/* MessageSquare - Messages */
+.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(15) > .menu__list-item-collapsible > .menu__link::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z'/%3E%3C/svg%3E");
+}
+
+/* MessagesSquare - Interactions */
+.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(16) > .menu__list-item-collapsible > .menu__link::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14 9a2 2 0 01-2 2H6l-4 4V3a2 2 0 012-2h8a2 2 0 012 2z'/%3E%3Cpath d='M18 9h2a2 2 0 012 2v11l-4-4h-6a2 2 0 01-2-2v-1'/%3E%3C/svg%3E");
+}
+
 /* Layers - Batches */
-.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(14) > .menu__list-item-collapsible > .menu__link::before {
+.theme-doc-sidebar-container .menu__list .menu__list .menu__list-item:nth-child(17) > .menu__list-item-collapsible > .menu__link::before {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 2L2 7l10 5 10-5-10-5z'/%3E%3Cpath d='M2 17l10 5 10-5'/%3E%3Cpath d='M2 12l10 5 10-5'/%3E%3C/svg%3E");
 }
 

--- a/src/llama_stack/providers/registry/messages.py
+++ b/src/llama_stack/providers/registry/messages.py
@@ -24,6 +24,10 @@ def available_providers() -> list[ProviderSpec]:
             api_dependencies=[
                 Api.inference,
             ],
-            description="Anthropic Messages API adapter that translates to the inference API.",
+            description=(
+                "Implements the Anthropic Messages API with two modes: native passthrough for providers "
+                "that support /v1/messages natively (e.g. Ollama, vLLM), and automatic translation for "
+                "all other providers by converting between Anthropic and OpenAI Chat Completions formats."
+            ),
         ),
     ]


### PR DESCRIPTION
## Summary
- Updates the messages provider registry description to accurately explain the two operating modes: native passthrough for providers that support `/v1/messages` natively (e.g. Ollama, vLLM), and automatic translation between Anthropic and OpenAI Chat Completions formats for all other providers.
- This description is used in auto-generated provider documentation.

## Test plan
- [x] Pre-commit hooks pass (provider codegen regenerated docs automatically)
- [x] No functional changes, description-only update

🤖 Generated with [Claude Code](https://claude.com/claude-code)