### PR TITLE
feat(docs): add Google Interactions API coverage analyzer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -147,6 +147,15 @@ repos:
         pass_filenames: false
         require_serial: true
         files: ^docs/static/(llama-stack-spec\.yaml|openai-spec.*\.yml|openresponses-spec\.json|openai-coverage\.json)$|^docs/docs/api-openai/conformance\.mdx$|^scripts/(openai_coverage|generate_openai_coverage_docs)\.py$
+      - id: google-interactions-coverage
+        name: Google Interactions API Coverage
+        additional_dependencies:
+          - *uv-dependency
+        entry: ./scripts/uv-run-with-index.sh run python scripts/google_interactions_coverage.py --check-regression --update --generate-docs --quiet
+        language: python
+        pass_filenames: false
+        require_serial: true
+        files: ^docs/static/google-interactions-(spec|coverage)\.json$|^docs/docs/api-google-interactions/conformance\.mdx$|^scripts/(google_interactions_coverage|generate_google_interactions_coverage_docs)\.py$|^src/llama_stack_api/interactions/models\.py$
       - id: provider-compat-matrix
         name: Provider Compatibility Matrix
         additional_dependencies:

--- a/docs/docs/api-google-interactions/conformance.mdx
+++ b/docs/docs/api-google-interactions/conformance.mdx
@@ -1,0 +1,282 @@
+---
+title: Google Interactions API Conformance
+description: Coverage status of Llama Stack against the Google Interactions API specification
+sidebar_label: Interactions Conformance
+sidebar_position: 5
+---
+
+# Google Interactions API Coverage Report
+
+Spec version: `v1beta`
+
+This page provides a detailed breakdown of Llama Stack's coverage of the
+[Google Interactions API](https://ai.google.dev/gemini-api/docs/interactions) specification.
+The coverage score increases as missing features are implemented.
+
+:::info Auto-generated
+This documentation is auto-generated from the Google Interactions API specification comparison.
+:::
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| **Overall Coverage Score** | 32.9% |
+| **Total Items Implemented** | 27/82 |
+| **Total Missing** | 55 |
+
+## Section Scores
+
+Sections are sorted by coverage score (lowest first, needing most attention).
+
+| Section | Score | Implemented | Total | Missing |
+|---------|-------|-------------|-------|---------|
+| Tool Types | 0.0% | 0 | 9 | 9 |
+| Content Types | 5.0% | 1 | 20 | 19 |
+| Endpoints | 25.0% | 1 | 4 | 3 |
+| GenerationConfig | 30.0% | 3 | 10 | 7 |
+| Usage | 30.0% | 3 | 10 | 7 |
+| Request Properties | 46.2% | 6 | 13 | 7 |
+| Streaming Events | 71.4% | 5 | 7 | 2 |
+| Response Properties | 88.9% | 8 | 9 | 1 |
+
+## Detailed Breakdown
+
+Below is a detailed breakdown of what is implemented and what is missing for each section.
+
+### Tool Types
+
+**Score:** 0.0% · **Implemented:** 0/9
+
+<details>
+<summary>Missing (9)</summary>
+
+- `CodeExecution`
+- `ComputerUse`
+- `FileSearch`
+- `Function`
+- `GoogleMaps`
+- `GoogleSearch`
+- `McpServer`
+- `Retrieval`
+- `UrlContext`
+
+</details>
+
+### Content Types
+
+**Score:** 5.0% · **Implemented:** 1/20
+
+<details>
+<summary>Implemented (1)</summary>
+
+- `TextContent`
+
+</details>
+
+<details>
+<summary>Missing (19)</summary>
+
+- `AudioContent`
+- `CodeExecutionCallContent`
+- `CodeExecutionResultContent`
+- `DocumentContent`
+- `FileSearchCallContent`
+- `FileSearchResultContent`
+- `FunctionCallContent`
+- `FunctionResultContent`
+- `GoogleMapsCallContent`
+- `GoogleMapsResultContent`
+- `GoogleSearchCallContent`
+- `GoogleSearchResultContent`
+- `ImageContent`
+- `McpServerToolCallContent`
+- `McpServerToolResultContent`
+- `ThoughtContent`
+- `UrlContextCallContent`
+- `UrlContextResultContent`
+- `VideoContent`
+
+</details>
+
+### Endpoints
+
+**Score:** 25.0% · **Implemented:** 1/4
+
+<details>
+<summary>Implemented (1)</summary>
+
+- `POST /{api_version}/interactions`
+
+</details>
+
+<details>
+<summary>Missing (3)</summary>
+
+- `DELETE /{api_version}/interactions/{id}`
+- `GET /{api_version}/interactions/{id}`
+- `POST /{api_version}/interactions/{id}/cancel`
+
+</details>
+
+### GenerationConfig
+
+**Score:** 30.0% · **Implemented:** 3/10
+
+<details>
+<summary>Implemented (3)</summary>
+
+- `max_output_tokens`
+- `temperature`
+- `top_p`
+
+</details>
+
+<details>
+<summary>Missing (7)</summary>
+
+- `image_config`
+- `seed`
+- `speech_config`
+- `stop_sequences`
+- `thinking_level`
+- `thinking_summaries`
+- `tool_choice`
+
+</details>
+
+<details>
+<summary>Extra in Llama Stack (1)</summary>
+
+These properties are in the Llama Stack implementation but not in the Google spec:
+
+- `top_k`
+
+</details>
+
+### Usage
+
+**Score:** 30.0% · **Implemented:** 3/10
+
+<details>
+<summary>Implemented (3)</summary>
+
+- `total_input_tokens`
+- `total_output_tokens`
+- `total_tokens`
+
+</details>
+
+<details>
+<summary>Missing (7)</summary>
+
+- `cached_tokens_by_modality`
+- `input_tokens_by_modality`
+- `output_tokens_by_modality`
+- `tool_use_tokens_by_modality`
+- `total_cached_tokens`
+- `total_thought_tokens`
+- `total_tool_use_tokens`
+
+</details>
+
+### Request Properties
+
+**Score:** 46.2% · **Implemented:** 6/13
+
+<details>
+<summary>Implemented (6)</summary>
+
+- `generation_config`
+- `input`
+- `model`
+- `response_modalities`
+- `stream`
+- `system_instruction`
+
+</details>
+
+<details>
+<summary>Missing (7)</summary>
+
+- `background`
+- `previous_interaction_id`
+- `response_format`
+- `response_mime_type`
+- `service_tier`
+- `store`
+- `tools`
+
+</details>
+
+### Streaming Events
+
+**Score:** 71.4% · **Implemented:** 5/7
+
+<details>
+<summary>Implemented (5)</summary>
+
+- `ContentDelta`
+- `ContentStart`
+- `ContentStop`
+- `InteractionCompleteEvent`
+- `InteractionStartEvent`
+
+</details>
+
+<details>
+<summary>Missing (2)</summary>
+
+- `ErrorEvent`
+- `InteractionStatusUpdate`
+
+</details>
+
+### Response Properties
+
+**Score:** 88.9% · **Implemented:** 8/9
+
+<details>
+<summary>Implemented (8)</summary>
+
+- `created`
+- `id`
+- `model`
+- `outputs`
+- `role`
+- `status`
+- `updated`
+- `usage`
+
+</details>
+
+<details>
+<summary>Missing (1)</summary>
+
+- `agent`
+
+</details>
+
+<details>
+<summary>Extra in Llama Stack (1)</summary>
+
+These properties are in the Llama Stack implementation but not in the Google spec:
+
+- `object`
+
+</details>
+
+## How to Improve Coverage
+
+To improve coverage scores:
+
+1. **Add Missing Properties**: Implement missing fields in request/response models in `src/llama_stack_api/interactions/models.py`
+2. **Add Content Types**: Support additional content types beyond text (images, audio, function calls, etc.)
+3. **Add Tool Support**: Implement tool declarations (Function, GoogleSearch, CodeExecution, etc.)
+4. **Add Missing Endpoints**: Implement GET, DELETE, and Cancel endpoints
+
+Run the coverage analyzer to check your progress:
+
+```bash
+python scripts/google_interactions_coverage.py --update --generate-docs
+```

--- a/docs/docs/api-google-interactions/index.mdx
+++ b/docs/docs/api-google-interactions/index.mdx
@@ -1,0 +1,58 @@
+---
+title: Google Interactions API Compatibility
+description: Google Interactions API compatibility layer in Llama Stack
+sidebar_label: Google Interactions
+sidebar_position: 1
+---
+
+# Google Interactions API Compatibility
+
+Llama Stack provides a compatibility layer for the [Google Interactions API](https://ai.google.dev/gemini-api/docs/interactions) (v1alpha), so teams using the Google GenAI SDK can point at a Llama Stack server with minimal code changes.
+
+```python
+from google import genai
+
+client = genai.Client(
+    http_options={"api_version": "v1alpha"},
+    vertexai=False,
+    api_key="fake",
+)
+# Override the base URL to point at Llama Stack
+client._api_client._url = "http://localhost:8321"
+
+response = client.models.generate_interaction(
+    model="llama-3.3-70b",
+    input="Hello",
+)
+print(response.outputs[0].text)
+```
+
+## Implemented endpoints
+
+| Endpoint | Method | Status |
+|----------|--------|--------|
+| `/v1alpha/interactions` | POST | Implemented |
+| `/v1alpha/interactions/{id}` | GET | Not yet |
+| `/v1alpha/interactions/{id}` | DELETE | Not yet |
+| `/v1alpha/interactions/{id}/cancel` | POST | Not yet |
+
+For property-level coverage details, see the [conformance report](/docs/api-google-interactions/conformance).
+
+## How it works
+
+The adapter translates Google Interactions requests into OpenAI Chat Completion calls through Llama Stack's inference API. This means any inference provider that Llama Stack supports (vLLM, Ollama, OpenAI, Bedrock, etc.) can serve the Google Interactions API.
+
+Supported features:
+
+- **Text generation** with string or multi-turn conversation input
+- **Streaming** via Server-Sent Events matching Google's event format
+- **System instructions** mapped to the system role
+- **Generation config** parameters (temperature, top_p, top_k, max_output_tokens)
+
+## Known limitations
+
+- Only text content is supported; multimodal inputs (images, audio, video) are not yet implemented
+- Tool declarations (Function, GoogleSearch, CodeExecution, MCP) are not yet supported
+- Background execution and interaction storage (`store`, `background`) are not available
+- The GET, DELETE, and Cancel endpoints are not yet implemented
+- Response modalities are accepted for compatibility but ignored

--- a/docs/docs/api-openai/index.mdx
+++ b/docs/docs/api-openai/index.mdx
@@ -9,7 +9,10 @@ sidebar_position: 1
 
 Llama Stack is OpenAI-first. The primary API surface implements the OpenAI spec, so you can use any OpenAI-compatible client, just change the base URL.
 
-Llama Stack also provides an Anthropic Messages API adapter at `/v1/messages` for teams that use the Anthropic SDK. See the [Messages provider documentation](/docs/providers/messages/) for details and current limitations.
+Llama Stack also provides compatibility layers for other SDKs:
+
+- **Anthropic Messages API** at `/v1/messages` for teams using the Anthropic SDK. See the [Messages provider documentation](/docs/providers/messages/) for details.
+- **Google Interactions API** at `/v1alpha/interactions` for teams using the Google GenAI SDK. See the [Google Interactions compatibility guide](/docs/api-google-interactions) for details.
 
 ```python
 from openai import OpenAI

--- a/docs/docs/concepts/apis/google_interactions.mdx
+++ b/docs/docs/concepts/apis/google_interactions.mdx
@@ -1,0 +1,54 @@
+---
+title: Google Interactions API
+description: Google Interactions API compatibility layer in Llama Stack
+sidebar_label: Google Interactions
+sidebar_position: 5
+---
+
+# Google Interactions API
+
+Llama Stack provides a compatibility layer for the [Google Interactions API](https://ai.google.dev/gemini-api/docs/interactions) (v1alpha). This lets teams using the Google GenAI SDK point at a Llama Stack server with minimal code changes, similar to how the OpenAI compatibility layer works.
+
+## How it works
+
+The adapter translates Google Interactions requests into OpenAI Chat Completion calls through Llama Stack's inference API. Any inference provider that Llama Stack supports (vLLM, Ollama, OpenAI, Bedrock, etc.) can serve the Google Interactions API.
+
+```
+Google GenAI SDK → /v1alpha/interactions → Llama Stack Inference → Any Provider
+```
+
+## Quick example
+
+```python
+from google import genai
+
+client = genai.Client(
+    http_options={"api_version": "v1alpha"},
+    vertexai=False,
+    api_key="fake",
+)
+# Override the base URL to point at Llama Stack
+client._api_client._url = "http://localhost:8321"
+
+response = client.models.generate_interaction(
+    model="llama-3.3-70b",
+    input="Hello",
+)
+print(response.outputs[0].text)
+```
+
+## What is supported
+
+- Text generation with string or multi-turn conversation input
+- Streaming via Server-Sent Events matching Google's event format
+- System instructions
+- Generation config parameters (temperature, top_p, top_k, max_output_tokens)
+
+## What is not yet supported
+
+- Multimodal inputs (images, audio, video, documents)
+- Tool declarations (Function, GoogleSearch, CodeExecution, MCP)
+- Background execution and interaction storage
+- GET, DELETE, and Cancel endpoints
+
+For a full property-level breakdown, see the [conformance report](/docs/api-google-interactions/conformance).

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -193,6 +193,10 @@ const config: Config = {
               to: '/docs/api-openai',
             },
             {
+              label: 'Google Interactions',
+              to: '/docs/api-google-interactions',
+            },
+            {
               label: 'Blog',
               to: '/blog',
             },

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -40,6 +40,7 @@ const sidebars: SidebarsConfig = {
           items: [
             'concepts/apis/index',
             'concepts/apis/api_providers',
+            'concepts/apis/google_interactions',
             'concepts/apis/external',
             'concepts/apis/api_leveling',
           ],

--- a/docs/static/google-interactions-coverage.json
+++ b/docs/static/google-interactions-coverage.json
@@ -1,5 +1,5 @@
 {
-  "google_spec": "/Users/leseb/conductor/workspaces/llama-stack-v1/auckland/docs/static/google-interactions-spec.json",
+  "google_spec": "docs/static/google-interactions-spec.json",
   "spec_version": "v1beta",
   "summary": {
     "overall_score": 32.9,

--- a/docs/static/google-interactions-coverage.json
+++ b/docs/static/google-interactions-coverage.json
@@ -1,0 +1,187 @@
+{
+  "google_spec": "/Users/leseb/conductor/workspaces/llama-stack-v1/auckland/docs/static/google-interactions-spec.json",
+  "spec_version": "v1beta",
+  "summary": {
+    "overall_score": 32.9,
+    "total_google_items": 82,
+    "total_implemented": 27,
+    "total_missing": 55
+  },
+  "sections": [
+    {
+      "section": "Endpoints",
+      "google_total": 4,
+      "implemented": 1,
+      "missing_count": 3,
+      "score": 25.0,
+      "supported": [
+        "POST /{api_version}/interactions"
+      ],
+      "missing": [
+        "DELETE /{api_version}/interactions/{id}",
+        "GET /{api_version}/interactions/{id}",
+        "POST /{api_version}/interactions/{id}/cancel"
+      ]
+    },
+    {
+      "section": "Request Properties",
+      "google_total": 13,
+      "implemented": 6,
+      "missing_count": 7,
+      "score": 46.2,
+      "supported": [
+        "generation_config",
+        "input",
+        "model",
+        "response_modalities",
+        "stream",
+        "system_instruction"
+      ],
+      "missing": [
+        "background",
+        "previous_interaction_id",
+        "response_format",
+        "response_mime_type",
+        "service_tier",
+        "store",
+        "tools"
+      ]
+    },
+    {
+      "section": "Response Properties",
+      "google_total": 9,
+      "implemented": 8,
+      "missing_count": 1,
+      "score": 88.9,
+      "supported": [
+        "created",
+        "id",
+        "model",
+        "outputs",
+        "role",
+        "status",
+        "updated",
+        "usage"
+      ],
+      "missing": [
+        "agent"
+      ],
+      "extra_in_llama_stack": [
+        "object"
+      ]
+    },
+    {
+      "section": "GenerationConfig",
+      "google_total": 10,
+      "implemented": 3,
+      "missing_count": 7,
+      "score": 30.0,
+      "supported": [
+        "max_output_tokens",
+        "temperature",
+        "top_p"
+      ],
+      "missing": [
+        "image_config",
+        "seed",
+        "speech_config",
+        "stop_sequences",
+        "thinking_level",
+        "thinking_summaries",
+        "tool_choice"
+      ],
+      "extra_in_llama_stack": [
+        "top_k"
+      ]
+    },
+    {
+      "section": "Usage",
+      "google_total": 10,
+      "implemented": 3,
+      "missing_count": 7,
+      "score": 30.0,
+      "supported": [
+        "total_input_tokens",
+        "total_output_tokens",
+        "total_tokens"
+      ],
+      "missing": [
+        "cached_tokens_by_modality",
+        "input_tokens_by_modality",
+        "output_tokens_by_modality",
+        "tool_use_tokens_by_modality",
+        "total_cached_tokens",
+        "total_thought_tokens",
+        "total_tool_use_tokens"
+      ]
+    },
+    {
+      "section": "Content Types",
+      "google_total": 20,
+      "implemented": 1,
+      "missing_count": 19,
+      "score": 5.0,
+      "supported": [
+        "TextContent"
+      ],
+      "missing": [
+        "AudioContent",
+        "CodeExecutionCallContent",
+        "CodeExecutionResultContent",
+        "DocumentContent",
+        "FileSearchCallContent",
+        "FileSearchResultContent",
+        "FunctionCallContent",
+        "FunctionResultContent",
+        "GoogleMapsCallContent",
+        "GoogleMapsResultContent",
+        "GoogleSearchCallContent",
+        "GoogleSearchResultContent",
+        "ImageContent",
+        "McpServerToolCallContent",
+        "McpServerToolResultContent",
+        "ThoughtContent",
+        "UrlContextCallContent",
+        "UrlContextResultContent",
+        "VideoContent"
+      ]
+    },
+    {
+      "section": "Tool Types",
+      "google_total": 9,
+      "implemented": 0,
+      "missing_count": 9,
+      "score": 0.0,
+      "supported": [],
+      "missing": [
+        "CodeExecution",
+        "ComputerUse",
+        "FileSearch",
+        "Function",
+        "GoogleMaps",
+        "GoogleSearch",
+        "McpServer",
+        "Retrieval",
+        "UrlContext"
+      ]
+    },
+    {
+      "section": "Streaming Events",
+      "google_total": 7,
+      "implemented": 5,
+      "missing_count": 2,
+      "score": 71.4,
+      "supported": [
+        "ContentDelta",
+        "ContentStart",
+        "ContentStop",
+        "InteractionCompleteEvent",
+        "InteractionStartEvent"
+      ],
+      "missing": [
+        "ErrorEvent",
+        "InteractionStatusUpdate"
+      ]
+    }
+  ]
+}

--- a/docs/static/google-interactions-spec.json
+++ b/docs/static/google-interactions-spec.json
@@ -1,0 +1,3649 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Gemini API",
+    "description": "The Gemini Interactions API is an experimental API that allows developers to build generative AI applications using Gemini models. Gemini is our most capable model, built from the ground up to be multimodal. It can generalize and seamlessly understand, operate across, and combine different types of information including language, images, audio, video, and code. You can use the Gemini API for use cases like reasoning across text and images, content generation, dialogue agents, summarization and classification systems, and more.",
+    "version": "v1beta",
+    "x-google-revision": "0"
+  },
+  "servers": [
+    {
+      "url": "https://generativelanguage.googleapis.com",
+      "description": "Global Endpoint"
+    }
+  ],
+  "paths": {
+    "/{api_version}/interactions": {
+      "parameters": [{ "$ref": "#/components/parameters/api_version" }],
+      "post": {
+        "operationId": "CreateInteraction",
+        "description": "Creates a new interaction.",
+        "security": [],
+        "parameters": [],
+        "requestBody": {
+          "description": "The request body.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateModelInteractionParams"
+                  },
+                  {
+                    "$ref": "#/components/schemas/CreateAgentInteractionParams"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Interaction" },
+                "examples": {
+                  "simple": {
+                    "summary": "Simple Request",
+                    "value": {
+                      "created": "2025-11-26T12:25:15Z",
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "model": "gemini-3-flash-preview",
+                      "object": "interaction",
+                      "outputs": [
+                        {
+                          "text": "Hello! I'm functioning perfectly and ready to assist you.\n\nHow are you doing today?",
+                          "type": "text"
+                        }
+                      ],
+                      "role": "model",
+                      "status": "completed",
+                      "updated": "2025-11-26T12:25:15Z",
+                      "usage": {
+                        "input_tokens_by_modality": [
+                          { "modality": "text", "tokens": 7 }
+                        ],
+                        "total_cached_tokens": 0,
+                        "total_input_tokens": 7,
+                        "total_output_tokens": 20,
+                        "total_thought_tokens": 22,
+                        "total_tokens": 49,
+                        "total_tool_use_tokens": 0
+                      }
+                    }
+                  },
+                  "multi_turn": {
+                    "summary": "Multi-turn",
+                    "value": {
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "model": "gemini-3-flash-preview",
+                      "status": "completed",
+                      "object": "interaction",
+                      "created": "2025-11-26T12:22:47Z",
+                      "updated": "2025-11-26T12:22:47Z",
+                      "role": "model",
+                      "outputs": [
+                        {
+                          "type": "text",
+                          "text": "The capital of France is Paris."
+                        }
+                      ],
+                      "usage": {
+                        "input_tokens_by_modality": [
+                          { "modality": "text", "tokens": 50 }
+                        ],
+                        "total_cached_tokens": 0,
+                        "total_input_tokens": 50,
+                        "total_output_tokens": 10,
+                        "total_thought_tokens": 0,
+                        "total_tokens": 60,
+                        "total_tool_use_tokens": 0
+                      }
+                    }
+                  },
+                  "multimodal_image": {
+                    "summary": "Image Input",
+                    "value": {
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "model": "gemini-3-flash-preview",
+                      "status": "completed",
+                      "object": "interaction",
+                      "created": "2025-11-26T12:22:47Z",
+                      "updated": "2025-11-26T12:22:47Z",
+                      "role": "model",
+                      "outputs": [
+                        {
+                          "type": "text",
+                          "text": "A white humanoid robot with glowing blue eyes stands holding a red skateboard."
+                        }
+                      ],
+                      "usage": {
+                        "input_tokens_by_modality": [
+                          { "modality": "text", "tokens": 10 },
+                          { "modality": "image", "tokens": 258 }
+                        ],
+                        "total_cached_tokens": 0,
+                        "total_input_tokens": 268,
+                        "total_output_tokens": 20,
+                        "total_thought_tokens": 0,
+                        "total_tokens": 288,
+                        "total_tool_use_tokens": 0
+                      }
+                    }
+                  },
+                  "function_calling": {
+                    "summary": "Function Calling",
+                    "value": {
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "model": "gemini-3-flash-preview",
+                      "status": "requires_action",
+                      "object": "interaction",
+                      "created": "2025-11-26T12:22:47Z",
+                      "updated": "2025-11-26T12:22:47Z",
+                      "role": "model",
+                      "outputs": [
+                        {
+                          "type": "function_call",
+                          "id": "gth23981",
+                          "name": "get_weather",
+                          "arguments": { "location": "Boston, MA" }
+                        }
+                      ],
+                      "usage": {
+                        "input_tokens_by_modality": [
+                          { "modality": "text", "tokens": 100 }
+                        ],
+                        "total_cached_tokens": 0,
+                        "total_input_tokens": 100,
+                        "total_output_tokens": 25,
+                        "total_thought_tokens": 0,
+                        "total_tokens": 125,
+                        "total_tool_use_tokens": 50
+                      }
+                    }
+                  },
+                  "deep_research": {
+                    "summary": "Deep Research",
+                    "value": {
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "agent": "deep-research-pro-preview-12-2025",
+                      "status": "completed",
+                      "object": "interaction",
+                      "created": "2025-11-26T12:22:47Z",
+                      "updated": "2025-11-26T12:22:47Z",
+                      "role": "agent",
+                      "outputs": [
+                        {
+                          "type": "text",
+                          "text": "Here is a comprehensive research report on the current state of cancer research..."
+                        }
+                      ],
+                      "usage": {
+                        "input_tokens_by_modality": [
+                          { "modality": "text", "tokens": 20 }
+                        ],
+                        "total_cached_tokens": 0,
+                        "total_input_tokens": 20,
+                        "total_output_tokens": 1000,
+                        "total_thought_tokens": 500,
+                        "total_tokens": 1520,
+                        "total_tool_use_tokens": 0
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error creating interaction",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": { "$ref": "#/components/schemas/Error" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "Creating an interaction",
+        "x-codeSamples": [
+          {
+            "lang": "sh",
+            "label": "simple",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3-flash-preview\",\n    \"input\": \"Hello, how are you?\"\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "simple",
+            "source": "from google import genai\n\nclient = genai.Client()\ninteraction = client.interactions.create(\n    model=\"gemini-3-flash-preview\",\n    input=\"Hello, how are you?\",\n)\nprint(interaction.outputs[-1].text)\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "simple",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3-flash-preview',\n    input: 'Hello, how are you?',\n});\nconsole.log(interaction.outputs[interaction.outputs.length - 1].text);\n"
+          },
+          {
+            "lang": "sh",
+            "label": "multi_turn",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3-flash-preview\",\n    \"input\": [\n      {\n        \"role\": \"user\",\n        \"content\": \"Hello!\"\n      },\n      {\n        \"role\": \"model\",\n        \"content\": \"Hi there! How can I help you today?\"\n      },\n      {\n        \"role\": \"user\",\n        \"content\": \"What is the capital of France?\"\n      }\n    ]\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "multi_turn",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3-flash-preview\",\n    input=[\n        { \"role\": \"user\", \"content\": \"Hello!\" },\n        { \"role\": \"model\", \"content\": \"Hi there! How can I help you today?\" },\n        { \"role\": \"user\", \"content\": \"What is the capital of France?\" }\n    ]\n)\nprint(response.outputs[-1].text)\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "multi_turn",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3-flash-preview',\n    input: [\n        { role: 'user', content: 'Hello' },\n        { role: 'model', content: 'Hi there! How can I help you today?' },\n        { role: 'user', content: 'What is the capital of France?' }\n    ]\n});\nconsole.log(interaction.outputs[interaction.outputs.length - 1].text);\n"
+          },
+          {
+            "lang": "sh",
+            "label": "multimodal_image",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3-flash-preview\",\n    \"input\": [\n      {\n        \"type\": \"text\",\n        \"text\": \"What is in this picture?\"\n      },\n      {\n        \"type\": \"image\",\n        \"data\": \"BASE64_ENCODED_IMAGE\",\n        \"mime_type\": \"image/png\"\n      }\n    ]\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "multimodal_image",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3-flash-preview\",\n    input=[\n      { \"type\": \"text\", \"text\": \"What is in this picture?\" },\n      { \"type\": \"image\", \"data\": \"BASE64_ENCODED_IMAGE\", \"mime_type\": \"image/png\" }\n    ]\n)\nprint(response.outputs[-1].text)\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "multimodal_image",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3-flash-preview',\n    input: [\n      { type: 'text', text: 'What is in this picture?' },\n      { type: 'image', data: 'BASE64_ENCODED_IMAGE', mime_type: 'image/png' }\n    ]\n});\nconsole.log(interaction.outputs[interaction.outputs.length - 1].text);\n"
+          },
+          {
+            "lang": "sh",
+            "label": "function_calling",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3-flash-preview\",\n    \"tools\": [\n      {\n        \"type\": \"function\",\n        \"name\": \"get_weather\",\n        \"description\": \"Get the current weather in a given location\",\n        \"parameters\": {\n          \"type\": \"object\",\n          \"properties\": {\n            \"location\": {\n              \"type\": \"string\",\n              \"description\": \"The city and state, e.g. San Francisco, CA\"\n            }\n          },\n          \"required\": [\n            \"location\"\n          ]\n        }\n      }\n    ],\n    \"input\": \"What is the weather like in Boston, MA?\"\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "function_calling",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3-flash-preview\",\n    tools=[{\n        \"type\": \"function\",\n        \"name\": \"get_weather\",\n        \"description\": \"Get the current weather in a given location\",\n        \"parameters\": {\n            \"type\": \"object\",\n            \"properties\": {\n                \"location\": {\n                    \"type\": \"string\",\n                    \"description\": \"The city and state, e.g. San Francisco, CA\"\n                }\n            },\n            \"required\": [\"location\"]\n        }\n    }],\n    input=\"What is the weather like in Boston, MA?\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "function_calling",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3-flash-preview',\n    tools: [{\n        type: 'function',\n        name: 'get_weather',\n        description: 'Get the current weather in a given location',\n        parameters: {\n            type: 'object',\n            properties: {\n                location: {\n                    type: 'string',\n                    description: 'The city and state, e.g. San Francisco, CA'\n                }\n            },\n            required: ['location']\n        }\n    }],\n    input: 'What is the weather like in Boston, MA?'\n});\nconsole.log(interaction.outputs[0]);\n"
+          },
+          {
+            "lang": "sh",
+            "label": "deep_research",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"agent\": \"deep-research-pro-preview-12-2025\",\n    \"input\": \"Find a cure to cancer\",\n    \"background\": true\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "deep_research",
+            "source": "from google import genai\n\nclient = genai.Client()\ninteraction = client.interactions.create(\n    agent=\"deep-research-pro-preview-12-2025\",\n    input=\"find a cure to cancer\",\n    background=True,\n)\nprint(interaction.status)\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "deep_research",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    agent: 'deep-research-pro-preview-12-2025',\n    input: 'find a cure to cancer',\n    background: true,\n});\nconsole.log(interaction.status);\n"
+          }
+        ]
+      }
+    },
+    "/{api_version}/interactions?model": {
+      "parameters": [{ "$ref": "#/components/parameters/api_version" }],
+      "post": {
+        "operationId": "CreateInteraction",
+        "description": "Creates a new interaction.",
+        "security": [],
+        "parameters": [],
+        "requestBody": {
+          "description": "The request body.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateModelInteractionParams"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Interaction" }
+              }
+            }
+          },
+          "default": {
+            "description": "Error creating interaction",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": { "$ref": "#/components/schemas/Error" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "Creating an interaction",
+        "x-internal": true
+      }
+    },
+    "/{api_version}/interactions?agent": {
+      "parameters": [{ "$ref": "#/components/parameters/api_version" }],
+      "post": {
+        "operationId": "CreateInteraction",
+        "description": "Creates a new interaction.",
+        "security": [],
+        "parameters": [],
+        "requestBody": {
+          "description": "The request body.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAgentInteractionParams"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Interaction" }
+              }
+            }
+          },
+          "default": {
+            "description": "Error creating interaction",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": { "$ref": "#/components/schemas/Error" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "Creating an interaction",
+        "x-internal": true
+      }
+    },
+    "/{api_version}/interactions/{id}": {
+      "get": {
+        "operationId": "getInteractionById",
+        "description": "Retrieves the full details of a single interaction based on its `Interaction.id`.",
+        "security": [],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The unique identifier of the interaction to retrieve.",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "stream",
+            "in": "query",
+            "schema": { "type": "boolean", "default": false },
+            "description": "If set to true, the generated content will be streamed incrementally."
+          },
+          {
+            "name": "last_event_id",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "Optional. If set, resumes the interaction stream from the next chunk after the event marked by the event id. Can only be used if `stream` is true."
+          },
+          {
+            "name": "include_input",
+            "in": "query",
+            "schema": { "type": "boolean", "default": false },
+            "description": "If set to true, includes the input in the response."
+          },
+          { "$ref": "#/components/parameters/api_version" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful retrieval of the interaction.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Interaction" },
+                "examples": {
+                  "get": {
+                    "summary": "Get Interaction",
+                    "value": {
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "model": "gemini-3-flash-preview",
+                      "status": "completed",
+                      "object": "interaction",
+                      "created": "2025-11-26T12:25:15Z",
+                      "updated": "2025-11-26T12:25:15Z",
+                      "role": "model",
+                      "outputs": [
+                        {
+                          "type": "text",
+                          "text": "I'm doing great, thank you for asking! How can I help you today?"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error getting interaction",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": { "$ref": "#/components/schemas/Error" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "Retrieving an interaction",
+        "x-codeSamples": [
+          {
+            "lang": "sh",
+            "label": "get",
+            "source": "curl -X GET https://generativelanguage.googleapis.com/v1beta/interactions/v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\"\n"
+          },
+          {
+            "lang": "python",
+            "label": "get",
+            "source": "from google import genai\n\nclient = genai.Client()\n\ninteraction = client.interactions.get(id=\"v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg\")\nprint(interaction.status)\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "get",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.get('v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg');\nconsole.log(interaction.status);\n"
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "deleteInteraction",
+        "description": "Deletes the interaction by id.",
+        "summary": "Deleting an interaction",
+        "security": [],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The unique identifier of the interaction to delete.",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          { "$ref": "#/components/parameters/api_version" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful deletion of the interaction.",
+            "content": {
+              "application/json": {
+                "schema": { "type": "object" },
+                "examples": {
+                  "delete": { "summary": "Delete Interaction", "value": {} }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error deleting interaction",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": { "$ref": "#/components/schemas/Error" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "sh",
+            "label": "delete",
+            "source": "curl -X DELETE https://generativelanguage.googleapis.com/v1beta/interactions/v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\"\n"
+          },
+          {
+            "lang": "python",
+            "label": "delete",
+            "source": "from google import genai\n\nclient = genai.Client()\nclient.interactions.delete(id=\"v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg\")\nprint(\"Interaction deleted successfully.\")\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "delete",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nawait ai.interactions.delete('v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg');\nconsole.log('Interaction deleted successfully.');\n"
+          }
+        ]
+      }
+    },
+    "/{api_version}/interactions/{id}/cancel": {
+      "post": {
+        "operationId": "cancelInteractionById",
+        "description": "Cancels an interaction by id. This only applies to background interactions that are still running.",
+        "security": [],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The unique identifier of the interaction to cancel.",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          { "$ref": "#/components/parameters/api_version" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful cancellation of the interaction.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Interaction" },
+                "examples": {
+                  "cancel": {
+                    "summary": "Cancel Interaction",
+                    "value": {
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "agent": "deep-research-pro-preview-12-2025",
+                      "status": "cancelled",
+                      "object": "interaction",
+                      "created": "2025-11-26T12:25:15Z",
+                      "updated": "2025-11-26T12:25:15Z",
+                      "role": "agent"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error cancelling interaction",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": { "$ref": "#/components/schemas/Error" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "Canceling an interaction",
+        "x-codeSamples": [
+          {
+            "lang": "sh",
+            "label": "cancel",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions/v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg/cancel \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\"\n"
+          },
+          {
+            "lang": "python",
+            "label": "cancel",
+            "source": "from google import genai\n\nclient = genai.Client()\n\ninteraction = client.interactions.cancel(id=\"v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg\")\nprint(interaction.status)\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "cancel",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.cancel('v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg');\nconsole.log(interaction.status);\n"
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "api_version": {
+        "name": "api_version",
+        "description": "Which version of the API to use.",
+        "schema": { "type": "string" },
+        "in": "path"
+      }
+    },
+    "securitySchemes": {},
+    "schemas": {
+      "Content": {
+        "description": "The content of the response.",
+        "type": "object",
+        "oneOf": [
+          { "$ref": "#/components/schemas/TextContent" },
+          { "$ref": "#/components/schemas/ImageContent" },
+          { "$ref": "#/components/schemas/AudioContent" },
+          { "$ref": "#/components/schemas/DocumentContent" },
+          { "$ref": "#/components/schemas/VideoContent" },
+          { "$ref": "#/components/schemas/ThoughtContent" },
+          { "$ref": "#/components/schemas/FunctionCallContent" },
+          { "$ref": "#/components/schemas/CodeExecutionCallContent" },
+          { "$ref": "#/components/schemas/UrlContextCallContent" },
+          { "$ref": "#/components/schemas/McpServerToolCallContent" },
+          { "$ref": "#/components/schemas/GoogleSearchCallContent" },
+          { "$ref": "#/components/schemas/FileSearchCallContent" },
+          { "$ref": "#/components/schemas/GoogleMapsCallContent" },
+          { "$ref": "#/components/schemas/FunctionResultContent" },
+          { "$ref": "#/components/schemas/CodeExecutionResultContent" },
+          { "$ref": "#/components/schemas/UrlContextResultContent" },
+          { "$ref": "#/components/schemas/GoogleSearchResultContent" },
+          { "$ref": "#/components/schemas/McpServerToolResultContent" },
+          { "$ref": "#/components/schemas/FileSearchResultContent" },
+          { "$ref": "#/components/schemas/GoogleMapsResultContent" }
+        ],
+        "discriminator": { "propertyName": "type" }
+      },
+      "TextContent": {
+        "description": "A text content block.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "text" },
+          "text": {
+            "description": "Required. The text content.",
+            "type": "string"
+          },
+          "annotations": {
+            "description": "Citation information for model-generated content.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Annotation" }
+          }
+        },
+        "required": ["type", "text"],
+        "examples": [
+          {
+            "text": {
+              "summary": "Text",
+              "value": { "type": "text", "text": "Hello, how are you?" }
+            }
+          }
+        ]
+      },
+      "Annotation": {
+        "description": "Citation information for model-generated content.",
+        "type": "object",
+        "oneOf": [
+          { "$ref": "#/components/schemas/UrlCitation" },
+          { "$ref": "#/components/schemas/FileCitation" },
+          { "$ref": "#/components/schemas/PlaceCitation" }
+        ],
+        "discriminator": { "propertyName": "type" }
+      },
+      "UrlCitation": {
+        "description": "A URL citation annotation.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "url_citation" },
+          "url": { "description": "The URL.", "type": "string" },
+          "title": { "description": "The title of the URL.", "type": "string" },
+          "start_index": {
+            "description": "Start of segment of the response that is attributed to this source.\n\nIndex indicates the start of the segment, measured in bytes.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "end_index": {
+            "description": "End of the attributed segment, exclusive.",
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": ["type"]
+      },
+      "FileCitation": {
+        "description": "A file citation annotation.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "file_citation" },
+          "document_uri": {
+            "description": "The URI of the file.",
+            "type": "string"
+          },
+          "file_name": {
+            "description": "The name of the file.",
+            "type": "string"
+          },
+          "source": {
+            "description": "Source attributed for a portion of the text.",
+            "type": "string"
+          },
+          "start_index": {
+            "description": "Start of segment of the response that is attributed to this source.\n\nIndex indicates the start of the segment, measured in bytes.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "end_index": {
+            "description": "End of the attributed segment, exclusive.",
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": ["type"]
+      },
+      "PlaceCitation": {
+        "description": "A place citation annotation.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "place_citation" },
+          "place_id": {
+            "description": "The ID of the place, in `places/{place_id}` format.",
+            "type": "string"
+          },
+          "name": { "description": "Title of the place.", "type": "string" },
+          "url": {
+            "description": "URI reference of the place.",
+            "type": "string"
+          },
+          "review_snippets": {
+            "description": "Snippets of reviews that are used to generate answers about the\nfeatures of a given place in Google Maps.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ReviewSnippet" }
+          },
+          "start_index": {
+            "description": "Start of segment of the response that is attributed to this source.\n\nIndex indicates the start of the segment, measured in bytes.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "end_index": {
+            "description": "End of the attributed segment, exclusive.",
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": ["type"]
+      },
+      "ReviewSnippet": {
+        "description": "Encapsulates a snippet of a user review that answers a question about\nthe features of a specific place in Google Maps.",
+        "type": "object",
+        "properties": {
+          "title": { "description": "Title of the review.", "type": "string" },
+          "url": {
+            "description": "A link that corresponds to the user review on Google Maps.",
+            "type": "string"
+          },
+          "review_id": {
+            "description": "The ID of the review snippet.",
+            "type": "string"
+          }
+        }
+      },
+      "ImageContent": {
+        "description": "An image content block.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "image" },
+          "data": {
+            "description": "The image content.",
+            "type": "string",
+            "format": "byte"
+          },
+          "uri": { "description": "The URI of the image.", "type": "string" },
+          "mime_type": {
+            "description": "The mime type of the image.",
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "PNG image format",
+              "JPEG image format",
+              "WebP image format",
+              "HEIC image format",
+              "HEIF image format",
+              "GIF image format",
+              "BMP image format",
+              "TIFF image format"
+            ],
+            "enum": [
+              "image/png",
+              "image/jpeg",
+              "image/webp",
+              "image/heic",
+              "image/heif",
+              "image/gif",
+              "image/bmp",
+              "image/tiff"
+            ]
+          },
+          "resolution": {
+            "description": "The resolution of the media.",
+            "$ref": "#/components/schemas/MediaResolution"
+          }
+        },
+        "required": ["type"],
+        "examples": [
+          {
+            "image": {
+              "summary": "Image",
+              "value": {
+                "type": "image",
+                "data": "BASE64_ENCODED_IMAGE",
+                "mime_type": "image/png"
+              }
+            }
+          }
+        ]
+      },
+      "AudioContent": {
+        "description": "An audio content block.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "audio" },
+          "data": {
+            "description": "The audio content.",
+            "type": "string",
+            "format": "byte"
+          },
+          "uri": { "description": "The URI of the audio.", "type": "string" },
+          "mime_type": {
+            "description": "The mime type of the audio.",
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "WAV audio format",
+              "MP3 audio format",
+              "AIFF audio format",
+              "AAC audio format",
+              "OGG audio format",
+              "FLAC audio format",
+              "MPEG audio format",
+              "M4A audio format",
+              "L16 audio format"
+            ],
+            "enum": [
+              "audio/wav",
+              "audio/mp3",
+              "audio/aiff",
+              "audio/aac",
+              "audio/ogg",
+              "audio/flac",
+              "audio/mpeg",
+              "audio/m4a",
+              "audio/l16"
+            ]
+          },
+          "rate": {
+            "description": "The sample rate of the audio.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "channels": {
+            "description": "The number of audio channels.",
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": ["type"],
+        "examples": [
+          {
+            "audio": {
+              "summary": "Audio",
+              "value": {
+                "type": "audio",
+                "data": "BASE64_ENCODED_AUDIO",
+                "mime_type": "audio/wav"
+              }
+            }
+          }
+        ]
+      },
+      "DocumentContent": {
+        "description": "A document content block.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "document" },
+          "data": {
+            "description": "The document content.",
+            "type": "string",
+            "format": "byte"
+          },
+          "uri": {
+            "description": "The URI of the document.",
+            "type": "string"
+          },
+          "mime_type": {
+            "description": "The mime type of the document.",
+            "type": "string",
+            "x-google-enum-descriptions": ["PDF document format"],
+            "enum": ["application/pdf"]
+          }
+        },
+        "required": ["type"],
+        "examples": [
+          {
+            "document": {
+              "summary": "Document",
+              "value": {
+                "type": "document",
+                "data": "BASE64_ENCODED_DOCUMENT",
+                "mime_type": "application/pdf"
+              }
+            }
+          }
+        ]
+      },
+      "VideoContent": {
+        "description": "A video content block.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "video" },
+          "data": {
+            "description": "The video content.",
+            "type": "string",
+            "format": "byte"
+          },
+          "uri": { "description": "The URI of the video.", "type": "string" },
+          "mime_type": {
+            "description": "The mime type of the video.",
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "MP4 video format",
+              "MPEG video format",
+              "MPG video format",
+              "MOV video format",
+              "AVI video format",
+              "FLV video format",
+              "WebM video format",
+              "WMV video format",
+              "3GPP video format"
+            ],
+            "enum": [
+              "video/mp4",
+              "video/mpeg",
+              "video/mpg",
+              "video/mov",
+              "video/avi",
+              "video/x-flv",
+              "video/webm",
+              "video/wmv",
+              "video/3gpp"
+            ]
+          },
+          "resolution": {
+            "description": "The resolution of the media.",
+            "$ref": "#/components/schemas/MediaResolution"
+          }
+        },
+        "required": ["type"],
+        "examples": [
+          {
+            "video": {
+              "summary": "Video",
+              "value": {
+                "type": "video",
+                "uri": "https://www.youtube.com/watch?v=9hE5-98ZeCg"
+              }
+            }
+          }
+        ]
+      },
+      "ThoughtContent": {
+        "description": "A thought content block.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "thought" },
+          "signature": {
+            "description": "Signature to match the backend source to be part of the generation.",
+            "type": "string",
+            "format": "byte"
+          },
+          "summary": {
+            "description": "A summary of the thought.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ThoughtSummaryContent" }
+          }
+        },
+        "required": ["type"],
+        "examples": [
+          {
+            "thought": {
+              "summary": "Thought",
+              "value": {
+                "type": "thought",
+                "summary": [
+                  {
+                    "type": "text",
+                    "text": "The user is asking about the weather. I should use the get_weather tool."
+                  }
+                ],
+                "signature": "CoMDAXLI2nynRYojJIy6B1Jh9os2crpWLfB0+19xcLsGG46bd8wjkF/6RNlRUdvHrXyjsHkG0BZFcuO/bPOyA6Xh5jANNgx82wPHjGExN8A4ZQn56FlMwyZoqFVQz0QyY1lfibFJ2zU3J87uw26OewzcuVX0KEcs+GIsZa3EA6WwqhbsOd3wtZB3Ua2Qf98VAWZTS5y/tWpql7jnU3/CU7pouxQr/Bwft3hwnJNesQ9/dDJTuaQ8Zprh9VRWf1aFFjpIueOjBRrlT3oW6/y/eRl/Gt9BQXCYTqg/38vHFUU4Wo/d9dUpvfCe/a3o97t2Jgxp34oFKcsVb4S5WJrykIkw+14DzVnTpCpbQNFckqvFLuqnJCkL0EQFtunBXI03FJpPu3T1XU6id8S7ojoJQZSauGUCgmaLqUGdMrd08oo81ecoJSLs51Re9N/lISGmjWFPGpqJLoGq6uo4FHz58hmeyXCgHG742BHz2P3MiH1CXHUT2J8mF6zLhf3SR9Qb3lkrobAh"
+              }
+            }
+          }
+        ]
+      },
+      "ThoughtSummaryContent": {
+        "type": "object",
+        "oneOf": [
+          { "$ref": "#/components/schemas/TextContent" },
+          { "$ref": "#/components/schemas/ImageContent" }
+        ],
+        "discriminator": { "propertyName": "type" }
+      },
+      "FunctionCallContent": {
+        "description": "A function tool call content block.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "function_call" },
+          "name": {
+            "description": "Required. The name of the tool to call.",
+            "type": "string"
+          },
+          "arguments": {
+            "description": "Required. The arguments to pass to the function.",
+            "type": "object",
+            "additionalProperties": {
+              "description": "Properties of the object."
+            }
+          },
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "name", "arguments", "id"],
+        "examples": [
+          {
+            "function_call": {
+              "summary": "Function Call",
+              "value": {
+                "type": "function_call",
+                "name": "get_weather",
+                "id": "gth23981",
+                "arguments": { "location": "Boston, MA" }
+              }
+            }
+          }
+        ]
+      },
+      "CodeExecutionCallContent": {
+        "description": "Code execution content.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "code_execution_call" },
+          "arguments": {
+            "description": "Required. The arguments to pass to the code execution.",
+            "$ref": "#/components/schemas/CodeExecutionCallArguments"
+          },
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "arguments", "id"],
+        "examples": [
+          {
+            "code_execution_call": {
+              "summary": "Code Execution Call",
+              "value": {
+                "type": "code_execution_call",
+                "id": "call_123456",
+                "arguments": {
+                  "language": "python",
+                  "code": "print('hello world')"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "CodeExecutionCallArguments": {
+        "description": "The arguments to pass to the code execution.",
+        "type": "object",
+        "properties": {
+          "language": {
+            "description": "Programming language of the `code`.",
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Python >= 3.10, with numpy and simpy available."
+            ],
+            "enum": ["python"]
+          },
+          "code": {
+            "description": "The code to be executed.",
+            "type": "string"
+          }
+        }
+      },
+      "UrlContextCallContent": {
+        "description": "URL context content.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "url_context_call" },
+          "arguments": {
+            "description": "Required. The arguments to pass to the URL context.",
+            "$ref": "#/components/schemas/UrlContextCallArguments"
+          },
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "arguments", "id"],
+        "examples": [
+          {
+            "url_context_call": {
+              "summary": "Url Context Call",
+              "value": {
+                "type": "url_context_call",
+                "id": "call_123456",
+                "arguments": { "urls": ["https://www.example.com"] }
+              }
+            }
+          }
+        ]
+      },
+      "UrlContextCallArguments": {
+        "description": "The arguments to pass to the URL context.",
+        "type": "object",
+        "properties": {
+          "urls": {
+            "description": "The URLs to fetch.",
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "McpServerToolCallContent": {
+        "description": "MCPServer tool call content.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "mcp_server_tool_call" },
+          "name": {
+            "description": "Required. The name of the tool which was called.",
+            "type": "string"
+          },
+          "server_name": {
+            "description": "Required. The name of the used MCP server.",
+            "type": "string"
+          },
+          "arguments": {
+            "description": "Required. The JSON object of arguments for the function.",
+            "type": "object",
+            "additionalProperties": {
+              "description": "Properties of the object."
+            }
+          },
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "name", "server_name", "arguments", "id"],
+        "examples": [
+          {
+            "mcp_server_tool_call": {
+              "summary": "Mcp Server Tool Call",
+              "value": {
+                "type": "mcp_server_tool_call",
+                "id": "call_123456",
+                "name": "get_forecast",
+                "server_name": "weather_server",
+                "arguments": { "city": "London" }
+              }
+            }
+          }
+        ]
+      },
+      "GoogleSearchCallContent": {
+        "description": "Google Search content.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "google_search_call" },
+          "arguments": {
+            "description": "Required. The arguments to pass to Google Search.",
+            "$ref": "#/components/schemas/GoogleSearchCallArguments"
+          },
+          "search_type": {
+            "description": "The type of search grounding enabled.",
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Setting this field enables web search. Only text results are returned.",
+              "Setting this field enables image search. Image bytes are returned.",
+              "Setting this field enables enterprise web search."
+            ],
+            "enum": ["web_search", "image_search", "enterprise_web_search"]
+          },
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "arguments", "id"],
+        "examples": [
+          {
+            "google_search_call": {
+              "summary": "Google Search Call",
+              "value": {
+                "type": "google_search_call",
+                "id": "call_123456",
+                "arguments": { "queries": ["weather in Boston"] }
+              }
+            }
+          }
+        ]
+      },
+      "GoogleSearchCallArguments": {
+        "description": "The arguments to pass to Google Search.",
+        "type": "object",
+        "properties": {
+          "queries": {
+            "description": "Web search queries for the following-up web search.",
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "FileSearchCallContent": {
+        "description": "File Search content.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "file_search_call" },
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "id"],
+        "examples": [
+          {
+            "file_search_call": {
+              "summary": "File Search Call",
+              "value": { "type": "file_search_call", "id": "call_123456" }
+            }
+          }
+        ]
+      },
+      "GoogleMapsCallContent": {
+        "description": "Google Maps content.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "google_maps_call" },
+          "arguments": {
+            "description": "The arguments to pass to the Google Maps tool.",
+            "$ref": "#/components/schemas/GoogleMapsCallArguments"
+          },
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "id"],
+        "examples": [
+          {
+            "google_maps_call": {
+              "summary": "Google Maps Call",
+              "value": {
+                "type": "google_maps_call",
+                "id": "call_123456",
+                "arguments": { "query": "best food near me" }
+              }
+            }
+          }
+        ]
+      },
+      "GoogleMapsCallArguments": {
+        "description": "The arguments to pass to the Google Maps tool.",
+        "type": "object",
+        "properties": {
+          "queries": {
+            "description": "The queries to be executed.",
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "FunctionResultContent": {
+        "description": "A function tool result content block.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "function_result" },
+          "name": {
+            "description": "The name of the tool that was called.",
+            "type": "string"
+          },
+          "is_error": {
+            "description": "Whether the tool call resulted in an error.",
+            "type": "boolean"
+          },
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          },
+          "result": {
+            "description": "The result of the tool call.",
+            "oneOf": [
+              { "type": "object" },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FunctionResultSubcontent"
+                },
+                "title": "FunctionResultSubcontentList"
+              },
+              { "type": "string" }
+            ]
+          }
+        },
+        "required": ["type", "call_id", "result"],
+        "examples": [
+          {
+            "function_result": {
+              "summary": "Function Result",
+              "value": {
+                "type": "function_result",
+                "name": "get_weather",
+                "call_id": "gth23981",
+                "result": [
+                  { "type": "text", "text": "{\"weather\":\"sunny\"}" }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "FunctionResultSubcontent": {
+        "type": "object",
+        "oneOf": [
+          { "$ref": "#/components/schemas/TextContent" },
+          { "$ref": "#/components/schemas/ImageContent" }
+        ],
+        "discriminator": { "propertyName": "type" }
+      },
+      "CodeExecutionResultContent": {
+        "description": "Code execution result content.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "code_execution_result" },
+          "result": {
+            "description": "Required. The output of the code execution.",
+            "type": "string"
+          },
+          "is_error": {
+            "description": "Whether the code execution resulted in an error.",
+            "type": "boolean"
+          },
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "result", "call_id"],
+        "examples": [
+          {
+            "code_execution_result": {
+              "summary": "Code Execution Result",
+              "value": {
+                "type": "code_execution_result",
+                "call_id": "call_123456",
+                "result": "hello world"
+              }
+            }
+          }
+        ]
+      },
+      "UrlContextResultContent": {
+        "description": "URL context result content.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "url_context_result" },
+          "result": {
+            "description": "Required. The results of the URL context.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/UrlContextResult" }
+          },
+          "is_error": {
+            "description": "Whether the URL context resulted in an error.",
+            "type": "boolean"
+          },
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "result", "call_id"],
+        "examples": [
+          {
+            "url_context_result": {
+              "summary": "Url Context Result",
+              "value": {
+                "type": "url_context_result",
+                "call_id": "call_123456",
+                "result": [
+                  { "url": "https://www.example.com", "status": "SUCCESS" }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "UrlContextResult": {
+        "description": "The result of the URL context.",
+        "type": "object",
+        "properties": {
+          "url": {
+            "description": "The URL that was fetched.",
+            "type": "string"
+          },
+          "status": {
+            "description": "The status of the URL retrieval.",
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Url retrieval is successful.",
+              "Url retrieval is failed due to error.",
+              "Url retrieval is failed because the content is behind paywall.",
+              "Url retrieval is failed because the content is unsafe."
+            ],
+            "enum": ["success", "error", "paywall", "unsafe"]
+          }
+        }
+      },
+      "GoogleSearchResultContent": {
+        "description": "Google Search result content.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "google_search_result" },
+          "result": {
+            "description": "Required. The results of the Google Search.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/GoogleSearchResult" }
+          },
+          "is_error": {
+            "description": "Whether the Google Search resulted in an error.",
+            "type": "boolean"
+          },
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "result", "call_id"],
+        "examples": [
+          {
+            "google_search_result": {
+              "summary": "Google Search Result",
+              "value": {
+                "type": "google_search_result",
+                "call_id": "call_123456",
+                "result": [
+                  {
+                    "url": "https://www.google.com/search?q=weather+in+Boston",
+                    "title": "Weather in Boston"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "GoogleSearchResult": {
+        "description": "The result of the Google Search.",
+        "type": "object",
+        "properties": {
+          "search_suggestions": {
+            "description": "Web content snippet that can be embedded in a web page or an app webview.",
+            "type": "string"
+          }
+        }
+      },
+      "McpServerToolResultContent": {
+        "description": "MCPServer tool result content.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "mcp_server_tool_result" },
+          "name": {
+            "description": "Name of the tool which is called for this specific tool call.",
+            "type": "string"
+          },
+          "server_name": {
+            "description": "The name of the used MCP server.",
+            "type": "string"
+          },
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          },
+          "result": {
+            "description": "The output from the MCP server call. Can be simple text or rich content.",
+            "oneOf": [
+              { "type": "object" },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FunctionResultSubcontent"
+                },
+                "title": "FunctionResultSubcontentList"
+              },
+              { "type": "string" }
+            ]
+          }
+        },
+        "required": ["type", "call_id", "result"],
+        "examples": [
+          {
+            "mcp_server_tool_result": {
+              "summary": "Mcp Server Tool Result",
+              "value": {
+                "type": "mcp_server_tool_result",
+                "name": "get_forecast",
+                "server_name": "weather_server",
+                "call_id": "call_123456",
+                "result": "sunny"
+              }
+            }
+          }
+        ]
+      },
+      "FileSearchResultContent": {
+        "description": "File Search result content.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "file_search_result" },
+          "result": {
+            "description": "Required. The results of the File Search.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/FileSearchResult" }
+          },
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "result", "call_id"],
+        "examples": [
+          {
+            "file_search_result": {
+              "summary": "File Search Result",
+              "value": {
+                "type": "file_search_result",
+                "call_id": "call_123456",
+                "result": [
+                  {
+                    "text": "search result chunk",
+                    "file_search_store": "file_search_store"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "FileSearchResult": {
+        "description": "The result of the File Search.",
+        "type": "object",
+        "properties": {
+          "custom_metadata": {
+            "description": "User provided metadata about the FileSearchResult.",
+            "type": "array",
+            "items": { "type": "object" }
+          }
+        }
+      },
+      "GoogleMapsResultContent": {
+        "description": "Google Maps result content.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "google_maps_result" },
+          "result": {
+            "description": "Required. The results of the Google Maps.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/GoogleMapsResult" }
+          },
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "result", "call_id"],
+        "examples": [
+          {
+            "google_maps_result": {
+              "summary": "Google Maps Result",
+              "value": {
+                "type": "google_maps_result",
+                "call_id": "call_123456",
+                "result": [
+                  {
+                    "places": [
+                      {
+                        "url": "https://www.google.com/maps/search/best+food+near+me",
+                        "name": "Tasty Restaurant"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "GoogleMapsResult": {
+        "description": "The result of the Google Maps.",
+        "type": "object",
+        "properties": {
+          "places": {
+            "description": "The places that were found.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Places" }
+          },
+          "widget_context_token": {
+            "description": "Resource name of the Google Maps widget context token.",
+            "type": "string"
+          }
+        }
+      },
+      "Places": {
+        "type": "object",
+        "properties": {
+          "place_id": {
+            "description": "The ID of the place, in `places/{place_id}` format.",
+            "type": "string"
+          },
+          "name": { "description": "Title of the place.", "type": "string" },
+          "url": {
+            "description": "URI reference of the place.",
+            "type": "string"
+          },
+          "review_snippets": {
+            "description": "Snippets of reviews that are used to generate answers about the\nfeatures of a given place in Google Maps.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ReviewSnippet" }
+          }
+        }
+      },
+      "Turn": {
+        "type": "object",
+        "properties": {
+          "role": {
+            "description": "The originator of this turn. Must be user for input or model for\nmodel output.",
+            "type": "string"
+          },
+          "content": {
+            "oneOf": [
+              {
+                "type": "array",
+                "items": { "$ref": "#/components/schemas/Content" },
+                "title": "ContentList"
+              },
+              { "type": "string" }
+            ]
+          }
+        },
+        "examples": [
+          {
+            "user_turn": {
+              "summary": "User Turn",
+              "value": {
+                "role": "user",
+                "content": [{ "type": "text", "text": "user turn" }]
+              }
+            }
+          },
+          {
+            "model_turn": {
+              "summary": "Model Turn",
+              "value": {
+                "role": "model",
+                "content": [{ "type": "text", "text": "model turn" }]
+              }
+            }
+          }
+        ]
+      },
+      "GenerationConfig": {
+        "description": "Configuration parameters for model interactions.",
+        "type": "object",
+        "properties": {
+          "temperature": {
+            "description": "Controls the randomness of the output.",
+            "type": "number",
+            "format": "float"
+          },
+          "top_p": {
+            "description": "The maximum cumulative probability of tokens to consider when sampling.",
+            "type": "number",
+            "format": "float"
+          },
+          "seed": {
+            "description": "Seed used in decoding for reproducibility.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "stop_sequences": {
+            "description": "A list of character sequences that will stop output interaction.",
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "thinking_level": {
+            "description": "The level of thought tokens that the model should generate.",
+            "$ref": "#/components/schemas/ThinkingLevel"
+          },
+          "thinking_summaries": {
+            "description": "Whether to include thought summaries in the response.",
+            "$ref": "#/components/schemas/ThinkingSummaries"
+          },
+          "max_output_tokens": {
+            "description": "The maximum number of tokens to include in the response.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "speech_config": {
+            "description": "Configuration for speech interaction.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/SpeechConfig" }
+          },
+          "image_config": {
+            "description": "Configuration for image interaction.",
+            "$ref": "#/components/schemas/ImageConfig"
+          },
+          "tool_choice": {
+            "description": "The tool choice configuration.",
+            "oneOf": [
+              { "$ref": "#/components/schemas/ToolChoiceType" },
+              { "$ref": "#/components/schemas/ToolChoiceConfig" }
+            ]
+          }
+        }
+      },
+      "ToolChoiceConfig": {
+        "description": "The tool choice configuration containing allowed tools.",
+        "type": "object",
+        "properties": {
+          "allowed_tools": {
+            "description": "The allowed tools.",
+            "$ref": "#/components/schemas/AllowedTools"
+          }
+        }
+      },
+      "AllowedTools": {
+        "description": "The configuration for allowed tools.",
+        "type": "object",
+        "properties": {
+          "mode": {
+            "description": "The mode of the tool choice.",
+            "$ref": "#/components/schemas/ToolChoiceType"
+          },
+          "tools": {
+            "description": "The names of the allowed tools.",
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "SpeechConfig": {
+        "description": "The configuration for speech interaction.",
+        "type": "object",
+        "properties": {
+          "voice": {
+            "description": "The voice of the speaker.",
+            "type": "string"
+          },
+          "language": {
+            "description": "The language of the speech.",
+            "type": "string"
+          },
+          "speaker": {
+            "description": "The speaker's name, it should match the speaker name given in the prompt.",
+            "type": "string"
+          }
+        }
+      },
+      "ImageConfig": {
+        "description": "The configuration for image interaction.",
+        "type": "object",
+        "properties": {
+          "aspect_ratio": {
+            "enum": [
+              "1:1",
+              "2:3",
+              "3:2",
+              "3:4",
+              "4:3",
+              "4:5",
+              "5:4",
+              "9:16",
+              "16:9",
+              "21:9",
+              "1:8",
+              "8:1",
+              "1:4",
+              "4:1"
+            ],
+            "x-google-enum-descriptions": [
+              "1:1 aspect ratio.",
+              "2:3 aspect ratio.",
+              "3:2 aspect ratio.",
+              "3:4 aspect ratio.",
+              "4:3 aspect ratio.",
+              "4:5 aspect ratio.",
+              "5:4 aspect ratio.",
+              "9:16 aspect ratio.",
+              "16:9 aspect ratio.",
+              "21:9 aspect ratio.",
+              "1:8 aspect ratio.",
+              "8:1 aspect ratio.",
+              "1:4 aspect ratio.",
+              "4:1 aspect ratio."
+            ]
+          },
+          "image_size": {
+            "enum": ["1K", "2K", "4K", "512"],
+            "x-google-enum-descriptions": [
+              "1K image size.",
+              "2K image size.",
+              "4K image size.",
+              "512 image size."
+            ]
+          }
+        }
+      },
+      "DynamicAgentConfig": {
+        "description": "Configuration for dynamic agents.",
+        "type": "object",
+        "properties": { "type": { "const": "dynamic" } },
+        "additionalProperties": {
+          "description": "For agents that are not supported statically in the API definition."
+        },
+        "required": ["type"]
+      },
+      "DeepResearchAgentConfig": {
+        "description": "Configuration for the Deep Research agent.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "deep-research" },
+          "thinking_summaries": {
+            "description": "Whether to include thought summaries in the response.",
+            "$ref": "#/components/schemas/ThinkingSummaries"
+          }
+        },
+        "required": ["type"]
+      },
+      "Tool": {
+        "description": "A tool that can be used by the model.",
+        "type": "object",
+        "oneOf": [
+          { "$ref": "#/components/schemas/Function" },
+          { "$ref": "#/components/schemas/CodeExecution" },
+          { "$ref": "#/components/schemas/UrlContext" },
+          { "$ref": "#/components/schemas/ComputerUse" },
+          { "$ref": "#/components/schemas/McpServer" },
+          { "$ref": "#/components/schemas/GoogleSearch" },
+          { "$ref": "#/components/schemas/FileSearch" },
+          { "$ref": "#/components/schemas/GoogleMaps" },
+          { "$ref": "#/components/schemas/Retrieval" }
+        ],
+        "discriminator": { "propertyName": "type" }
+      },
+      "Function": {
+        "description": "A tool that can be used by the model.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "function" },
+          "name": {
+            "description": "The name of the function.",
+            "type": "string"
+          },
+          "description": {
+            "description": "A description of the function.",
+            "type": "string"
+          },
+          "parameters": {
+            "description": "The JSON Schema for the function's parameters."
+          }
+        },
+        "required": ["type"],
+        "x-codeSamples": [
+          {
+            "lang": "sh",
+            "label": "function_calling",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3-flash-preview\",\n    \"tools\": [{\n      \"type\": \"function\",\n      \"name\": \"get_weather\",\n      \"description\": \"Get the current weather in a given location\",\n      \"parameters\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"location\": {\n            \"type\": \"string\",\n            \"description\": \"The city and state, e.g. San Francisco, CA\"\n          }\n        },\n        \"required\": [\"location\"]\n      }\n    }],\n    \"input\": \"What is the weather like in Boston, MA?\"\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "function_calling",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3-flash-preview\",\n    tools=[{\n        \"type\": \"function\",\n        \"name\": \"get_weather\",\n        \"description\": \"Get the current weather in a given location\",\n        \"parameters\": {\n            \"type\": \"object\",\n            \"properties\": {\n                \"location\": {\n                    \"type\": \"string\",\n                    \"description\": \"The city and state, e.g. San Francisco, CA\"\n                }\n            },\n            \"required\": [\"location\"]\n        }\n    }],\n    input=\"What is the weather like in Boston?\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "function_calling",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3-flash-preview',\n    tools: [{\n        type: 'function',\n        name: 'get_weather',\n        description: 'Get the current weather in a given location',\n        parameters: {\n            type: 'object',\n            properties: {\n                location: {\n                    type: 'string',\n                    description: 'The city and state, e.g. San Francisco, CA'\n                }\n            },\n            required: ['location']\n        }\n    }],\n    input: 'What is the weather like in Boston?'\n});\nconsole.log(interaction.outputs[0]);\n"
+          }
+        ]
+      },
+      "CodeExecution": {
+        "description": "A tool that can be used by the model to execute code.",
+        "type": "object",
+        "properties": { "type": { "const": "code_execution" } },
+        "required": ["type"],
+        "x-codeSamples": [
+          {
+            "lang": "sh",
+            "label": "code_execution",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3-flash-preview\",\n    \"tools\": [{\n      \"type\": \"code_execution\"\n    }],\n    \"input\": \"Calculate the first 10 Fibonacci numbers\"\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "code_execution",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3-flash-preview\",\n    tools=[{\"type\": \"code_execution\"}],\n    input=\"Calculate the first 10 Fibonacci numbers\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "code_execution",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3-flash-preview',\n    tools: [{ type: 'code_execution' }],\n    input: 'Calculate the first 10 Fibonacci numbers'\n});\nconsole.log(interaction.outputs[0]);\n"
+          }
+        ]
+      },
+      "UrlContext": {
+        "description": "A tool that can be used by the model to fetch URL context.",
+        "type": "object",
+        "properties": { "type": { "const": "url_context" } },
+        "required": ["type"],
+        "x-codeSamples": [
+          {
+            "lang": "sh",
+            "label": "url_context",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3-flash-preview\",\n    \"tools\": [{\n      \"type\": \"url_context\"\n    }],\n    \"input\": \"Summarize https://www.example.com\"\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "url_context",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3-flash-preview\",\n    tools=[{\"type\": \"url_context\"}],\n    input=\"Summarize https://www.example.com\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "url_context",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3-flash-preview',\n    tools: [{ type: 'url_context' }],\n    input: 'Summarize https://www.example.com'\n});\nconsole.log(interaction.outputs[0]);\n"
+          }
+        ]
+      },
+      "ComputerUse": {
+        "description": "A tool that can be used by the model to interact with the computer.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "computer_use" },
+          "environment": {
+            "description": "The environment being operated.",
+            "type": "string",
+            "x-google-enum-descriptions": ["Operates in a web browser."],
+            "enum": ["browser"]
+          },
+          "excludedPredefinedFunctions": {
+            "description": "The list of predefined functions that are excluded from the model call.",
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "required": ["type"],
+        "x-codeSamples": [
+          {
+            "lang": "sh",
+            "label": "computer_use",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-2.5-computer-use-preview-10-2025\",\n    \"tools\": [{\n      \"type\": \"computer_use\",\n    }],\n    \"input\": \"Find a flight to Tokyo\"\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "computer_use",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-2.5-computer-use-preview-10-2025\",\n    tools=[{\"type\": \"computer_use\"}],\n    input=\"Find a flight to Tokyo\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "computer_use",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-2.5-computer-use-preview-10-2025',\n    tools: [{ type: 'computer_use'}],\n    input: 'Find a flight to Tokyo'\n});\nconsole.log(interaction.outputs[0]);\n"
+          }
+        ]
+      },
+      "McpServer": {
+        "description": "A MCPServer is a server that can be called by the model to perform actions.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "mcp_server" },
+          "name": {
+            "description": "The name of the MCPServer.",
+            "type": "string"
+          },
+          "url": {
+            "description": "The full URL for the MCPServer endpoint.\nExample: \"https://api.example.com/mcp\"",
+            "type": "string"
+          },
+          "headers": {
+            "description": "Optional: Fields for authentication headers, timeouts, etc., if needed.",
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+          },
+          "allowed_tools": {
+            "description": "The allowed tools.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/AllowedTools" }
+          }
+        },
+        "required": ["type"],
+        "x-codeSamples": [
+          {
+            "lang": "sh",
+            "label": "mcp_server",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3-flash-preview\",\n    \"tools\": [{\n      \"type\": \"mcp_server\",\n      \"name\": \"weather_service\",\n      \"url\": \"https://gemini-api-demos.uc.r.appspot.com/mcp\"\n    }],\n    \"input\": \"Today is 12-05-2025, what is the temperature today in London?\"\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "mcp_server",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3-flash-preview\",\n    tools=[{\n        \"type\": \"mcp_server\",\n        \"name\": \"weather_service\",\n        \"url\": \"https://gemini-api-demos.uc.r.appspot.com/mcp\"\n    }],\n    input=\"Today is 12-05-2025, what is the temperature today in London?\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "mcp_server",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3-flash-preview',\n    tools: [{\n        type: 'mcp_server',\n        name: 'weather_service',\n        url: 'https://gemini-api-demos.uc.r.appspot.com/mcp'\n    }],\n    input: 'Today is 12-05-2025, what is the temperature today in London?'\n});\nconsole.log(interaction.outputs[0]);\n"
+          }
+        ]
+      },
+      "GoogleSearch": {
+        "description": "A tool that can be used by the model to search Google.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "google_search" },
+          "search_types": {
+            "description": "The types of search grounding to enable.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "x-google-enum-descriptions": [
+                "Setting this field enables web search. Only text results are returned.",
+                "Setting this field enables image search. Image bytes are returned.",
+                "Setting this field enables enterprise web search."
+              ],
+              "enum": ["web_search", "image_search", "enterprise_web_search"]
+            }
+          }
+        },
+        "required": ["type"],
+        "x-codeSamples": [
+          {
+            "lang": "sh",
+            "label": "google_search",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3-flash-preview\",\n    \"tools\": [{\n      \"type\": \"google_search\"\n    }],\n    \"input\": \"Who is the current president of France?\"\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "google_search",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3-flash-preview\",\n    tools=[{\"type\": \"google_search\"}],\n    input=\"Who is the current president of France?\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "google_search",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3-flash-preview',\n    tools: [{ type: 'google_search' }],\n    input: 'Who is the current president of France?'\n});\nconsole.log(interaction.outputs[0]);\n"
+          }
+        ]
+      },
+      "FileSearch": {
+        "description": "A tool that can be used by the model to search files.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "file_search" },
+          "file_search_store_names": {
+            "description": "The file search store names to search.",
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "top_k": {
+            "description": "The number of semantic retrieval chunks to retrieve.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "metadata_filter": {
+            "description": "Metadata filter to apply to the semantic retrieval documents and chunks.",
+            "type": "string"
+          }
+        },
+        "required": ["type"],
+        "x-codeSamples": [
+          {
+            "lang": "sh",
+            "label": "file_search",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3-flash-preview\",\n    \"tools\": [{\n      \"type\": \"file_search\",\n      \"file_search_store_names\": [\"fileSearchStores/m64d1sevsr4y-xfyawui3fxqg\"]\n    }],\n    \"input\": \"Who is the author of the book?\"\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "file_search",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3-flash-preview\",\n    tools=[{\n        \"type\": \"file_search\",\n        \"file_search_store_names\": [\"fileSearchStores/m64d1sevsr4y-xfyawui3fxqg\"]\n    }],\n    input=\"Who is the author of the book?\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "file_search",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3-flash-preview',\n    tools: [{\n        type: 'file_search',\n        file_search_store_names: ['fileSearchStores/m64d1sevsr4y-xfyawui3fxqg']\n    }],\n    input: 'Who is the author of the book?'\n});\nconsole.log(interaction.outputs[0]);\n"
+          }
+        ]
+      },
+      "GoogleMaps": {
+        "description": "A tool that can be used by the model to call Google Maps.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "google_maps" },
+          "enable_widget": {
+            "description": "Whether to return a widget context token in the tool call result of the\nresponse.",
+            "type": "boolean"
+          },
+          "latitude": {
+            "description": "The latitude of the user's location.",
+            "type": "number",
+            "format": "double"
+          },
+          "longitude": {
+            "description": "The longitude of the user's location.",
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "required": ["type"],
+        "x-codeSamples": [
+          {
+            "lang": "sh",
+            "label": "google_maps",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3-flash-preview\",\n    \"tools\": [{\n      \"type\": \"google_maps\",\n      \"latitude\": 37.7749,\n      \"longitude\": -122.4194\n    }],\n    \"input\": \"What is the best food near me?\"\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "google_maps",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3-flash-preview\",\n    tools=[{\n        \"type\": \"google_maps\",\n        \"latitude\": 37.7749,\n        \"longitude\": -122.4194\n    }],\n    input=\"What is the best food near me?\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "google_maps",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3-flash-preview',\n    tools: [{\n        type: 'google_maps',\n        latitude: 37.7749,\n        longitude: -122.4194\n    }],\n    input: 'What is the best food near me?'\n});\nconsole.log(interaction.outputs[0]);\n"
+          }
+        ]
+      },
+      "Retrieval": {
+        "description": "A tool that can be used by the model to retrieve files.",
+        "type": "object",
+        "properties": {
+          "type": { "const": "retrieval" },
+          "retrieval_types": {
+            "description": "The types of file retrieval to enable.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "x-google-enum-descriptions": [""],
+              "enum": ["vertex_ai_search"]
+            }
+          },
+          "vertex_ai_search_config": {
+            "description": "Used to specify configuration for VertexAISearch.",
+            "$ref": "#/components/schemas/VertexAISearchConfig"
+          }
+        },
+        "required": ["type"]
+      },
+      "VertexAISearchConfig": {
+        "description": "Used to specify configuration for VertexAISearch.",
+        "type": "object",
+        "properties": {
+          "engine": {
+            "description": "Optional. Used to specify Vertex AI Search engine.",
+            "type": "string"
+          },
+          "datastores": {
+            "description": "Optional. Used to specify Vertex AI Search datastores.",
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "Usage": {
+        "description": "Statistics on the interaction request's token usage.",
+        "type": "object",
+        "properties": {
+          "total_input_tokens": {
+            "description": "Number of tokens in the prompt (context).",
+            "type": "integer",
+            "format": "int32"
+          },
+          "input_tokens_by_modality": {
+            "description": "A breakdown of input token usage by modality.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ModalityTokens" }
+          },
+          "total_cached_tokens": {
+            "description": "Number of tokens in the cached part of the prompt (the cached content).",
+            "type": "integer",
+            "format": "int32"
+          },
+          "cached_tokens_by_modality": {
+            "description": "A breakdown of cached token usage by modality.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ModalityTokens" }
+          },
+          "total_output_tokens": {
+            "description": "Total number of tokens across all the generated responses.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "output_tokens_by_modality": {
+            "description": "A breakdown of output token usage by modality.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ModalityTokens" }
+          },
+          "total_tool_use_tokens": {
+            "description": "Number of tokens present in tool-use prompt(s).",
+            "type": "integer",
+            "format": "int32"
+          },
+          "tool_use_tokens_by_modality": {
+            "description": "A breakdown of tool-use token usage by modality.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ModalityTokens" }
+          },
+          "total_thought_tokens": {
+            "description": "Number of tokens of thoughts for thinking models.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "total_tokens": {
+            "description": "Total token count for the interaction request (prompt + responses + other\ninternal tokens).",
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "ModalityTokens": {
+        "description": "The token count for a single response modality.",
+        "type": "object",
+        "properties": {
+          "modality": {
+            "description": "The modality associated with the token count.",
+            "$ref": "#/components/schemas/ResponseModality"
+          },
+          "tokens": {
+            "description": "Number of tokens for the modality.",
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "InteractionStartEvent": {
+        "type": "object",
+        "properties": {
+          "event_type": { "const": "interaction.start" },
+          "interaction": { "$ref": "#/components/schemas/Interaction" },
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from\nthis event.",
+            "type": "string"
+          }
+        },
+        "required": ["event_type", "interaction"],
+        "examples": [
+          {
+            "interaction_start": {
+              "summary": "Interaction Start",
+              "value": {
+                "event_type": "interaction.start",
+                "interaction": {
+                  "id": "v1_ChdTMjQ0YWJ5TUF1TzcxZThQdjRpcnFRcxIXUzI0NGFieU1BdU83MWU4UHY0aXJxUXM",
+                  "model": "gemini-3-flash-preview",
+                  "object": "interaction",
+                  "status": "in_progress"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "InteractionCompleteEvent": {
+        "type": "object",
+        "properties": {
+          "event_type": { "const": "interaction.complete" },
+          "interaction": {
+            "description": "Required. The completed interaction with empty outputs to reduce the payload size.\nUse the preceding ContentDelta events for the actual output.",
+            "$ref": "#/components/schemas/Interaction"
+          },
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from\nthis event.",
+            "type": "string"
+          }
+        },
+        "required": ["event_type", "interaction"],
+        "examples": [
+          {
+            "interaction_complete": {
+              "summary": "Interaction Complete",
+              "value": {
+                "event_type": "interaction.complete",
+                "interaction": {
+                  "created": "2025-12-09T18:45:40Z",
+                  "id": "v1_ChdTMjQ0YWJ5TUF1TzcxZThQdjRpcnFRcxIXUzI0NGFieU1BdU83MWU4UHY0aXJxUXM",
+                  "model": "gemini-3-flash-preview",
+                  "object": "interaction",
+                  "role": "model",
+                  "status": "completed",
+                  "updated": "2025-12-09T18:45:40Z",
+                  "usage": {
+                    "input_tokens_by_modality": [
+                      { "modality": "text", "tokens": 11 }
+                    ],
+                    "total_cached_tokens": 0,
+                    "total_input_tokens": 11,
+                    "total_output_tokens": 364,
+                    "total_thought_tokens": 1120,
+                    "total_tokens": 1495,
+                    "total_tool_use_tokens": 0
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "InteractionStatusUpdate": {
+        "type": "object",
+        "properties": {
+          "event_type": { "const": "interaction.status_update" },
+          "interaction_id": { "type": "string" },
+          "status": {
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "The interaction is in progress.",
+              "The interaction requires action.",
+              "The interaction is completed.",
+              "The interaction is failed.",
+              "The interaction is cancelled.",
+              "The interaction is incomplete."
+            ],
+            "enum": [
+              "in_progress",
+              "requires_action",
+              "completed",
+              "failed",
+              "cancelled",
+              "incomplete"
+            ]
+          },
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from\nthis event.",
+            "type": "string"
+          }
+        },
+        "required": ["event_type", "interaction_id", "status"],
+        "examples": [
+          {
+            "interaction_status_update": {
+              "summary": "Interaction Status Update",
+              "value": {
+                "event_type": "interaction.status_update",
+                "interaction_id": "v1_ChdTMjQ0YWJ5TUF1TzcxZThQdjRpcnFRcxIXUzI0NGFieU1BdU83MWU4UHY0aXJxUXM",
+                "status": "in_progress"
+              }
+            }
+          }
+        ]
+      },
+      "ContentStart": {
+        "type": "object",
+        "properties": {
+          "event_type": { "const": "content.start" },
+          "index": { "type": "integer", "format": "int32" },
+          "content": { "$ref": "#/components/schemas/Content" },
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from\nthis event.",
+            "type": "string"
+          }
+        },
+        "required": ["event_type", "index", "content"],
+        "examples": [
+          {
+            "content_start": {
+              "summary": "Content Start",
+              "value": {
+                "event_type": "content.start",
+                "content": { "type": "text" },
+                "index": 1
+              }
+            }
+          }
+        ]
+      },
+      "ContentDelta": {
+        "type": "object",
+        "properties": {
+          "event_type": { "const": "content.delta" },
+          "index": { "type": "integer", "format": "int32" },
+          "delta": { "$ref": "#/components/schemas/ContentDeltaData" },
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from\nthis event.",
+            "type": "string"
+          }
+        },
+        "required": ["event_type", "index", "delta"],
+        "examples": [
+          {
+            "content_delta": {
+              "summary": "Content Delta",
+              "value": {
+                "event_type": "content.delta",
+                "delta": {
+                  "type": "text",
+                  "text": "Elara’s life was a symphony of quiet moments. A librarian, she found solace in the hushed aisles, the scent of aged paper, and the predictable rhythm of her days. Her small apartment, meticulously ordered, reflected this internal calm, save"
+                },
+                "index": 1
+              }
+            }
+          }
+        ]
+      },
+      "ContentDeltaData": {
+        "description": "The delta content data for a content block.",
+        "type": "object",
+        "oneOf": [
+          { "$ref": "#/components/schemas/TextDelta" },
+          { "$ref": "#/components/schemas/ImageDelta" },
+          { "$ref": "#/components/schemas/AudioDelta" },
+          { "$ref": "#/components/schemas/DocumentDelta" },
+          { "$ref": "#/components/schemas/VideoDelta" },
+          { "$ref": "#/components/schemas/ThoughtSummaryDelta" },
+          { "$ref": "#/components/schemas/ThoughtSignatureDelta" },
+          { "$ref": "#/components/schemas/FunctionCallDelta" },
+          { "$ref": "#/components/schemas/CodeExecutionCallDelta" },
+          { "$ref": "#/components/schemas/UrlContextCallDelta" },
+          { "$ref": "#/components/schemas/GoogleSearchCallDelta" },
+          { "$ref": "#/components/schemas/McpServerToolCallDelta" },
+          { "$ref": "#/components/schemas/FileSearchCallDelta" },
+          { "$ref": "#/components/schemas/GoogleMapsCallDelta" },
+          { "$ref": "#/components/schemas/FunctionResultDelta" },
+          { "$ref": "#/components/schemas/CodeExecutionResultDelta" },
+          { "$ref": "#/components/schemas/UrlContextResultDelta" },
+          { "$ref": "#/components/schemas/GoogleSearchResultDelta" },
+          { "$ref": "#/components/schemas/McpServerToolResultDelta" },
+          { "$ref": "#/components/schemas/FileSearchResultDelta" },
+          { "$ref": "#/components/schemas/GoogleMapsResultDelta" },
+          { "$ref": "#/components/schemas/TextAnnotationDelta" }
+        ],
+        "discriminator": { "propertyName": "type" }
+      },
+      "TextDelta": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "text" },
+          "text": { "type": "string" }
+        },
+        "required": ["type", "text"]
+      },
+      "ImageDelta": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "image" },
+          "data": { "type": "string", "format": "byte" },
+          "uri": { "type": "string" },
+          "mime_type": {
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "PNG image format",
+              "JPEG image format",
+              "WebP image format",
+              "HEIC image format",
+              "HEIF image format",
+              "GIF image format",
+              "BMP image format",
+              "TIFF image format"
+            ],
+            "enum": [
+              "image/png",
+              "image/jpeg",
+              "image/webp",
+              "image/heic",
+              "image/heif",
+              "image/gif",
+              "image/bmp",
+              "image/tiff"
+            ]
+          },
+          "resolution": {
+            "description": "The resolution of the media.",
+            "$ref": "#/components/schemas/MediaResolution"
+          }
+        },
+        "required": ["type"]
+      },
+      "AudioDelta": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "audio" },
+          "data": { "type": "string", "format": "byte" },
+          "uri": { "type": "string" },
+          "mime_type": {
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "WAV audio format",
+              "MP3 audio format",
+              "AIFF audio format",
+              "AAC audio format",
+              "OGG audio format",
+              "FLAC audio format",
+              "MPEG audio format",
+              "M4A audio format",
+              "L16 audio format"
+            ],
+            "enum": [
+              "audio/wav",
+              "audio/mp3",
+              "audio/aiff",
+              "audio/aac",
+              "audio/ogg",
+              "audio/flac",
+              "audio/mpeg",
+              "audio/m4a",
+              "audio/l16"
+            ]
+          },
+          "rate": {
+            "description": "The sample rate of the audio.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "channels": {
+            "description": "The number of audio channels.",
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": ["type"]
+      },
+      "DocumentDelta": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "document" },
+          "data": { "type": "string", "format": "byte" },
+          "uri": { "type": "string" },
+          "mime_type": {
+            "type": "string",
+            "x-google-enum-descriptions": ["PDF document format"],
+            "enum": ["application/pdf"]
+          }
+        },
+        "required": ["type"]
+      },
+      "VideoDelta": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "video" },
+          "data": { "type": "string", "format": "byte" },
+          "uri": { "type": "string" },
+          "mime_type": {
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "MP4 video format",
+              "MPEG video format",
+              "MPG video format",
+              "MOV video format",
+              "AVI video format",
+              "FLV video format",
+              "WebM video format",
+              "WMV video format",
+              "3GPP video format"
+            ],
+            "enum": [
+              "video/mp4",
+              "video/mpeg",
+              "video/mpg",
+              "video/mov",
+              "video/avi",
+              "video/x-flv",
+              "video/webm",
+              "video/wmv",
+              "video/3gpp"
+            ]
+          },
+          "resolution": {
+            "description": "The resolution of the media.",
+            "$ref": "#/components/schemas/MediaResolution"
+          }
+        },
+        "required": ["type"]
+      },
+      "ThoughtSummaryDelta": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "thought_summary" },
+          "content": {
+            "description": "A new summary item to be added to the thought.",
+            "$ref": "#/components/schemas/ThoughtSummaryContent"
+          }
+        },
+        "required": ["type"]
+      },
+      "ThoughtSignatureDelta": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "thought_signature" },
+          "signature": {
+            "description": "Signature to match the backend source to be part of the generation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type"]
+      },
+      "FunctionCallDelta": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "function_call" },
+          "name": { "type": "string" },
+          "arguments": {
+            "type": "object",
+            "additionalProperties": {
+              "description": "Properties of the object."
+            }
+          },
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "name", "arguments", "id"]
+      },
+      "CodeExecutionCallDelta": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "code_execution_call" },
+          "arguments": {
+            "$ref": "#/components/schemas/CodeExecutionCallArguments"
+          },
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "arguments", "id"]
+      },
+      "UrlContextCallDelta": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "url_context_call" },
+          "arguments": {
+            "$ref": "#/components/schemas/UrlContextCallArguments"
+          },
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "arguments", "id"]
+      },
+      "GoogleSearchCallDelta": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "google_search_call" },
+          "arguments": {
+            "$ref": "#/components/schemas/GoogleSearchCallArguments"
+          },
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "arguments", "id"]
+      },
+      "McpServerToolCallDelta": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "mcp_server_tool_call" },
+          "name": { "type": "string" },
+          "server_name": { "type": "string" },
+          "arguments": {
+            "type": "object",
+            "additionalProperties": {
+              "description": "Properties of the object."
+            }
+          },
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "name", "server_name", "arguments", "id"]
+      },
+      "FileSearchCallDelta": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "file_search_call" },
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "id"]
+      },
+      "GoogleMapsCallDelta": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "google_maps_call" },
+          "arguments": {
+            "description": "The arguments to pass to the Google Maps tool.",
+            "$ref": "#/components/schemas/GoogleMapsCallArguments"
+          },
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "id"]
+      },
+      "FunctionResultDelta": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "function_result" },
+          "name": { "type": "string" },
+          "is_error": { "type": "boolean" },
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          },
+          "result": {
+            "oneOf": [
+              { "type": "object" },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FunctionResultSubcontent"
+                },
+                "title": "FunctionResultSubcontentList"
+              },
+              { "type": "string" }
+            ]
+          }
+        },
+        "required": ["type", "call_id", "result"]
+      },
+      "CodeExecutionResultDelta": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "code_execution_result" },
+          "result": { "type": "string" },
+          "is_error": { "type": "boolean" },
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "result", "call_id"]
+      },
+      "UrlContextResultDelta": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "url_context_result" },
+          "result": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/UrlContextResult" }
+          },
+          "is_error": { "type": "boolean" },
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "result", "call_id"]
+      },
+      "GoogleSearchResultDelta": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "google_search_result" },
+          "result": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/GoogleSearchResult" }
+          },
+          "is_error": { "type": "boolean" },
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "result", "call_id"]
+      },
+      "McpServerToolResultDelta": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "mcp_server_tool_result" },
+          "name": { "type": "string" },
+          "server_name": { "type": "string" },
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          },
+          "result": {
+            "oneOf": [
+              { "type": "object" },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FunctionResultSubcontent"
+                },
+                "title": "FunctionResultSubcontentList"
+              },
+              { "type": "string" }
+            ]
+          }
+        },
+        "required": ["type", "call_id", "result"]
+      },
+      "FileSearchResultDelta": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "file_search_result" },
+          "result": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/FileSearchResult" }
+          },
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "result", "call_id"]
+      },
+      "GoogleMapsResultDelta": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "google_maps_result" },
+          "result": {
+            "description": "The results of the Google Maps.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/GoogleMapsResult" }
+          },
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte"
+          }
+        },
+        "required": ["type", "call_id"]
+      },
+      "TextAnnotationDelta": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "text_annotation" },
+          "annotations": {
+            "description": "Citation information for model-generated content.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Annotation" }
+          }
+        },
+        "required": ["type"]
+      },
+      "ContentStop": {
+        "type": "object",
+        "properties": {
+          "event_type": { "const": "content.stop" },
+          "index": { "type": "integer", "format": "int32" },
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from\nthis event.",
+            "type": "string"
+          }
+        },
+        "required": ["event_type", "index"],
+        "examples": [
+          {
+            "content_stop": {
+              "summary": "Content Stop",
+              "value": { "event_type": "content.stop", "index": 1 }
+            }
+          }
+        ]
+      },
+      "ErrorEvent": {
+        "type": "object",
+        "properties": {
+          "event_type": { "const": "error" },
+          "error": { "$ref": "#/components/schemas/Error" },
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from\nthis event.",
+            "type": "string"
+          }
+        },
+        "required": ["event_type"],
+        "examples": [
+          {
+            "error_event": {
+              "summary": "Error Event",
+              "value": {
+                "event_type": "error",
+                "error": {
+                  "message": "Failed to get completed interaction: Result not found.",
+                  "code": "not_found"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "Error": {
+        "description": "Error message from an interaction.",
+        "type": "object",
+        "properties": {
+          "code": {
+            "description": "A URI that identifies the error type.",
+            "type": "string"
+          },
+          "message": {
+            "description": "A human-readable error message.",
+            "type": "string"
+          }
+        }
+      },
+      "MediaResolution": {
+        "type": "string",
+        "x-google-enum-descriptions": [
+          "Low resolution.",
+          "Medium resolution.",
+          "High resolution.",
+          "Ultra high resolution."
+        ],
+        "enum": ["low", "medium", "high", "ultra_high"]
+      },
+      "ToolChoiceType": {
+        "type": "string",
+        "x-google-enum-descriptions": [
+          "Auto tool choice.",
+          "Any tool choice.",
+          "No tool choice.",
+          "Validated tool choice."
+        ],
+        "enum": ["auto", "any", "none", "validated"]
+      },
+      "ThinkingLevel": {
+        "type": "string",
+        "x-google-enum-descriptions": [
+          "Little to no thinking.",
+          "Low thinking level.",
+          "Medium thinking level.",
+          "High thinking level."
+        ],
+        "enum": ["minimal", "low", "medium", "high"]
+      },
+      "ThinkingSummaries": {
+        "type": "string",
+        "x-google-enum-descriptions": [
+          "Auto thinking summaries.",
+          "No thinking summaries."
+        ],
+        "enum": ["auto", "none"]
+      },
+      "ResponseModality": {
+        "type": "string",
+        "x-google-enum-descriptions": [
+          "Indicates the model should return text.",
+          "Indicates the model should return images.",
+          "Indicates the model should return audio.",
+          "Indicates the model should return video.",
+          "Indicates the model should return documents."
+        ],
+        "enum": ["text", "image", "audio", "video", "document"]
+      },
+      "Interaction": {
+        "description": "The Interaction resource.",
+        "properties": {
+          "model": {
+            "$ref": "#/components/schemas/ModelOption",
+            "description": "The name of the `Model` used for generating the interaction."
+          },
+          "agent": {
+            "$ref": "#/components/schemas/AgentOption",
+            "description": "The name of the `Agent` used for generating the interaction."
+          },
+          "id": {
+            "description": "Required. Output only. A unique identifier for the interaction completion.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "status": {
+            "description": "Required. Output only. The status of the interaction.",
+            "readOnly": true,
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "The interaction is in progress.",
+              "The interaction requires action.",
+              "The interaction is completed.",
+              "The interaction is failed.",
+              "The interaction is cancelled.",
+              "The interaction is incomplete."
+            ],
+            "enum": [
+              "in_progress",
+              "requires_action",
+              "completed",
+              "failed",
+              "cancelled",
+              "incomplete"
+            ]
+          },
+          "created": {
+            "description": "Required. Output only. The time at which the response was created in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "readOnly": true,
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated": {
+            "description": "Required. Output only. The time at which the response was last updated in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "readOnly": true,
+            "type": "string",
+            "format": "date-time"
+          },
+          "role": {
+            "description": "Output only. The role of the interaction.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "outputs": {
+            "description": "Output only. Responses from the model.",
+            "readOnly": true,
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Content" }
+          },
+          "system_instruction": {
+            "description": "System instruction for the interaction.",
+            "type": "string"
+          },
+          "tools": {
+            "description": "A list of tool declarations the model may call during interaction.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Tool" }
+          },
+          "usage": {
+            "description": "Output only. Statistics on the interaction request's token usage.",
+            "readOnly": true,
+            "$ref": "#/components/schemas/Usage"
+          },
+          "response_modalities": {
+            "description": "The requested modalities of the response (TEXT, IMAGE, AUDIO).",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ResponseModality" }
+          },
+          "response_format": {
+            "description": "Enforces that the generated response is a JSON object that complies with\nthe JSON schema specified in this field."
+          },
+          "response_mime_type": {
+            "description": "The mime type of the response. This is required if response_format is set.",
+            "type": "string"
+          },
+          "previous_interaction_id": {
+            "description": "The ID of the previous interaction, if any.",
+            "type": "string"
+          },
+          "service_tier": {
+            "description": "The service tier for the interaction.",
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Flex service tier.",
+              "Standard service tier.",
+              "Priority service tier."
+            ],
+            "enum": ["flex", "standard", "priority"]
+          },
+          "input": { "$ref": "#/components/schemas/InteractionsInput" },
+          "generation_config": {
+            "description": "Input only. Configuration parameters for the model interaction.",
+            "writeOnly": true,
+            "$ref": "#/components/schemas/GenerationConfig"
+          },
+          "agent_config": {
+            "description": "Configuration parameters for the agent interaction.",
+            "oneOf": [
+              { "$ref": "#/components/schemas/DynamicAgentConfig" },
+              { "$ref": "#/components/schemas/DeepResearchAgentConfig" }
+            ],
+            "discriminator": { "propertyName": "type" }
+          }
+        },
+        "required": ["id", "status", "created", "updated"],
+        "example": {
+          "created": "2025-12-04T15:01:45Z",
+          "id": "v1_ChdXS0l4YWZXTk9xbk0xZThQczhEcmlROBIXV0tJeGFmV05PcW5NMWU4UHM4RHJpUTg",
+          "model": "gemini-3-flash-preview",
+          "object": "interaction",
+          "outputs": [
+            {
+              "text": "Hello! I'm doing well, functioning as expected. Thank you for asking! How are you doing today?",
+              "type": "text"
+            }
+          ],
+          "role": "model",
+          "status": "completed",
+          "updated": "2025-12-04T15:01:45Z",
+          "usage": {
+            "input_tokens_by_modality": [{ "modality": "text", "tokens": 7 }],
+            "total_cached_tokens": 0,
+            "total_input_tokens": 7,
+            "total_output_tokens": 23,
+            "total_thought_tokens": 49,
+            "total_tokens": 79,
+            "total_tool_use_tokens": 0
+          }
+        }
+      },
+      "CreateModelInteractionParams": {
+        "description": "Parameters for creating model interactions",
+        "properties": {
+          "model": {
+            "$ref": "#/components/schemas/ModelOption",
+            "description": "The name of the `Model` used for generating the interaction."
+          },
+          "stream": {
+            "description": "Input only. Whether the interaction will be streamed.",
+            "writeOnly": true,
+            "type": "boolean"
+          },
+          "store": {
+            "description": "Input only. Whether to store the response and request for later retrieval.",
+            "writeOnly": true,
+            "type": "boolean"
+          },
+          "background": {
+            "description": "Input only. Whether to run the model interaction in the background.",
+            "writeOnly": true,
+            "type": "boolean"
+          },
+          "id": {
+            "description": "Required. Output only. A unique identifier for the interaction completion.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "status": {
+            "description": "Required. Output only. The status of the interaction.",
+            "readOnly": true,
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "The interaction is in progress.",
+              "The interaction requires action.",
+              "The interaction is completed.",
+              "The interaction is failed.",
+              "The interaction is cancelled.",
+              "The interaction is incomplete."
+            ],
+            "enum": [
+              "in_progress",
+              "requires_action",
+              "completed",
+              "failed",
+              "cancelled",
+              "incomplete"
+            ]
+          },
+          "created": {
+            "description": "Required. Output only. The time at which the response was created in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "readOnly": true,
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated": {
+            "description": "Required. Output only. The time at which the response was last updated in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "readOnly": true,
+            "type": "string",
+            "format": "date-time"
+          },
+          "role": {
+            "description": "Output only. The role of the interaction.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "outputs": {
+            "description": "Output only. Responses from the model.",
+            "readOnly": true,
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Content" }
+          },
+          "system_instruction": {
+            "description": "System instruction for the interaction.",
+            "type": "string"
+          },
+          "tools": {
+            "description": "A list of tool declarations the model may call during interaction.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Tool" }
+          },
+          "usage": {
+            "description": "Output only. Statistics on the interaction request's token usage.",
+            "readOnly": true,
+            "$ref": "#/components/schemas/Usage"
+          },
+          "response_modalities": {
+            "description": "The requested modalities of the response (TEXT, IMAGE, AUDIO).",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ResponseModality" }
+          },
+          "response_format": {
+            "description": "Enforces that the generated response is a JSON object that complies with\nthe JSON schema specified in this field."
+          },
+          "response_mime_type": {
+            "description": "The mime type of the response. This is required if response_format is set.",
+            "type": "string"
+          },
+          "previous_interaction_id": {
+            "description": "The ID of the previous interaction, if any.",
+            "type": "string"
+          },
+          "service_tier": {
+            "description": "The service tier for the interaction.",
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Flex service tier.",
+              "Standard service tier.",
+              "Priority service tier."
+            ],
+            "enum": ["flex", "standard", "priority"]
+          },
+          "input": { "$ref": "#/components/schemas/InteractionsInput" },
+          "generation_config": {
+            "description": "Input only. Configuration parameters for the model interaction.",
+            "writeOnly": true,
+            "$ref": "#/components/schemas/GenerationConfig"
+          }
+        },
+        "required": ["model", "input"]
+      },
+      "CreateAgentInteractionParams": {
+        "description": "Parameters for creating agent interactions",
+        "properties": {
+          "agent": {
+            "$ref": "#/components/schemas/AgentOption",
+            "description": "The name of the `Agent` used for generating the interaction."
+          },
+          "stream": {
+            "description": "Input only. Whether the interaction will be streamed.",
+            "writeOnly": true,
+            "type": "boolean"
+          },
+          "store": {
+            "description": "Input only. Whether to store the response and request for later retrieval.",
+            "writeOnly": true,
+            "type": "boolean"
+          },
+          "background": {
+            "description": "Input only. Whether to run the model interaction in the background.",
+            "writeOnly": true,
+            "type": "boolean"
+          },
+          "id": {
+            "description": "Required. Output only. A unique identifier for the interaction completion.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "status": {
+            "description": "Required. Output only. The status of the interaction.",
+            "readOnly": true,
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "The interaction is in progress.",
+              "The interaction requires action.",
+              "The interaction is completed.",
+              "The interaction is failed.",
+              "The interaction is cancelled.",
+              "The interaction is incomplete."
+            ],
+            "enum": [
+              "in_progress",
+              "requires_action",
+              "completed",
+              "failed",
+              "cancelled",
+              "incomplete"
+            ]
+          },
+          "created": {
+            "description": "Required. Output only. The time at which the response was created in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "readOnly": true,
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated": {
+            "description": "Required. Output only. The time at which the response was last updated in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "readOnly": true,
+            "type": "string",
+            "format": "date-time"
+          },
+          "role": {
+            "description": "Output only. The role of the interaction.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "outputs": {
+            "description": "Output only. Responses from the model.",
+            "readOnly": true,
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Content" }
+          },
+          "system_instruction": {
+            "description": "System instruction for the interaction.",
+            "type": "string"
+          },
+          "tools": {
+            "description": "A list of tool declarations the model may call during interaction.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Tool" }
+          },
+          "usage": {
+            "description": "Output only. Statistics on the interaction request's token usage.",
+            "readOnly": true,
+            "$ref": "#/components/schemas/Usage"
+          },
+          "response_modalities": {
+            "description": "The requested modalities of the response (TEXT, IMAGE, AUDIO).",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ResponseModality" }
+          },
+          "response_format": {
+            "description": "Enforces that the generated response is a JSON object that complies with\nthe JSON schema specified in this field."
+          },
+          "response_mime_type": {
+            "description": "The mime type of the response. This is required if response_format is set.",
+            "type": "string"
+          },
+          "previous_interaction_id": {
+            "description": "The ID of the previous interaction, if any.",
+            "type": "string"
+          },
+          "service_tier": {
+            "description": "The service tier for the interaction.",
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Flex service tier.",
+              "Standard service tier.",
+              "Priority service tier."
+            ],
+            "enum": ["flex", "standard", "priority"]
+          },
+          "input": { "$ref": "#/components/schemas/InteractionsInput" },
+          "agent_config": {
+            "description": "Configuration parameters for the agent interaction.",
+            "oneOf": [
+              { "$ref": "#/components/schemas/DynamicAgentConfig" },
+              { "$ref": "#/components/schemas/DeepResearchAgentConfig" }
+            ],
+            "discriminator": { "propertyName": "type" }
+          }
+        },
+        "required": ["agent", "input"]
+      },
+      "InteractionsInput": {
+        "description": "The input for the interaction.",
+        "oneOf": [
+          {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Content" },
+            "title": "ContentList"
+          },
+          { "type": "string" },
+          {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Turn" },
+            "title": "TurnList"
+          },
+          { "$ref": "#/components/schemas/Content" }
+        ]
+      },
+      "InteractionSseEvent": {
+        "type": "object",
+        "oneOf": [
+          { "$ref": "#/components/schemas/InteractionStartEvent" },
+          { "$ref": "#/components/schemas/InteractionCompleteEvent" },
+          { "$ref": "#/components/schemas/InteractionStatusUpdate" },
+          { "$ref": "#/components/schemas/ContentStart" },
+          { "$ref": "#/components/schemas/ContentDelta" },
+          { "$ref": "#/components/schemas/ContentStop" },
+          { "$ref": "#/components/schemas/ErrorEvent" }
+        ],
+        "discriminator": { "propertyName": "event_type" }
+      },
+      "ModelOption": {
+        "title": "Model",
+        "description": "The model that will complete your prompt.\\n\\nSee [models](https://ai.google.dev/gemini-api/docs/models) for additional details.",
+        "anyOf": [
+          { "type": "string" },
+          {
+            "description": "An agentic capability model designed for direct interface interaction, allowing Gemini to perceive and navigate digital environments.",
+            "const": "gemini-2.5-computer-use-preview-10-2025",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "Our first hybrid reasoning model which supports a 1M token context window and has thinking budgets.",
+            "const": "gemini-2.5-flash",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "Our native image generation model, optimized for speed, flexibility, and contextual understanding. Text input and output is priced the same as 2.5 Flash.",
+            "const": "gemini-2.5-flash-image",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "Our smallest and most cost effective model, built for at scale usage.",
+            "const": "gemini-2.5-flash-lite",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "The latest model based on Gemini 2.5 Flash lite optimized for cost-efficiency, high throughput and high quality.",
+            "const": "gemini-2.5-flash-lite-preview-09-2025",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "Our native audio models optimized for higher quality audio outputs with better pacing, voice naturalness, verbosity, and mood.",
+            "const": "gemini-2.5-flash-native-audio-preview-12-2025",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "The latest model based on the 2.5 Flash model. 2.5 Flash Preview is best for large scale processing, low-latency, high volume tasks that require thinking, and agentic use cases.",
+            "const": "gemini-2.5-flash-preview-09-2025",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "Our 2.5 Flash text-to-speech model optimized for powerful, low-latency controllable speech generation.",
+            "const": "gemini-2.5-flash-preview-tts",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "Our state-of-the-art multipurpose model, which excels at coding and complex reasoning tasks.",
+            "const": "gemini-2.5-pro",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "Our 2.5 Pro text-to-speech audio model optimized for powerful, low-latency speech generation for more natural outputs and easier to steer prompts.",
+            "const": "gemini-2.5-pro-preview-tts",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "Our most intelligent model built for speed, combining frontier intelligence with superior search and grounding.",
+            "const": "gemini-3-flash-preview",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "State-of-the-art image generation and editing model.",
+            "const": "gemini-3-pro-image-preview",
+            "x-stainless-nominal": "false`"
+          },
+          {
+            "description": "Our most intelligent model with SOTA reasoning and multimodal understanding, and powerful agentic and vibe coding capabilities.",
+            "const": "gemini-3-pro-preview",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "Our latest SOTA reasoning model with unprecedented depth and nuance, and powerful multimodal understanding and coding capabilities.",
+            "const": "gemini-3.1-pro-preview",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "Pro-level visual intelligence with Flash-speed efficiency and reality-grounded generation capabilities.",
+            "const": "gemini-3.1-flash-image-preview",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "Our most cost-efficient model, optimized for high-volume agentic tasks, translation, and simple data processing.",
+            "const": "gemini-3.1-flash-lite-preview",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "Our low-latency, music generation model optimized for high-fidelity audio clips and precise rhythmic control.",
+            "const": "lyria-3-clip-preview",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "Our advanced, full-song generative model with deep compositional understanding, optimized for precise structural control and complex transitions across diverse musical styles.",
+            "const": "lyria-3-pro-preview",
+            "x-stainless-nominal": false
+          }
+        ]
+      },
+      "AgentOption": {
+        "title": "Agent",
+        "description": "The agent to interact with.",
+        "anyOf": [
+          { "type": "string" },
+          {
+            "description": "Gemini Deep Research Agent",
+            "const": "deep-research-pro-preview-12-2025",
+            "x-stainless-nominal": false
+          }
+        ]
+      }
+    }
+  }
+}

--- a/scripts/generate_google_interactions_coverage_docs.py
+++ b/scripts/generate_google_interactions_coverage_docs.py
@@ -92,8 +92,7 @@ def generate_docs(coverage_path: Path, output_path: Path) -> None:
         lines.append(f"### {section['section']}")
         lines.append("")
         lines.append(
-            f"**Score:** {section['score']}% · "
-            f"**Implemented:** {section['implemented']}/{section['google_total']}"
+            f"**Score:** {section['score']}% · **Implemented:** {section['implemented']}/{section['google_total']}"
         )
         lines.append("")
 
@@ -139,8 +138,7 @@ def generate_docs(coverage_path: Path, output_path: Path) -> None:
             " in `src/llama_stack_api/interactions/models.py`",
             "2. **Add Content Types**: Support additional content types beyond text"
             " (images, audio, function calls, etc.)",
-            "3. **Add Tool Support**: Implement tool declarations"
-            " (Function, GoogleSearch, CodeExecution, etc.)",
+            "3. **Add Tool Support**: Implement tool declarations (Function, GoogleSearch, CodeExecution, etc.)",
             "4. **Add Missing Endpoints**: Implement GET, DELETE, and Cancel endpoints",
             "",
             "Run the coverage analyzer to check your progress:",

--- a/scripts/generate_google_interactions_coverage_docs.py
+++ b/scripts/generate_google_interactions_coverage_docs.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""
+Generates Google Interactions API coverage documentation from the coverage JSON file.
+
+Usage:
+    python scripts/generate_google_interactions_coverage_docs.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+REPO_ROOT = SCRIPT_DIR.parent
+DEFAULT_COVERAGE_JSON = REPO_ROOT / "docs" / "static" / "google-interactions-coverage.json"
+DEFAULT_OUTPUT = REPO_ROOT / "docs" / "docs" / "api-google-interactions" / "conformance.mdx"
+
+
+def generate_docs(coverage_path: Path, output_path: Path) -> None:
+    """Generate markdown documentation from coverage JSON."""
+    with open(coverage_path) as f:
+        coverage = json.load(f)
+
+    summary = coverage["summary"]
+    sections = coverage["sections"]
+
+    # Sort sections by score (lowest first)
+    sorted_sections = sorted(sections, key=lambda s: s["score"])
+
+    lines = [
+        "---",
+        "title: Google Interactions API Conformance",
+        "description: Coverage status of Llama Stack against the Google Interactions API specification",
+        "sidebar_label: Interactions Conformance",
+        "sidebar_position: 5",
+        "---",
+        "",
+        "# Google Interactions API Coverage Report",
+        "",
+        f"Spec version: `{coverage.get('spec_version', 'unknown')}`",
+        "",
+        "This page provides a detailed breakdown of Llama Stack's coverage of the",
+        "[Google Interactions API](https://ai.google.dev/gemini-api/docs/interactions) specification.",
+        "The coverage score increases as missing features are implemented.",
+        "",
+        ":::info Auto-generated",
+        "This documentation is auto-generated from the Google Interactions API specification comparison.",
+        ":::",
+        "",
+        "## Summary",
+        "",
+        "| Metric | Value |",
+        "|--------|-------|",
+        f"| **Overall Coverage Score** | {summary['overall_score']}% |",
+        f"| **Total Items Implemented** | {summary['total_implemented']}/{summary['total_google_items']} |",
+        f"| **Total Missing** | {summary['total_missing']} |",
+        "",
+        "## Section Scores",
+        "",
+        "Sections are sorted by coverage score (lowest first, needing most attention).",
+        "",
+        "| Section | Score | Implemented | Total | Missing |",
+        "|---------|-------|-------------|-------|---------|",
+    ]
+
+    for section in sorted_sections:
+        lines.append(
+            f"| {section['section']} | {section['score']}% "
+            f"| {section['implemented']} | {section['google_total']} "
+            f"| {section['missing_count']} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Detailed Breakdown",
+            "",
+            "Below is a detailed breakdown of what is implemented and what is missing for each section.",
+            "",
+        ]
+    )
+
+    for section in sorted_sections:
+        lines.append(f"### {section['section']}")
+        lines.append("")
+        lines.append(
+            f"**Score:** {section['score']}% · "
+            f"**Implemented:** {section['implemented']}/{section['google_total']}"
+        )
+        lines.append("")
+
+        if section["supported"]:
+            lines.append("<details>")
+            lines.append(f"<summary>Implemented ({section['implemented']})</summary>")
+            lines.append("")
+            for item in section["supported"]:
+                lines.append(f"- `{item}`")
+            lines.append("")
+            lines.append("</details>")
+            lines.append("")
+
+        if section["missing"]:
+            lines.append("<details>")
+            lines.append(f"<summary>Missing ({section['missing_count']})</summary>")
+            lines.append("")
+            for item in section["missing"]:
+                lines.append(f"- `{item}`")
+            lines.append("")
+            lines.append("</details>")
+            lines.append("")
+
+        if section.get("extra_in_llama_stack"):
+            lines.append("<details>")
+            lines.append(f"<summary>Extra in Llama Stack ({len(section['extra_in_llama_stack'])})</summary>")
+            lines.append("")
+            lines.append("These properties are in the Llama Stack implementation but not in the Google spec:")
+            lines.append("")
+            for item in section["extra_in_llama_stack"]:
+                lines.append(f"- `{item}`")
+            lines.append("")
+            lines.append("</details>")
+            lines.append("")
+
+    lines.extend(
+        [
+            "## How to Improve Coverage",
+            "",
+            "To improve coverage scores:",
+            "",
+            "1. **Add Missing Properties**: Implement missing fields in request/response models"
+            " in `src/llama_stack_api/interactions/models.py`",
+            "2. **Add Content Types**: Support additional content types beyond text"
+            " (images, audio, function calls, etc.)",
+            "3. **Add Tool Support**: Implement tool declarations"
+            " (Function, GoogleSearch, CodeExecution, etc.)",
+            "4. **Add Missing Endpoints**: Implement GET, DELETE, and Cancel endpoints",
+            "",
+            "Run the coverage analyzer to check your progress:",
+            "",
+            "```bash",
+            "python scripts/google_interactions_coverage.py --update --generate-docs",
+            "```",
+        ]
+    )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n")
+    print(f"Generated documentation: {output_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate Google Interactions coverage documentation")
+    parser.add_argument(
+        "--coverage-json",
+        type=Path,
+        default=DEFAULT_COVERAGE_JSON,
+        help="Path to coverage JSON file",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Output markdown file path",
+    )
+    args = parser.parse_args()
+
+    if not args.coverage_json.exists():
+        print(f"Coverage JSON not found: {args.coverage_json}")
+        print("Run 'python scripts/google_interactions_coverage.py --update' first")
+        return 1
+
+    generate_docs(args.coverage_json, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/google_interactions_coverage.py
+++ b/scripts/google_interactions_coverage.py
@@ -266,11 +266,7 @@ def calculate_coverage(spec_path: Path) -> dict[str, Any]:
     # 2. Request properties (CreateModelInteractionParams)
     request_schema = schemas.get("CreateModelInteractionParams", {})
     request_props = _get_schema_properties(request_schema, spec)
-    input_props = {
-        k: v
-        for k, v in request_props.items()
-        if not (isinstance(v, dict) and v.get("readOnly"))
-    }
+    input_props = {k: v for k, v in request_props.items() if not (isinstance(v, dict) and v.get("readOnly"))}
     sections.append(_compare_properties("Request Properties", input_props, IMPLEMENTED_REQUEST_PROPS))
 
     # 3. Response properties (Interaction schema)
@@ -286,9 +282,7 @@ def calculate_coverage(spec_path: Path) -> dict[str, Any]:
     # 4. GenerationConfig
     gen_config_schema = schemas.get("GenerationConfig", {})
     gen_config_props = _get_schema_properties(gen_config_schema, spec)
-    sections.append(
-        _compare_properties("GenerationConfig", gen_config_props, IMPLEMENTED_GENERATION_CONFIG_PROPS)
-    )
+    sections.append(_compare_properties("GenerationConfig", gen_config_props, IMPLEMENTED_GENERATION_CONFIG_PROPS))
 
     # 5. Usage
     usage_schema = schemas.get("Usage", {})

--- a/scripts/google_interactions_coverage.py
+++ b/scripts/google_interactions_coverage.py
@@ -1,0 +1,463 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""
+Google Interactions API Coverage Analyzer
+
+Compares Llama Stack's Interactions implementation against Google's official
+OpenAPI spec and generates a coverage report showing:
+- Which endpoints are implemented
+- Which request/response properties are supported
+- Which content types, tools, and streaming events are covered
+- A conformance score
+
+Usage:
+    python scripts/google_interactions_coverage.py [--update] [--generate-docs] [--check-regression] [--quiet]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).parent
+REPO_ROOT = SCRIPT_DIR.parent
+DEFAULT_SPEC = REPO_ROOT / "docs" / "static" / "google-interactions-spec.json"
+DEFAULT_OUTPUT = REPO_ROOT / "docs" / "static" / "google-interactions-coverage.json"
+
+
+def _load_spec(path: Path) -> dict[str, Any]:
+    """Load the Google Interactions OpenAPI spec."""
+    return json.loads(path.read_text())
+
+
+def _resolve_ref(ref: str, spec: dict[str, Any]) -> dict[str, Any]:
+    """Resolve a $ref pointer in the spec."""
+    if not ref.startswith("#/"):
+        return {}
+    parts = ref[2:].split("/")
+    resolved = spec
+    for part in parts:
+        resolved = resolved.get(part, {})
+    return resolved if isinstance(resolved, dict) else {}
+
+
+def _get_schema_properties(
+    schema: dict[str, Any],
+    spec: dict[str, Any],
+    visited: set[str] | None = None,
+) -> dict[str, Any]:
+    """Extract all direct property names and their schemas from a schema, resolving refs."""
+    if visited is None:
+        visited = set()
+
+    if "$ref" in schema:
+        ref = schema["$ref"]
+        if ref in visited:
+            return {}
+        visited.add(ref)
+        return _get_schema_properties(_resolve_ref(ref, spec), spec, visited)
+
+    props = {}
+    if "properties" in schema:
+        props.update(schema["properties"])
+
+    for key in ("allOf", "oneOf", "anyOf"):
+        if key in schema:
+            for sub in schema[key]:
+                props.update(_get_schema_properties(sub, spec, visited))
+
+    return props
+
+
+def _collect_content_types(spec: dict[str, Any]) -> list[str]:
+    """Extract all content type names from the Content oneOf schema."""
+    content_schema = spec.get("components", {}).get("schemas", {}).get("Content", {})
+    types = []
+    for variant in content_schema.get("oneOf", []):
+        if "$ref" in variant:
+            name = variant["$ref"].split("/")[-1]
+            types.append(name)
+    return sorted(types)
+
+
+def _collect_tool_types(spec: dict[str, Any]) -> list[str]:
+    """Extract all tool type names from the Tool oneOf schema."""
+    tool_schema = spec.get("components", {}).get("schemas", {}).get("Tool", {})
+    types = []
+    for variant in tool_schema.get("oneOf", []):
+        if "$ref" in variant:
+            name = variant["$ref"].split("/")[-1]
+            types.append(name)
+    return sorted(types)
+
+
+def _collect_streaming_events(spec: dict[str, Any]) -> list[str]:
+    """Extract all streaming event type names from InteractionSseEvent."""
+    sse_schema = spec.get("components", {}).get("schemas", {}).get("InteractionSseEvent", {})
+    events = []
+    for variant in sse_schema.get("oneOf", []):
+        if "$ref" in variant:
+            name = variant["$ref"].split("/")[-1]
+            events.append(name)
+    return sorted(events)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Llama Stack implementation model
+# ──────────────────────────────────────────────────────────────────────
+
+# What Llama Stack currently implements, derived from the Pydantic models
+# in src/llama_stack_api/interactions/models.py and the FastAPI routes.
+
+IMPLEMENTED_ENDPOINTS = {
+    "POST /{api_version}/interactions": True,
+    "GET /{api_version}/interactions/{id}": False,
+    "DELETE /{api_version}/interactions/{id}": False,
+    "POST /{api_version}/interactions/{id}/cancel": False,
+}
+
+# Request properties we support (from GoogleCreateInteractionRequest)
+IMPLEMENTED_REQUEST_PROPS = {
+    "model",
+    "input",
+    "system_instruction",
+    "generation_config",
+    "stream",
+    "response_modalities",
+}
+
+# Response properties we support (from GoogleInteractionResponse)
+IMPLEMENTED_RESPONSE_PROPS = {
+    "id",
+    "created",
+    "status",
+    "updated",
+    "model",
+    "outputs",
+    "role",
+    "usage",
+    "object",
+}
+
+# GenerationConfig properties we support
+IMPLEMENTED_GENERATION_CONFIG_PROPS = {
+    "temperature",
+    "top_k",
+    "top_p",
+    "max_output_tokens",
+}
+
+# Usage properties we support
+IMPLEMENTED_USAGE_PROPS = {
+    "total_input_tokens",
+    "total_output_tokens",
+    "total_tokens",
+}
+
+# Content types we support
+IMPLEMENTED_CONTENT_TYPES = {
+    "TextContent",
+}
+
+# Tool types we support
+IMPLEMENTED_TOOL_TYPES: set[str] = set()
+
+# Streaming events we support
+IMPLEMENTED_STREAMING_EVENTS = {
+    "InteractionStartEvent",
+    "ContentStart",
+    "ContentDelta",
+    "ContentStop",
+    "InteractionCompleteEvent",
+}
+
+
+def _compare_properties(
+    section_name: str,
+    google_props: dict[str, Any],
+    implemented: set[str],
+) -> dict[str, Any]:
+    """Compare a set of Google spec properties against what we implement."""
+    google_names = set(google_props.keys())
+    supported = google_names & implemented
+    missing = sorted(google_names - implemented)
+    extra = sorted(implemented - google_names)
+
+    total = len(google_names) if google_names else 1
+    score = round(len(supported) / total * 100, 1)
+
+    result: dict[str, Any] = {
+        "section": section_name,
+        "google_total": len(google_names),
+        "implemented": len(supported),
+        "missing_count": len(missing),
+        "score": score,
+        "supported": sorted(supported),
+        "missing": missing,
+    }
+    if extra:
+        result["extra_in_llama_stack"] = extra
+    return result
+
+
+def _compare_list(
+    section_name: str,
+    google_items: list[str],
+    implemented: set[str],
+) -> dict[str, Any]:
+    """Compare a list of items from Google spec against what we implement."""
+    google_set = set(google_items)
+    supported = google_set & implemented
+    missing = sorted(google_set - implemented)
+
+    total = len(google_items) if google_items else 1
+    score = round(len(supported) / total * 100, 1)
+
+    return {
+        "section": section_name,
+        "google_total": len(google_items),
+        "implemented": len(supported),
+        "missing_count": len(missing),
+        "score": score,
+        "supported": sorted(supported),
+        "missing": missing,
+    }
+
+
+def calculate_coverage(spec_path: Path) -> dict[str, Any]:
+    """Calculate coverage of Google Interactions API."""
+    spec = _load_spec(spec_path)
+    schemas = spec.get("components", {}).get("schemas", {})
+
+    sections: list[dict[str, Any]] = []
+
+    # 1. Endpoints
+    google_endpoints = []
+    for path, path_item in spec.get("paths", {}).items():
+        for method, op in path_item.items():
+            if isinstance(op, dict) and not op.get("x-internal"):
+                google_endpoints.append(f"{method.upper()} {path}")
+
+    ep_google = set(google_endpoints)
+    ep_impl = {ep for ep, supported in IMPLEMENTED_ENDPOINTS.items() if supported}
+    ep_missing = sorted(ep_google - ep_impl)
+
+    ep_total = len(ep_google) if ep_google else 1
+    ep_section = {
+        "section": "Endpoints",
+        "google_total": len(ep_google),
+        "implemented": len(ep_impl),
+        "missing_count": len(ep_missing),
+        "score": round(len(ep_impl) / ep_total * 100, 1),
+        "supported": sorted(ep_impl),
+        "missing": ep_missing,
+    }
+    sections.append(ep_section)
+
+    # 2. Request properties (CreateModelInteractionParams)
+    request_schema = schemas.get("CreateModelInteractionParams", {})
+    request_props = _get_schema_properties(request_schema, spec)
+    input_props = {
+        k: v
+        for k, v in request_props.items()
+        if not (isinstance(v, dict) and v.get("readOnly"))
+    }
+    sections.append(_compare_properties("Request Properties", input_props, IMPLEMENTED_REQUEST_PROPS))
+
+    # 3. Response properties (Interaction schema)
+    response_schema = schemas.get("Interaction", {})
+    response_props = _get_schema_properties(response_schema, spec)
+    output_props = {
+        k: v
+        for k, v in response_props.items()
+        if isinstance(v, dict) and (v.get("readOnly") or k in ("model", "agent"))
+    }
+    sections.append(_compare_properties("Response Properties", output_props, IMPLEMENTED_RESPONSE_PROPS))
+
+    # 4. GenerationConfig
+    gen_config_schema = schemas.get("GenerationConfig", {})
+    gen_config_props = _get_schema_properties(gen_config_schema, spec)
+    sections.append(
+        _compare_properties("GenerationConfig", gen_config_props, IMPLEMENTED_GENERATION_CONFIG_PROPS)
+    )
+
+    # 5. Usage
+    usage_schema = schemas.get("Usage", {})
+    usage_props = _get_schema_properties(usage_schema, spec)
+    sections.append(_compare_properties("Usage", usage_props, IMPLEMENTED_USAGE_PROPS))
+
+    # 6. Content types
+    content_types = _collect_content_types(spec)
+    sections.append(_compare_list("Content Types", content_types, IMPLEMENTED_CONTENT_TYPES))
+
+    # 7. Tool types
+    tool_types = _collect_tool_types(spec)
+    sections.append(_compare_list("Tool Types", tool_types, IMPLEMENTED_TOOL_TYPES))
+
+    # 8. Streaming events
+    streaming_events = _collect_streaming_events(spec)
+    sections.append(_compare_list("Streaming Events", streaming_events, IMPLEMENTED_STREAMING_EVENTS))
+
+    # Overall score: weighted by google_total per section
+    total_google = sum(s["google_total"] for s in sections)
+    total_impl = sum(s["implemented"] for s in sections)
+    overall_score = round(total_impl / total_google * 100, 1) if total_google else 0.0
+
+    return {
+        "google_spec": str(spec_path),
+        "spec_version": spec.get("info", {}).get("version", "unknown"),
+        "summary": {
+            "overall_score": overall_score,
+            "total_google_items": total_google,
+            "total_implemented": total_impl,
+            "total_missing": total_google - total_impl,
+        },
+        "sections": sections,
+    }
+
+
+def print_summary(report: dict[str, Any]) -> None:
+    """Print a human-readable summary."""
+    summary = report["summary"]
+
+    print()
+    print("=" * 65)
+    print("Google Interactions API Coverage Report")
+    print(f"Spec version: {report['spec_version']}")
+    print("=" * 65)
+    print()
+    print(f"Overall Coverage: {summary['overall_score']}%")
+    print(f"  Implemented: {summary['total_implemented']}/{summary['total_google_items']}")
+    print(f"  Missing:     {summary['total_missing']}")
+    print()
+
+    print(f"{'Section':<25} {'Score':>6}  {'Impl':>5} / {'Total':>5}  {'Missing':>7}")
+    print("-" * 65)
+
+    for section in report["sections"]:
+        name = section["section"]
+        score = section["score"]
+        impl = section["implemented"]
+        total = section["google_total"]
+        missing = section["missing_count"]
+        print(f"{name:<25} {score:>5.1f}%  {impl:>5} / {total:>5}  {missing:>7}")
+
+    print()
+
+    for section in report["sections"]:
+        if not section["missing"]:
+            continue
+
+        print(f"--- {section['section']} ---")
+        print(f"  Missing ({section['missing_count']}):")
+        for item in section["missing"]:
+            print(f"    - {item}")
+        if section.get("extra_in_llama_stack"):
+            print("  Extra in Llama Stack:")
+            for item in section["extra_in_llama_stack"]:
+                print(f"    + {item}")
+        print()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Google Interactions API coverage analyzer")
+    parser.add_argument(
+        "--google-spec",
+        type=Path,
+        default=DEFAULT_SPEC,
+        help="Path to Google Interactions OpenAPI spec",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Output path for coverage JSON",
+    )
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="Update the coverage file",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Only output errors",
+    )
+    parser.add_argument(
+        "--generate-docs",
+        action="store_true",
+        help="Also generate documentation from coverage report",
+    )
+    parser.add_argument(
+        "--check-regression",
+        action="store_true",
+        help="Fail if coverage score decreases compared to existing report",
+    )
+
+    args = parser.parse_args()
+
+    if not args.google_spec.exists():
+        print(f"Error: spec not found at {args.google_spec}")
+        print(
+            "Download it with: curl -o docs/static/google-interactions-spec.json"
+            " https://ai.google.dev/api/interactions.openapi.json"
+        )
+        sys.exit(1)
+
+    # Load existing coverage for regression check
+    previous_score: float | None = None
+    if args.check_regression and args.output.exists():
+        try:
+            with open(args.output) as f:
+                previous_report = json.load(f)
+                previous_score = previous_report.get("summary", {}).get("overall_score")
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"Error: could not load previous report: {e}")
+            sys.exit(1)
+
+    report = calculate_coverage(args.google_spec)
+    new_score = report["summary"]["overall_score"]
+
+    # Check for coverage regression
+    if args.check_regression and previous_score is not None:
+        if new_score < previous_score:
+            print(f"Coverage regression detected: {previous_score}% -> {new_score}%")
+            print(f"Coverage decreased by {previous_score - new_score:.1f} percentage points")
+            print()
+            print("To fix this, ensure your changes don't reduce Google Interactions API coverage.")
+            print("If this is intentional, update the coverage baseline with:")
+            print(f"  python {__file__} --update --generate-docs")
+            sys.exit(1)
+        elif new_score > previous_score and not args.quiet:
+            print(f"Coverage improved: {previous_score}% -> {new_score}% (+{new_score - previous_score:.1f}%)")
+
+    if not args.quiet:
+        print_summary(report)
+
+    if args.update:
+        with open(args.output, "w") as f:
+            json.dump(report, f, indent=2)
+            f.write("\n")
+        if not args.quiet:
+            print(f"Report written to {args.output}")
+
+    if args.generate_docs:
+        result = subprocess.run(
+            [sys.executable, SCRIPT_DIR / "generate_google_interactions_coverage_docs.py"],
+            cwd=REPO_ROOT,
+        )
+        if result.returncode != 0:
+            sys.exit(result.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/google_interactions_coverage.py
+++ b/scripts/google_interactions_coverage.py
@@ -307,7 +307,7 @@ def calculate_coverage(spec_path: Path) -> dict[str, Any]:
     overall_score = round(total_impl / total_google * 100, 1) if total_google else 0.0
 
     return {
-        "google_spec": str(spec_path),
+        "google_spec": str(spec_path.relative_to(REPO_ROOT)),
         "spec_version": spec.get("info", {}).get("version", "unknown"),
         "summary": {
             "overall_score": overall_score,


### PR DESCRIPTION
## Summary

- Add a coverage analyzer that compares Llama Stack's Interactions implementation against Google's official OpenAPI spec (v1beta), mirroring the existing OpenAI conformance tooling
- Pre-commit hook with regression detection keeps the coverage JSON and MDX docs in sync automatically
- Documentation: index page, conformance report, concepts page, footer link, sidebar entry, and cross-link from OpenAI compatibility page

Current coverage is **32.9%** — the implementation supports text generation and streaming but lacks multimodal content types, tool declarations, and CRUD endpoints.

## Test plan

- [ ] `uv run pre-commit run --all-files` passes (all 38 hooks)
- [ ] `python scripts/google_interactions_coverage.py` produces correct terminal output and JSON
- [ ] Docusaurus dev server renders pages at `/docs/api-google-interactions`, `/docs/api-google-interactions/conformance`, and `/docs/concepts/apis/google_interactions`
- [ ] Footer link to Google Interactions is visible
- [ ] Sidebar shows Google Interactions under Concepts > APIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)