### PR TITLE
build: bump pypdf to ≥6.10.0 in vector_io provider deps

### DIFF
--- a/src/llama_stack/providers/registry/vector_io.py
+++ b/src/llama_stack/providers/registry/vector_io.py
@@ -13,7 +13,7 @@ from llama_stack_api import (
 )
 
 # Common dependencies for all vector IO providers that support document processing
-DEFAULT_VECTOR_IO_DEPS = ["chardet", "pypdf>=6.7.2"]
+DEFAULT_VECTOR_IO_DEPS = ["chardet", "pypdf>=6.10.0"]
 
 
 def available_providers() -> list[ProviderSpec]:


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
Bump `pypdf` minimum version in DEFAULT_VECTOR_IO_DEPS to fix Llama Stack on FIPS clusters.
<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->

<!-- For API changes, include:
1. A testing script (Python, curl, etc.) that exercises the new/modified endpoints
2. The output from running your script

Example:
```python
...
...
```

Output:
```
<paste actual output here>
```
-->
