### PR TITLE
docs: clean up footer links and rename OpenAI label

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -189,7 +189,7 @@ const config: Config = {
               to: '/docs/api-overview',
             },
             {
-              label: 'OpenAI Compatibility',
+              label: 'OpenAI',
               to: '/docs/api-openai',
             },
             {
@@ -200,10 +200,6 @@ const config: Config = {
               label: 'Google Interactions',
               to: '/docs/api-google-interactions',
             },
-            {
-              label: 'Blog',
-              to: '/blog',
-            },
           ],
         },
         {
@@ -212,10 +208,6 @@ const config: Config = {
             {
               label: 'Discord',
               href: 'https://discord.gg/llama-stack',
-            },
-            {
-              label: 'GitHub Discussions',
-              href: 'https://github.com/llamastack/llama-stack/discussions',
             },
             {
               label: 'Issues',


### PR DESCRIPTION
## Summary
- Remove GitHub Discussions link from the Community footer section (discussions are not enabled)
- Remove Blog link from the API footer section
- Rename "OpenAI Compatibility" to "OpenAI" for brevity

## Test plan
- [ ] Verify docs site builds: `cd docs && yarn build`
- [ ] Check footer renders correctly with updated links

🤖 Generated with [Claude Code](https://claude.com/claude-code)