### PR TITLE
ci: auto-trigger docs site deploy when docs change on main

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -32,5 +32,6 @@ Llama Stack uses GitHub Actions for Continuous Integration (CI). Below is a tabl
 | Close stale issues and PRs | [stale_bot.yml](stale_bot.yml) | Run the Stale Bot action |
 | Test External Providers Installed via Module | [test-external-provider-module.yml](test-external-provider-module.yml) | Test External Provider installation via Python module |
 | Test External API and Providers | [test-external.yml](test-external.yml) | Test the External API and Provider mechanisms |
+| Trigger Docs Deploy | [trigger-docs-deploy.yml](trigger-docs-deploy.yml) | Trigger docs site rebuild after docs change |
 | UI Tests | [ui-unit-tests.yml](ui-unit-tests.yml) | Run the UI test suite |
 | Unit Tests | [unit-tests.yml](unit-tests.yml) | Run the unit test suite |

--- a/.github/workflows/trigger-docs-deploy.yml
+++ b/.github/workflows/trigger-docs-deploy.yml
@@ -1,0 +1,25 @@
+name: Trigger Docs Deploy
+
+run-name: Trigger docs site rebuild after docs change
+
+on:
+  push:
+    branches: [main]
+    paths: ['docs/**']
+
+concurrency:
+  group: trigger-docs-deploy
+  cancel-in-progress: true
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger docs site build and deploy
+        run: |
+          gh api repos/llamastack/llamastack.github.io/dispatches \
+            -f event_type=docs-update \
+            -f 'client_payload[sha]=${{ github.sha }}' \
+            -f 'client_payload[ref]=${{ github.ref }}'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
## Summary

- Adds a workflow that sends a `repository_dispatch` event to `llamastack/llamastack.github.io` whenever files under `docs/` are pushed to main
- Eliminates the need to manually trigger the docs site build after merging documentation PRs
- Uses `RELEASE_PAT` for cross-repo authentication (same token used by other cross-repo workflows)

## Companion PR

This requires a corresponding change in `llamastack/llamastack.github.io` to add `repository_dispatch` as a trigger to `build-and-deploy.yml`. That PR will be sent separately.

## Test plan

- [ ] Verify workflow YAML is valid (CI lint check)
- [ ] After both PRs merge, merge a docs change to main and confirm the docs site workflow triggers automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)