### PR TITLE
fix(docs): add missing sidebar icons and fix 404s for API tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ client-sdks/openapi/openapi-config.json
 client-sdks/openapi/sdks/
 client-sdks/openapi/.openapi-generator/
 .agentready
+.gstack/

--- a/client-sdks/stainless/openapi.yml
+++ b/client-sdks/stainless/openapi.yml
@@ -15236,6 +15236,9 @@ tags:
 - description: APIs for inspecting the Llama Stack service, including health status, available API routes with methods and implementing providers.
   name: Inspect
   x-displayName: Inspect
+- description: Anthropic Messages API compatibility layer for creating messages and counting tokens.
+  name: Messages
+  x-displayName: Messages
 - description: ''
   name: Models
 - description: Protocol for prompt management operations.
@@ -15253,8 +15256,14 @@ tags:
   name: ToolGroups
 - description: ''
   name: ToolRuntime
+- description: Tool listing and management.
+  name: Tools
+  x-displayName: Tools
 - description: ''
   name: VectorIO
+- description: OpenAI Responses API for agent orchestration with tool use, multi-turn conversations, and background processing.
+  name: Responses
+  x-displayName: Responses
 x-tagGroups:
 - name: Operations
   tags:
@@ -15264,13 +15273,16 @@ x-tagGroups:
   - Files
   - Inference
   - Inspect
+  - Messages
   - Models
   - Prompts
   - Providers
+  - Responses
   - Safety
   - Shields
   - ToolGroups
   - ToolRuntime
+  - Tools
   - VectorIO
 security:
 - Default: []

--- a/docs/docs/api-overview.mdx
+++ b/docs/docs/api-overview.mdx
@@ -36,7 +36,6 @@ Llama Stack implements the OpenAI API and organizes endpoints by stability level
         { title: 'File Processors', endpoint: '/v1alpha/file_processors', href: '/docs/api-experimental/process-file-v-1-alpha-file-processors-process-post', blurb: 'Document ingestion and chunking' },
         { title: 'Interactions', endpoint: '/v1alpha/interactions', href: '/docs/api-experimental/llama-stack-specification-experimental-apis', blurb: 'Google Interactions API compatibility layer' },
         { title: 'Connectors', endpoint: '/v1beta/connectors', href: '/docs/api-experimental/llama-stack-specification-experimental-apis', blurb: 'External tool and service connectors' },
-        { title: 'Eval', endpoint: '/v1alpha/eval', href: '/docs/api-experimental/eval', blurb: 'Evaluation pipelines and benchmarks' },
         { title: 'Datasets', endpoint: '/v1beta/datasets', href: '/docs/api-experimental/datasets', blurb: 'Dataset management' },
       ],
     },

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -330,6 +330,14 @@ const sidebars: SidebarsConfig = {
   stableApiSidebar: require('./docs/api/sidebar.ts').default,
   experimentalApiSidebar: require('./docs/api-experimental/sidebar.ts').default,
   deprecatedApiSidebar: require('./docs/api-deprecated/sidebar.ts').default,
+
+  // OpenAI compatibility sidebar
+  openaiCompatSidebar: [
+    'api-openai/index',
+    'api-openai/anthropic_messages',
+    'api-openai/conformance',
+    'api-openai/provider_matrix',
+  ],
 };
 
 export default sidebars;

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -441,6 +441,32 @@ h3 {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cellipse cx='12' cy='5' rx='9' ry='3'/%3E%3Cpath d='M3 5v14c0 1.66 4.03 3 9 3s9-1.34 9-3V5'/%3E%3Cpath d='M3 12c0 1.66 4.03 3 9 3s9-1.34 9-3'/%3E%3C/svg%3E");
 }
 
+/* API sidebar icons (top-level categories beyond position 10) */
+/* ClipboardCheck - Safety (position 11) */
+.theme-doc-sidebar-container .menu__list > .menu__list-item:nth-child(11) > .menu__list-item-collapsible > .menu__link::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='8' y='2' width='8' height='4' rx='1' ry='1'/%3E%3Cpath d='M16 4h2a2 2 0 012 2v14a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2h2'/%3E%3Cpath d='M9 14l2 2 4-4'/%3E%3C/svg%3E");
+}
+
+/* Shield - Shields (position 12) */
+.theme-doc-sidebar-container .menu__list > .menu__list-item:nth-child(12) > .menu__list-item-collapsible > .menu__link::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z'/%3E%3C/svg%3E");
+}
+
+/* Wrench - Tools (position 13) */
+.theme-doc-sidebar-container .menu__list > .menu__list-item:nth-child(13) > .menu__list-item-collapsible > .menu__link::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z'/%3E%3C/svg%3E");
+}
+
+/* Database - VectorIO (position 14) */
+.theme-doc-sidebar-container .menu__list > .menu__list-item:nth-child(14) > .menu__list-item-collapsible > .menu__link::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cellipse cx='12' cy='5' rx='9' ry='3'/%3E%3Cpath d='M3 5v14c0 1.66 4.03 3 9 3s9-1.34 9-3V5'/%3E%3Cpath d='M3 12c0 1.66 4.03 3 9 3s9-1.34 9-3'/%3E%3C/svg%3E");
+}
+
+/* ArrowLeftRight - Responses (position 15) */
+.theme-doc-sidebar-container .menu__list > .menu__list-item:nth-child(15) > .menu__list-item-collapsible > .menu__link::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230d7377' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 7H3'/%3E%3Cpath d='M18 4l3 3-3 3'/%3E%3Cpath d='M3 17h18'/%3E%3Cpath d='M6 14l-3 3 3 3'/%3E%3C/svg%3E");
+}
+
 /* Dark mode: lighter icon stroke */
 [data-theme='dark'] .menu__list > .menu__list-item > .menu__list-item-collapsible > .menu__link::before,
 [data-theme='dark'] .menu__list .menu__list .menu__list-item-collapsible > .menu__link::before {

--- a/docs/static/deprecated-llama-stack-spec.yaml
+++ b/docs/static/deprecated-llama-stack-spec.yaml
@@ -10266,6 +10266,9 @@ tags:
 - description: APIs for inspecting the Llama Stack service, including health status, available API routes with methods and implementing providers.
   name: Inspect
   x-displayName: Inspect
+- description: Anthropic Messages API compatibility layer for creating messages and counting tokens.
+  name: Messages
+  x-displayName: Messages
 - description: ''
   name: Models
 - description: Protocol for prompt management operations.
@@ -10283,8 +10286,14 @@ tags:
   name: ToolGroups
 - description: ''
   name: ToolRuntime
+- description: Tool listing and management.
+  name: Tools
+  x-displayName: Tools
 - description: ''
   name: VectorIO
+- description: OpenAI Responses API for agent orchestration with tool use, multi-turn conversations, and background processing.
+  name: Responses
+  x-displayName: Responses
 x-tagGroups:
 - name: Operations
   tags:
@@ -10294,13 +10303,16 @@ x-tagGroups:
   - Files
   - Inference
   - Inspect
+  - Messages
   - Models
   - Prompts
   - Providers
+  - Responses
   - Safety
   - Shields
   - ToolGroups
   - ToolRuntime
+  - Tools
   - VectorIO
 security:
 - Default: []

--- a/docs/static/experimental-llama-stack-spec.yaml
+++ b/docs/static/experimental-llama-stack-spec.yaml
@@ -10904,6 +10904,9 @@ tags:
 - description: APIs for inspecting the Llama Stack service, including health status, available API routes with methods and implementing providers.
   name: Inspect
   x-displayName: Inspect
+- description: Anthropic Messages API compatibility layer for creating messages and counting tokens.
+  name: Messages
+  x-displayName: Messages
 - description: ''
   name: Models
 - description: Protocol for prompt management operations.
@@ -10921,8 +10924,14 @@ tags:
   name: ToolGroups
 - description: ''
   name: ToolRuntime
+- description: Tool listing and management.
+  name: Tools
+  x-displayName: Tools
 - description: ''
   name: VectorIO
+- description: OpenAI Responses API for agent orchestration with tool use, multi-turn conversations, and background processing.
+  name: Responses
+  x-displayName: Responses
 x-tagGroups:
 - name: Operations
   tags:
@@ -10932,13 +10941,16 @@ x-tagGroups:
   - Files
   - Inference
   - Inspect
+  - Messages
   - Models
   - Prompts
   - Providers
+  - Responses
   - Safety
   - Shields
   - ToolGroups
   - ToolRuntime
+  - Tools
   - VectorIO
 security:
 - Default: []

--- a/docs/static/llama-stack-spec.yaml
+++ b/docs/static/llama-stack-spec.yaml
@@ -14472,6 +14472,9 @@ tags:
 - description: APIs for inspecting the Llama Stack service, including health status, available API routes with methods and implementing providers.
   name: Inspect
   x-displayName: Inspect
+- description: Anthropic Messages API compatibility layer for creating messages and counting tokens.
+  name: Messages
+  x-displayName: Messages
 - description: ''
   name: Models
 - description: Protocol for prompt management operations.
@@ -14489,8 +14492,14 @@ tags:
   name: ToolGroups
 - description: ''
   name: ToolRuntime
+- description: Tool listing and management.
+  name: Tools
+  x-displayName: Tools
 - description: ''
   name: VectorIO
+- description: OpenAI Responses API for agent orchestration with tool use, multi-turn conversations, and background processing.
+  name: Responses
+  x-displayName: Responses
 x-tagGroups:
 - name: Operations
   tags:
@@ -14500,13 +14509,16 @@ x-tagGroups:
   - Files
   - Inference
   - Inspect
+  - Messages
   - Models
   - Prompts
   - Providers
+  - Responses
   - Safety
   - Shields
   - ToolGroups
   - ToolRuntime
+  - Tools
   - VectorIO
 security:
 - Default: []

--- a/docs/static/stainless-llama-stack-spec.yaml
+++ b/docs/static/stainless-llama-stack-spec.yaml
@@ -15236,6 +15236,9 @@ tags:
 - description: APIs for inspecting the Llama Stack service, including health status, available API routes with methods and implementing providers.
   name: Inspect
   x-displayName: Inspect
+- description: Anthropic Messages API compatibility layer for creating messages and counting tokens.
+  name: Messages
+  x-displayName: Messages
 - description: ''
   name: Models
 - description: Protocol for prompt management operations.
@@ -15253,8 +15256,14 @@ tags:
   name: ToolGroups
 - description: ''
   name: ToolRuntime
+- description: Tool listing and management.
+  name: Tools
+  x-displayName: Tools
 - description: ''
   name: VectorIO
+- description: OpenAI Responses API for agent orchestration with tool use, multi-turn conversations, and background processing.
+  name: Responses
+  x-displayName: Responses
 x-tagGroups:
 - name: Operations
   tags:
@@ -15264,13 +15273,16 @@ x-tagGroups:
   - Files
   - Inference
   - Inspect
+  - Messages
   - Models
   - Prompts
   - Providers
+  - Responses
   - Safety
   - Shields
   - ToolGroups
   - ToolRuntime
+  - Tools
   - VectorIO
 security:
 - Default: []

--- a/scripts/openapi_generator/_legacy_order.py
+++ b/scripts/openapi_generator/_legacy_order.py
@@ -333,6 +333,11 @@ LEGACY_TAGS = [
         "name": "Inspect",
         "x-displayName": "Inspect",
     },
+    {
+        "description": "Anthropic Messages API compatibility layer for creating messages and counting tokens.",
+        "name": "Messages",
+        "x-displayName": "Messages",
+    },
     {"description": "", "name": "Models"},
     {"description": "Protocol for prompt management operations.", "name": "Prompts", "x-displayName": "Prompts"},
     {
@@ -344,7 +349,17 @@ LEGACY_TAGS = [
     {"description": "", "name": "Shields"},
     {"description": "", "name": "ToolGroups"},
     {"description": "", "name": "ToolRuntime"},
+    {
+        "description": "Tool listing and management.",
+        "name": "Tools",
+        "x-displayName": "Tools",
+    },
     {"description": "", "name": "VectorIO"},
+    {
+        "description": "OpenAI Responses API for agent orchestration with tool use, multi-turn conversations, and background processing.",
+        "name": "Responses",
+        "x-displayName": "Responses",
+    },
 ]
 
 LEGACY_TAG_ORDER = [
@@ -354,13 +369,16 @@ LEGACY_TAG_ORDER = [
     "Files",
     "Inference",
     "Inspect",
+    "Messages",
     "Models",
     "Prompts",
     "Providers",
+    "Responses",
     "Safety",
     "Shields",
     "ToolGroups",
     "ToolRuntime",
+    "Tools",
     "VectorIO",
 ]
 
@@ -374,13 +392,16 @@ LEGACY_TAG_GROUPS = [
             "Files",
             "Inference",
             "Inspect",
+            "Messages",
             "Models",
             "Prompts",
             "Providers",
+            "Responses",
             "Safety",
             "Shields",
             "ToolGroups",
             "ToolRuntime",
+            "Tools",
             "VectorIO",
         ],
     }


### PR DESCRIPTION
# What does this PR do?

Fixes several docs issues: missing sidebar icons for Responses/Tools/Messages/Shields/VectorIO in the API reference sidebar, 404s on `/docs/api/responses`, `/docs/api/tools`, and `/docs/api/messages` linked from the API overview page, the `/docs/api-openai/anthropic_messages` page rendering without any sidebar navigation, and a stale eval API entry on the api-overview page.

## Root causes

1. **Missing icons**: CSS `nth-child` selectors only covered positions 2-10 for top-level sidebar categories. The API sidebar has 15 categories.
2. **404 pages**: The OpenAPI spec's `tags` section in `_legacy_order.py` did not declare "Responses", "Tools", or "Messages" tags, so the `docusaurus-plugin-openapi-docs` plugin never generated tag overview pages for them (`.tag.mdx` files), even though endpoints used those tags.
3. **No sidebar on api-openai pages**: The `api-openai` docs were only referenced as external `link` types in the sidebar config, not as proper doc items belonging to a sidebar.
4. **Stale eval entry**: The eval API was removed but still listed in the experimental APIs section of `api-overview.mdx`.

## Changes

- **`scripts/openapi_generator/_legacy_order.py`**: Added "Responses", "Tools", and "Messages" to `LEGACY_TAGS`, `LEGACY_TAG_ORDER`, and `LEGACY_TAG_GROUPS` with descriptions.
- **Regenerated OpenAPI specs**: All four spec files updated with the new tag declarations.
- **`docs/src/css/custom.css`**: Added SVG icons for sidebar positions 11-15 (Safety, Shields, Tools, VectorIO, Responses).
- **`docs/sidebars.ts`**: Added `openaiCompatSidebar` for the api-openai section pages.
- **`docs/docs/api-overview.mdx`**: Removed defunct eval API entry from the experimental APIs section.

## Test Plan

1. Run `npm exec docusaurus gen-api-docs all` and verify `responses.tag.mdx`, `tools.tag.mdx`, and `messages.tag.mdx` are generated
2. Start dev server and verify `/docs/api/responses`, `/docs/api/tools`, `/docs/api/messages` return 200
3. Verify all API sidebar categories have icons
4. Verify `/docs/api-openai/anthropic_messages` renders with a sidebar
5. Verify main docs sidebar icons are unaffected
6. Verify eval entry is no longer on the api-overview page