### PR TITLE
fix(ci): add --group test to unused recordings check

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Check if any unused recordings
         run: |
           set -e
-          PYTHONPATH=$PWD uv run ./scripts/cleanup_recordings.py --delete
+          PYTHONPATH=$PWD uv run --group test ./scripts/cleanup_recordings.py --delete
           changes=$(git status --short tests/integration | grep 'recordings' || true)
           if [ -n "$changes" ]; then
             echo "::error::Unused integration recordings detected. Run 'PYTHONPATH=$(pwd) uv run ./scripts/cleanup_recordings.py --delete' locally and commit the deletions."


### PR DESCRIPTION
# What does this PR do?

The "Check if any unused recordings" pre-commit CI step runs `cleanup_recordings.py` which invokes `pytest --collect-only` across `tests/integration/`. This fails because `tests/integration/interactions/conftest.py` imports `google.genai` at the top level, but `google-genai` is only in the `test` dependency group. The `uv run` invocation was missing `--group test`, so the package wasn't available.

Adds `--group test` to the `uv run` invocation so all test dependencies are available during collection.

## Test Plan

Verified that `google-genai` is listed under `[dependency-groups] test` in `pyproject.toml`. The fix ensures `uv run --group test` installs it before running the cleanup script.