### PR TITLE
fix(logging): log registry refresh cancel as warning

### DIFF
--- a/src/llama_stack/core/stack.py
+++ b/src/llama_stack/core/stack.py
@@ -753,7 +753,7 @@ class Stack:
             import traceback
 
             if task.cancelled():
-                logger.error("Model refresh task cancelled")
+                logger.warning("Model refresh task cancelled")
             elif task.exception():
                 logger.error("Model refresh task failed", error=str(task.exception()))
                 traceback.print_exception(task.exception())


### PR DESCRIPTION
# What does this PR do?
canceling the registry refresh is a deliberate user action

it should not be logged as an error as it currently is, downgrade it to a warning

## Test Plan
1. start a llama stack server
```
uv pip install llama-stack[starter]
uv run llama stack run starter
```
2. ctrl-c to shut down the server