### PR TITLE
fix(ci): pin semgrep for UBI9 glibc 2.34 compatibility

### DIFF
--- a/.github/workflows/providers-build.yml
+++ b/.github/workflows/providers-build.yml
@@ -196,12 +196,18 @@ jobs:
             .distribution_spec.container_image = "registry.access.redhat.com/ubi9:latest"
           ' src/llama_stack/distributions/ci-tests/config.yaml
 
+      - name: Create UBI9 pip constraints
+        run: |
+          # UBI9 ships glibc 2.34; semgrep >= 1.158 requires manylinux_2_35
+          echo "semgrep<1.158" > ubi9-constraints.txt
+
       - name: Build UBI9 container image
         run: |
           BASE_IMAGE=$(yq -r '.distribution_spec.container_image // "registry.access.redhat.com/ubi9:latest"' src/llama_stack/distributions/ci-tests/config.yaml)
           BUILD_ARGS=(--build-arg "INSTALL_MODE=editable" --build-arg "DISTRO_NAME=ci-tests")
           BUILD_ARGS+=(--build-arg "BASE_IMAGE=$BASE_IMAGE")
           BUILD_ARGS+=(--build-arg "RUN_CONFIG_PATH=/workspace/src/llama_stack/distributions/ci-tests/config.yaml")
+          BUILD_ARGS+=(--build-arg "PIP_CONSTRAINT_FILE=/workspace/ubi9-constraints.txt")
           if [ -n "${UV_EXTRA_INDEX_URL:-}" ]; then
             BUILD_ARGS+=(--build-arg "UV_EXTRA_INDEX_URL=$UV_EXTRA_INDEX_URL")
           fi

--- a/containers/Containerfile
+++ b/containers/Containerfile
@@ -31,6 +31,7 @@ ARG RUN_CONFIG_PATH=""
 ARG UV_HTTP_TIMEOUT=500
 ARG UV_EXTRA_INDEX_URL=""
 ARG UV_INDEX_STRATEGY=""
+ARG PIP_CONSTRAINT_FILE=""
 ENV UV_HTTP_TIMEOUT=${UV_HTTP_TIMEOUT}
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
@@ -121,6 +122,9 @@ RUN set -eux; \
 # Explicitly unset UV index env vars to ensure we only use PyPI for distribution deps
 RUN set -eux; \
     unset UV_EXTRA_INDEX_URL UV_INDEX_STRATEGY; \
+    if [ -n "$PIP_CONSTRAINT_FILE" ] && [ -f "$PIP_CONSTRAINT_FILE" ]; then \
+        export UV_CONSTRAINT="$PIP_CONSTRAINT_FILE"; \
+    fi; \
     if [ -z "$DISTRO_NAME" ]; then \
         echo "DISTRO_NAME must be provided" >&2; \
         exit 1; \


### PR DESCRIPTION
# What does this PR do?

The UBI9 container build (`build-ubi9-container-distribution`) fails because `semgrep >= 1.158` ships `manylinux_2_35` wheels requiring glibc 2.35, but UBI9 only has glibc 2.34. The `codeshield` package (used by the `inline::code-scanner` safety provider) depends on `semgrep>1.68` with no upper bound, so the container build resolves the latest incompatible version.

This adds a `PIP_CONSTRAINT_FILE` build arg to the Containerfile and uses it in the UBI9 CI job to constrain `semgrep<1.158`. Non-UBI9 builds are unaffected.

## Test Plan

- CI should pass the `build-ubi9-container-distribution` job which was previously failing: https://github.com/llamastack/llama-stack/actions/runs/24389812082/job/71232613594
- Verified `uv run pre-commit run --all-files` passes locally