### PR TITLE
fix(docs): consolidate sidebar and polish navbar icons

### DIFF
--- a/docs/docs/api-anthropic-messages/conformance.mdx
+++ b/docs/docs/api-anthropic-messages/conformance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Anthropic Messages API Conformance
 description: Detailed conformance status of Llama Stack against the Anthropic Messages API specification
-sidebar_label: API Conformance
+sidebar_label: Conformance
 sidebar_position: 2
 ---
 

--- a/docs/docs/api-openai/conformance.mdx
+++ b/docs/docs/api-openai/conformance.mdx
@@ -1,7 +1,7 @@
 ---
 title: OpenAI API Conformance
 description: Detailed conformance status of Llama Stack against the OpenAI API specification
-sidebar_label: API Conformance
+sidebar_label: Conformance
 sidebar_position: 2
 ---
 

--- a/docs/docs/api-openai/index.mdx
+++ b/docs/docs/api-openai/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: OpenAI API Compatibility
 description: OpenAI-compatible APIs and features in Llama Stack
-sidebar_label: OpenAI Compatibility
+sidebar_label: OpenAI
 sidebar_position: 1
 ---
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -245,7 +245,7 @@ const config: Config = {
     },
     colorMode: {
       defaultMode: 'dark',
-      respectPrefersColorScheme: true,
+      respectPrefersColorScheme: false,
     },
     prism: {
       theme: require('prism-react-renderer').themes.oneDark,

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -42,7 +42,7 @@ const sidebars: SidebarsConfig = {
             'concepts/apis/api_providers',
             {
               type: 'category',
-              label: 'OpenAI Compatibility',
+              label: 'OpenAI',
               collapsed: false,
               link: { type: 'doc', id: 'api-openai/index' },
               items: [
@@ -57,6 +57,7 @@ const sidebars: SidebarsConfig = {
               collapsed: false,
               link: { type: 'doc', id: 'api-anthropic-messages/index' },
               items: [
+                'api-openai/anthropic_messages',
                 'api-anthropic-messages/conformance',
               ],
             },
@@ -354,13 +355,6 @@ const sidebars: SidebarsConfig = {
   experimentalApiSidebar: require('./docs/api-experimental/sidebar.ts').default,
   deprecatedApiSidebar: require('./docs/api-deprecated/sidebar.ts').default,
 
-  // OpenAI compatibility sidebar
-  openaiCompatSidebar: [
-    'api-openai/index',
-    'api-openai/anthropic_messages',
-    'api-openai/conformance',
-    'api-openai/provider_matrix',
-  ],
 };
 
 export default sidebars;

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -8,6 +8,10 @@
 
 /* ========== LIGHT MODE ========== */
 :root {
+  /* Search icon - clean Lucide style */
+  --ifm-navbar-search-input-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="%2368717b" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>');
+  --ifm-navbar-search-input-placeholder-color: #68717b;
+
   /* Primary - teal/navy derived from logo */
   --ifm-color-primary: #0d7377;
   --ifm-color-primary-dark: #0b6165;
@@ -72,6 +76,7 @@
 
 /* ========== DARK MODE ========== */
 [data-theme='dark'] {
+  --ifm-navbar-search-input-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="%239ca3af" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>');
   --ifm-color-primary: #2dbdc2;
   --ifm-color-primary-dark: #1aafb4;
   --ifm-color-primary-darker: #12979b;
@@ -167,6 +172,12 @@ h3 {
 
 [data-theme='dark'] .navbar {
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* Search input font */
+.navbar__search-input {
+  font-family: var(--ifm-font-family-base);
+  font-size: 0.875rem;
 }
 
 /* Logo styling */

--- a/docs/src/theme/Icon/DarkMode/index.tsx
+++ b/docs/src/theme/Icon/DarkMode/index.tsx
@@ -1,0 +1,10 @@
+import React, {type ReactNode} from 'react';
+import type {Props} from '@theme/Icon/DarkMode';
+
+export default function IconDarkMode(props: Props): ReactNode {
+  return (
+    <svg viewBox="0 0 24 24" width={18} height={18} fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+    </svg>
+  );
+}

--- a/docs/src/theme/Icon/LightMode/index.tsx
+++ b/docs/src/theme/Icon/LightMode/index.tsx
@@ -1,0 +1,18 @@
+import React, {type ReactNode} from 'react';
+import type {Props} from '@theme/Icon/LightMode';
+
+export default function IconLightMode(props: Props): ReactNode {
+  return (
+    <svg viewBox="0 0 24 24" width={18} height={18} fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <circle cx={12} cy={12} r={4} />
+      <path d="M12 2v2" />
+      <path d="M12 20v2" />
+      <path d="m4.93 4.93 1.41 1.41" />
+      <path d="m17.66 17.66 1.41 1.41" />
+      <path d="M2 12h2" />
+      <path d="M20 12h2" />
+      <path d="m6.34 17.66-1.41 1.41" />
+      <path d="m19.07 4.93-1.41 1.41" />
+    </svg>
+  );
+}

--- a/scripts/generate_anthropic_coverage_docs.py
+++ b/scripts/generate_anthropic_coverage_docs.py
@@ -41,7 +41,7 @@ def generate_docs(
         "---",
         "title: Anthropic Messages API Conformance",
         "description: Detailed conformance status of Llama Stack against the Anthropic Messages API specification",
-        "sidebar_label: API Conformance",
+        "sidebar_label: Conformance",
         "sidebar_position: 2",
         "---",
         "",

--- a/scripts/generate_openai_coverage_docs.py
+++ b/scripts/generate_openai_coverage_docs.py
@@ -92,7 +92,7 @@ def generate_docs(
         "---",
         "title: OpenAI API Conformance",
         "description: Detailed conformance status of Llama Stack against the OpenAI API specification",
-        "sidebar_label: API Conformance",
+        "sidebar_label: Conformance",
         "sidebar_position: 2",
         "---",
         "",


### PR DESCRIPTION
# What does this PR do?

Fixes sidebar inconsistency on the api-openai docs pages where navigating between pages would cause the sidebar to switch between `openaiCompatSidebar` (4 items) and `tutorialSidebar` (full docs nav), making the sidebar appear to disappear.

- Remove the separate `openaiCompatSidebar` and consolidate all api-openai pages into `tutorialSidebar` so the sidebar stays consistent across all pages
- Rename sidebar labels for brevity: "OpenAI Compatibility" → "OpenAI", "API Conformance" → "Conformance"
- Replace dark/light mode toggle icons with cleaner Lucide-style stroke icons at 18px and remove the system color mode third state
- Replace the search input icon with a Lucide-style icon and apply the site font to the search placeholder

## Test Plan

1. Build and serve docs locally: `cd docs && npm install && npx docusaurus build && npx docusaurus serve`
2. Navigate to `/docs/api-openai` and click each sidebar item — verify the full docs sidebar persists on every page
3. Click "how the Responses API works internally" link in the content — verify sidebar stays consistent on the responses-flow page
4. Verify the dark/light mode toggle shows clean stroke icons
5. Verify the search input uses the site font (Public Sans)