### PR TITLE
feat(config): allow model registry refresh interval to be configurable

### DIFF
--- a/docs/docs/distributions/configuration.mdx
+++ b/docs/docs/distributions/configuration.mdx
@@ -257,7 +257,19 @@ server:
   tls_certfile: "/path/to/cert.pem"  # Optional: Path to TLS certificate for HTTPS
   tls_keyfile: "/path/to/key.pem"    # Optional: Path to TLS key for HTTPS
   cors: true  # Optional: Enable CORS (dev mode) or full config object
+  registry_refresh_interval_seconds: 300  # Optional: Interval between registry refreshes (default: 300)
 ```
+
+### Registry Refresh Interval
+
+The server periodically refreshes its model registry to sync model information from providers. By default this happens every 300 seconds (5 minutes). You can override this interval:
+
+```yaml
+server:
+  registry_refresh_interval_seconds: 60  # Refresh every 60 seconds
+```
+
+The value must be a positive integer representing seconds.
 
 ### CORS Configuration
 

--- a/src/llama_stack/core/datatypes.py
+++ b/src/llama_stack/core/datatypes.py
@@ -775,6 +775,11 @@ class ServerConfig(BaseModel):
         default=1,
         description="Number of workers to use for the server",
     )
+    registry_refresh_interval_seconds: int = Field(
+        default=300,
+        description="Interval in seconds between registry refreshes for syncing model information from providers",
+        gt=0,
+    )
 
 
 class StackConfig(BaseModel):

--- a/src/llama_stack/core/stack.py
+++ b/src/llama_stack/core/stack.py
@@ -747,7 +747,8 @@ class Stack:
         assert self.impls is not None, "Must call initialize() before starting"
 
         global REGISTRY_REFRESH_TASK
-        REGISTRY_REFRESH_TASK = asyncio.create_task(refresh_registry_task(self.impls))
+        interval = self.run_config.server.registry_refresh_interval_seconds
+        REGISTRY_REFRESH_TASK = asyncio.create_task(refresh_registry_task(self.impls, interval))
 
         def cb(task):
             import traceback
@@ -810,13 +811,13 @@ async def refresh_registry_once(impls: dict[Api, Any]):
         await routing_table.refresh()
 
 
-async def refresh_registry_task(impls: dict[Api, Any]):
+async def refresh_registry_task(impls: dict[Api, Any], interval_seconds: int = REGISTRY_REFRESH_INTERVAL_SECONDS):
     """Background task that periodically refreshes routing table registries."""
-    logger.info("starting registry refresh task")
+    logger.info("starting registry refresh task", interval_seconds=interval_seconds)
     while True:
         await refresh_registry_once(impls)
 
-        await asyncio.sleep(REGISTRY_REFRESH_INTERVAL_SECONDS)
+        await asyncio.sleep(interval_seconds)
 
 
 def get_stack_run_config_from_distro(distro: str) -> StackConfig:

--- a/tests/unit/core/test_stack_validation.py
+++ b/tests/unit/core/test_stack_validation.py
@@ -15,6 +15,7 @@ from llama_stack.core.datatypes import (
     RerankerModel,
     RewriteQueryParams,
     SafetyConfig,
+    ServerConfig,
     StackConfig,
     VectorStoresConfig,
 )
@@ -393,3 +394,47 @@ class TestRegisterConnectors:
         await register_connectors(config, {})
 
         # Should complete without error (early return)
+
+
+class TestServerConfigRegistryRefreshInterval:
+    def test_default_value(self):
+        """Test that registry_refresh_interval_seconds defaults to 300."""
+        config = ServerConfig()
+        assert config.registry_refresh_interval_seconds == 300
+
+    def test_custom_value(self):
+        """Test that registry_refresh_interval_seconds can be set to a custom value."""
+        config = ServerConfig(registry_refresh_interval_seconds=60)
+        assert config.registry_refresh_interval_seconds == 60
+
+    def test_rejects_zero(self):
+        """Test that registry_refresh_interval_seconds rejects zero."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="registry_refresh_interval_seconds"):
+            ServerConfig(registry_refresh_interval_seconds=0)
+
+    def test_rejects_negative(self):
+        """Test that registry_refresh_interval_seconds rejects negative values."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="registry_refresh_interval_seconds"):
+            ServerConfig(registry_refresh_interval_seconds=-1)
+
+    def test_value_threads_to_stack_config(self):
+        """Test that registry_refresh_interval_seconds is accessible via StackConfig.server."""
+        stack_config = StackConfig(
+            distro_name="test",
+            providers={},
+            storage=StorageConfig(
+                backends={},
+                stores=ServerStoresConfig(
+                    metadata=None,
+                    inference=None,
+                    conversations=None,
+                    prompts=None,
+                ),
+            ),
+            server=ServerConfig(registry_refresh_interval_seconds=120),
+        )
+        assert stack_config.server.registry_refresh_interval_seconds == 120


### PR DESCRIPTION
# What does this PR do?
Currently, the stack model registry refresh is set to a hardcoded value of 5 minutes. I have kept this default but allowed for the ability to configure a custom refresh second interval as part of the stack config YAML. This ensures no impact to current users but allows for additional server configuration options for admins.

## Test Plan
Added several unit tests to validate the new config value

