### PR TITLE
feat: remove conventional pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,13 +35,6 @@ repos:
     hooks:
     -   id: actionlint
 
--   repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v3.6.0
-    hooks:
-    -   id: conventional-pre-commit
-        stages: [commit-msg]
-        args: [--verbose]
-
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:


### PR DESCRIPTION
i can't merge main into my branches because contentional-pre-commit prevents merge commit messages.

this project uses squash merge on PRs and has a ci check for conventional PR titles.

this means commits need not follow the conventional structure, the PR must.