### PR TITLE
fix(docs): incorrect model names in "Getting Started" docs

### DIFF
--- a/docs/docs/getting_started/detailed_tutorial.mdx
+++ b/docs/docs/getting_started/detailed_tutorial.mdx
@@ -28,7 +28,7 @@ for m in models.data:
 
 # Simple chat
 response = client.chat.completions.create(
-    model="llama3.2:3b",
+    model="ollama/llama3.2:3b",
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "Write a haiku about open source"},
@@ -47,7 +47,7 @@ from openai import OpenAI
 client = OpenAI(base_url="http://localhost:8321/v1", api_key="fake")
 
 stream = client.chat.completions.create(
-    model="llama3.2:3b",
+    model="ollama/llama3.2:3b",
     messages=[{"role": "user", "content": "Explain RAG in 3 sentences"}],
     stream=True,
 )
@@ -68,7 +68,7 @@ from openai import OpenAI
 client = OpenAI(base_url="http://localhost:8321/v1", api_key="fake")
 
 response = client.responses.create(
-    model="llama3.2:3b",
+    model="ollama/llama3.2:3b",
     input="What is the weather like in San Francisco?",
     tools=[{
         "type": "function",
@@ -114,7 +114,7 @@ print(f"Vector store: {vector_store.id}")
 
 # Ask questions with file search
 response = client.responses.create(
-    model="llama3.2:3b",
+    model="ollama/llama3.2:3b",
     input="What are the key points in this document?",
     tools=[{
         "type": "file_search",
@@ -135,14 +135,14 @@ client = OpenAI(base_url="http://localhost:8321/v1", api_key="fake")
 
 # First turn
 r1 = client.responses.create(
-    model="llama3.2:3b",
+    model="ollama/llama3.2:3b",
     input="My name is Alice and I'm building a RAG app",
 )
 print("Assistant:", r1.output_text)
 
 # Second turn - references the first
 r2 = client.responses.create(
-    model="llama3.2:3b",
+    model="ollama/llama3.2:3b",
     input="What did I say my name was?",
     previous_response_id=r1.id,
 )
@@ -159,7 +159,7 @@ from openai import OpenAI
 client = OpenAI(base_url="http://localhost:8321/v1", api_key="fake")
 
 response = client.responses.create(
-    model="llama3.2:3b",
+    model="ollama/llama3.2:3b",
     input="List files in the current directory",
     tools=[{
         "type": "mcp",
@@ -178,6 +178,7 @@ The same code works with any backend. Just change the server config:
 <TabItem value="ollama" label="Ollama" default>
 
 ```bash
+export OLLAMA_URL=http://localhost:11434/v1
 uv run llama stack run starter
 ```
 
@@ -213,7 +214,7 @@ client.initialize()
 
 # Use the same OpenAI-compatible interface
 response = client.responses.create(
-    model="llama3.2:3b",
+    model="ollama/llama3.2:3b",
     input="Hello from library mode!",
 )
 print(response.output_text)

--- a/docs/docs/getting_started/migrate_existing_app.mdx
+++ b/docs/docs/getting_started/migrate_existing_app.mdx
@@ -5,9 +5,12 @@ sidebar_position: 2
 title: Migrate an existing app
 ---
 
-If you already have an application built on the OpenAI or Anthropic SDK, migrating to Llama Stack is straightforward. In most cases you only need to change the `base_url`.
+If you already have an application built on the OpenAI or Anthropic SDK, migrating to Llama Stack is straightforward. In most cases you only need to change the `base_url`
+and the 'model' name to include the provider for the model you wish to use.
 
 ## From OpenAI
+
+This example shows a move from a direct interaction to the OpenAI API to a local Llama3.2 model hosted via Ollama.
 
 **Before** (talking directly to OpenAI):
 
@@ -34,7 +37,7 @@ client = OpenAI(
 )
 
 response = client.chat.completions.create(
-    model="llama3.2:3b",  # use a model registered in your server
+    model="ollama/llama3.2:3b",  # use a model registered in your server
     messages=[{"role": "user", "content": "Hello!"}],
 )
 print(response.choices[0].message.content)
@@ -72,7 +75,7 @@ client = OpenAI(
 )
 
 response = client.chat.completions.create(
-    model="llama3.2:3b",
+    model="ollama/llama3.2:3b",
     messages=[{"role": "user", "content": "Hello!"}],
 )
 print(response.choices[0].message.content)


### PR DESCRIPTION
# What does this PR do?
requests to Llama Stack need the provider id prepending the model name

fix broken examples in the "Getting Started" section of the docs

## Test Plan
i ran all these manually