### PR TITLE
docs: add Docker Hub container image references for distributions

### DIFF
--- a/docs/docs/concepts/architecture.mdx
+++ b/docs/docs/concepts/architecture.mdx
@@ -124,11 +124,14 @@ Key features:
 
 A distribution is a pre-configured run config for a target environment. Think Kubernetes distributions (AKS, EKS, GKE) - the API stays the same, each distribution wires different backends.
 
-| Distribution | Use case |
-|-------------|----------|
-| `starter` | General purpose, supports most providers |
-| `dell`, `nvidia` | Hardware-specific optimizations |
-| Custom | Build your own with `llama stack build` |
+| Distribution | Use case | Container Image | Documentation |
+|--------------|----------|-----------------|---------------|
+| `starter` | General purpose, supports most providers | [`llamastack/distribution-starter`](https://hub.docker.com/r/llamastack/distribution-starter) | [Starter Guide](/docs/distributions/self_hosted_distro/starter) |
+| `starter-gpu` | Starter + HuggingFace GPU provider for post-training | [`llamastack/distribution-starter-gpu`](https://hub.docker.com/r/llamastack/distribution-starter-gpu) | — |
+| `postgres-demo` | Starter with PostgreSQL storage | [`llamastack/distribution-postgres-demo`](https://hub.docker.com/r/llamastack/distribution-postgres-demo) | — |
+| `dell` | Dell-specific hardware optimizations | [`llamastack/distribution-dell`](https://hub.docker.com/r/llamastack/distribution-dell) | — |
+| `nvidia` | NVIDIA-specific hardware optimizations | — | [NVIDIA Guide](/docs/distributions/self_hosted_distro/nvidia) |
+| Custom | Build your own by creating a custom `config.yaml` | — | [Building Custom Distributions](/docs/distributions/building_distro) |
 
 ## Storage
 

--- a/docs/docs/concepts/architecture.mdx
+++ b/docs/docs/concepts/architecture.mdx
@@ -127,7 +127,6 @@ A distribution is a pre-configured run config for a target environment. Think Ku
 | Distribution | Use case | Container Image | Documentation |
 |--------------|----------|-----------------|---------------|
 | `starter` | General purpose, supports most providers | [`llamastack/distribution-starter`](https://hub.docker.com/r/llamastack/distribution-starter) | [Starter Guide](/docs/distributions/self_hosted_distro/starter) |
-| `starter-gpu` | Starter + HuggingFace GPU provider for post-training | [`llamastack/distribution-starter-gpu`](https://hub.docker.com/r/llamastack/distribution-starter-gpu) | — |
 | `postgres-demo` | Starter with PostgreSQL storage | [`llamastack/distribution-postgres-demo`](https://hub.docker.com/r/llamastack/distribution-postgres-demo) | — |
 | `dell` | Dell-specific hardware optimizations | [`llamastack/distribution-dell`](https://hub.docker.com/r/llamastack/distribution-dell) | — |
 | `nvidia` | NVIDIA-specific hardware optimizations | — | [NVIDIA Guide](/docs/distributions/self_hosted_distro/nvidia) |

--- a/docs/docs/concepts/distributions.mdx
+++ b/docs/docs/concepts/distributions.mdx
@@ -14,10 +14,10 @@ A distribution is a pre-configured run config that bundles specific providers fo
 Most users should start with `starter`. It includes all providers and auto-enables them based on available environment variables:
 
 ```bash
-# Local with Ollama (auto-detected)
-uv run llama stack run starter
+# With Ollama (local inference)
+OLLAMA_URL=http://localhost:11434 uv run llama stack run starter
 
-# With OpenAI
+# With OpenAI (remote inference)
 OPENAI_API_KEY=sk-xxx uv run llama stack run starter
 ```
 
@@ -27,7 +27,9 @@ The starter distribution uses FAISS for vector storage, sentence-transformers fo
 
 **Self-hosted**: Run Llama Stack on your own infrastructure with your choice of inference backend (Ollama, vLLM, or cloud providers like OpenAI, Bedrock, etc.). The `starter` distribution covers this use case.
 
-**Hardware-specific**: Optimized for specific hardware. Examples include `nvidia` and `dell` distributions with vendor-specific provider configurations.
+**Hardware-specific**: Optimized for specific hardware. Examples include `nvidia` and `dell` distributions with vendor-specific provider configurations. The `dell` distribution is available as a pre-built container image at [`llamastack/distribution-dell`](https://hub.docker.com/r/llamastack/distribution-dell).
+
+**Starter variants**: The `starter-gpu` distribution adds the HuggingFace GPU provider for post-training workflows ([`llamastack/distribution-starter-gpu`](https://hub.docker.com/r/llamastack/distribution-starter-gpu)). The `postgres-demo` distribution is the starter pre-configured with PostgreSQL storage ([`llamastack/distribution-postgres-demo`](https://hub.docker.com/r/llamastack/distribution-postgres-demo)).
 
 ## Custom Distributions
 

--- a/docs/docs/concepts/distributions.mdx
+++ b/docs/docs/concepts/distributions.mdx
@@ -29,7 +29,7 @@ The starter distribution uses FAISS for vector storage, sentence-transformers fo
 
 **Hardware-specific**: Optimized for specific hardware. Examples include `nvidia` and `dell` distributions with vendor-specific provider configurations. The `dell` distribution is available as a pre-built container image at [`llamastack/distribution-dell`](https://hub.docker.com/r/llamastack/distribution-dell).
 
-**Starter variants**: The `starter-gpu` distribution adds the HuggingFace GPU provider for post-training workflows ([`llamastack/distribution-starter-gpu`](https://hub.docker.com/r/llamastack/distribution-starter-gpu)). The `postgres-demo` distribution is the starter pre-configured with PostgreSQL storage ([`llamastack/distribution-postgres-demo`](https://hub.docker.com/r/llamastack/distribution-postgres-demo)).
+**Starter variants**: The `postgres-demo` distribution is the starter pre-configured with PostgreSQL storage ([`llamastack/distribution-postgres-demo`](https://hub.docker.com/r/llamastack/distribution-postgres-demo)).
 
 ## Custom Distributions
 

--- a/docs/docs/deploying/kubernetes_deployment.mdx
+++ b/docs/docs/deploying/kubernetes_deployment.mdx
@@ -176,7 +176,7 @@ EOF
 - `server.storage.size`: Size of the persistent volume for model and data storage
 - `server.storage.mountPath`: Where to mount the storage in the container
 
-**Note:** For a complete list of supported distributions, see [distributions.json](https://github.com/llamastack/llama-stack-k8s-operator/blob/main/distributions.json) in the operator repository. To use a custom or non-supported distribution, set the `server.distribution.image` field with your container image instead of  `server.distribution.name`.
+**Note:** For a complete list of supported distributions, see [distributions.json](https://github.com/llamastack/llama-stack-k8s-operator/blob/main/distributions.json) in the operator repository. Pre-built container images are available on [Docker Hub](https://hub.docker.com/u/llamastack) (e.g., `llamastack/distribution-starter`, `llamastack/distribution-starter-gpu`, `llamastack/distribution-postgres-demo`, `llamastack/distribution-dell`). To use a custom or non-supported distribution, set the `server.distribution.image` field with your container image instead of `server.distribution.name`.
 
 The operator automatically creates:
 - A Deployment for the Llama Stack server

--- a/docs/docs/deploying/kubernetes_deployment.mdx
+++ b/docs/docs/deploying/kubernetes_deployment.mdx
@@ -176,7 +176,7 @@ EOF
 - `server.storage.size`: Size of the persistent volume for model and data storage
 - `server.storage.mountPath`: Where to mount the storage in the container
 
-**Note:** For a complete list of supported distributions, see [distributions.json](https://github.com/llamastack/llama-stack-k8s-operator/blob/main/distributions.json) in the operator repository. Pre-built container images are available on [Docker Hub](https://hub.docker.com/u/llamastack) (e.g., `llamastack/distribution-starter`, `llamastack/distribution-starter-gpu`, `llamastack/distribution-postgres-demo`, `llamastack/distribution-dell`). To use a custom or non-supported distribution, set the `server.distribution.image` field with your container image instead of `server.distribution.name`.
+**Note:** For a complete list of supported distributions, see [distributions.json](https://github.com/llamastack/llama-stack-k8s-operator/blob/main/distributions.json) in the operator repository. Pre-built container images are available on [Docker Hub](https://hub.docker.com/u/llamastack) (e.g., `llamastack/distribution-starter`, `llamastack/distribution-postgres-demo`, `llamastack/distribution-dell`). To use a custom or non-supported distribution, set the `server.distribution.image` field with your container image instead of `server.distribution.name`.
 
 The operator automatically creates:
 - A Deployment for the Llama Stack server

--- a/docs/docs/distributions/list_of_distributions.mdx
+++ b/docs/docs/distributions/list_of_distributions.mdx
@@ -7,11 +7,14 @@ sidebar_position: 2
 
 # Available Distributions
 
-| Distribution | Use Case | Inference |
-|-------------|----------|-----------|
-| `starter` | General purpose, prototyping, production | Ollama, OpenAI, vLLM, Bedrock, and more |
-| `nvidia` | NVIDIA NeMo Microservices | NVIDIA NIM |
-| Custom | Your own provider mix | Any supported provider |
+| Distribution | Use Case | Inference | Container Image |
+|-------------|----------|-----------|-----------------|
+| `starter` | General purpose, prototyping, production | Ollama, OpenAI, vLLM, Bedrock, and more | [`llamastack/distribution-starter`](https://hub.docker.com/r/llamastack/distribution-starter) |
+| `starter-gpu` | GPU post-training with HuggingFace | Same as starter + HuggingFace GPU provider | [`llamastack/distribution-starter-gpu`](https://hub.docker.com/r/llamastack/distribution-starter-gpu) |
+| `postgres-demo` | Starter with PostgreSQL storage | Same as starter | [`llamastack/distribution-postgres-demo`](https://hub.docker.com/r/llamastack/distribution-postgres-demo) |
+| `dell` | Dell hardware optimizations | Dell-specific providers | [`llamastack/distribution-dell`](https://hub.docker.com/r/llamastack/distribution-dell) |
+| `nvidia` | NVIDIA NeMo Microservices | NVIDIA NIM | — |
+| Custom | Your own provider mix | Any supported provider | — |
 
 ## Starter (Recommended)
 
@@ -22,6 +25,37 @@ uv run llama stack run starter
 ```
 
 It supports local inference (Ollama), cloud providers (OpenAI, Bedrock, Azure, etc.), and everything in between. See the [Starter Guide](self_hosted_distro/starter) for details.
+
+## Starter GPU
+
+The starter distribution with the HuggingFace GPU provider added for post-training workflows. Run it with the pre-built container image:
+
+```bash
+docker run -it --gpus all \
+  -p 8321:8321 \
+  -v ~/.llama:/root/.llama \
+  llamastack/distribution-starter-gpu
+```
+
+## PostgreSQL Demo
+
+A variant of the starter distribution pre-configured with PostgreSQL storage instead of SQLite. Suitable for production-like deployments and demos:
+
+```bash
+docker run -it \
+  -p 8321:8321 \
+  -v ~/.llama:/root/.llama \
+  -e POSTGRES_HOST=host.docker.internal \
+  -e POSTGRES_PORT=5432 \
+  -e POSTGRES_DB=llamastack \
+  -e POSTGRES_USER=llamastack \
+  -e POSTGRES_PASSWORD=llamastack \
+  llamastack/distribution-postgres-demo
+```
+
+## Dell
+
+Optimized for Dell hardware with vendor-specific provider configurations. Available as a pre-built container image: [`llamastack/distribution-dell`](https://hub.docker.com/r/llamastack/distribution-dell).
 
 ## NVIDIA
 
@@ -43,7 +77,12 @@ Build your own distribution when you need a specific provider mix. See [Building
 graph TD
     A[What do you need?] --> B{Have specific hardware?}
     B -->|NVIDIA| C[Use nvidia distro]
+    B -->|Dell| G[Use dell distro]
     B -->|No| D{Want managed hosting?}
     D -->|Yes| E[Use remote-hosted]
-    D -->|No| F[Use starter]
+    D -->|No| H{Need GPU post-training?}
+    H -->|Yes| I[Use starter-gpu]
+    H -->|No| J{Need PostgreSQL storage?}
+    J -->|Yes| K[Use postgres-demo]
+    J -->|No| F[Use starter]
 ```

--- a/docs/docs/distributions/list_of_distributions.mdx
+++ b/docs/docs/distributions/list_of_distributions.mdx
@@ -10,7 +10,6 @@ sidebar_position: 2
 | Distribution | Use Case | Inference | Container Image |
 |-------------|----------|-----------|-----------------|
 | `starter` | General purpose, prototyping, production | Ollama, OpenAI, vLLM, Bedrock, and more | [`llamastack/distribution-starter`](https://hub.docker.com/r/llamastack/distribution-starter) |
-| `starter-gpu` | GPU post-training with HuggingFace | Same as starter + HuggingFace GPU provider | [`llamastack/distribution-starter-gpu`](https://hub.docker.com/r/llamastack/distribution-starter-gpu) |
 | `postgres-demo` | Starter with PostgreSQL storage | Same as starter | [`llamastack/distribution-postgres-demo`](https://hub.docker.com/r/llamastack/distribution-postgres-demo) |
 | `dell` | Dell hardware optimizations | Dell-specific providers | [`llamastack/distribution-dell`](https://hub.docker.com/r/llamastack/distribution-dell) |
 | `nvidia` | NVIDIA NeMo Microservices | NVIDIA NIM | — |
@@ -25,17 +24,6 @@ uv run llama stack run starter
 ```
 
 It supports local inference (Ollama), cloud providers (OpenAI, Bedrock, Azure, etc.), and everything in between. See the [Starter Guide](self_hosted_distro/starter) for details.
-
-## Starter GPU
-
-The starter distribution with the HuggingFace GPU provider added for post-training workflows. Run it with the pre-built container image:
-
-```bash
-docker run -it --gpus all \
-  -p 8321:8321 \
-  -v ~/.llama:/root/.llama \
-  llamastack/distribution-starter-gpu
-```
 
 ## PostgreSQL Demo
 
@@ -80,9 +68,7 @@ graph TD
     B -->|Dell| G[Use dell distro]
     B -->|No| D{Want managed hosting?}
     D -->|Yes| E[Use remote-hosted]
-    D -->|No| H{Need GPU post-training?}
-    H -->|Yes| I[Use starter-gpu]
-    H -->|No| J{Need PostgreSQL storage?}
+    D -->|No| J{Need PostgreSQL storage?}
     J -->|Yes| K[Use postgres-demo]
     J -->|No| F[Use starter]
 ```

--- a/docs/docs/distributions/self_hosted_distro/starter.md
+++ b/docs/docs/distributions/self_hosted_distro/starter.md
@@ -160,6 +160,16 @@ Quick start:
 uvx --from 'llama-stack[starter]' llama stack run starter
 ```
 
+Or run the pre-built container image from [Docker Hub](https://hub.docker.com/r/llamastack/distribution-starter):
+
+```bash
+docker run -it \
+  -p 8321:8321 \
+  -v ~/.llama:/root/.llama \
+  -e OLLAMA_URL=http://host.docker.internal:11434 \
+  llamastack/distribution-starter
+```
+
 ### PostgreSQL Storage
 
 By default, the starter distribution uses SQLite. For production, use PostgreSQL:
@@ -167,6 +177,12 @@ By default, the starter distribution uses SQLite. For production, use PostgreSQL
 ```bash
 uvx --from 'llama-stack[starter]' llama stack run starter::run-with-postgres-store.yaml
 ```
+
+A pre-built container image with PostgreSQL storage is also available as [`llamastack/distribution-postgres-demo`](https://hub.docker.com/r/llamastack/distribution-postgres-demo).
+
+### GPU Post-Training
+
+For workflows requiring GPU-accelerated post-training via HuggingFace, use the [`llamastack/distribution-starter-gpu`](https://hub.docker.com/r/llamastack/distribution-starter-gpu) container image.
 
 Required environment variables for PostgreSQL:
 

--- a/docs/docs/distributions/self_hosted_distro/starter.md
+++ b/docs/docs/distributions/self_hosted_distro/starter.md
@@ -180,10 +180,6 @@ uvx --from 'llama-stack[starter]' llama stack run starter::run-with-postgres-sto
 
 A pre-built container image with PostgreSQL storage is also available as [`llamastack/distribution-postgres-demo`](https://hub.docker.com/r/llamastack/distribution-postgres-demo).
 
-### GPU Post-Training
-
-For workflows requiring GPU-accelerated post-training via HuggingFace, use the [`llamastack/distribution-starter-gpu`](https://hub.docker.com/r/llamastack/distribution-starter-gpu) container image.
-
 Required environment variables for PostgreSQL:
 
 | Variable | Default |

--- a/docs/docs/distributions/starting_llama_stack_server.mdx
+++ b/docs/docs/distributions/starting_llama_stack_server.mdx
@@ -43,7 +43,6 @@ Other pre-built images are available on [Docker Hub](https://hub.docker.com/u/ll
 | Image | Description |
 |-------|-------------|
 | [`llamastack/distribution-starter`](https://hub.docker.com/r/llamastack/distribution-starter) | General purpose (recommended) |
-| [`llamastack/distribution-starter-gpu`](https://hub.docker.com/r/llamastack/distribution-starter-gpu) | Starter + HuggingFace GPU provider for post-training |
 | [`llamastack/distribution-postgres-demo`](https://hub.docker.com/r/llamastack/distribution-postgres-demo) | Starter with PostgreSQL storage |
 | [`llamastack/distribution-dell`](https://hub.docker.com/r/llamastack/distribution-dell) | Dell hardware optimizations |
 

--- a/docs/docs/distributions/starting_llama_stack_server.mdx
+++ b/docs/docs/distributions/starting_llama_stack_server.mdx
@@ -38,6 +38,15 @@ docker run -it \
   llamastack/distribution-starter
 ```
 
+Other pre-built images are available on [Docker Hub](https://hub.docker.com/u/llamastack):
+
+| Image | Description |
+|-------|-------------|
+| [`llamastack/distribution-starter`](https://hub.docker.com/r/llamastack/distribution-starter) | General purpose (recommended) |
+| [`llamastack/distribution-starter-gpu`](https://hub.docker.com/r/llamastack/distribution-starter-gpu) | Starter + HuggingFace GPU provider for post-training |
+| [`llamastack/distribution-postgres-demo`](https://hub.docker.com/r/llamastack/distribution-postgres-demo) | Starter with PostgreSQL storage |
+| [`llamastack/distribution-dell`](https://hub.docker.com/r/llamastack/distribution-dell) | Dell hardware optimizations |
+
 See [Building Custom Distributions](./building_distro) to create your own image.
 
 </TabItem>

--- a/docs/docs/getting_started/quickstart.mdx
+++ b/docs/docs/getting_started/quickstart.mdx
@@ -32,6 +32,19 @@ uvx --from 'llama-stack[starter]' llama stack run starter
 ```
 
 </TabItem>
+<TabItem value="docker" label="Docker">
+
+Run a pre-built container image from [Docker Hub](https://hub.docker.com/r/llamastack/distribution-starter):
+
+```bash
+docker run -it \
+  -p 8321:8321 \
+  -v ~/.llama:/root/.llama \
+  -e OLLAMA_URL=http://host.docker.internal:11434 \
+  llamastack/distribution-starter
+```
+
+</TabItem>
 </Tabs>
 
 :::tip Project setup


### PR DESCRIPTION
# What does this PR do?
The current docs have very sparing mentions of our official distribution container images - this PR adds them to give users additional options for running our official distros, i.e. in containerized environments

I took care to only add docs around the images we actively maintain, i.e. what has been [updated in the last two weeks on Docker Hub](https://hub.docker.com/u/llamastack) - this consists of 4 images:
- `llamastack/distribution-starter`
- `llamastack/distribution-postgres-demo`
- `llamastack/distribution-dell`
- `llamastack/distribution-starter-gpu`

I am happy to remove the references to any of these if it's desired by the maintainers, but I would argue if that is the case then we should also disable the publishing automation that is updating the respective image