### PR TITLE
feat(containers): add nvidia distribution to Docker Hub publish matrix

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -901,6 +901,8 @@ jobs:
             platforms: linux/amd64,linux/arm64
           - distro: postgres-demo
             platforms: linux/amd64,linux/arm64
+          - distro: nvidia
+            platforms: linux/amd64,linux/arm64
 
     steps:
       - name: Free disk space

--- a/docs/docs/concepts/architecture.mdx
+++ b/docs/docs/concepts/architecture.mdx
@@ -129,7 +129,7 @@ A distribution is a pre-configured run config for a target environment. Think Ku
 | `starter` | General purpose, supports most providers | [`llamastack/distribution-starter`](https://hub.docker.com/r/llamastack/distribution-starter) | [Starter Guide](/docs/distributions/self_hosted_distro/starter) |
 | `postgres-demo` | Starter with PostgreSQL storage | [`llamastack/distribution-postgres-demo`](https://hub.docker.com/r/llamastack/distribution-postgres-demo) | — |
 | `dell` | Dell-specific hardware optimizations | [`llamastack/distribution-dell`](https://hub.docker.com/r/llamastack/distribution-dell) | — |
-| `nvidia` | NVIDIA-specific hardware optimizations | — | [NVIDIA Guide](/docs/distributions/self_hosted_distro/nvidia) |
+| `nvidia` | NVIDIA-specific hardware optimizations | [`llamastack/distribution-nvidia`](https://hub.docker.com/r/llamastack/distribution-nvidia) | [NVIDIA Guide](/docs/distributions/self_hosted_distro/nvidia) |
 | Custom | Build your own by creating a custom `config.yaml` | — | [Building Custom Distributions](/docs/distributions/building_distro) |
 
 ## Storage

--- a/docs/docs/concepts/distributions.mdx
+++ b/docs/docs/concepts/distributions.mdx
@@ -27,7 +27,7 @@ The starter distribution uses FAISS for vector storage, sentence-transformers fo
 
 **Self-hosted**: Run Llama Stack on your own infrastructure with your choice of inference backend (Ollama, vLLM, or cloud providers like OpenAI, Bedrock, etc.). The `starter` distribution covers this use case.
 
-**Hardware-specific**: Optimized for specific hardware. Examples include `nvidia` and `dell` distributions with vendor-specific provider configurations. The `dell` distribution is available as a pre-built container image at [`llamastack/distribution-dell`](https://hub.docker.com/r/llamastack/distribution-dell).
+**Hardware-specific**: Optimized for specific hardware. Examples include `nvidia` and `dell` distributions with vendor-specific provider configurations. The `nvidia` distribution is available as a pre-built container image at [`llamastack/distribution-nvidia`](https://hub.docker.com/r/llamastack/distribution-nvidia), and the `dell` distribution at [`llamastack/distribution-dell`](https://hub.docker.com/r/llamastack/distribution-dell).
 
 **Starter variants**: The `postgres-demo` distribution is the starter pre-configured with PostgreSQL storage ([`llamastack/distribution-postgres-demo`](https://hub.docker.com/r/llamastack/distribution-postgres-demo)).
 

--- a/docs/docs/distributions/list_of_distributions.mdx
+++ b/docs/docs/distributions/list_of_distributions.mdx
@@ -12,7 +12,7 @@ sidebar_position: 2
 | `starter` | General purpose, prototyping, production | Ollama, OpenAI, vLLM, Bedrock, and more | [`llamastack/distribution-starter`](https://hub.docker.com/r/llamastack/distribution-starter) |
 | `postgres-demo` | Starter with PostgreSQL storage | Same as starter | [`llamastack/distribution-postgres-demo`](https://hub.docker.com/r/llamastack/distribution-postgres-demo) |
 | `dell` | Dell hardware optimizations | Dell-specific providers | [`llamastack/distribution-dell`](https://hub.docker.com/r/llamastack/distribution-dell) |
-| `nvidia` | NVIDIA NeMo Microservices | NVIDIA NIM | — |
+| `nvidia` | NVIDIA NeMo Microservices | NVIDIA NIM | [`llamastack/distribution-nvidia`](https://hub.docker.com/r/llamastack/distribution-nvidia) |
 | Custom | Your own provider mix | Any supported provider | — |
 
 ## Starter (Recommended)
@@ -47,7 +47,7 @@ Optimized for Dell hardware with vendor-specific provider configurations. Availa
 
 ## NVIDIA
 
-Optimized for NVIDIA NeMo Microservices. See the [NVIDIA Guide](self_hosted_distro/nvidia).
+Optimized for NVIDIA NeMo Microservices. Available as a pre-built container image: [`llamastack/distribution-nvidia`](https://hub.docker.com/r/llamastack/distribution-nvidia). See the [NVIDIA Guide](self_hosted_distro/nvidia).
 
 ## Passthrough
 

--- a/docs/docs/distributions/starting_llama_stack_server.mdx
+++ b/docs/docs/distributions/starting_llama_stack_server.mdx
@@ -44,6 +44,7 @@ Other pre-built images are available on [Docker Hub](https://hub.docker.com/u/ll
 |-------|-------------|
 | [`llamastack/distribution-starter`](https://hub.docker.com/r/llamastack/distribution-starter) | General purpose (recommended) |
 | [`llamastack/distribution-postgres-demo`](https://hub.docker.com/r/llamastack/distribution-postgres-demo) | Starter with PostgreSQL storage |
+| [`llamastack/distribution-nvidia`](https://hub.docker.com/r/llamastack/distribution-nvidia) | NVIDIA NeMo Microservices |
 | [`llamastack/distribution-dell`](https://hub.docker.com/r/llamastack/distribution-dell) | Dell hardware optimizations |
 
 See [Building Custom Distributions](./building_distro) to create your own image.


### PR DESCRIPTION
# What does this PR do?
While working on https://github.com/llamastack/llama-stack/pull/5564 I noticed that NVIDIA was the only included distribution that didn't have a pre-built container image available on our DockerHub: https://llamastack.github.io/docs/distributions/list_of_distributions

The nvidia distribution already has a complete config.yaml and uses remote::nvidia for inference (CPU-only, API calls to NVIDIA NIM), so no GPU base image is needed. This adds it to the pypi.yml publish matrix alongside starter and postgres-demo, and updates docs to reference the new container image.

**Important:** If this PR is accepted by the community, the repo will need to be created prior to this merging such that the build automation can successfully push it
